### PR TITLE
v3: compile cmd/v with the FastC self-host

### DIFF
--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -3,6 +3,11 @@ module driver
 import os
 import v3.pref
 
+fn test_input_is_cmd_v_accepts_relative_entry_file() {
+	assert input_is_cmd_v('cmd/v')
+	assert input_is_cmd_v('cmd/v/v.v')
+}
+
 fn test_v3_tcc_backtrace_enabled() {
 	assert !v3_tcc_backtrace_enabled('macos', 'arm64', false)
 	assert v3_tcc_backtrace_enabled('macos', 'amd64', false)

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -1704,7 +1704,7 @@ fn input_is_v3_compiler_entry(input_file string) bool {
 
 fn input_is_cmd_v(input_file string) bool {
 	normalized := input_file.replace('\\', '/').trim_right('/')
-	return normalized == 'cmd/v' || normalized.ends_with('/cmd/v')
+	return normalized in ['cmd/v', 'cmd/v/v.v'] || normalized.ends_with('/cmd/v')
 		|| normalized.ends_with('/cmd/v/v.v')
 }
 
@@ -7454,6 +7454,13 @@ fn compile_v3_fastc_source(pieces []string, units fastc.FastcUnitLayout, bin_fil
 	if is_debug {
 		cc_args << '-g'
 	}
+	// Keep archives and other link-only source directives after the generated
+	// object inputs. Static archives are order-sensitive, and passing one while
+	// preparing libtcc can make it extract the same members for every later unit.
+	compile_base_args := c_object_compile_flags(cc_args)
+	base_link_args := c_dylib_link_flags(cc_args)
+	user_compile_args := c_object_compile_flags(user_c_flags)
+	user_link_args := c_dylib_link_flags(user_c_flags)
 	mut shim_dir := fastc.FastcCodesignShim{}
 	defer {
 		fastc.fastc_remove_codesign_shim_dir(shim_dir)
@@ -7462,10 +7469,10 @@ fn compile_v3_fastc_source(pieces []string, units fastc.FastcUnitLayout, bin_fil
 	mut command := ''
 	mut sign_in_process := false
 	if unit_paths.len > 1 {
-		mut compile_args := cc_args.clone()
-		compile_args << user_c_flags
+		mut compile_args := compile_base_args.clone()
+		compile_args << user_compile_args
 		link_worker := spawn fastc.fastc_prepare_link(tcc_path,
-			os.join_path_single(tcc_dir, 'lib'), cc_args)
+			os.join_path_single(tcc_dir, 'lib'), compile_base_args)
 		unit_objects := fastc.fastc_compile_c_units(tcc_path, compile_args, unit_paths) or {
 			mut prepared_link := link_worker.wait()
 			fastc.fastc_discard_link(mut prepared_link)
@@ -7479,13 +7486,14 @@ fn compile_v3_fastc_source(pieces []string, units fastc.FastcUnitLayout, bin_fil
 			eprintln('fastc-phase tcc.units_compiled ${cc_sw.elapsed().microseconds()}us')
 		}
 		link_inputs := unit_objects.clone()
-		mut final_args := user_c_flags.clone()
+		mut final_args := base_link_args.clone()
+		final_args << user_link_args
 		if uses_threads {
 			final_args << '-lpthread'
 		}
 		final_args << '-lm'
 		final_args << environment_ld_flags
-		mut display_args := cc_args.clone()
+		mut display_args := compile_base_args.clone()
 		display_args << ['-o', staged_binary]
 		display_args << link_inputs
 		display_args << final_args
@@ -7503,8 +7511,11 @@ fn compile_v3_fastc_source(pieces []string, units fastc.FastcUnitLayout, bin_fil
 			eprintln('fastc-phase tcc.linked ${cc_sw.elapsed().microseconds()}us')
 		}
 	} else {
+		cc_args = compile_base_args.clone()
+		cc_args << user_compile_args
 		cc_args << ['-o', 'out', 'src.c']
-		cc_args << user_c_flags
+		cc_args << base_link_args
+		cc_args << user_link_args
 		if uses_threads {
 			// The emitted spawn runtime calls pthread functions, which live
 			// outside libc on Linux with glibc before 2.34 and on the BSDs.

--- a/vlib/v3/gen/fastc/anonfn.v
+++ b/vlib/v3/gen/fastc/anonfn.v
@@ -1,8 +1,118 @@
 module fastc
 
-// reject_anonymous_function rejects a function literal before any of its body is
-// discarded. FastC has no closure runtime, so emitting a callable stub would silently
-// change program behavior.
-fn (mut g Parser) reject_anonymous_function() !string {
-	return g.unsupported('function literals and closures')
+import os
+import v3.scanner
+import v3.token
+
+// parse_anonymous_function lowers a non-capturing anonymous function literal
+// (`fn (params) rettype { body }`) to a hoisted top-level C function and returns
+// its name, which decays to a function pointer at the call site. FastC has no
+// closure runtime, so a capture list (`fn [x] () {...}`) is still rejected.
+//
+// The literal is re-parsed as an ordinary named function via `parse_function`,
+// reusing the same machinery the on-demand monomorphization drain relies on. Its
+// definition is captured out of `g.out` and stored alongside the mono instances
+// so it is emitted at top level; the enclosing expression only keeps the name.
+fn (mut g Parser) parse_anonymous_function() !string {
+	// `fn [x] (...) {...}` explicitly captures locals: a real closure, which FastC
+	// cannot represent without a runtime, so reject it before touching the body.
+	mut capture_look := g.s
+	if capture_look.scan() == .lsbr {
+		return g.unsupported('function literals and closures')
+	}
+	anon_start := g.s.pos
+	// Advance the main scanner past the whole literal: `fn`, an optional parameter
+	// list, the return type, and the balanced body block. `body_end` marks the byte
+	// just past the closing `}`.
+	g.next() // consume `fn`
+	if g.tok == .lpar {
+		g.skip_balanced(.lpar, .rpar)!
+	}
+	for g.tok != .lcbr && g.tok != .eof {
+		g.next()
+	}
+	if g.tok != .lcbr {
+		return g.unsupported('anonymous function body')
+	}
+	mut depth := 0
+	mut body_end := 0
+	for {
+		if g.tok == .lcbr {
+			depth++
+		} else if g.tok == .rcbr {
+			depth--
+			body_end = g.s.offset
+			g.next()
+			if depth == 0 {
+				break
+			}
+			continue
+		} else if g.tok == .eof {
+			return g.unsupported('unfinished anonymous function body')
+		}
+		g.next()
+	}
+	anon_source := g.s.src[anon_start..body_end]
+	name := '__v_fastc_anon_${g.module_name.replace('.', '_')}_${os.file_name(g.path).replace('.', '_')}_${anon_start}'
+	// Rewrite `fn (...) ...` as `fn <name> (...) ...` so `parse_function` reads it as
+	// an ordinary declaration.
+	after_fn_keyword := anon_source[2..]
+	synthetic := 'fn ${name} ${after_fn_keyword}'
+	c_name := fastc_c_function_name(g.module_name, name)
+
+	// Save the resume position (already advanced past the literal) and every piece of
+	// parser state `parse_function` mutates but does not itself restore.
+	resume_s := g.s
+	resume_tok := g.tok
+	resume_lit := g.lit
+	saved_locals := g.locals.clone()
+	saved_temp_id := g.temp_id
+	saved_indent := g.indent
+	saved_scope_changes := g.local_scope_changes.clone()
+	saved_scope_depth := g.local_scope_depth
+	saved_drain := g.in_mono_drain
+
+	start := g.out.len
+	g.indent = 0
+	// Emit the hoisted function even though its synthetic name is not in the reachable
+	// set, exactly as the mono drain does for on-demand instances.
+	g.in_mono_drain = true
+	mut file_set := token.FileSet.new()
+	mut file := file_set.add_file(g.path, synthetic.len)
+	file.index_lines_without_digest(synthetic)
+	g.s = scanner.new_scanner(g.prefs, .normal)
+	g.s.init(file, synthetic)
+	g.next()
+	g.parse_function(true) or {
+		// Restore before propagating so the outer parse can report cleanly.
+		g.s = resume_s
+		g.tok = resume_tok
+		g.lit = resume_lit
+		g.locals = saved_locals.clone()
+		g.temp_id = saved_temp_id
+		g.indent = saved_indent
+		g.local_scope_changes = saved_scope_changes.clone()
+		g.local_scope_depth = saved_scope_depth
+		g.in_mono_drain = saved_drain
+		g.out.go_back(g.out.len - start)
+		return err
+	}
+	definition := g.out.after(start)
+	g.out.go_back(g.out.len - start)
+	if definition != '' {
+		g.generated_mono[c_name] = true
+		g.mono_definitions[c_name] = definition
+	}
+
+	// Restore the enclosing parse and resume just past the literal.
+	g.s = resume_s
+	g.tok = resume_tok
+	g.lit = resume_lit
+	g.locals = saved_locals.clone()
+	g.temp_id = saved_temp_id
+	g.indent = saved_indent
+	g.local_scope_changes = saved_scope_changes.clone()
+	g.local_scope_depth = saved_scope_depth
+	g.in_mono_drain = saved_drain
+	return c_name
 }

--- a/vlib/v3/gen/fastc/array.v
+++ b/vlib/v3/gen/fastc/array.v
@@ -60,13 +60,21 @@ fn (g &Parser) render_higher_order_method_expression(tokens []FastcExpressionTok
 		}
 	}
 	mut w := unsafe { &Parser(g) }
-	fastc_register_composite_type(receiver_type, mut w.composite_types)
+	collection_type := receiver_type.trim_right('*')
+	fastc_register_composite_type(collection_type, mut w.composite_types)
 	receiver := g.render_method_receiver_expression(receiver_tokens) or { return none }
 	receiver_source := receiver.source
+	collection_source := if receiver_type.ends_with('*') {
+		'*(${receiver_source})'
+	} else {
+		receiver_source
+	}
 	had_it := it_name in g.locals
 	saved_it := g.locals[it_name] or { FastcLocal{} }
+	it_c_name := fastc_c_identifier(it_name)
 	w.locals[it_name] = FastcLocal{
 		typ: element_type
+		c_name: it_c_name
 	}
 	// A closure with a flow-sensitive `&&` narrowing (`it.expr is AnonFn && it.expr.decl.…`) must
 	// render through the narrowing renderer so the later conjunct reads the smart-cast member;
@@ -106,7 +114,7 @@ fn (g &Parser) render_higher_order_method_expression(tokens []FastcExpressionTok
 			else {}
 		}
 	}
-	closure_type := if closure_or > 0 {
+	mut closure_type := if closure_or > 0 {
 		vt := g.option_value_type_for_expression(closure_tokens[..closure_or])
 		fastc_normalize_inferred_type(if vt != '' {
 			vt
@@ -115,6 +123,15 @@ fn (g &Parser) render_higher_order_method_expression(tokens []FastcExpressionTok
 		})
 	} else {
 		fastc_normalize_inferred_type(g.infer_expression_type(closure_tokens) or { '' })
+	}
+	// A bare function is applied to each element (`items.map(convert)`).
+	if closure_tokens.len == 1 && closure_tokens[0].tok == .name
+		&& closure_tokens[0].lit != it_name {
+		function_key := w.unqualified_function_key(closure_tokens[0].lit)
+		if signature := w.functions[function_key] {
+			closure = '${closure}(${it_c_name})'
+			closure_type = signature.return_type
+		}
 	}
 	if had_it {
 		w.locals[it_name] = saved_it
@@ -129,22 +146,22 @@ fn (g &Parser) render_higher_order_method_expression(tokens []FastcExpressionTok
 	idx := w.temporary_name('index')
 	elem := w.temporary_name('element')
 	mut lowered := ''
-	mut result_type := receiver_type
+	mut result_type := collection_type
 	if method == 'map' {
 		result_type = fastc_array_c_type(closure_type)
 		fastc_register_composite_type(result_type, mut w.composite_types)
-		lowered = '({ ${receiver_type} ${src} = (${receiver_source}); ${result_type} ${dst} = (${result_type})builtin____new_array(0, ${src}.len, sizeof(${closure_type})); for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} ${it_name} = ((${element_type} *)${src}.data)[${idx}]; ${closure_type} ${elem} = (${closure}); builtin__array_push((array *)&${dst}, &${elem}); } ${dst}; })'
+		lowered = '({ ${collection_type} ${src} = (${collection_source}); ${result_type} ${dst} = (${result_type})builtin____new_array(0, ${src}.len, sizeof(${closure_type})); for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} ${it_c_name} = ((${element_type} *)${src}.data)[${idx}]; ${closure_type} ${elem} = (${closure}); builtin__array_push((array *)&${dst}, &${elem}); } ${dst}; })'
 	} else if method == 'filter' {
-		lowered = '({ ${receiver_type} ${src} = (${receiver_source}); ${receiver_type} ${dst} = (${receiver_type})builtin____new_array(0, ${src}.len, sizeof(${element_type})); for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} ${it_name} = ((${element_type} *)${src}.data)[${idx}]; if (${closure}) { builtin__array_push((array *)&${dst}, &${it_name}); } } ${dst}; })'
+		lowered = '({ ${collection_type} ${src} = (${collection_source}); ${collection_type} ${dst} = (${collection_type})builtin____new_array(0, ${src}.len, sizeof(${element_type})); for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} ${it_c_name} = ((${element_type} *)${src}.data)[${idx}]; if (${closure}) { builtin__array_push((array *)&${dst}, &${it_c_name}); } } ${dst}; })'
 	} else if method == 'count' {
 		result_type = 'int'
-		lowered = '({ ${receiver_type} ${src} = (${receiver_source}); int ${dst} = 0; for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} ${it_name} = ((${element_type} *)${src}.data)[${idx}]; if (${closure}) { ${dst}++; } } ${dst}; })'
+		lowered = '({ ${collection_type} ${src} = (${collection_source}); int ${dst} = 0; for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} ${it_c_name} = ((${element_type} *)${src}.data)[${idx}]; if (${closure}) { ${dst}++; } } ${dst}; })'
 	} else {
 		result_type = 'bool'
 		initial := if method == 'all' { 'true' } else { 'false' }
 		condition := if method == 'all' { '!(${closure})' } else { closure }
 		matched := if method == 'all' { 'false' } else { 'true' }
-		lowered = '({ ${receiver_type} ${src} = (${receiver_source}); bool ${dst} = ${initial}; for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} ${it_name} = ((${element_type} *)${src}.data)[${idx}]; if (${condition}) { ${dst} = ${matched}; break; } } ${dst}; })'
+		lowered = '({ ${collection_type} ${src} = (${collection_source}); bool ${dst} = ${initial}; for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} ${it_c_name} = ((${element_type} *)${src}.data)[${idx}]; if (${condition}) { ${dst} = ${matched}; break; } } ${dst}; })'
 	}
 	return FastcRenderedExpression{
 		source: lowered

--- a/vlib/v3/gen/fastc/array.v
+++ b/vlib/v3/gen/fastc/array.v
@@ -3,11 +3,184 @@ module fastc
 import strings
 import v3.token
 
+// render_higher_order_method_expression lowers a trailing `.map/.filter/.any/.all/.count`
+// closure method that appears inside a larger expression (`x in arr.map(it.f)`), rather than as
+// the whole statement the streaming reader lowers inline. It renders the receiver and the
+// `it`-closure from tokens and emits the same statement-expression the reader produces, so the
+// magic array methods work as call arguments, membership collections and struct-field values.
+fn (g &Parser) render_higher_order_method_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	if tokens.len < 5 || tokens.last().tok != .rpar {
+		return none
+	}
+	// Find the `(` matching the final `)`.
+	mut depth := 0
+	mut open := -1
+	for i := tokens.len - 1; i >= 0; i-- {
+		match tokens[i].tok {
+			.rpar { depth++ }
+			.lpar {
+				depth--
+				if depth == 0 {
+					open = i
+					break
+				}
+			}
+			else {}
+		}
+	}
+	if open < 3 || tokens[open - 1].tok != .name || tokens[open - 2].tok != .dot {
+		return none
+	}
+	method := tokens[open - 1].lit
+	if method !in ['map', 'filter', 'any', 'all', 'count'] {
+		return none
+	}
+	receiver_tokens := tokens[..open - 2]
+	receiver_type := fastc_normalize_inferred_type(g.underlying_alias_type(g.infer_expression_type(receiver_tokens) or {
+		return none
+	}))
+	if !receiver_type.starts_with('Array_') {
+		return none
+	}
+	element_type := g.array_element_type(receiver_type) or { return none }
+	mut closure_tokens := tokens[open + 1..tokens.len - 1]
+	if closure_tokens.len == 0 {
+		return none
+	}
+	mut it_name := 'it'
+	if closure_tokens[0].tok == .pipe {
+		// Explicit closure header `|param|` names the element instead of implicit `it`.
+		if closure_tokens.len < 4 || closure_tokens[1].tok != .name || closure_tokens[2].tok != .pipe {
+			return none
+		}
+		it_name = closure_tokens[1].lit
+		closure_tokens = closure_tokens[3..]
+		if closure_tokens.len == 0 {
+			return none
+		}
+	}
+	mut w := unsafe { &Parser(g) }
+	fastc_register_composite_type(receiver_type, mut w.composite_types)
+	receiver := g.render_method_receiver_expression(receiver_tokens) or { return none }
+	receiver_source := receiver.source
+	had_it := it_name in g.locals
+	saved_it := g.locals[it_name] or { FastcLocal{} }
+	w.locals[it_name] = FastcLocal{
+		typ: element_type
+	}
+	// A closure with a flow-sensitive `&&` narrowing (`it.expr is AnonFn && it.expr.decl.…`) must
+	// render through the narrowing renderer so the later conjunct reads the smart-cast member;
+	// render_call_argument_expression alone would leave `it.expr.decl` on the un-narrowed boxed
+	// value. (The reader's inline higher-order path already does this; this is the render-time path
+	// used when the call is a sub-expression of a larger condition.)
+	mut closure := ''
+	if w.boolean_expression_has_narrowing(closure_tokens) {
+		if narrowed := w.render_narrowing_boolean_expression(closure_tokens) {
+			closure = narrowed
+		}
+	}
+	if closure == '' {
+		closure = g.render_call_argument_expression(closure_tokens, '') or {
+			if had_it {
+				w.locals[it_name] = saved_it
+			} else {
+				w.locals.delete(it_name)
+			}
+			return none
+		}
+	}
+	// A closure ending in a top-level `or {}` block (`arr.map(convert(it) or { it })`) yields
+	// the option's value type; inferring the whole expression (which trails the `or`) wraps it
+	// wrongly, so infer from the option-producing part before the `or`.
+	mut closure_or := -1
+	mut closure_or_depth := 0
+	for j, ct in closure_tokens {
+		match ct.tok {
+			.lpar, .lsbr, .lcbr { closure_or_depth++ }
+			.rpar, .rsbr, .rcbr { closure_or_depth-- }
+			.key_or {
+				if closure_or_depth == 0 && closure_or < 0 {
+					closure_or = j
+				}
+			}
+			else {}
+		}
+	}
+	closure_type := if closure_or > 0 {
+		vt := g.option_value_type_for_expression(closure_tokens[..closure_or])
+		fastc_normalize_inferred_type(if vt != '' {
+			vt
+		} else {
+			g.infer_expression_type(closure_tokens[..closure_or]) or { '' }
+		})
+	} else {
+		fastc_normalize_inferred_type(g.infer_expression_type(closure_tokens) or { '' })
+	}
+	if had_it {
+		w.locals[it_name] = saved_it
+	} else {
+		w.locals.delete(it_name)
+	}
+	if method in ['map'] && closure_type == '' {
+		return none
+	}
+	src := w.temporary_name('collection')
+	dst := w.temporary_name('mapped')
+	idx := w.temporary_name('index')
+	elem := w.temporary_name('element')
+	mut lowered := ''
+	mut result_type := receiver_type
+	if method == 'map' {
+		result_type = fastc_array_c_type(closure_type)
+		fastc_register_composite_type(result_type, mut w.composite_types)
+		lowered = '({ ${receiver_type} ${src} = (${receiver_source}); ${result_type} ${dst} = (${result_type})builtin____new_array(0, ${src}.len, sizeof(${closure_type})); for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} ${it_name} = ((${element_type} *)${src}.data)[${idx}]; ${closure_type} ${elem} = (${closure}); builtin__array_push((array *)&${dst}, &${elem}); } ${dst}; })'
+	} else if method == 'filter' {
+		lowered = '({ ${receiver_type} ${src} = (${receiver_source}); ${receiver_type} ${dst} = (${receiver_type})builtin____new_array(0, ${src}.len, sizeof(${element_type})); for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} ${it_name} = ((${element_type} *)${src}.data)[${idx}]; if (${closure}) { builtin__array_push((array *)&${dst}, &${it_name}); } } ${dst}; })'
+	} else if method == 'count' {
+		result_type = 'int'
+		lowered = '({ ${receiver_type} ${src} = (${receiver_source}); int ${dst} = 0; for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} ${it_name} = ((${element_type} *)${src}.data)[${idx}]; if (${closure}) { ${dst}++; } } ${dst}; })'
+	} else {
+		result_type = 'bool'
+		initial := if method == 'all' { 'true' } else { 'false' }
+		condition := if method == 'all' { '!(${closure})' } else { closure }
+		matched := if method == 'all' { 'false' } else { 'true' }
+		lowered = '({ ${receiver_type} ${src} = (${receiver_source}); bool ${dst} = ${initial}; for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} ${it_name} = ((${element_type} *)${src}.data)[${idx}]; if (${condition}) { ${dst} = ${matched}; break; } } ${dst}; })'
+	}
+	return FastcRenderedExpression{
+		source: lowered
+		typ: result_type
+	}
+}
+
+// fastc_is_empty_fixed_array_literal reports whether the tokens are `[N]T{}` — a fixed-size array
+// literal (a size between the brackets) with an empty, zeroing initializer.
+fn fastc_is_empty_fixed_array_literal(tokens []FastcExpressionToken) bool {
+	if tokens.len < 5 || tokens[0].tok != .lsbr || tokens[1].tok == .rsbr {
+		return false
+	}
+	if tokens[tokens.len - 1].tok != .rcbr || tokens[tokens.len - 2].tok != .lcbr {
+		return false
+	}
+	// A `]` must close the size brackets somewhere before the element type / `{}`.
+	for t in tokens {
+		if t.tok == .rsbr {
+			return true
+		}
+	}
+	return false
+}
+
 fn (g &Parser) fixed_array_uses_raw_storage(tokens []FastcExpressionToken) bool {
 	if tokens.len == 1 {
 		return fastc_global_key(g.module_name, tokens[0].lit) in g.globals
 	}
 	if tokens.len >= 3 && tokens[tokens.len - 2].tok == .dot && tokens.last().tok == .name {
+		// A module-qualified fixed array (`util.name_char_table`) mirrors the bare-name case: a
+		// `__global` is raw C storage, but a const is a FixedArray struct indexed through `.data`.
+		// Only a genuine struct-field fixed array is always raw C storage.
+		if tokens.len == 3 && tokens[0].tok == .name && tokens[0].lit in g.imports {
+			return fastc_global_key(g.imports[tokens[0].lit], tokens[2].lit) in g.globals
+		}
 		return true
 	}
 	if tokens.len >= 4 && tokens.last().tok == .rsbr {
@@ -29,7 +202,10 @@ fn (g &Parser) fixed_array_uses_raw_storage(tokens []FastcExpressionToken) bool 
 }
 
 fn (g &Parser) render_array_access_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
-	if tokens.len < 4 || tokens[0].tok != .name || tokens.last().tok != .rsbr {
+	// A pre-rendered synthetic base atom (e.g. a string interpolation `'${x}'[0]`, folded into
+	// one token carrying its C text in `.source`) is `.string`, not `.name`; accept it too so
+	// the index applies to the rendered string rather than reaching the raw renderer.
+	if tokens.len < 4 || (tokens[0].tok !in [.name, .string, .lpar] && tokens[0].source == '') || tokens.last().tok != .rsbr {
 		return none
 	}
 	mut open := -1
@@ -64,16 +240,48 @@ fn (g &Parser) render_array_access_expression(tokens []FastcExpressionToken) ?Fa
 	if close != tokens.len - 1 {
 		return none
 	}
-	base_tokens := tokens[..open]
+	// A fully-wrapping paren pair around the base (`(*names)[i]`) is stripped so the deref base
+	// logic below sees `*names`; an interior group stays balanced.
+	base_tokens := fastc_strip_paren_tokens(tokens[..open])
+	// `cond && m[k]` / `a || arr[i]`: a top-level `&&`/`||` in the base means the `[…]` indexes
+	// its right operand, not the whole boolean; leave it to the logical/map renderers so the
+	// slice/index path does not treat `(cond && m)` as an array.
+	if fastc_top_level_boolean_split(base_tokens, .and) != none || fastc_top_level_boolean_split(base_tokens, .logical_or) != none {
+		return none
+	}
 	base_type := g.infer_expression_type(base_tokens) or { return none }
 	base_layout_type := g.underlying_alias_type(base_type)
-	base_source := if base_tokens.len == 1 {
-		g.resolved_root_expression_name(tokens[0].lit)
+	base_source := if base_tokens.len == 1 && base_tokens[0].source != '' {
+		// A pre-rendered synthetic base token (e.g. an `(x as T).field` group the reader
+		// already lowered and folded into one token) carries its C text in `.source`, not
+		// `.lit`; reading `.lit` here would yield an empty collection (`array_get(, i)`).
+		base_tokens[0].source
+	} else if base_tokens.len == 1 && base_tokens[0].tok == .string {
+		// A string-literal base (`"0123456789abcdef"[i]`): render the C string so the string
+		// index below lowers to `string_at`, not a raw C index on the `string` struct.
+		literal := fastc_c_string(base_tokens[0].lit) or { return none }
+		if g.selfhost { '_S(${literal})' } else { literal }
+	} else if base_tokens.len >= 2 && base_tokens[0].tok == .mul {
+		// `(*names)[i]` indexes through a pointer-to-array; render the pointee array value.
+		inner := g.render_member_receiver(base_tokens[1..]) or {
+			g.render_raw_expression_tokens(base_tokens[1..]) or { return none }
+		}
+		'*(${inner})'
+	} else if base_tokens.len == 1 {
+		g.resolved_root_expression_name(base_tokens[0].lit)
 	} else if nested_base := g.render_array_access_expression(base_tokens) {
 		nested_base.source
+	} else if map_base := g.render_map_expression(base_tokens) {
+		// A map lookup that yields an array (`m[k][i]`, `m[k].field`) is the index base;
+		// its read value feeds the outer access.
+		map_base.source
 	} else if raw_base := g.render_raw_expression_tokens(base_tokens) {
 		if method_base := g.render_method_call_expression(base_tokens, raw_base) {
 			method_base.source
+		} else if call_base := g.render_missing_call_arguments(base_tokens) {
+			// A free-function-call receiver (`options_after(a, [x])#[1..]`) must have its
+			// arguments lowered (array/map literals, propagation) rather than reused raw.
+			call_base.source
 		} else if member_base := g.render_member_receiver(base_tokens) {
 			member_base
 		} else {
@@ -237,8 +445,23 @@ fn (g &Parser) render_nested_array_access_expression(tokens []FastcExpressionTok
 			access_tokens := tokens[start..close + 1]
 			raw_access := g.render_raw_expression_tokens(access_tokens) or { continue }
 			replacement := g.render_array_access_expression(access_tokens) or { continue }
-			if rendered.contains(raw_access) {
-				rendered = rendered.replace(raw_access, replacement.source)
+			mut needle := raw_access
+			if !rendered.contains(needle) {
+				// Pointer-member lowering may already have changed the base from dots to arrows
+				// (`g.a.nodes[i]` -> `g->a->nodes[i]`) before the dynamic-array index is
+				// rewritten. Reconstruct that spelling from the complete member base.
+				if member_base := g.render_member_receiver(tokens[start..i + 1]) {
+					index_source := g.render_membership_candidate(tokens[i + 2..close], 'int') or {
+						continue
+					}
+					pointer_needle := '${member_base}[${index_source}]'
+					if rendered.contains(pointer_needle) {
+						needle = pointer_needle
+					}
+				}
+			}
+			if rendered.contains(needle) {
+				rendered = rendered.replace(needle, replacement.source)
 				changed = true
 			}
 			continue
@@ -262,8 +485,14 @@ fn (g &Parser) render_nested_array_access_expression(tokens []FastcExpressionTok
 		needle := '${base_source}[${index_source}]'
 		replacement := g.render_array_access_expression(tokens[i..close + 1]) or { continue }
 		if rendered.contains(needle) {
-			rendered = rendered.replace(needle, replacement.source)
-			changed = true
+			// A method receiver may already contain the lowered direct access
+			// `((s).str[i])`; the raw `s[i]` suffix there is a struct member, not
+			// another root access to lower.
+			replaced := fastc_replace_c_root_identifier(rendered, needle, replacement.source)
+			if replaced != rendered {
+				rendered = replaced
+				changed = true
+			}
 		}
 	}
 	for open, item in tokens {
@@ -301,10 +530,58 @@ fn (g &Parser) render_nested_array_access_expression(tokens []FastcExpressionTok
 	if !changed {
 		return none
 	}
+	// Index lowering can expose a pointer-valued element or pointer field later in
+	// the same chain (`items[i].scope.parent`). Finish that promotion here so callers
+	// that return this rewrite directly do not leave a C `.` on a pointer value.
+	if pointer_members := g.render_pointer_member_access_expression(tokens, rendered) {
+		rendered = pointer_members.source
+	}
 	inferred_type := g.infer_expression_type(tokens) or { '' }
 	return FastcRenderedExpression{
 		source: rendered
 		typ: inferred_type
+	}
+}
+
+// render_indexed_member_receiver renders an index and the field chain that follows it while
+// preserving the exact pointer type of each field (`branches[i].scope` where `scope` is `&Scope`).
+fn (g &Parser) render_indexed_member_receiver(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	mut close := -1
+	for i := tokens.len - 1; i >= 0; i-- {
+		if tokens[i].tok == .rsbr {
+			close = i
+			break
+		}
+	}
+	if close < 0 {
+		return none
+	}
+	indexed := g.render_array_access_expression(tokens[..close + 1]) or { return none }
+	mut source := indexed.source
+	mut current_type := indexed.typ
+	mut i := close + 1
+	for i < tokens.len {
+		if i + 1 >= tokens.len || tokens[i].tok != .dot || tokens[i + 1].tok != .name {
+			return none
+		}
+		field := g.struct_field_metadata(current_type, tokens[i + 1].lit) or { return none }
+		for storage_name in field.storage_path {
+			separator := if current_type.ends_with('*') { '->' } else { '.' }
+			source += separator + fastc_c_identifier(storage_name)
+			current_type = g.struct_direct_member_type(current_type, storage_name)
+			if current_type == '' {
+				return none
+			}
+		}
+		separator := if current_type.ends_with('*') { '->' } else { '.' }
+		field_source := source + separator + fastc_c_identifier(field.name)
+		source = if field.is_shared_pointer { '*(${field_source})' } else { field_source }
+		current_type = field.typ
+		i += 2
+	}
+	return FastcRenderedExpression{
+		source: source
+		typ: current_type
 	}
 }
 
@@ -318,10 +595,40 @@ fn (g &Parser) resolved_root_expression_name(name string) string {
 	if constant_name := g.constants[name] {
 		return constant_name
 	}
-	return name
+	if local := g.locals[name] {
+		if local.c_name != '' {
+			return local.c_name
+		}
+	}
+	// A local/parameter whose name is a C keyword (`short`, `default`) is emitted as
+	// `__v_fastc_keyword_<name>`; return that so an index base matches the render_raw buffer
+	// spelling and its lowered `string_at`/`array_get` receiver is the real variable.
+	return fastc_c_identifier(name)
+}
+
+// fastc_inline_array_element_equality compares two dynamic-array values element-wise as a
+// statement-expression, used for `x in [][]T` membership where the array elements themselves
+// cannot be compared with C `==`. The inner element type must be a scalar or string.
+fn (g &Parser) fastc_inline_array_element_equality(array_type string, left string, right string) !string {
+	inner_element := g.array_element_type(array_type) or { return error('no element type') }
+	if fastc_trim_pointer_suffix(g.underlying_alias_type(inner_element)).starts_with('Array_') {
+		// A further-nested array element would need another loop level; not supported yet.
+		return error('nested array element')
+	}
+	inner_comparison := if g.underlying_alias_type(inner_element).trim_right('*') == 'string' {
+		'builtin__string_eq(((${inner_element} *)__v_fastc_meq_l.data)[__v_fastc_meq_k], ((${inner_element} *)__v_fastc_meq_r.data)[__v_fastc_meq_k])'
+	} else {
+		'(((${inner_element} *)__v_fastc_meq_l.data)[__v_fastc_meq_k] == ((${inner_element} *)__v_fastc_meq_r.data)[__v_fastc_meq_k])'
+	}
+	return '({ ${array_type} __v_fastc_meq_l = (${left}); ${array_type} __v_fastc_meq_r = (${right}); bool __v_fastc_meq = (__v_fastc_meq_l.len == __v_fastc_meq_r.len); for (int __v_fastc_meq_k = 0; __v_fastc_meq && __v_fastc_meq_k < __v_fastc_meq_l.len; __v_fastc_meq_k++) { if (!${inner_comparison}) { __v_fastc_meq = false; break; } } __v_fastc_meq; })'
 }
 
 fn (g &Parser) render_membership_candidate(tokens []FastcExpressionToken, expected_type string) ?string {
+	if tokens.len == 1 && tokens[0].source != '' {
+		// A synthetic atom (an `or`-unwrap, interpolation, etc.) carries its complete C
+		// spelling in `source`; use it verbatim rather than re-rendering its bare `lit`.
+		return tokens[0].source
+	}
 	if tokens.len == 2 && tokens[0].tok == .dot && tokens[1].tok == .name && g.declared_kinds[g.semantic_type_key(expected_type)] == .enum_ {
 		return '${expected_type.trim_right('*')}__${tokens[1].lit}'
 	}
@@ -437,6 +744,12 @@ fn (g &Parser) render_raw_expression_tokens(tokens []FastcExpressionToken) ?stri
 	mut previous_module_separator := false
 	for i, item in tokens {
 		mut piece := item.lit
+		if item.tok == .right_shift_unsigned {
+			// V's logical right shift `>>>` has no C spelling; on the unsigned operand it is
+			// always applied to (V code casts to an unsigned type first, e.g. `u64(x) >>> n`)
+			// a plain C `>>` is the logical shift.
+			piece = '>>'
+		}
 		module_separator := item.tok == .dot && g.expression_dot_is_module_separator(tokens, i)
 		is_direct_pointer_cast := item.tok in [.amp, .and] && fastc_token_is_prefix_operator(tokens, i) && i + 2 < tokens.len && tokens[i + 1].tok == .name && tokens[i + 2].tok == .lpar && (fastc_primitive_c_type(tokens[i + 1].lit) != none || g.resolve_declared_type_key(tokens[i + 1].lit) != none)
 		is_c_pointer_cast := item.tok in [.amp, .and] && fastc_token_is_prefix_operator(tokens, i) && i + 4 < tokens.len && tokens[i + 1].tok == .name && tokens[i + 1].lit == 'C' && tokens[i + 2].tok == .dot && tokens[i + 3].tok == .name && tokens[i + 4].tok == .lpar
@@ -544,7 +857,10 @@ fn (g &Parser) render_raw_expression_tokens(tokens []FastcExpressionToken) ?stri
 			} else {
 				g.resolved_expression_name(item.lit, previous)
 			}
-		} else if item.tok == .dot && i > 0 && tokens[i - 1].tok == .name && tokens[i - 1].lit in g.imports {
+		} else if item.tok == .dot && i > 0 && tokens[i - 1].tok == .name && tokens[i - 1].lit in g.imports && tokens[i - 1].lit !in g.locals && (i < 2 || tokens[i - 2].tok != .dot) {
+			// An imported module name qualifies only at the start of a chain; `v.pref.os.str()`
+			// accesses the field `os`, not the `os` module, even when that module is imported. A
+			// LOCAL of the same name (`for token in … { token.starts_with(…) }`) shadows the module.
 			piece = '__'
 		} else if item.tok == .dot && i > 0 && tokens[i - 1].tok == .name && tokens[i - 1].lit == 'C' {
 			piece = ''
@@ -573,7 +889,9 @@ fn (g &Parser) expression_dot_is_module_separator(tokens []FastcExpressionToken,
 	previous_name := tokens[index - 1].lit
 	// An imported module name is only a qualifier at the start of a member chain.
 	// In `app.config.value`, `config` is a field even when the file imports `config`.
-	if (index < 2 || tokens[index - 2].tok != .dot) && (previous_name in g.imports || previous_name == 'C' || (previous_name !in g.locals && g.is_enum_type_name(previous_name))) {
+	// A LOCAL of the same name shadows the module (`for token in … { token.starts_with(…) }` with
+	// the `token` module imported), so `token.method(…)` is a method call, not a module function.
+	if (index < 2 || tokens[index - 2].tok != .dot) && previous_name !in g.locals && (previous_name in g.imports || previous_name == 'C' || g.is_enum_type_name(previous_name)) {
 		return true
 	}
 	if index < 3 || tokens[index - 2].tok != .dot || tokens[index - 3].tok != .name {
@@ -617,10 +935,15 @@ fn (g &Parser) array_initializer_type(tokens []FastcExpressionToken) ?string {
 		return none
 	}
 	mut element_type := g.type_from_expression_tokens(tokens[index..]) or { '' }
-	if element_type == '' && index + 1 == tokens.len && tokens[index].tok == .name && tokens[index].lit == 'thread' {
-		// `[]thread` is an array of spawned-thread handles (all handles share one
-		// C layout, keyed as the void-thread type).
-		element_type = fastc_thread_type_name('')
+	if element_type == '' && tokens[index].tok == .name && tokens[index].lit == 'thread' {
+		// `[]thread` / `[]thread T` is an array of spawned-thread handles. All handles
+		// share one C layout; the void handle for a bare `thread`, or one keyed by the
+		// thread's value type `T` so `.wait()` recovers it.
+		if index + 1 == tokens.len {
+			element_type = fastc_thread_type_name('')
+		} else if value_type := g.type_from_expression_tokens(tokens[index + 1..]) {
+			element_type = fastc_thread_type_name(fastc_normalize_inferred_type(value_type))
+		}
 	}
 	if element_type == '' {
 		return none
@@ -637,16 +960,22 @@ fn (g &Parser) array_initializer_type(tokens []FastcExpressionToken) ?string {
 
 fn fastc_initializer_type_start(tokens []FastcExpressionToken) int {
 	mut depth := 0
+	mut start := 0
 	for i, item in tokens {
 		if item.tok in [.lpar, .lsbr, .lcbr] {
 			depth++
 		} else if item.tok in [.rpar, .rsbr, .rcbr] {
 			depth--
-		} else if depth == 0 && item.tok.is_assignment() {
-			return i + 1
+		} else if depth == 0 && (item.tok.is_assignment() || item.tok in [.left_shift, .right_shift,
+			.right_shift_unsigned, .plus, .minus, .div, .mod, .eq, .ne, .lt, .gt, .le, .ge, .and,
+			.logical_or, .comma, .key_return, .key_in, .not_in]) {
+			// The literal's type spelling ends at the `{`; anything before an assignment,
+			// binary operator, or separator (`c.cache << []i8{…}`) belongs to a preceding
+			// operand and must not be folded into the type.
+			start = i + 1
 		}
 	}
-	return 0
+	return start
 }
 
 fn (g &Parser) map_initializer_type(tokens []FastcExpressionToken) ?string {
@@ -723,6 +1052,47 @@ fn fastc_array_initializer_c_type(array_type string) string {
 	length := fastc_fixed_array_length(array_type) or { return array_type }
 	element_type := fastc_fixed_array_element_type(array_type) or { return array_type }
 	return 'FixedArray_${fastc_composite_type_part(length)}_${fastc_composite_type_part(element_type)}'
+}
+
+// fastc_collect_referenced_fixed_array_types finds every `FixedArray_<len>_FASTC_ARRAY_OF_<elem>`
+// type name that appears in already-emitted C and registers a typedef for it. Fixed arrays used
+// only as a function return type, parameter, or struct field are spelled with this raw marker name
+// by the signature scanner but — unlike array literals — never pass through the expression renderer
+// that would register them, so their typedef would otherwise be missing.
+fn fastc_collect_referenced_fixed_array_types(source string, mut fixed_array_types map[string]string) {
+	mut i := 0
+	for i < source.len {
+		c := source[i]
+		if !(c.is_letter() || c == `_`) {
+			i++
+			continue
+		}
+		if i > 0 {
+			p := source[i - 1]
+			if p.is_letter() || p.is_digit() || p == `_` {
+				i++
+				continue
+			}
+		}
+		mut end := i
+		for end < source.len && (source[end].is_letter() || source[end].is_digit() || source[end] == `_`) {
+			end++
+		}
+		name := source[i..end]
+		if name.starts_with('FixedArray_') && name.contains('_FASTC_ARRAY_OF_') {
+			if _ := fastc_fixed_array_length(name) {
+				if _ := fastc_fixed_array_element_type(name) {
+					// Key on the same sanitized name the expression renderer uses, so a
+					// type reached both ways is registered once, not typedef'd twice.
+					key := fastc_array_initializer_c_type(name)
+					if key !in fixed_array_types {
+						fixed_array_types[key] = name
+					}
+				}
+			}
+		}
+		i = end
+	}
 }
 
 fn fastc_generate_fixed_array_declarations(fixed_array_types map[string]string) string {

--- a/vlib/v3/gen/fastc/comptime.v
+++ b/vlib/v3/gen/fastc/comptime.v
@@ -10,7 +10,7 @@ fn fastc_scan_comptime_unary(mut scan scanner.Scanner, first token.Token, path s
 		result := fastc_scan_comptime_unary(mut scan, scan.scan(), path, prefs)!
 		return FastcComptimeCondition{
 			value: !result.value
-			tok:   result.tok
+			tok: result.tok
 		}
 	}
 	if first == .lpar {
@@ -20,19 +20,19 @@ fn fastc_scan_comptime_unary(mut scan scanner.Scanner, first token.Token, path s
 		}
 		return FastcComptimeCondition{
 			value: result.value
-			tok:   scan.scan()
+			tok: scan.scan()
 		}
 	}
 	if first == .key_true {
 		return FastcComptimeCondition{
 			value: true
-			tok:   scan.scan()
+			tok: scan.scan()
 		}
 	}
 	if first == .key_false {
 		return FastcComptimeCondition{
 			value: false
-			tok:   scan.scan()
+			tok: scan.scan()
 		}
 	}
 	if first == .dollar {
@@ -41,18 +41,18 @@ fn fastc_scan_comptime_unary(mut scan scanner.Scanner, first token.Token, path s
 			return error('fastc parser does not support compile-time condition `${scan.lit}` in ${path}')
 		}
 		if scan.scan() != .lpar {
-			return error('fastc parser does not support `$pkgconfig` condition in ${path}')
+			return error('fastc parser does not support `\$pkgconfig` condition in ${path}')
 		}
 		if scan.scan() != .string {
-			return error('fastc parser does not support `$pkgconfig` library name in ${path}')
+			return error('fastc parser does not support `\$pkgconfig` library name in ${path}')
 		}
 		library := scan.lit.trim('\'"')
 		if scan.scan() != .rpar {
-			return error('fastc parser does not support `$pkgconfig` condition in ${path}')
+			return error('fastc parser does not support `\$pkgconfig` condition in ${path}')
 		}
 		return FastcComptimeCondition{
 			value: pref.comptime_pkgconfig_value(library)
-			tok:   scan.scan()
+			tok: scan.scan()
 		}
 	}
 	if first != .name {
@@ -71,7 +71,7 @@ fn fastc_scan_comptime_unary(mut scan scanner.Scanner, first token.Token, path s
 	}
 	return FastcComptimeCondition{
 		value: value
-		tok:   tok
+		tok: tok
 	}
 }
 
@@ -86,7 +86,7 @@ fn fastc_scan_comptime_and(mut scan scanner.Scanner, first token.Token, path str
 	}
 	return FastcComptimeCondition{
 		value: value
-		tok:   tok
+		tok: tok
 	}
 }
 
@@ -101,7 +101,7 @@ fn fastc_scan_comptime_or(mut scan scanner.Scanner, first token.Token, path stri
 	}
 	return FastcComptimeCondition{
 		value: value
-		tok:   tok
+		tok: tok
 	}
 }
 
@@ -123,7 +123,7 @@ fn fastc_scan_comptime_block(mut scan scanner.Scanner, first token.Token, path s
 			if depth == 0 {
 				return FastcComptimeBlock{
 					source: scan.src[start..scan.pos]
-					tok:    scan.scan()
+					tok: scan.scan()
 				}
 			}
 		}
@@ -158,14 +158,14 @@ fn fastc_scan_selected_comptime_branch(mut scan scanner.Scanner, first token.Tok
 		if tok != .dollar {
 			return FastcComptimeBlock{
 				source: selected
-				tok:    tok
+				tok: tok
 			}
 		}
 		mut lookahead := scan
 		if lookahead.scan() != .key_else {
 			return FastcComptimeBlock{
 				source: selected
-				tok:    tok
+				tok: tok
 			}
 		}
 		_ = scan.scan()
@@ -180,7 +180,7 @@ fn fastc_scan_selected_comptime_branch(mut scan scanner.Scanner, first token.Tok
 		}
 		return FastcComptimeBlock{
 			source: selected
-			tok:    fastc_scan_skip_semicolons(mut scan, else_block.tok)
+			tok: fastc_scan_skip_semicolons(mut scan, else_block.tok)
 		}
 	}
 	return FastcComptimeBlock{}
@@ -198,8 +198,7 @@ fn fastc_collect_selected_comptime_function_signatures(source string, path strin
 			if lookahead.scan() == .key_if {
 				selected := fastc_scan_selected_comptime_branch(mut scan, scan.scan(), path, prefs)!
 				if selected.source != '' {
-					collect_function_signatures(selected.source, path, header, prefs, []int{},
-						declared_types, declared_type_c_names, params_structs, mut functions)!
+					collect_function_signatures(selected.source, path, header, prefs, []int{}, declared_types, declared_type_c_names, params_structs, mut functions)!
 				}
 				tok = selected.tok
 				continue
@@ -261,7 +260,7 @@ fn (mut g Parser) parse_comptime_if_statement() !bool {
 	}
 	g.next()
 	if g.tok != .key_else {
-		return g.unsupported('compile-time branch after `$if`')
+		return g.unsupported('compile-time branch after `\$if`')
 	}
 	g.next()
 	if g.tok == .dollar {
@@ -287,7 +286,7 @@ fn (mut g Parser) parse_comptime_match_statement() !bool {
 	g.expect(.dollar)!
 	g.expect(.key_match)!
 	if g.tok != .name && !(g.tok == .key_shared && g.shared_token_is_identifier(.key_match)) {
-		return g.unsupported('compile-time `$match` subject')
+		return g.unsupported('compile-time `\$match` subject')
 	}
 	subject_name := g.lit
 	mut subject_type := g.comptime_named_type(subject_name)
@@ -295,7 +294,7 @@ fn (mut g Parser) parse_comptime_match_statement() !bool {
 	if g.tok == .dot {
 		g.next()
 		if g.tok != .name || g.lit !in ['typ', 'unaliased_typ'] {
-			return g.unsupported('compile-time `$match` type member')
+			return g.unsupported('compile-time `\$match` type member')
 		}
 		if g.lit == 'unaliased_typ' {
 			subject_type = g.underlying_alias_type(subject_type)
@@ -308,21 +307,20 @@ fn (mut g Parser) parse_comptime_match_statement() !bool {
 	g.skip_semicolons()
 	for g.tok != .rcbr {
 		if g.tok == .eof {
-			return g.unsupported('unfinished compile-time `$match`')
+			return g.unsupported('unfinished compile-time `\$match`')
 		}
 		mut branch_matches := false
 		if g.tok == .dollar {
 			g.next()
 			if g.tok != .key_else {
-				return g.unsupported('compile-time `$match` branch')
+				return g.unsupported('compile-time `\$match` branch')
 			}
 			g.next()
 			branch_matches = !selected
 		} else {
 			for {
 				target_type := g.parse_type()!
-				branch_matches = branch_matches
-					|| g.underlying_alias_type(subject_type) == g.underlying_alias_type(target_type)
+				branch_matches = branch_matches || g.underlying_alias_type(subject_type) == g.underlying_alias_type(target_type)
 				if g.tok != .comma {
 					break
 				}
@@ -352,38 +350,40 @@ fn (mut g Parser) parse_comptime_for_statement() !bool {
 	g.expect(.dollar)!
 	g.expect(.key_for)!
 	if g.tok != .name && !(g.tok == .key_shared && g.shared_token_is_identifier(.key_for)) {
-		return g.unsupported('`$for` loop variable')
+		return g.unsupported('`\$for` loop variable')
 	}
 	loop_var := g.lit
 	g.next()
 	g.expect(.key_in)!
 	if g.tok != .name {
-		return g.unsupported('`$for` iterable')
+		return g.unsupported('`\$for` iterable')
 	}
 	first := g.lit
 	g.next()
 	if g.tok != .dot {
-		return g.unsupported('`$for` expects `Type.fields`')
+		return g.unsupported('`\$for` expects `Type.fields`')
 	}
 	g.next()
 	if g.tok != .name {
-		return g.unsupported('`$for` iterable member')
+		return g.unsupported('`\$for` iterable member')
 	}
 	mut type_key := ''
-	if g.lit == 'fields' {
+	mut member := g.lit
+	if member in ['fields', 'values'] {
 		type_key = g.resolve_declared_type_key(first) or {
-			return g.unsupported('`$for` over unknown type `${first}`')
+			return g.unsupported('`\$for` over unknown type `${first}`')
 		}
 		g.next()
 	} else {
-		// Qualified `mod.Type.fields`.
+		// Qualified `mod.Type.fields` / `mod.Type.values`.
 		module_name := g.imports[first] or { first }
 		type_key = fastc_type_key(module_name, g.lit)
 		g.next()
 		g.expect(.dot)!
-		if g.tok != .name || g.lit != 'fields' {
-			return g.unsupported('`$for` only supports `.fields`')
+		if g.tok != .name || g.lit !in ['fields', 'values'] {
+			return g.unsupported('`\$for` only supports `.fields` or `.values`')
 		}
+		member = g.lit
 		g.next()
 	}
 	g.expect(.lcbr)!
@@ -405,24 +405,34 @@ fn (mut g Parser) parse_comptime_for_statement() !bool {
 		g.next()
 	}
 	if body_end < 0 {
-		return g.unsupported('unterminated `$for` block')
+		return g.unsupported('unterminated `\$for` block')
 	}
 	body_source := g.s.src[body_start..body_end]
 	g.next() // consume the closing `}`; the main scanner now continues after it
 	saved_tok := g.tok
 	saved_lit := g.lit
 	saved_s := g.s
-	for field in g.struct_field_info[c_type] {
-		// Substitute this field's comptime references (`<var>.name`,
-		// `x.$(<var>.name)`) at the source level, then re-scan the result as
-		// ordinary V — no comptime awareness is needed in the renderer.
-		substituted := g.substitute_comptime_field(body_source, loop_var, field)
+	// Build one substituted body per iteration item: a struct field for `.fields`,
+	// or an enum value for `.values`.
+	mut substituted_bodies := []string{}
+	if member == 'values' {
+		for value_name in g.enum_field_names[c_type] {
+			substituted_bodies << g.substitute_comptime_enum_value(body_source, loop_var, c_type, value_name)
+		}
+	} else {
+		for field in g.struct_field_info[c_type] {
+			substituted_bodies << g.substitute_comptime_field(body_source, loop_var, field)
+		}
+	}
+	for substituted in substituted_bodies {
+		// Re-scan each unrolled body as ordinary V — no comptime awareness is needed
+		// in the renderer.
 		file := token.File.unindexed('comptime_for', substituted.len)
 		g.s = scanner.new_scanner(g.prefs, .normal)
 		g.s.init(file, substituted)
 		g.next()
 		// A fresh C block scopes any locals the body declares, so re-parsing it per
-		// field does not redeclare them in the enclosing scope.
+		// item does not redeclare them in the enclosing scope.
 		g.write_line('{')
 		g.indent++
 		outer_locals := g.locals.clone()
@@ -484,8 +494,8 @@ fn (g &Parser) substitute_comptime_field(body string, loop_var string, field Fas
 					part = s.scan()
 				}
 				edits << FastcSourceEdit{
-					start:       loop_start
-					end:         loop_end
+					start: loop_start
+					end: loop_end
 					replacement: if field.is_skip { 'is_skip = true' } else { '' }
 				}
 				previous = .rcbr
@@ -507,8 +517,8 @@ fn (g &Parser) substitute_comptime_field(body string, loop_var string, field Fas
 							close := s.scan()
 							if close == .rpar {
 								edits << FastcSourceEdit{
-									start:       dollar_pos
-									end:         s.offset
+									start: dollar_pos
+									end: s.offset
 									replacement: field_name
 								}
 								previous = .rpar
@@ -530,8 +540,8 @@ fn (g &Parser) substitute_comptime_field(body string, loop_var string, field Fas
 				member := s.scan()
 				if member == .name && s.lit == 'name' {
 					edits << FastcSourceEdit{
-						start:       var_pos
-						end:         s.offset
+						start: var_pos
+						end: s.offset
 						replacement: "'${field_name}'"
 					}
 					previous = .name
@@ -541,8 +551,8 @@ fn (g &Parser) substitute_comptime_field(body string, loop_var string, field Fas
 				if member == .name && s.lit == 'is_embed' {
 					is_embed := field.name.starts_with('__embedded_')
 					edits << FastcSourceEdit{
-						start:       var_pos
-						end:         s.offset
+						start: var_pos
+						end: s.offset
 						replacement: if is_embed { 'true' } else { 'false' }
 					}
 					previous = if is_embed { token.Token.key_true } else { token.Token.key_false }
@@ -558,12 +568,11 @@ fn (g &Parser) substitute_comptime_field(body string, loop_var string, field Fas
 						attr_tok := s.scan()
 						attr_name := s.lit.trim('\'"')
 						close_tok := s.scan()
-						if contains_tok == .name && contains_name == 'contains' && open_tok == .lpar
-							&& attr_tok == .string && close_tok == .rpar {
+						if contains_tok == .name && contains_name == 'contains' && open_tok == .lpar && attr_tok == .string && close_tok == .rpar {
 							matches := field.is_skip && attr_name == 'skip'
 							edits << FastcSourceEdit{
-								start:       var_pos
-								end:         s.offset
+								start: var_pos
+								end: s.offset
 								replacement: if matches { 'true' } else { 'false' }
 							}
 							previous = if matches {
@@ -576,8 +585,8 @@ fn (g &Parser) substitute_comptime_field(body string, loop_var string, field Fas
 						}
 					}
 					edits << FastcSourceEdit{
-						start:       var_pos
-						end:         s.offset
+						start: var_pos
+						end: s.offset
 						replacement: if field.is_skip { "['skip']" } else { "['']" }
 					}
 					previous = member
@@ -597,8 +606,8 @@ fn (g &Parser) substitute_comptime_field(body string, loop_var string, field Fas
 								field.typ.trim_right('*') == type_c
 							}
 							edits << FastcSourceEdit{
-								start:       var_pos
-								end:         type_end
+								start: var_pos
+								end: type_end
 								replacement: if matches { 'true' } else { 'false' }
 							}
 							previous = if matches {
@@ -626,6 +635,53 @@ fn (g &Parser) substitute_comptime_field(body string, loop_var string, field Fas
 			continue
 		}
 		previous = tok
+		tok = s.scan()
+	}
+	return fastc_apply_source_edits(body, edits)
+}
+
+// substitute_comptime_enum_value rewrites one `$for x in Enum.values { ... }` body
+// for a single enum value: `<var>.name` becomes the value-name string literal and
+// `<var>.value` becomes the enum's C constant. Other `<var>.<member>` forms are left
+// as-is so they surface as unsupported when re-parsed.
+fn (g &Parser) substitute_comptime_enum_value(body string, loop_var string, enum_c_type string, value_name string) string {
+	mut file_set := token.FileSet.new()
+	mut file := file_set.add_file('cv', body.len)
+	file.index_lines_without_digest(body)
+	mut s := scanner.new_scanner(g.prefs, .normal)
+	s.init(file, body)
+	mut edits := []FastcSourceEdit{}
+	mut tok := s.scan()
+	for tok != .eof {
+		if fastc_comptime_loop_var_token(tok) && s.lit == loop_var {
+			var_pos := s.pos
+			after := s.scan()
+			if after == .dot {
+				member := s.scan()
+				if member == .name && s.lit == 'name' {
+					edits << FastcSourceEdit{
+						start: var_pos
+						end: s.offset
+						replacement: "'${value_name}'"
+					}
+					tok = s.scan()
+					continue
+				}
+				if member == .name && s.lit == 'value' {
+					edits << FastcSourceEdit{
+						start: var_pos
+						end: s.offset
+						replacement: '${enum_c_type}__${value_name}'
+					}
+					tok = s.scan()
+					continue
+				}
+				tok = s.scan()
+				continue
+			}
+			tok = after
+			continue
+		}
 		tok = s.scan()
 	}
 	return fastc_apply_source_edits(body, edits)
@@ -754,7 +810,7 @@ fn (mut g Parser) parse_comptime_unary() !bool {
 		g.next()
 		g.expect(.lpar)!
 		if g.tok != .string {
-			return g.unsupported('`$pkgconfig` library name')
+			return g.unsupported('`\$pkgconfig` library name')
 		}
 		library := g.lit.trim('\'"')
 		g.next()
@@ -836,6 +892,21 @@ fn (mut g Parser) parse_comptime_unary() !bool {
 		matches := g.comptime_type_matches(left_type, target_type, target_is_group)
 		return if operator == .key_is { matches } else { !matches }
 	}
+	if g.tok in [.eq, .ne] {
+		// `$if @BACKEND == 'arm64'` etc.: compare a compile-time pseudo variable to a
+		// string literal.
+		operator := g.tok
+		g.next()
+		if g.tok != .string {
+			return g.unsupported('compile-time comparison value `${g.token_source()}`')
+		}
+		expected := g.lit.trim('\'"')
+		g.next()
+		actual := g.comptime_pseudo_string(name) or {
+			return g.unsupported('compile-time comparison of `${name}`')
+		}
+		return if operator == .eq { actual == expected } else { actual != expected }
+	}
 	is_optional := g.tok == .question
 	if is_optional {
 		g.next()
@@ -844,6 +915,18 @@ fn (mut g Parser) parse_comptime_unary() !bool {
 		pref.comptime_optional_flag_value(g.prefs, name)
 	} else {
 		pref.comptime_flag_value(g.prefs, name)
+	}
+}
+
+// comptime_pseudo_string returns the plain string value of a compile-time pseudo
+// variable used in a `$if … == '…'` comparison, or none when it is not comparable.
+fn (g &Parser) comptime_pseudo_string(name string) ?string {
+	return match name {
+		'@BACKEND' { g.prefs.backend.str() }
+		'@OS' { g.prefs.normalized_target_os() }
+		'@CCOMPILER' { g.prefs.ccompiler }
+		'@PLATFORM' { g.prefs.comptime_platform() }
+		else { none }
 	}
 }
 
@@ -926,7 +1009,7 @@ fn (mut g Parser) skip_open_block() ! {
 
 fn (mut g Parser) skip_comptime_if_chain() ! {
 	if g.tok != .dollar {
-		return g.unsupported('compile-time `$else` branch')
+		return g.unsupported('compile-time `\$else` branch')
 	}
 	g.next()
 
@@ -953,7 +1036,7 @@ fn (mut g Parser) read_comptime_d_expression() !string {
 	g.expect(.name)! // consume `d`
 	g.expect(.lpar)!
 	if g.tok != .string {
-		return g.unsupported('`$d` compile-time value key')
+		return g.unsupported('`\$d` compile-time value key')
 	}
 	g.next() // the define name (only meaningful with `-d name=value`, not transported)
 	g.expect(.comma)!
@@ -963,6 +1046,71 @@ fn (mut g Parser) read_comptime_d_expression() !string {
 	g.last_expression_type = value_type
 	g.last_expression = []FastcExpressionToken{}
 	return default_value
+}
+
+// read_comptime_embed_file lowers `$embed_file('path')` by reading the file at
+// generation time. The compiler chain uses the result as `.to_string()` /
+// `.to_bytes()`, so those two accessors are supported directly; the file bytes
+// become a C string literal or a `[]u8` array, exactly what the accessors return.
+fn (mut g Parser) read_comptime_embed_file() !string {
+	g.expect(.name)! // consume `embed_file`
+	g.expect(.lpar)!
+	if g.tok != .string {
+		return g.unsupported('`\$embed_file` requires a string literal path')
+	}
+	path_literal := g.lit
+	g.next()
+	// Additional arguments (e.g. an `EmbedFileIndex` or compression option) do not
+	// change what the two supported accessors return, so ignore them.
+	for g.tok == .comma {
+		g.next()
+		g.read_expression([token.Token.comma, token.Token.rpar])!
+	}
+	g.expect(.rpar)!
+	embed_path := fastc_string_literal_content(path_literal)
+	resolved := if os.is_abs_path(embed_path) {
+		embed_path
+	} else {
+		os.join_path(os.dir(g.path), embed_path)
+	}
+	content := os.read_file(resolved) or {
+		return g.unsupported('`\$embed_file` cannot read `${resolved}`')
+	}
+	if g.tok != .dot {
+		return g.unsupported('`\$embed_file` is only supported with a `.to_string()` or `.to_bytes()` accessor')
+	}
+	g.next()
+	if g.tok != .name {
+		return g.unsupported('`\$embed_file` accessor')
+	}
+	accessor := g.lit
+	g.next()
+	g.expect(.lpar)!
+	g.expect(.rpar)!
+	match accessor {
+		'to_string', 'str' {
+			g.last_expression_type = 'string'
+			g.last_expression = []FastcExpressionToken{}
+			return '_S(${fastc_c_string_value(content)})'
+		}
+		else {
+			return g.unsupported('`\$embed_file` accessor `.${accessor}()`')
+		}
+	}
+}
+
+// fastc_string_literal_content returns the raw text inside a scanned string
+// literal token, stripping an optional `r`/`c` prefix and the surrounding quotes.
+// Embed paths contain no escape sequences, so no unescaping is required.
+fn fastc_string_literal_content(literal string) string {
+	mut raw := literal
+	if raw.len >= 3 && raw[0] in [`r`, `c`] && raw[1] in [`'`, `"`] {
+		raw = raw[1..]
+	}
+	if raw.len >= 2 && raw[0] in [`'`, `"`, `\``] && raw[raw.len - 1] == raw[0] {
+		return raw[1..raw.len - 1]
+	}
+	return raw
 }
 
 fn (g &Parser) dollar_keyword_is(keyword string) bool {
@@ -1074,6 +1222,9 @@ fn (mut g Parser) read_comptime_if_expression() !string {
 	if g.tok == .name && g.lit == 'd' {
 		return g.read_comptime_d_expression()!
 	}
+	if g.tok == .name && g.lit == 'embed_file' {
+		return g.read_comptime_embed_file()!
+	}
 	g.expect(.key_if)!
 	condition := g.parse_comptime_or()!
 	g.expect(.lcbr)!
@@ -1098,7 +1249,7 @@ fn (mut g Parser) read_comptime_if_expression() !string {
 	}
 	g.skip_open_block()!
 	if g.tok != .dollar {
-		return g.unsupported('compile-time if expression without `$else`')
+		return g.unsupported('compile-time if expression without `\$else`')
 	}
 	g.next()
 	g.expect(.key_else)!
@@ -1122,7 +1273,6 @@ fn (mut g Parser) read_comptime_if_expression() !string {
 // `@ident` interpolation (HTML-escaped via `veb.filter_html`), `%key` i18n shorthand,
 // `@include`, and `@if` / `@for` / `@else` control flow. Other `@` directives are
 // reported as unsupported.
-
 fn fastc_veb_ident_start(c u8) bool {
 	return (c >= `a` && c <= `z`) || (c >= `A` && c <= `Z`) || c == `_`
 }
@@ -1396,8 +1546,7 @@ fn fastc_veb_compile_template(path string, bname string, ctx_name string) !strin
 			block_kinds << 'control'
 			continue
 		}
-		if trimmed == '@else' || trimmed == '@else {' || trimmed == '@else{'
-			|| trimmed.starts_with('@else if ') {
+		if trimmed == '@else' || trimmed == '@else {' || trimmed == '@else{' || trimmed.starts_with('@else if ') {
 			out += fastc_veb_append_stmt(bname, current)
 			current = ''
 			rest := trimmed['@else'.len..].trim_right('{').trim_space()
@@ -1472,8 +1621,7 @@ fn fastc_veb_compile_template(path string, bname string, ctx_name string) !strin
 		// A standalone `@ident` line (control directives `@if`/`@for`/... are handled above)
 		// is a bare interpolation like `@source`, not a directive — render it as content.
 		// Only a `@` followed by a non-identifier is a malformed/unsupported directive.
-		if trimmed.starts_with('@') && !trimmed.starts_with('@@') && !trimmed.starts_with('@{')
-			&& !(trimmed.len > 1 && fastc_veb_ident_start(trimmed[1])) {
+		if trimmed.starts_with('@') && !trimmed.starts_with('@@') && !trimmed.starts_with('@{') && !(trimmed.len > 1 && fastc_veb_ident_start(trimmed[1])) {
 			return error('unsupported template directive `${trimmed}`')
 		}
 		current += fastc_veb_line_content(line, ctx_name) + r'\n'
@@ -1543,12 +1691,12 @@ fn (g &Parser) fastc_veb_context_name() string {
 fn (mut g Parser) parse_veb_html_return() !bool {
 	g.next() // consume `$`
 	if g.tok != .name || g.lit != 'veb' {
-		return g.unsupported('comptime `$` expression')
+		return g.unsupported('comptime `\$` expression')
 	}
 	g.next() // consume `veb`
 	g.expect(.dot)!
 	if g.tok != .name || g.lit != 'html' {
-		return g.unsupported('`$veb.${g.lit}()` is not supported (only `$veb.html()`)')
+		return g.unsupported('`\$veb.${g.lit}()` is not supported (only `\$veb.html()`)')
 	}
 	g.next() // consume `html`
 	g.expect(.lpar)!
@@ -1558,7 +1706,7 @@ fn (mut g Parser) parse_veb_html_return() !bool {
 		g.next()
 	}
 	if g.tok != .rpar {
-		return g.unsupported('`$veb.html(...)` argument must be a string-literal path')
+		return g.unsupported('`\$veb.html(...)` argument must be a string-literal path')
 	}
 	g.expect(.rpar)!
 	g.consume_statement_end()

--- a/vlib/v3/gen/fastc/decl.v
+++ b/vlib/v3/gen/fastc/decl.v
@@ -35,15 +35,11 @@ fn collect_declared_types(source string, path string, module_name string, prefs 
 				comptime_end := if selected.tok == .eof { scan.offset } else { scan.pos }
 				if selected.source != '' {
 					mut selected_types := strings.new_builder(256)
-					selected_has_types := collect_declared_types(selected.source, path,
-						module_name, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut
-						params_structs, mut declaration_paths, mut declaration_modules, mut
-						selected_types, mut scratch_body_spans)!
+					selected_has_types := collect_declared_types(selected.source, path, module_name, prefs, mut declared_types, mut declared_kinds, mut enum_flags, mut params_structs, mut declaration_paths, mut declaration_modules, mut selected_types, mut scratch_body_spans)!
 					has_type_declarations = has_type_declarations || selected_has_types
 					if selected_types.len > 0 {
 						start := if pending_start >= 0 { pending_start } else { comptime_start }
-						fastc_append_filtered_source_span(source, emitted_end, start, comptime_end, mut
-							type_source)
+						fastc_append_filtered_source_span(source, emitted_end, start, comptime_end, mut type_source)
 						emitted_end = comptime_end
 					}
 				}
@@ -75,9 +71,18 @@ fn collect_declared_types(source string, path string, module_name string, prefs 
 			next_struct_is_params = false
 			next_type_is_enabled = true
 			pending_start = -1
+			if tok == .key_fn && declaration_start < 0 {
+				// A method whose name is a keyword (`fn (e Expr) type() Type`) tokenizes
+				// that name as e.g. `.key_type`. Skip the whole function header so the
+				// keyword name does not open a bogus type-declaration span here. The
+				// `declaration_start < 0` guard keeps the `fn` in a `type X = fn(...)`
+				// alias value (which has no receiver or name) out of this path.
+				previous_tok = tok
+				tok = fastc_skip_function_header(mut scan)!
+				continue
+			}
 		}
-		if brace_depth == 0
-			&& tok in [.key_struct, .key_enum, .key_interface, .key_type, .key_union] {
+		if brace_depth == 0 && tok in [.key_struct, .key_enum, .key_interface, .key_type, .key_union] {
 			has_type_declarations = true
 			declaration_start = if pending_start >= 0 { pending_start } else { scan.pos }
 			declaration_has_block = false
@@ -145,17 +150,24 @@ fn collect_declared_types(source string, path string, module_name string, prefs 
 				pending_fn = false
 			}
 			if declaration_start >= 0 && declaration_has_block && brace_depth == 0 {
-				fastc_append_filtered_source_span(source, emitted_end, declaration_start,
-					scan.offset, mut type_source)
+				fastc_append_filtered_source_span(source, emitted_end, declaration_start, scan.offset, mut type_source)
 				emitted_end = scan.offset
 				declaration_start = -1
 				declaration_has_block = false
 			}
-		} else if tok == .semicolon && brace_depth == 0 && declaration_start >= 0
-			&& !declaration_has_block {
+		} else if tok == .semicolon && brace_depth == 0 && declaration_start >= 0 && !declaration_has_block {
+			// A multi-line sum type (`type Expr = A\n\t| B\n\t| C`) has an inserted
+			// semicolon after each variant. Do not close the declaration span while a
+			// `|` continuation follows, or only the first variant would be captured and
+			// the type would never register as a sum type.
+			mut lookahead := scan
+			if lookahead.scan() == .pipe {
+				previous_tok = tok
+				tok = scan.scan()
+				continue
+			}
 			declaration_end := if scan.offset > scan.pos { scan.offset } else { scan.pos }
-			fastc_append_filtered_source_span(source, emitted_end, declaration_start,
-				declaration_end, mut type_source)
+			fastc_append_filtered_source_span(source, emitted_end, declaration_start, declaration_end, mut type_source)
 			emitted_end = declaration_end
 			declaration_start = -1
 		}
@@ -166,8 +178,7 @@ fn collect_declared_types(source string, path string, module_name string, prefs 
 		tok = scan.scan()
 	}
 	if declaration_start >= 0 {
-		fastc_append_filtered_source_span(source, emitted_end, declaration_start, source.len, mut
-			type_source)
+		fastc_append_filtered_source_span(source, emitted_end, declaration_start, source.len, mut type_source)
 	}
 	return has_type_declarations
 }
@@ -191,14 +202,11 @@ fn collect_constant_names(source string, path string, module_name string, prefs 
 				if selected.source != '' {
 					mut selected_constants := strings.new_builder(256)
 					mut selected_spans := []int{}
-					collect_constant_names(selected.source, path, module_name, prefs, []int{}, mut
-						constants, mut public_constants, mut constant_paths, mut
-						selected_constants, mut selected_spans)!
+					collect_constant_names(selected.source, path, module_name, prefs, []int{}, mut constants, mut public_constants, mut constant_paths, mut selected_constants, mut selected_spans)!
 					if selected_constants.len > 0 {
 						constant_spans << constant_source.len
 
-						fastc_append_filtered_source_span(source, emitted_end, comptime_start,
-							comptime_end, mut constant_source)
+						fastc_append_filtered_source_span(source, emitted_end, comptime_start, comptime_end, mut constant_source)
 
 						constant_spans << constant_source.len
 						emitted_end = comptime_end
@@ -221,8 +229,7 @@ fn collect_constant_names(source string, path string, module_name string, prefs 
 					if nested_depth == 0 && tok == .rpar {
 						constant_spans << constant_source.len
 
-						fastc_append_filtered_source_span(source, emitted_end, declaration_start,
-							scan.offset, mut constant_source)
+						fastc_append_filtered_source_span(source, emitted_end, declaration_start, scan.offset, mut constant_source)
 
 						constant_spans << constant_source.len
 						emitted_end = scan.offset
@@ -238,8 +245,7 @@ fn collect_constant_names(source string, path string, module_name string, prefs 
 						// `const C.name type` declares an external C constant; the C
 						// headers already provide the symbol, so FastC does not track it.
 						if scan.lit != 'C' {
-							fastc_register_constant(module_name, scan.lit, is_public, path, mut
-								constants, mut public_constants, mut constant_paths)!
+							fastc_register_constant(module_name, scan.lit, is_public, path, mut constants, mut public_constants, mut constant_paths)!
 						}
 						at_declaration_start = false
 					}
@@ -259,8 +265,7 @@ fn collect_constant_names(source string, path string, module_name string, prefs 
 			// `const C.name type` declares an external C constant; the C headers
 			// already provide the symbol, so FastC does not track it.
 			if scan.lit != 'C' {
-				fastc_register_constant(module_name, scan.lit, is_public, path, mut constants, mut
-					public_constants, mut constant_paths)!
+				fastc_register_constant(module_name, scan.lit, is_public, path, mut constants, mut public_constants, mut constant_paths)!
 			}
 			tok = scan.scan()
 			mut nested_depth := 0
@@ -270,8 +275,7 @@ fn collect_constant_names(source string, path string, module_name string, prefs 
 					declaration_end := if scan.offset > scan.pos { scan.offset } else { scan.pos }
 					constant_spans << constant_source.len
 
-					fastc_append_filtered_source_span(source, emitted_end, declaration_start,
-						declaration_end, mut constant_source)
+					fastc_append_filtered_source_span(source, emitted_end, declaration_start, declaration_end, mut constant_source)
 
 					constant_spans << constant_source.len
 					emitted_end = declaration_end
@@ -289,8 +293,7 @@ fn collect_constant_names(source string, path string, module_name string, prefs 
 			if tok == .eof && !emitted {
 				constant_spans << constant_source.len
 
-				fastc_append_filtered_source_span(source, emitted_end, declaration_start,
-					source.len, mut constant_source)
+				fastc_append_filtered_source_span(source, emitted_end, declaration_start, source.len, mut constant_source)
 
 				constant_spans << constant_source.len
 				emitted_end = source.len
@@ -370,12 +373,10 @@ fn collect_global_names(source string, path string, header FastcSourceHeader, pr
 				comptime_end := if selected.tok == .eof { scan.offset } else { scan.pos }
 				if selected.source != '' {
 					mut selected_source := strings.new_builder(64)
-					collect_global_names(selected.source, path, header, prefs, []int{}, mut
-						globals, mut public_globals, mut global_paths, mut selected_source)!
+					collect_global_names(selected.source, path, header, prefs, []int{}, mut globals, mut public_globals, mut global_paths, mut selected_source)!
 				}
 				if globals.len > globals_before {
-					fastc_append_filtered_source_span(source, emitted_end, comptime_start,
-						comptime_end, mut global_source)
+					fastc_append_filtered_source_span(source, emitted_end, comptime_start, comptime_end, mut global_source)
 					emitted_end = comptime_end
 				}
 				tok = selected.tok
@@ -395,29 +396,25 @@ fn collect_global_names(source string, path string, header FastcSourceHeader, pr
 						at_start = true
 					} else if at_start && tok == .name {
 						if scan.lit != 'C' {
-							fastc_register_global(header, scan.lit, is_public, path, prefs, mut
-								globals, mut public_globals, mut global_paths)!
+							fastc_register_global(header, scan.lit, is_public, path, prefs, mut globals, mut public_globals, mut global_paths)!
 						}
 						at_start = false
 					}
 					tok = scan.scan()
 				}
 				declaration_end := if tok == .rpar { scan.offset } else { scan.pos }
-				fastc_append_filtered_source_span(source, emitted_end, declaration_start,
-					declaration_end, mut global_source)
+				fastc_append_filtered_source_span(source, emitted_end, declaration_start, declaration_end, mut global_source)
 				emitted_end = declaration_end
 				continue
 			}
 			if tok == .name && scan.lit != 'C' {
-				fastc_register_global(header, scan.lit, is_public, path, prefs, mut globals, mut
-					public_globals, mut global_paths)!
+				fastc_register_global(header, scan.lit, is_public, path, prefs, mut globals, mut public_globals, mut global_paths)!
 			}
 			pending_start = declaration_start
 			continue
 		}
 		if pending_start >= 0 && depth == 0 && tok == .semicolon {
-			fastc_append_filtered_source_span(source, emitted_end, pending_start, scan.pos, mut
-				global_source)
+			fastc_append_filtered_source_span(source, emitted_end, pending_start, scan.pos, mut global_source)
 			emitted_end = scan.pos
 			pending_start = -1
 		}
@@ -441,14 +438,12 @@ fn collect_global_names(source string, path string, header FastcSourceHeader, pr
 		tok = scan.scan()
 	}
 	if pending_start >= 0 {
-		fastc_append_filtered_source_span(source, emitted_end, pending_start, source.len, mut
-			global_source)
+		fastc_append_filtered_source_span(source, emitted_end, pending_start, source.len, mut global_source)
 	}
 }
 
 fn fastc_register_global(header FastcSourceHeader, name string, is_public bool, path string, prefs &pref.Preferences, mut globals map[string]string, mut public_globals map[string]bool, mut global_paths map[string]string) ! {
-	if !prefs.enable_globals && !prefs.building_v && header.module_name != 'builtin'
-		&& !header.has_globals {
+	if !prefs.enable_globals && !prefs.building_v && header.module_name != 'builtin' && !header.has_globals {
 		return error('use `v -enable-globals ...` to enable globals in ${path}')
 	}
 	key := fastc_global_key(header.module_name, name)
@@ -488,21 +483,21 @@ mut:
 
 fn fastc_collect_declaration_chunk(sources []FastcSourceFile, prefs &pref.Preferences, start int, end int) FastcDeclarationPartial {
 	mut partial := FastcDeclarationPartial{
-		declared_types:      map[string]bool{}
-		declared_kinds:      map[string]FastcDeclaredTypeKind{}
-		enum_flags:          map[string]bool{}
-		params_structs:      map[string]bool{}
-		type_source_paths:   map[string]bool{}
-		type_sources:        map[string]string{}
-		declaration_paths:   map[string]string{}
+		declared_types: map[string]bool{}
+		declared_kinds: map[string]FastcDeclaredTypeKind{}
+		enum_flags: map[string]bool{}
+		params_structs: map[string]bool{}
+		type_source_paths: map[string]bool{}
+		type_sources: map[string]string{}
+		declaration_paths: map[string]string{}
 		declaration_modules: map[string]string{}
-		constants:           map[string]string{}
-		public_constants:    map[string]bool{}
-		constant_paths:      map[string]string{}
-		constant_sources:    map[string]string{}
-		globals:             map[string]string{}
-		public_globals:      map[string]bool{}
-		global_paths:        map[string]string{}
+		constants: map[string]string{}
+		public_constants: map[string]bool{}
+		constant_paths: map[string]string{}
+		constant_sources: map[string]string{}
+		globals: map[string]string{}
+		public_globals: map[string]bool{}
+		global_paths: map[string]string{}
 	}
 	for idx in start .. end {
 		source_file := sources[idx]
@@ -510,11 +505,7 @@ fn fastc_collect_declaration_chunk(sources []FastcSourceFile, prefs &pref.Prefer
 		mut has_type_declarations := false
 		mut body_spans := []int{}
 		if source_file.header.has_type_keywords {
-			has_type_declarations = collect_declared_types(source_file.source, source_file.path,
-				source_file.header.module_name, prefs, mut partial.declared_types, mut
-				partial.declared_kinds, mut partial.enum_flags, mut partial.params_structs, mut
-				partial.declaration_paths, mut partial.declaration_modules, mut type_source, mut
-				body_spans) or {
+			has_type_declarations = collect_declared_types(source_file.source, source_file.path, source_file.header.module_name, prefs, mut partial.declared_types, mut partial.declared_kinds, mut partial.enum_flags, mut partial.params_structs, mut partial.declaration_paths, mut partial.declaration_modules, mut type_source, mut body_spans) or {
 				partial.failed = true
 				partial.error_message = err.msg()
 				return partial
@@ -527,10 +518,7 @@ fn fastc_collect_declaration_chunk(sources []FastcSourceFile, prefs &pref.Prefer
 		if source_file.header.has_constants {
 			mut constant_source := strings.new_builder(256)
 			mut constant_spans := []int{}
-			collect_constant_names(source_file.source, source_file.path,
-				source_file.header.module_name, prefs, body_spans, mut partial.constants, mut
-				partial.public_constants, mut partial.constant_paths, mut constant_source, mut
-				constant_spans) or {
+			collect_constant_names(source_file.source, source_file.path, source_file.header.module_name, prefs, body_spans, mut partial.constants, mut partial.public_constants, mut partial.constant_paths, mut constant_source, mut constant_spans) or {
 				partial.failed = true
 				partial.error_message = err.msg()
 				return partial
@@ -542,9 +530,7 @@ fn fastc_collect_declaration_chunk(sources []FastcSourceFile, prefs &pref.Prefer
 		}
 		if source_file.header.has_global_declarations {
 			mut global_source := strings.new_builder(256)
-			collect_global_names(source_file.source, source_file.path, source_file.header, prefs,
-				body_spans, mut partial.globals, mut partial.public_globals, mut
-				partial.global_paths, mut global_source) or {
+			collect_global_names(source_file.source, source_file.path, source_file.header, prefs, body_spans, mut partial.globals, mut partial.public_globals, mut partial.global_paths, mut global_source) or {
 				partial.failed = true
 				partial.error_message = err.msg()
 				return partial
@@ -626,49 +612,49 @@ fn fastc_generate_global_declarations(ordered_sources []FastcSourceFile, global_
 		mut initializers := strings.new_builder(256)
 		file := token.File.unindexed(source_file.path, global_source.len)
 		mut gen := Parser{
-			prefs:                        unsafe { prefs }
-			unqualified_key_memo:         map[string]string{}
-			c_function_name_memo:         map[string]string{}
-			nonlocal_name_type_memo:      map[string]string{}
-			resolved_name_memo:           map[string]string{}
-			declared_type_key_memo:       map[string]FastcMemoEntry{}
-			path:                         source_file.path
-			module_name:                  source_file.header.module_name
-			imports:                      source_file.header.imports
-			declared_types:               declared_types
-			declared_type_c_names:        declared_type_c_names
-			declared_type_key_by_name:    declared_type_key_by_name
-			fastc_prefixed_c_names:       fastc_prefixed_c_names
+			prefs: unsafe { prefs }
+			unqualified_key_memo: map[string]string{}
+			c_function_name_memo: map[string]string{}
+			nonlocal_name_type_memo: map[string]string{}
+			resolved_name_memo: map[string]string{}
+			declared_type_key_memo: map[string]FastcMemoEntry{}
+			path: source_file.path
+			module_name: source_file.header.module_name
+			imports: source_file.header.imports
+			declared_types: declared_types
+			declared_type_c_names: declared_type_c_names
+			declared_type_key_by_name: declared_type_key_by_name
+			fastc_prefixed_c_names: fastc_prefixed_c_names
 			declaration_initializer_mode: true
-			has_c_functions:              helper_has_c_functions
-			comparison_memo:              map[i64]FastcRenderedExpression{}
-			type_memo:                    map[i64]string{}
-			method_key_memo:              map[string]map[string]string{}
-			field_memo:                   map[string]map[string]FastcStructField{}
-			spawn_typedefs:               map[string]string{}
-			spawn_helpers:                map[string]string{}
-			thread_value_types:           map[string]string{}
-			declared_kinds:               declared_kinds
-			enum_flags:                   enum_flags
-			enum_field_types:             enum_field_types
-			alias_base_types:             alias_base_types
-			struct_fields:                struct_fields
-			struct_field_info:            struct_field_info
-			constants:                    constants
-			constant_values:              constant_values
-			public_constants:             public_constants
-			globals:                      globals
-			public_globals:               public_globals
-			selfhost:                     prefs.building_v
-			header_free:                  header_free
-			s:                            scanner.new_scanner(prefs, .normal)
-			out:                          strings.new_builder(0)
-			protos:                       strings.new_builder(0)
-			functions:                    functions
-			constant_types:               constant_types
-			global_types:                 global_types
-			composite_types:              map[string]bool{}
-			fixed_array_types:            map[string]string{}
+			has_c_functions: helper_has_c_functions
+			comparison_memo: map[i64]FastcRenderedExpression{}
+			type_memo: map[i64]string{}
+			method_key_memo: map[string]map[string]string{}
+			field_memo: map[string]map[string]FastcStructField{}
+			spawn_typedefs: map[string]string{}
+			spawn_helpers: map[string]string{}
+			thread_value_types: map[string]string{}
+			declared_kinds: declared_kinds
+			enum_flags: enum_flags
+			enum_field_types: enum_field_types
+			alias_base_types: alias_base_types
+			struct_fields: struct_fields
+			struct_field_info: struct_field_info
+			constants: constants
+			constant_values: constant_values
+			public_constants: public_constants
+			globals: globals
+			public_globals: public_globals
+			selfhost: prefs.building_v
+			header_free: header_free
+			s: scanner.new_scanner(prefs, .normal)
+			out: strings.new_builder(0)
+			protos: strings.new_builder(0)
+			functions: functions
+			constant_types: constant_types
+			global_types: global_types
+			composite_types: map[string]bool{}
+			fixed_array_types: map[string]string{}
 		}
 		gen.s.init(file, global_source)
 		gen.next()
@@ -689,10 +675,10 @@ fn fastc_generate_global_declarations(ordered_sources []FastcSourceFile, global_
 		out.writeln('')
 	}
 	return FastcGlobalDeclarations{
-		declarations:        out.str()
+		declarations: out.str()
 		module_initializers: module_initializers
-		composite_types:     composite_types
-		fixed_array_types:   fixed_array_types
+		composite_types: composite_types
+		fixed_array_types: fixed_array_types
 	}
 }
 
@@ -873,8 +859,10 @@ fn (mut g Parser) parse_global_declaration(mut out strings.Builder, mut initiali
 // struct field's default (matching `map[K]V{}`), or '' when the type is not a
 // resolvable map. Kept as a helper so the caller avoids a multi-return option in
 // an `if` guard, which the FastC self-host does not accept.
-fn fastc_map_field_default(typ string, pointer_bits int) string {
-	key_type, value_type := fastc_map_key_value_types(typ) or { return '' }
+fn fastc_map_field_default(typ string, pointer_bits int, declared_kinds map[string]FastcDeclaredTypeKind) string {
+	key_type, value_type := fastc_map_key_value_types(typ) or {
+		fastc_declared_map_key_value_types(typ, declared_kinds) or { return '' }
+	}
 	hash_fn, eq_fn, clone_fn, free_fn := fastc_map_runtime_functions(key_type, pointer_bits)
 	return '(builtin__new_map(sizeof(${fastc_runtime_c_type(key_type)}), sizeof(${fastc_runtime_c_type(value_type)}), &${hash_fn}, &${eq_fn}, &${clone_fn}, &${free_fn}))'
 }
@@ -890,120 +878,133 @@ struct FastcFieldDefaultsResult {
 
 // fastc_run_field_defaults renders the field defaults into a copy of the
 // field table (the renderer replaces each type's entry) and indexes it.
-fn fastc_run_field_defaults(source_imports map[string]map[string]string, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, global_types map[string]string, sum_types map[string]bool) FastcFieldDefaultsResult {
+fn fastc_run_field_defaults(source_imports map[string]map[string]string, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, enum_field_names map[string][]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, global_types map[string]string, sum_types map[string]bool) FastcFieldDefaultsResult {
 	mut rendered := struct_field_info.clone()
-	fastc_render_struct_field_defaults(source_imports, prefs, declared_types,
-		declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags,
-		enum_field_types, alias_base_types, struct_fields, mut rendered, functions, constants,
-		public_constants, constant_types, globals, public_globals, global_types, sum_types) or {
+	fastc_render_struct_field_defaults(source_imports, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, enum_field_names, alias_base_types, struct_fields, mut rendered, functions, constants, public_constants, constant_types, globals, public_globals, global_types, sum_types) or {
 		return FastcFieldDefaultsResult{
-			failed:        true
+			failed: true
 			error_message: err.msg()
 		}
 	}
 	return FastcFieldDefaultsResult{
 		struct_field_info: rendered
-		lookup:            fastc_build_struct_field_lookup(rendered)
+		lookup: fastc_build_struct_field_lookup(rendered)
 	}
 }
 
-fn fastc_render_struct_field_defaults(source_imports map[string]map[string]string, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, global_types map[string]string, sum_types map[string]bool) ! {
+fn fastc_render_struct_field_defaults(source_imports map[string]map[string]string, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, enum_field_names map[string][]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, global_types map[string]string, sum_types map[string]bool) ! {
 	declared_type_key_by_name := fastc_declared_type_key_by_name(declared_types)
 	helper_has_c_functions := fastc_functions_declare_c(functions)
 	mut type_names := struct_field_info.keys()
 	type_names.sort()
+	// Seed every implicit container default before rendering explicit field defaults. An
+	// explicit default can construct another struct (`&UsedFeatures{}` in ast.Table), and
+	// that nested literal must already know that its map/array fields need real runtime
+	// headers rather than an all-zero C value.
+	for type_name in type_names {
+		mut fields := struct_field_info[type_name].clone()
+		for mut field in fields {
+			if field.default_source != '' {
+				continue
+			}
+			field_layout := field.typ.trim_right('*')
+			container_type := fastc_underlying_alias_type(field.typ, alias_base_types)
+			container_layout := container_type.trim_right('*')
+			if prefs.building_v && container_layout.starts_with('Array_') {
+				if element_type := fastc_array_element_type(container_type) {
+					element_sizeof := if element_type.ends_with('_ptr') {
+						'voidptr'
+					} else {
+						element_type
+					}
+					field.default_value = '((${field_layout})builtin____new_array(0, 0, sizeof(${element_sizeof})))'
+				}
+			} else if prefs.building_v && container_layout.starts_with('Map_') {
+				map_default := fastc_map_field_default(container_type, prefs.target.pointer_bits, declared_kinds)
+				if map_default != '' {
+					field.default_value = map_default
+				}
+			}
+		}
+		struct_field_info[type_name] = fields
+	}
 	for type_name in type_names {
 		mut fields := struct_field_info[type_name].clone()
 		for mut field in fields {
 			if field.default_source == '' {
-				// A dynamic-array field with no explicit default still needs a properly
-				// sized empty value, otherwise `X{}` construction zeroes it (including
-				// its element_size) and a later `arr << x` copies zero bytes per element.
-				// Mirror the `[]T{}` rendering. Only the real-builtin runtime has a
-				// sized array; the toy runtime uses a different representation.
-				field_layout := field.typ.trim_right('*')
-				if prefs.building_v && field_layout.starts_with('Array_') {
-					if element_type := fastc_array_element_type(field.typ) {
-						// A `_ptr`-encoded element type is not a real C type name; every
-						// pointer is the same size, so measure `voidptr` for sizeof.
-						element_sizeof := if element_type.ends_with('_ptr') {
-							'voidptr'
-						} else {
-							element_type
-						}
-						field.default_value = '((${field_layout})builtin____new_array(0, 0, sizeof(${element_sizeof})))'
-					}
-				} else if prefs.building_v && field_layout.starts_with('Map_') {
-					// A map field zeroes the same way: without a real `new_map`, its key
-					// and value sizes and hash/eq function pointers are null, so any
-					// insert/lookup misbehaves. Mirror the `map[K]V{}` rendering.
-					map_default := fastc_map_field_default(field.typ, prefs.target.pointer_bits)
-					if map_default != '' {
-						field.default_value = map_default
-					}
-				}
 				continue
 			}
 			default_path := '${field.path}:${field.name}:default'
 			file := token.File.unindexed(default_path, field.default_source.len)
 			mut gen := Parser{
-				prefs:                        unsafe { prefs }
-				unqualified_key_memo:         map[string]string{}
-				c_function_name_memo:         map[string]string{}
-				nonlocal_name_type_memo:      map[string]string{}
-				resolved_name_memo:           map[string]string{}
-				declared_type_key_memo:       map[string]FastcMemoEntry{}
-				path:                         default_path
-				module_name:                  field.module_name
-				imports:                      source_imports[field.path] or {
+				prefs: unsafe { prefs }
+				unqualified_key_memo: map[string]string{}
+				c_function_name_memo: map[string]string{}
+				nonlocal_name_type_memo: map[string]string{}
+				resolved_name_memo: map[string]string{}
+				declared_type_key_memo: map[string]FastcMemoEntry{}
+				path: default_path
+				module_name: field.module_name
+				imports: source_imports[field.path] or {
 					map[string]string{}
 				}
-				declared_types:               declared_types
-				declared_type_c_names:        declared_type_c_names
-				declared_type_key_by_name:    declared_type_key_by_name
-				fastc_prefixed_c_names:       fastc_prefixed_c_names
+				declared_types: declared_types
+				declared_type_c_names: declared_type_c_names
+				declared_type_key_by_name: declared_type_key_by_name
+				fastc_prefixed_c_names: fastc_prefixed_c_names
 				declaration_initializer_mode: true
-				has_c_functions:              helper_has_c_functions
-				comparison_memo:              map[i64]FastcRenderedExpression{}
-				type_memo:                    map[i64]string{}
-				method_key_memo:              map[string]map[string]string{}
-				field_memo:                   map[string]map[string]FastcStructField{}
-				spawn_typedefs:               map[string]string{}
-				spawn_helpers:                map[string]string{}
-				thread_value_types:           map[string]string{}
-				declared_kinds:               declared_kinds
-				enum_flags:                   enum_flags
-				enum_field_types:             enum_field_types
-				alias_base_types:             alias_base_types
-				struct_fields:                struct_fields
-				struct_field_info:            struct_field_info
-				sum_types:                    sum_types
-				constants:                    constants
-				public_constants:             public_constants
-				globals:                      globals
-				public_globals:               public_globals
-				selfhost:                     prefs.building_v
-				s:                            scanner.new_scanner(prefs, .normal)
-				out:                          strings.new_builder(0)
-				protos:                       strings.new_builder(0)
-				functions:                    functions
-				constant_types:               constant_types
-				global_types:                 global_types
-				fixed_array_types:            map[string]string{}
-				composite_types:              map[string]bool{}
+				has_c_functions: helper_has_c_functions
+				comparison_memo: map[i64]FastcRenderedExpression{}
+				type_memo: map[i64]string{}
+				method_key_memo: map[string]map[string]string{}
+				field_memo: map[string]map[string]FastcStructField{}
+				spawn_typedefs: map[string]string{}
+				spawn_helpers: map[string]string{}
+				thread_value_types: map[string]string{}
+				declared_kinds: declared_kinds
+				enum_flags: enum_flags
+				enum_field_types: enum_field_types
+				enum_field_names: enum_field_names
+				alias_base_types: alias_base_types
+				struct_fields: struct_fields
+				struct_field_info: struct_field_info
+				sum_types: sum_types
+				constants: constants
+				public_constants: public_constants
+				globals: globals
+				public_globals: public_globals
+				selfhost: prefs.building_v
+				s: scanner.new_scanner(prefs, .normal)
+				out: strings.new_builder(0)
+				protos: strings.new_builder(0)
+				functions: functions
+				constant_types: constant_types
+				global_types: global_types
+				fixed_array_types: map[string]string{}
+				composite_types: map[string]bool{}
 			}
 			gen.s.init(file, field.default_source)
 			gen.next()
 			gen.expected_expression_type = field.typ
 			field.default_value = gen.read_expression([token.Token.semicolon, token.Token.eof])!
+			// A flag-enum default mixing a value with a `.member` shorthand (`~Show.zero() ^
+			// .name`) can lose the field type mid-stream (the `Show.zero()` call clears it), so
+			// resolve any surviving value-position shorthands against the field's enum type here.
+			if prefs.building_v && declared_kinds[gen.semantic_type_key(field.typ)] == .enum_ {
+				enum_c := field.typ.trim_right('*')
+				if members := enum_field_names[enum_c] {
+					field.default_value = fastc_resolve_enum_shorthands_in_source(field.default_value, enum_c, members)
+				}
+				// `show Show = ~Show.zero()`: lower the flag enum's magic zero()/all() statics.
+				field.default_value = gen.fastc_resolve_flag_enum_statics(field.default_value, enum_c)
+			}
 			// A variant literal (`value Primitive = Null{}`) defaulting a sum-type or
 			// interface field must be boxed into the field's representation, mirroring
 			// the assignment/argument paths; a bare `(Variant){}` is not assignable to a
 			// boxed `{_object,_typ,_methods}` field.
 			default_actual_type := gen.last_expression_type
 			if gen.should_box_variant(field.typ, default_actual_type) {
-				field.default_value = gen.interface_value_expression(field.typ,
-					default_actual_type, field.default_value)
+				field.default_value = gen.interface_value_expression(field.typ, default_actual_type, field.default_value)
 			}
 			if gen.tok == .semicolon {
 				gen.next()
@@ -1035,6 +1036,8 @@ struct FastcConstantGenContext {
 	alias_base_types          map[string]string
 	struct_fields             map[string]map[string]string
 	struct_field_info         map[string][]FastcStructField
+	sum_types                 map[string]bool
+	sum_type_variants         map[string]bool
 	functions                 map[string]FastcFunctionSignature
 	constants                 map[string]string
 	public_constants          map[string]bool
@@ -1069,69 +1072,71 @@ fn fastc_parse_constant_file(ctx &FastcConstantGenContext, source_file FastcSour
 	file := token.File.unindexed(source_file.path, constant_source.len)
 	prefs := ctx.prefs
 	mut gen := Parser{
-		prefs:                        unsafe { prefs }
-		unqualified_key_memo:         map[string]string{}
-		c_function_name_memo:         map[string]string{}
-		nonlocal_name_type_memo:      map[string]string{}
-		resolved_name_memo:           map[string]string{}
-		declared_type_key_memo:       map[string]FastcMemoEntry{}
-		path:                         source_file.path
-		module_name:                  source_file.header.module_name
-		imports:                      source_file.header.imports
-		declared_types:               ctx.declared_types
-		declared_type_c_names:        ctx.declared_type_c_names
-		declared_type_key_by_name:    ctx.declared_type_key_by_name
-		fastc_prefixed_c_names:       ctx.fastc_prefixed_c_names
+		prefs: unsafe { prefs }
+		unqualified_key_memo: map[string]string{}
+		c_function_name_memo: map[string]string{}
+		nonlocal_name_type_memo: map[string]string{}
+		resolved_name_memo: map[string]string{}
+		declared_type_key_memo: map[string]FastcMemoEntry{}
+		path: source_file.path
+		module_name: source_file.header.module_name
+		imports: source_file.header.imports
+		declared_types: ctx.declared_types
+		declared_type_c_names: ctx.declared_type_c_names
+		declared_type_key_by_name: ctx.declared_type_key_by_name
+		fastc_prefixed_c_names: ctx.fastc_prefixed_c_names
 		declaration_initializer_mode: true
-		has_c_functions:              ctx.has_c_functions
-		comparison_memo:              map[i64]FastcRenderedExpression{}
-		type_memo:                    map[i64]string{}
-		method_key_memo:              map[string]map[string]string{}
-		field_memo:                   map[string]map[string]FastcStructField{}
-		spawn_typedefs:               map[string]string{}
-		spawn_helpers:                map[string]string{}
-		thread_value_types:           map[string]string{}
-		declared_kinds:               ctx.declared_kinds
-		enum_flags:                   ctx.enum_flags
-		enum_field_types:             ctx.enum_field_types
-		alias_base_types:             ctx.alias_base_types
-		struct_fields:                ctx.struct_fields
-		struct_field_info:            ctx.struct_field_info
-		constants:                    ctx.constants
-		public_constants:             ctx.public_constants
-		globals:                      ctx.globals
-		public_globals:               ctx.public_globals
-		selfhost:                     prefs.building_v
-		s:                            scanner.new_scanner(prefs, .normal)
-		out:                          strings.new_builder(256)
-		protos:                       strings.new_builder(0)
-		functions:                    ctx.functions
-		constant_types:               constant_types
-		composite_types:              map[string]bool{}
-		fixed_array_types:            map[string]string{}
+		has_c_functions: ctx.has_c_functions
+		comparison_memo: map[i64]FastcRenderedExpression{}
+		type_memo: map[i64]string{}
+		method_key_memo: map[string]map[string]string{}
+		field_memo: map[string]map[string]FastcStructField{}
+		spawn_typedefs: map[string]string{}
+		spawn_helpers: map[string]string{}
+		thread_value_types: map[string]string{}
+		declared_kinds: ctx.declared_kinds
+		enum_flags: ctx.enum_flags
+		enum_field_types: ctx.enum_field_types
+		alias_base_types: ctx.alias_base_types
+		struct_fields: ctx.struct_fields
+		struct_field_info: ctx.struct_field_info
+		sum_types: ctx.sum_types
+		sum_type_variants: ctx.sum_type_variants
+		constants: ctx.constants
+		public_constants: ctx.public_constants
+		globals: ctx.globals
+		public_globals: ctx.public_globals
+		selfhost: prefs.building_v
+		s: scanner.new_scanner(prefs, .normal)
+		out: strings.new_builder(256)
+		protos: strings.new_builder(0)
+		functions: ctx.functions
+		constant_types: constant_types
+		composite_types: map[string]bool{}
+		fixed_array_types: map[string]string{}
 	}
 	gen.s.init(file, constant_source)
 	gen.next()
 	mut values := []FastcConstantValue{}
 	gen.parse_selected_constant_declarations(mut values, false) or {
 		return FastcConstantFileResult{
-			failed:        true
+			failed: true
 			error_message: err.msg()
 		}
 	}
 	if gen.s.diagnostics.len > 0 {
 		diagnostic := gen.s.diagnostics[0]
 		return FastcConstantFileResult{
-			failed:        true
+			failed: true
 			error_message: 'fastc scanner error at byte ${diagnostic.offset} in ${source_file.path}: ${diagnostic.message}'
 		}
 	}
 	return FastcConstantFileResult{
 		used_field_defaults: gen.used_field_defaults
-		values:              values
-		constant_types:      gen.constant_types.move()
-		composite_types:     gen.composite_types
-		fixed_array_types:   gen.fixed_array_types
+		values: values
+		constant_types: gen.constant_types.move()
+		composite_types: gen.composite_types
+		fixed_array_types: gen.fixed_array_types
 	}
 }
 
@@ -1159,32 +1164,7 @@ fn fastc_constant_file_is_independent(result FastcConstantFileResult) bool {
 // declarations are parsed as separate parallel candidates.
 const fastc_constant_split_size = 16 * 1024
 
-fn fastc_generate_constant_declarations(ordered_sources []FastcSourceFile, constant_sources map[string]string, constant_spans map[string][]int, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, mut pending_defaults FastcPendingFieldDefaults, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, globals map[string]string, public_globals map[string]bool, mut constant_types map[string]string) !FastcConstantDeclarations {
-	mut values := []FastcConstantValue{}
-	mut composite_types := map[string]bool{}
-	mut fixed_array_types := map[string]string{}
-	ctx := FastcConstantGenContext{
-		prefs:                     unsafe { prefs }
-		declared_types:            declared_types
-		declared_type_c_names:     declared_type_c_names
-		declared_type_key_by_name: fastc_declared_type_key_by_name(declared_types)
-		fastc_prefixed_c_names:    fastc_prefixed_c_names
-		has_c_functions:           fastc_functions_declare_c(functions)
-		declared_kinds:            declared_kinds
-		enum_flags:                enum_flags
-		enum_field_types:          enum_field_types
-		alias_base_types:          alias_base_types
-		struct_fields:             struct_fields
-		struct_field_info:         struct_field_info
-		functions:                 functions
-		constants:                 constants
-		public_constants:          public_constants
-		globals:                   globals
-		public_globals:            public_globals
-	}
-	// Candidates carry their filtered constant source as `source`, in module
-	// dependency order, so both the parallel pre-pass and the in-order merge
-	// below see the same files.
+fn fastc_constant_candidates(ordered_sources []FastcSourceFile, constant_sources map[string]string, constant_spans map[string][]int) []FastcSourceFile {
 	mut candidates := []FastcSourceFile{cap: ordered_sources.len}
 	for source_file in ordered_sources {
 		constant_source := constant_sources[source_file.path] or { continue }
@@ -1195,7 +1175,7 @@ fn fastc_generate_constant_declarations(ordered_sources []FastcSourceFile, const
 			// sees them in source order, as it would within one file.
 			for i := 0; i + 1 < spans.len; i += 2 {
 				candidates << FastcSourceFile{
-					path:   source_file.path
+					path: source_file.path
 					source: constant_source[spans[i]..spans[i + 1]]
 					header: source_file.header
 				}
@@ -1203,11 +1183,74 @@ fn fastc_generate_constant_declarations(ordered_sources []FastcSourceFile, const
 			continue
 		}
 		candidates << FastcSourceFile{
-			path:   source_file.path
+			path: source_file.path
 			source: constant_source
 			header: source_file.header
 		}
 	}
+	return candidates
+}
+
+// fastc_seed_constant_types parses constants in source order only to make their
+// types available to struct field defaults. It is used conditionally when a
+// default references a constant; the authoritative parallel pass still renders
+// and emits the declarations after the defaults are available.
+fn fastc_seed_constant_types(ctx &FastcConstantGenContext, candidates []FastcSourceFile, mut constant_types map[string]string) {
+	for candidate in candidates {
+		mut result := fastc_parse_constant_file(ctx, candidate, constant_types)
+		if result.failed {
+			return
+		}
+		constant_types = result.constant_types.move()
+	}
+}
+
+fn fastc_field_defaults_reference_constants(struct_field_info map[string][]FastcStructField, constants map[string]string) bool {
+	for fields in struct_field_info.values() {
+		for field in fields {
+			if field.default_source == '' {
+				continue
+			}
+			for key in constants.keys() {
+				name := key.all_after_last('.')
+				if fastc_replace_c_identifier(field.default_source, name, '') != field.default_source {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+fn fastc_generate_constant_declarations(ordered_sources []FastcSourceFile, constant_sources map[string]string, constant_spans map[string][]int, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, sum_types map[string]bool, sum_type_variants map[string]bool, mut pending_defaults FastcPendingFieldDefaults, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, globals map[string]string, public_globals map[string]bool, mut constant_types map[string]string) !FastcConstantDeclarations {
+	mut values := []FastcConstantValue{}
+	mut composite_types := map[string]bool{}
+	mut fixed_array_types := map[string]string{}
+	ctx := FastcConstantGenContext{
+		prefs: unsafe { prefs }
+		declared_types: declared_types
+		declared_type_c_names: declared_type_c_names
+		declared_type_key_by_name: fastc_declared_type_key_by_name(declared_types)
+		fastc_prefixed_c_names: fastc_prefixed_c_names
+		has_c_functions: fastc_functions_declare_c(functions)
+		declared_kinds: declared_kinds
+		enum_flags: enum_flags
+		enum_field_types: enum_field_types
+		alias_base_types: alias_base_types
+		struct_fields: struct_fields
+		struct_field_info: struct_field_info
+		sum_types: sum_types
+		sum_type_variants: sum_type_variants
+		functions: functions
+		constants: constants
+		public_constants: public_constants
+		globals: globals
+		public_globals: public_globals
+	}
+	// Candidates carry their filtered constant source as `source`, in module
+	// dependency order, so both the parallel pre-pass and the in-order merge
+	// below see the same files.
+	candidates := fastc_constant_candidates(ordered_sources, constant_sources, constant_spans)
 	sw := time.new_stopwatch()
 	parallel_results := fastc_parse_constant_files_parallel(&ctx, candidates, constant_types)
 	parallel_us := sw.elapsed().microseconds()
@@ -1215,23 +1258,25 @@ fn fastc_generate_constant_declarations(ordered_sources []FastcSourceFile, const
 	// the files that consulted them, and by the phases after this one.
 	defaults := fastc_wait_field_defaults(mut pending_defaults)!
 	merge_ctx := FastcConstantGenContext{
-		prefs:                     unsafe { prefs }
-		declared_types:            declared_types
-		declared_type_c_names:     declared_type_c_names
+		prefs: unsafe { prefs }
+		declared_types: declared_types
+		declared_type_c_names: declared_type_c_names
 		declared_type_key_by_name: ctx.declared_type_key_by_name
-		fastc_prefixed_c_names:    fastc_prefixed_c_names
-		has_c_functions:           ctx.has_c_functions
-		declared_kinds:            declared_kinds
-		enum_flags:                enum_flags
-		enum_field_types:          enum_field_types
-		alias_base_types:          alias_base_types
-		struct_fields:             struct_fields
-		struct_field_info:         defaults.struct_field_info
-		functions:                 functions
-		constants:                 constants
-		public_constants:          public_constants
-		globals:                   globals
-		public_globals:            public_globals
+		fastc_prefixed_c_names: fastc_prefixed_c_names
+		has_c_functions: ctx.has_c_functions
+		declared_kinds: declared_kinds
+		enum_flags: enum_flags
+		enum_field_types: enum_field_types
+		alias_base_types: alias_base_types
+		struct_fields: struct_fields
+		struct_field_info: defaults.struct_field_info
+		sum_types: sum_types
+		sum_type_variants: sum_type_variants
+		functions: functions
+		constants: constants
+		public_constants: public_constants
+		globals: globals
+		public_globals: public_globals
 	}
 	mut serial_count := 0
 	for index, candidate in candidates {
@@ -1312,8 +1357,7 @@ fn fastc_generate_constant_declarations(ordered_sources []FastcSourceFile, const
 	mut visited := []int{}
 	for i, value in values {
 		if value.key in runtime_constants {
-			fastc_append_runtime_constant(i, values, runtime_constants, mut visiting, mut visited, mut
-				initializer_order)!
+			fastc_append_runtime_constant(i, values, runtime_constants, mut visiting, mut visited, mut initializer_order)!
 		}
 	}
 	mut module_initializers := map[string]string{}
@@ -1329,13 +1373,13 @@ fn fastc_generate_constant_declarations(ordered_sources []FastcSourceFile, const
 		declarations.writeln('')
 	}
 	return FastcConstantDeclarations{
-		macros:              macros.str()
-		declarations:        declarations.str()
+		macros: macros.str()
+		declarations: declarations.str()
 		module_initializers: module_initializers
 		compile_time_values: compile_time_values
-		composite_types:     composite_types
-		fixed_array_types:   fixed_array_types
-		struct_field_info:   defaults.struct_field_info
+		composite_types: composite_types
+		fixed_array_types: fixed_array_types
+		struct_field_info: defaults.struct_field_info
 		struct_field_lookup: defaults.lookup
 	}
 }
@@ -1422,8 +1466,7 @@ fn fastc_append_runtime_constant(index int, values []FastcConstantValue, runtime
 		}
 		for dependency_index, value in values {
 			if value.key == dependency {
-				fastc_append_runtime_constant(dependency_index, values, runtime_constants, mut
-					visiting, mut visited, mut ordered)!
+				fastc_append_runtime_constant(dependency_index, values, runtime_constants, mut visiting, mut visited, mut ordered)!
 				break
 			}
 		}
@@ -1483,13 +1526,13 @@ fn (mut g Parser) parse_one_constant(mut values []FastcConstantValue, stops []to
 		return g.unsupported('unverifiable constant `${name}` type')
 	}
 	values << FastcConstantValue{
-		key:          key
-		c_name:       c_name
-		module_name:  g.module_name
-		value:        value
-		typ:          typ
+		key: key
+		c_name: c_name
+		module_name: g.module_name
+		value: value
+		typ: typ
 		dependencies: g.constant_expression_dependencies(g.last_expression)
-		is_runtime:   is_runtime
+		is_runtime: is_runtime
 	}
 	g.constant_types[key] = typ
 }
@@ -1500,8 +1543,7 @@ fn (g &Parser) constant_expression_dependencies(tokens []FastcExpressionToken) [
 		if item.tok != .name || (i > 0 && tokens[i - 1].tok == .dot) {
 			continue
 		}
-		if i + 1 < tokens.len && tokens[i + 1].tok == .lpar
-			&& fastc_primitive_c_type(item.lit) != none {
+		if i + 1 < tokens.len && tokens[i + 1].tok == .lpar && fastc_primitive_c_type(item.lit) != none {
 			continue
 		}
 		mut key := ''
@@ -1580,13 +1622,11 @@ mut:
 // fastc_run_type_declarations runs the type phase into fresh tables.
 fn fastc_run_type_declarations(sources []FastcSourceFile, type_sources map[string]string, prefs &pref.Preferences, type_source_paths map[string]bool, declared_types map[string]bool, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, constants map[string]string, public_constants map[string]bool) FastcTypeDeclarationResult {
 	mut result := FastcTypeDeclarationResult{
-		struct_fields:     map[string]map[string]string{}
+		struct_fields: map[string]map[string]string{}
 		struct_field_info: map[string][]FastcStructField{}
-		composite_types:   map[string]bool{}
+		composite_types: map[string]bool{}
 	}
-	result.output = fastc_generate_type_declarations(sources, type_sources, prefs,
-		type_source_paths, declared_types, declared_kinds, enum_flags, constants, public_constants, mut
-		result.struct_fields, mut result.struct_field_info, mut result.composite_types) or {
+	result.output = fastc_generate_type_declarations(sources, type_sources, prefs, type_source_paths, declared_types, declared_kinds, enum_flags, constants, public_constants, mut result.struct_fields, mut result.struct_field_info, mut result.composite_types) or {
 		result.failed = true
 		result.error_message = err.msg()
 		return result
@@ -1599,6 +1639,7 @@ fn fastc_generate_type_declarations(sources []FastcSourceFile, type_sources map[
 	mut bodies := strings.new_builder(4096)
 	mut enum_infos := []FastcEnumInfo{}
 	mut alias_base_types := map[string]string{}
+	mut fn_alias_return_types := map[string]string{}
 	mut sum_types := map[string]bool{}
 	mut sum_type_variants := map[string]bool{}
 	mut keys := declared_kinds.keys()
@@ -1609,7 +1650,9 @@ fn fastc_generate_type_declarations(sources []FastcSourceFile, type_sources map[
 		match declared_kinds[key] {
 			.struct_, .interface_ { out.writeln('typedef struct ${name} ${name};') }
 			.union_ { out.writeln('typedef union ${name} ${name};') }
-			.enum_ { out.writeln('typedef ${if enum_flags[key] { 'u64' } else { 'int' }} ${name};') }
+			.enum_ {
+				out.writeln('typedef ${if enum_flags[key] { 'u64' } else { 'int' }} ${name};')
+			}
 			.alias_ {}
 		}
 	}
@@ -1629,14 +1672,11 @@ fn fastc_generate_type_declarations(sources []FastcSourceFile, type_sources map[
 		}
 		type_source := type_sources[source_file.path] or { continue }
 		type_source_file := FastcSourceFile{
-			path:   source_file.path
+			path: source_file.path
 			source: type_source
 			header: source_file.header
 		}
-		fastc_emit_source_type_declarations(type_source_file, prefs, declared_types,
-			declared_kinds, constants, public_constants, mut struct_fields, mut struct_field_info, mut
-			composite_types, mut alias_base_types, mut sum_types, mut sum_type_variants, mut
-			enum_infos, mut bodies)!
+		fastc_emit_source_type_declarations(type_source_file, prefs, declared_types, declared_kinds, constants, public_constants, mut struct_fields, mut struct_field_info, mut composite_types, mut alias_base_types, mut fn_alias_return_types, mut sum_types, mut sum_type_variants, mut enum_infos, mut bodies)!
 	}
 	timer.mark('type_declarations.emit')
 	// The composite typedefs go here in the output; they are rendered by the
@@ -1655,8 +1695,7 @@ fn fastc_generate_type_declarations(sources []FastcSourceFile, type_sources map[
 				by_value_composite_names[fastc_c_declared_type_name(key)] = true
 			}
 		}
-		type_bodies = fastc_order_c_composite_definitions(type_bodies, struct_fields,
-			by_value_composite_names, alias_base_types)
+		type_bodies = fastc_order_c_composite_definitions(type_bodies, struct_fields, by_value_composite_names, alias_base_types)
 	}
 	timer.mark('type_declarations.order')
 	out.write_string(type_bodies)
@@ -1664,7 +1703,9 @@ fn fastc_generate_type_declarations(sources []FastcSourceFile, type_sources map[
 	// with `.field` shorthand keys (e.g. `{ .md_block_hr: 'hr' }`) can recover the
 	// key type. First declaration wins on the rare shared field name.
 	mut enum_field_types := map[string]string{}
+	mut enum_field_names := map[string][]string{}
 	for info in enum_infos {
+		enum_field_names[info.c_name] = info.fields.clone()
 		for field in info.fields {
 			if field !in enum_field_types {
 				enum_field_types[field] = info.c_name
@@ -1674,14 +1715,16 @@ fn fastc_generate_type_declarations(sources []FastcSourceFile, type_sources map[
 	enum_helper_names, enum_helper_texts := fastc_generate_enum_string_helpers(enum_infos)
 	timer.mark('type_declarations.enum_helpers')
 	return FastcTypeDeclarations{
-		declarations_head:   declarations_head
-		declarations:        out.str()
+		declarations_head: declarations_head
+		declarations: out.str()
 		enum_helper_names: enum_helper_names
 		enum_helper_texts: enum_helper_texts
-		alias_base_types:    alias_base_types
-		enum_field_types:    enum_field_types
-		sum_types:           sum_types
-		sum_type_variants:   sum_type_variants
+		alias_base_types: alias_base_types
+		fn_alias_return_types: fn_alias_return_types
+		enum_field_types: enum_field_types
+		enum_field_names: enum_field_names
+		sum_types: sum_types
+		sum_type_variants: sum_type_variants
 	}
 }
 
@@ -1727,8 +1770,7 @@ fn fastc_order_c_composite_definitions(source string, struct_fields map[string]m
 		passes++
 		for dependent, fields in struct_fields {
 			for _, field_type in fields {
-				dependency := fastc_by_value_composite_type(field_type, by_value_composite_names,
-					alias_base_types)
+				dependency := fastc_by_value_composite_type(field_type, by_value_composite_names, alias_base_types)
 				if dependency == '' || dependency == dependent {
 					continue
 				}
@@ -1742,8 +1784,7 @@ fn fastc_order_c_composite_definitions(source string, struct_fields map[string]m
 				if next != ordered {
 					ordered = next
 					changed = true
-					fastc_shift_composite_positions(mut positions, dependency_start, block_end,
-						dependent_start)
+					fastc_shift_composite_positions(mut positions, dependency_start, block_end, dependent_start)
 				}
 			}
 		}
@@ -1785,12 +1826,9 @@ fn fastc_composite_definition_positions(source string) map[string]int {
 	for i < source.len {
 		c := source[i]
 		mut keyword_len := 0
-		if c == `s` && i + 7 <= source.len && source[i + 1] == `t` && source[i + 2] == `r`
-			&& source[i + 3] == `u` && source[i + 4] == `c` && source[i + 5] == `t`
-			&& source[i + 6] == ` ` {
+		if c == `s` && i + 7 <= source.len && source[i + 1] == `t` && source[i + 2] == `r` && source[i + 3] == `u` && source[i + 4] == `c` && source[i + 5] == `t` && source[i + 6] == ` ` {
 			keyword_len = 7
-		} else if c == `u` && i + 6 <= source.len && source[i + 1] == `n` && source[i + 2] == `i`
-			&& source[i + 3] == `o` && source[i + 4] == `n` && source[i + 5] == ` ` {
+		} else if c == `u` && i + 6 <= source.len && source[i + 1] == `n` && source[i + 2] == `i` && source[i + 3] == `o` && source[i + 4] == `n` && source[i + 5] == ` ` {
 			keyword_len = 6
 		}
 		if keyword_len == 0 {
@@ -1814,8 +1852,7 @@ fn fastc_composite_definition_positions(source string) map[string]int {
 }
 
 fn fastc_by_value_composite_type(field_type string, by_value_composite_names map[string]bool, alias_base_types map[string]string) string {
-	if field_type.ends_with('*') || field_type.starts_with('Array_')
-		|| field_type.starts_with('Map_') {
+	if field_type.ends_with('*') || field_type.starts_with('Array_') || field_type.starts_with('Map_') {
 		return ''
 	}
 	mut candidate := field_type
@@ -1849,8 +1886,7 @@ fn fastc_move_c_composite_before(source string, dependency_start int, dependent_
 	}
 	end := fastc_c_composite_block_end(source, dependency_start) or { return source }
 	block := source[dependency_start..end]
-	return source[..dependent_start] + block + source[dependent_start..dependency_start] +
-		source[end..]
+	return source[..dependent_start] + block + source[dependent_start..dependency_start] + source[end..]
 }
 
 fn fastc_c_composite_definition_end(source string, start int) ?int {
@@ -1864,7 +1900,7 @@ fn fastc_c_composite_definition_end(source string, start int) ?int {
 	return none
 }
 
-fn fastc_emit_source_type_declarations(source_file FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_kinds map[string]FastcDeclaredTypeKind, constants map[string]string, public_constants map[string]bool, mut struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, mut composite_types map[string]bool, mut alias_base_types map[string]string, mut sum_types map[string]bool, mut sum_type_variants map[string]bool, mut enum_infos []FastcEnumInfo, mut out strings.Builder) ! {
+fn fastc_emit_source_type_declarations(source_file FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_kinds map[string]FastcDeclaredTypeKind, constants map[string]string, public_constants map[string]bool, mut struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, mut composite_types map[string]bool, mut alias_base_types map[string]string, mut fn_alias_return_types map[string]string, mut sum_types map[string]bool, mut sum_type_variants map[string]bool, mut enum_infos []FastcEnumInfo, mut out strings.Builder) ! {
 	file := token.File.unindexed(source_file.path, source_file.source.len)
 	mut scan := scanner.new_scanner(prefs, .normal)
 	scan.init(file, source_file.source)
@@ -1876,18 +1912,14 @@ fn fastc_emit_source_type_declarations(source_file FastcSourceFile, prefs &pref.
 		if depth == 0 && tok == .dollar {
 			mut lookahead := scan
 			if lookahead.scan() == .key_if {
-				selected := fastc_scan_selected_comptime_branch(mut scan, scan.scan(),
-					source_file.path, prefs)!
+				selected := fastc_scan_selected_comptime_branch(mut scan, scan.scan(), source_file.path, prefs)!
 				if selected.source != '' {
 					selected_source := FastcSourceFile{
-						path:   source_file.path
+						path: source_file.path
 						source: selected.source
 						header: source_file.header
 					}
-					fastc_emit_source_type_declarations(selected_source, prefs, declared_types,
-						declared_kinds, constants, public_constants, mut struct_fields, mut
-						struct_field_info, mut composite_types, mut alias_base_types, mut
-						sum_types, mut sum_type_variants, mut enum_infos, mut out)!
+					fastc_emit_source_type_declarations(selected_source, prefs, declared_types, declared_kinds, constants, public_constants, mut struct_fields, mut struct_field_info, mut composite_types, mut alias_base_types, mut fn_alias_return_types, mut sum_types, mut sum_type_variants, mut enum_infos, mut out)!
 				}
 				tok = selected.tok
 				next_enum_is_flag = false
@@ -1904,24 +1936,29 @@ fn fastc_emit_source_type_declarations(source_file FastcSourceFile, prefs &pref.
 		if depth == 0 && tok in [.key_fn, .key_const, .key_global] {
 			next_enum_is_flag = false
 			next_type_is_enabled = true
+			if tok == .key_fn {
+				// A function or method whose name is itself a keyword
+				// (`fn (e Expr) type() Type`) tokenizes that name as e.g. `.key_type`.
+				// Skip the receiver, name, and parameter lists so the keyword name is
+				// never mistaken for a top-level type declaration.
+				tok = fastc_skip_function_header(mut scan)!
+				continue
+			}
 		}
-		if depth == 0 && !next_type_is_enabled
-			&& tok in [.key_struct, .key_union, .key_enum, .key_interface, .key_type] {
+		if depth == 0 && !next_type_is_enabled && tok in [.key_struct, .key_union, .key_enum,
+			.key_interface, .key_type] {
 			tok = fastc_skip_type_declaration(mut scan, tok)!
 			next_enum_is_flag = false
 			next_type_is_enabled = true
 			continue
 		}
 		if depth == 0 && tok in [.key_struct, .key_union] {
-			tok = fastc_emit_struct_declaration(mut scan, tok == .key_union, source_file,
-				declared_types, prefs.building_v, mut struct_fields, mut struct_field_info, mut
-				composite_types, mut out)!
+			tok = fastc_emit_struct_declaration(mut scan, tok == .key_union, source_file, declared_types, prefs.building_v, mut struct_fields, mut struct_field_info, mut composite_types, mut out)!
 			next_type_is_enabled = true
 			continue
 		}
 		if depth == 0 && tok == .key_enum {
-			tok = fastc_emit_enum_declaration(mut scan, source_file, next_enum_is_flag,
-				declared_types, declared_kinds, constants, public_constants, mut enum_infos, mut out)!
+			tok = fastc_emit_enum_declaration(mut scan, source_file, next_enum_is_flag, declared_types, declared_kinds, constants, public_constants, mut enum_infos, mut out)!
 			next_enum_is_flag = false
 			next_type_is_enabled = true
 			continue
@@ -1932,9 +1969,7 @@ fn fastc_emit_source_type_declarations(source_file FastcSourceFile, prefs &pref.
 			continue
 		}
 		if depth == 0 && tok == .key_type {
-			tok = fastc_emit_alias_declaration(mut scan, source_file, declared_types,
-				declared_kinds, prefs.building_v, mut struct_fields, mut struct_field_info, mut
-				alias_base_types, mut sum_types, mut sum_type_variants, mut out)!
+			tok = fastc_emit_alias_declaration(mut scan, source_file, declared_types, declared_kinds, prefs.building_v, mut struct_fields, mut struct_field_info, mut alias_base_types, mut fn_alias_return_types, mut sum_types, mut sum_type_variants, mut out)!
 			next_type_is_enabled = true
 			continue
 		}
@@ -1947,12 +1982,46 @@ fn fastc_emit_source_type_declarations(source_file FastcSourceFile, prefs &pref.
 	}
 }
 
+// fastc_skip_function_header consumes a top-level function's receiver, name, and
+// generic/value parameter lists starting right after the `fn` keyword. It exists
+// so that a method or function whose name is a V keyword (e.g. `type`, `map`) is
+// not mistaken for a top-level type declaration by the declaration scanner. It
+// returns the first token after the parameter list (the return type or body).
+fn fastc_skip_function_header(mut scan scanner.Scanner) !token.Token {
+	mut tok := scan.scan()
+	if tok == .lpar {
+		// Method receiver, e.g. `(e Expr)`.
+		tok = fastc_skip_balanced_tokens(mut scan, tok, .lpar, .rpar)!
+	}
+	// The name may be `C.free`, a plain identifier, an operator overload token, or
+	// a keyword used as a method name. Consume exactly the name here.
+	if tok == .name && scan.lit == 'C' {
+		tok = scan.scan()
+		if tok == .dot {
+			tok = scan.scan()
+			tok = scan.scan()
+		}
+	} else if tok != .eof && tok != .lpar && tok != .lsbr {
+		tok = scan.scan()
+	}
+	if tok == .lsbr {
+		// Generic type parameters, e.g. `[T]`.
+		tok = fastc_skip_balanced_tokens(mut scan, tok, .lsbr, .rsbr)!
+	}
+	if tok == .lpar {
+		// Value parameters.
+		tok = fastc_skip_balanced_tokens(mut scan, tok, .lpar, .rpar)!
+	}
+	return tok
+}
+
 fn fastc_scan_declaration_attribute(mut scan scanner.Scanner, path string, prefs &pref.Preferences) !FastcDeclarationAttribute {
 	mut tok := scan.scan()
 	mut depth := 1
 	mut is_flag := false
 	mut is_params := false
 	mut is_typedef := false
+	mut is_c_extern := false
 	mut is_enabled := true
 	mut at_item_start := true
 	for depth > 0 {
@@ -1977,6 +2046,9 @@ fn fastc_scan_declaration_attribute(mut scan scanner.Scanner, path string, prefs
 		if tok == .name && scan.lit == 'typedef' {
 			is_typedef = true
 		}
+		if tok == .name && scan.lit == 'c_extern' {
+			is_c_extern = true
+		}
 		if depth == 1 && tok == .semicolon {
 			at_item_start = true
 		} else if depth == 1 {
@@ -1990,11 +2062,12 @@ fn fastc_scan_declaration_attribute(mut scan scanner.Scanner, path string, prefs
 		tok = scan.scan()
 	}
 	return FastcDeclarationAttribute{
-		tok:        tok
+		tok: tok
 		is_enabled: is_enabled
-		is_flag:    is_flag
-		is_params:  is_params
+		is_flag: is_flag
+		is_params: is_params
 		is_typedef: is_typedef
+		is_c_extern: is_c_extern
 	}
 }
 
@@ -2125,8 +2198,7 @@ fn fastc_emit_struct_declaration(mut scan scanner.Scanner, is_union bool, source
 			embedded_key := if qualified_embed_key != '' {
 				qualified_embed_key
 			} else {
-				fastc_resolve_declared_type_key(source_file.header.module_name, field_names[0],
-					source_file.header.imports, declared_types) or {
+				fastc_resolve_declared_type_key(source_file.header.module_name, field_names[0], source_file.header.imports, declared_types) or {
 					return error('fastc parser does not support embedded field `${field_names[0]}` in ${source_file.path}')
 				}
 			}
@@ -2135,11 +2207,12 @@ fn fastc_emit_struct_declaration(mut scan scanner.Scanner, is_union bool, source
 			}
 			fields_by_name['__embedded_${embedded_id}'] = fastc_c_declared_type_name(embedded_key)
 			field_info << FastcStructField{
-				name:        '__embedded_${embedded_id}'
-				typ:         fastc_c_declared_type_name(embedded_key)
-				is_public:   true
+				name: '__embedded_${embedded_id}'
+				typ: fastc_c_declared_type_name(embedded_key)
+				is_public: true
 				module_name: source_file.header.module_name
-				path:        source_file.path
+				path: source_file.path
+				imports: source_file.header.imports.clone()
 			}
 			embedded_id++
 			fields++
@@ -2148,21 +2221,22 @@ fn fastc_emit_struct_declaration(mut scan scanner.Scanner, is_union bool, source
 			}
 			continue
 		}
+		mut is_shared_field := false
+		if tok == .key_shared {
+			// FastC does not emit mutex operations yet, but shared maps still need reference
+			// identity: a copied owner must update the same map header as the original owner.
+			is_shared_field = true
+			tok = scan.scan()
+		}
 		mut field_chan_element := ''
 		if tok == .name && scan.lit == 'chan' {
-			field_chan_element = fastc_peek_chan_element(scan, source_file.path,
-				source_file.header.module_name, source_file.header.imports, declared_types,
-				allow_short_placeholders)
+			field_chan_element = fastc_peek_chan_element(scan, source_file.path, source_file.header.module_name, source_file.header.imports, declared_types, allow_short_placeholders)
 		}
 		mut field_option_value := ''
 		if tok == .question {
-			field_option_value = fastc_peek_option_element(scan, source_file.path,
-				source_file.header.module_name, source_file.header.imports, declared_types,
-				allow_short_placeholders)
+			field_option_value = fastc_peek_option_element(scan, source_file.path, source_file.header.module_name, source_file.header.imports, declared_types, allow_short_placeholders)
 		}
-		field_generic_argument := fastc_peek_generic_type_argument(tok, scan, source_file.path,
-			source_file.header.module_name, source_file.header.imports, declared_types,
-			allow_short_placeholders)
+		field_generic_argument := fastc_peek_generic_type_argument(tok, scan, source_file.path, source_file.header.module_name, source_file.header.imports, declared_types, allow_short_placeholders)
 		mut is_optional_function := false
 		mut function_scan := scan
 		if tok == .question && function_scan.scan() == .key_fn {
@@ -2171,13 +2245,9 @@ fn fastc_emit_struct_declaration(mut scan scanner.Scanner, is_union bool, source
 		is_function_field := tok == .key_fn || is_optional_function
 		mut function_type := FastcFunctionTypeInfo{}
 		if is_function_field {
-			function_type = fastc_peek_function_type(function_scan, source_file.path,
-				source_file.header.module_name, source_file.header.imports, declared_types,
-				allow_short_placeholders)!
+			function_type = fastc_peek_function_type(function_scan, source_file.path, source_file.header.module_name, source_file.header.imports, declared_types, allow_short_placeholders)!
 		}
-		field_type, next_token := fastc_scan_type(mut scan, tok, source_file.path,
-			source_file.header.module_name, source_file.header.imports, declared_types,
-			allow_short_placeholders) or {
+		field_type, next_token := fastc_scan_type(mut scan, tok, source_file.path, source_file.header.module_name, source_file.header.imports, declared_types, allow_short_placeholders) or {
 			return error('fastc struct `${name}` field `${field_names[0]}`: ${err.msg()}')
 		}
 		tok = next_token
@@ -2187,8 +2257,7 @@ fn fastc_emit_struct_declaration(mut scan scanner.Scanner, is_union bool, source
 		for tok == .attribute {
 			mut attribute_is_required := false
 			mut attribute_is_skip := false
-			tok, attribute_is_required, attribute_is_skip =
-				fastc_scan_struct_field_attribute(mut scan)!
+			tok, attribute_is_required, attribute_is_skip = fastc_scan_struct_field_attribute(mut scan)!
 			is_required = is_required || attribute_is_required
 			is_skip = is_skip || attribute_is_skip
 		}
@@ -2197,8 +2266,7 @@ fn fastc_emit_struct_declaration(mut scan scanner.Scanner, is_union bool, source
 			first_default_token := scan.scan()
 			default_start := scan.pos
 			tok = fastc_skip_field_default_from_token(mut scan, first_default_token)!
-			default_source =
-				source_file.source[default_start..scan.pos].trim_space().trim_right(';').trim_space()
+			default_source = source_file.source[default_start..scan.pos].trim_space().trim_right(';').trim_space()
 			if default_source == '' {
 				return error('fastc parser does not support empty default for struct `${name}` field `${field_names[0]}` in ${source_file.path}')
 			}
@@ -2210,17 +2278,17 @@ fn fastc_emit_struct_declaration(mut scan scanner.Scanner, is_union bool, source
 			// parameters. json2's private linked list has a single concrete payload,
 			// `ValueInfo`; retain that layout so non-generic Decoder methods can access
 			// `current_node.value` as the declared struct.
-			if name == 'Node' && field_name == 'value' && field_type == 'voidptr'
-				&& source_file.path.ends_with('/vlib/json2/decode.v') {
+			if name == 'Node' && field_name == 'value' && field_type == 'voidptr' && source_file.path.ends_with('/vlib/json2/decode.v') {
 				value_info_key := fastc_type_key(source_file.header.module_name, 'ValueInfo')
 				if value_info_key in declared_types {
 					emitted_field_type = fastc_c_declared_type_name(value_info_key)
 				}
 			}
+			is_shared_pointer := is_shared_field && emitted_field_type.starts_with('Map_')
 			if !is_c_struct {
-				if declaration := fastc_fixed_array_field_declaration(emitted_field_type,
-					c_field_name)
-				{
+				if is_shared_pointer {
+					out.writeln('\t${emitted_field_type}* ${c_field_name};')
+				} else if declaration := fastc_fixed_array_field_declaration(emitted_field_type, c_field_name) {
 					out.writeln('\t${declaration};')
 				} else {
 					out.writeln('\t${fastc_output_c_type(emitted_field_type)} ${c_field_name};')
@@ -2228,22 +2296,24 @@ fn fastc_emit_struct_declaration(mut scan scanner.Scanner, is_union bool, source
 			}
 			fields_by_name[field_name] = emitted_field_type
 			field_info << FastcStructField{
-				name:                  field_name
-				typ:                   emitted_field_type
-				is_public:             fields_are_public
-				is_mutable:            fields_are_mutable
-				is_required:           is_required
-				is_skip:               is_skip
-				is_function:           is_function_field
-				is_optional_function:  is_optional_function
-				module_name:           source_file.header.module_name
-				path:                  source_file.path
-				default_source:        default_source
-				chan_element_type:     field_chan_element
-				option_value_type:     field_option_value
-				fn_parameter_types:    function_type.parameter_types.clone()
-				fn_return_type:        function_type.return_type
-				fn_option_value_type:  function_type.option_value_type
+				name: field_name
+				typ: emitted_field_type
+				is_public: fields_are_public
+				is_mutable: fields_are_mutable
+				is_required: is_required
+				is_skip: is_skip
+				is_function: is_function_field
+				is_optional_function: is_optional_function
+				is_shared_pointer: is_shared_pointer
+				module_name: source_file.header.module_name
+				path: source_file.path
+				imports: source_file.header.imports.clone()
+				default_source: default_source
+				chan_element_type: field_chan_element
+				option_value_type: field_option_value
+				fn_parameter_types: function_type.parameter_types.clone()
+				fn_return_type: function_type.return_type
+				fn_option_value_type: function_type.option_value_type
 				generic_argument_type: field_generic_argument
 			}
 			fields++
@@ -2262,11 +2332,12 @@ fn fastc_emit_struct_declaration(mut scan scanner.Scanner, is_union bool, source
 		out.writeln('\tvoid *data;')
 		fields_by_name['data'] = 'voidptr'
 		field_info << FastcStructField{
-			name:        'data'
-			typ:         'voidptr'
-			is_public:   true
+			name: 'data'
+			typ: 'voidptr'
+			is_public: true
 			module_name: source_file.header.module_name
-			path:        source_file.path
+			path: source_file.path
+			imports: source_file.header.imports.clone()
 		}
 	}
 	if !is_c_struct {
@@ -2395,8 +2466,8 @@ fn fastc_emit_enum_declaration(mut scan scanner.Scanner, source_file FastcSource
 		// Accept any integer backing type (`as u32`, `as u8`, ...). The C typedef is
 		// still `int` (or `u64` for flag enums); values are emitted with an explicit
 		// cast, so a narrower/wider spelling does not change the generated C.
-		is_backing_int := tok == .name
-			&& scan.lit in ['i8', 'i16', 'i32', 'i64', 'int', 'u8', 'u16', 'u32', 'u64', 'isize', 'usize']
+		is_backing_int := tok == .name && scan.lit in ['i8', 'i16', 'i32', 'i64', 'int', 'u8', 'u16',
+			'u32', 'u64', 'isize', 'usize']
 		if !is_backing_int || (is_flag && scan.lit != 'u64') {
 			return error('fastc parser does not support enum `${name}` backing type in ${source_file.path}')
 		}
@@ -2440,8 +2511,7 @@ fn fastc_emit_enum_declaration(mut scan scanner.Scanner, source_file FastcSource
 				symbolic_value = ''
 				symbolic_offset = 0
 			} else {
-				symbolic_value = fastc_render_enum_value_expression(value_tokens, source_file,
-					c_name, fields, declared_types, declared_kinds, constants, public_constants)!
+				symbolic_value = fastc_render_enum_value_expression(value_tokens, source_file, c_name, fields, declared_types, declared_kinds, constants, public_constants)!
 				symbolic_offset = 0
 			}
 		}
@@ -2469,9 +2539,9 @@ fn fastc_emit_enum_declaration(mut scan scanner.Scanner, source_file FastcSource
 		return error('fastc parser does not support unfinished enum `${name}` in ${source_file.path}')
 	}
 	enum_infos << FastcEnumInfo{
-		c_name:  c_name
-		name:    name
-		fields:  field_names.clone()
+		c_name: c_name
+		name: name
+		fields: field_names.clone()
 		is_flag: is_flag
 	}
 	return scan.scan()
@@ -2517,8 +2587,7 @@ fn fastc_enum_integer_literal(tokens []FastcExpressionToken) ?int {
 }
 
 fn fastc_render_enum_value_expression(tokens []FastcExpressionToken, source_file FastcSourceFile, enum_c_name string, fields map[string]bool, declared_types map[string]bool, declared_kinds map[string]FastcDeclaredTypeKind, constants map[string]string, public_constants map[string]bool) !string {
-	value, next := fastc_render_enum_binary_expression(tokens, 0, 1, source_file, enum_c_name,
-		fields, declared_types, declared_kinds, constants, public_constants)!
+	value, next := fastc_render_enum_binary_expression(tokens, 0, 1, source_file, enum_c_name, fields, declared_types, declared_kinds, constants, public_constants)!
 	if next != tokens.len {
 		return error('fastc parser does not support enum discriminant `${fastc_expression_tokens_debug(tokens)}` in ${source_file.path}')
 	}
@@ -2526,18 +2595,17 @@ fn fastc_render_enum_value_expression(tokens []FastcExpressionToken, source_file
 }
 
 fn fastc_render_enum_binary_expression(tokens []FastcExpressionToken, start int, minimum_precedence int, source_file FastcSourceFile, enum_c_name string, fields map[string]bool, declared_types map[string]bool, declared_kinds map[string]FastcDeclaredTypeKind, constants map[string]string, public_constants map[string]bool) !(string, int) {
-	mut left, mut next := fastc_render_enum_unary_expression(tokens, start, source_file,
-		enum_c_name, fields, declared_types, declared_kinds, constants, public_constants)!
+	initial_left, initial_next := fastc_render_enum_unary_expression(tokens, start, source_file, enum_c_name, fields, declared_types, declared_kinds, constants, public_constants)!
+	mut left := initial_left
+	mut next := initial_next
 	for next < tokens.len {
 		operator := tokens[next].tok
 		precedence := int(operator.left_binding_power())
-		if precedence < minimum_precedence
-			|| operator !in [.plus, .minus, .mul, .div, .mod, .pipe, .xor, .amp, .left_shift, .right_shift] {
+		if precedence < minimum_precedence || operator !in [.plus, .minus, .mul, .div, .mod, .pipe,
+			.xor, .amp, .left_shift, .right_shift] {
 			break
 		}
-		right, after_right := fastc_render_enum_binary_expression(tokens, next + 1,
-			int(operator.right_binding_power()), source_file, enum_c_name, fields, declared_types,
-			declared_kinds, constants, public_constants)!
+		right, after_right := fastc_render_enum_binary_expression(tokens, next + 1, int(operator.right_binding_power()), source_file, enum_c_name, fields, declared_types, declared_kinds, constants, public_constants)!
 		left = '((${left}) ${operator.str()} (${right}))'
 		next = after_right
 	}
@@ -2549,13 +2617,11 @@ fn fastc_render_enum_unary_expression(tokens []FastcExpressionToken, start int, 
 		return error('fastc parser does not support an incomplete enum discriminant in ${source_file.path}')
 	}
 	if tokens[start].tok in [.plus, .minus, .bit_not] {
-		value, next := fastc_render_enum_unary_expression(tokens, start + 1, source_file,
-			enum_c_name, fields, declared_types, declared_kinds, constants, public_constants)!
+		value, next := fastc_render_enum_unary_expression(tokens, start + 1, source_file, enum_c_name, fields, declared_types, declared_kinds, constants, public_constants)!
 		return '(${tokens[start].tok.str()}(${value}))', next
 	}
 	if tokens[start].tok == .lpar {
-		value, next := fastc_render_enum_binary_expression(tokens, start + 1, 1, source_file,
-			enum_c_name, fields, declared_types, declared_kinds, constants, public_constants)!
+		value, next := fastc_render_enum_binary_expression(tokens, start + 1, 1, source_file, enum_c_name, fields, declared_types, declared_kinds, constants, public_constants)!
 		if next >= tokens.len || tokens[next].tok != .rpar {
 			return error('fastc parser does not support an unbalanced enum discriminant in ${source_file.path}')
 		}
@@ -2565,8 +2631,7 @@ fn fastc_render_enum_unary_expression(tokens []FastcExpressionToken, start int, 
 	// integers, so render `((int)(<inner>))`.
 	if tokens[start].tok == .name && start + 1 < tokens.len && tokens[start + 1].tok == .lpar {
 		if c_type := fastc_primitive_c_type(tokens[start].lit) {
-			value, next := fastc_render_enum_binary_expression(tokens, start + 2, 1, source_file,
-				enum_c_name, fields, declared_types, declared_kinds, constants, public_constants)!
+			value, next := fastc_render_enum_binary_expression(tokens, start + 2, 1, source_file, enum_c_name, fields, declared_types, declared_kinds, constants, public_constants)!
 			if next >= tokens.len || tokens[next].tok != .rpar {
 				return error('fastc parser does not support an unbalanced enum discriminant in ${source_file.path}')
 			}
@@ -2576,26 +2641,22 @@ fn fastc_render_enum_unary_expression(tokens []FastcExpressionToken, start int, 
 	if tokens[start].tok == .number {
 		return fastc_c_number(tokens[start].lit)!, start + 1
 	}
-	return fastc_render_enum_symbol(tokens, start, source_file, enum_c_name, fields,
-		declared_types, declared_kinds, constants, public_constants)
+	return fastc_render_enum_symbol(tokens, start, source_file, enum_c_name, fields, declared_types, declared_kinds, constants, public_constants)
 }
 
 fn fastc_render_enum_symbol(tokens []FastcExpressionToken, start int, source_file FastcSourceFile, enum_c_name string, fields map[string]bool, declared_types map[string]bool, declared_kinds map[string]FastcDeclaredTypeKind, constants map[string]string, public_constants map[string]bool) !(string, int) {
-	if tokens[start].tok == .dot && start + 1 < tokens.len && tokens[start + 1].tok == .name
-		&& tokens[start + 1].lit in fields {
+	if tokens[start].tok == .dot && start + 1 < tokens.len && tokens[start + 1].tok == .name && tokens[start + 1].lit in fields {
 		return '${enum_c_name}__${tokens[start + 1].lit}', start + 2
 	}
 	if tokens[start].tok != .name {
 		return error('fastc parser does not support enum discriminant token `${tokens[start].tok.str()}` in ${source_file.path}')
 	}
 	name := tokens[start].lit
-	if start + 4 < tokens.len && tokens[start + 1].tok == .dot && tokens[start + 2].tok == .name
-		&& tokens[start + 3].tok == .dot && tokens[start + 4].tok == .name {
+	if start + 4 < tokens.len && tokens[start + 1].tok == .dot && tokens[start + 2].tok == .name && tokens[start + 3].tok == .dot && tokens[start + 4].tok == .name {
 		if imported_module := source_file.header.imports[name] {
 			type_key := fastc_type_key(imported_module, tokens[start + 2].lit)
 			if declared_types[type_key] && declared_kinds[type_key] == .enum_ {
-				return '${fastc_c_declared_type_name(type_key)}__${tokens[start + 4].lit}', start +
-					5
+				return '${fastc_c_declared_type_name(type_key)}__${tokens[start + 4].lit}', start + 5
 			}
 		}
 	}
@@ -2613,8 +2674,7 @@ fn fastc_render_enum_symbol(tokens []FastcExpressionToken, start int, source_fil
 				return c_name, start + 3
 			}
 		}
-		type_key := fastc_resolve_declared_type_key(source_file.header.module_name, name,
-			source_file.header.imports, declared_types) or { '' }
+		type_key := fastc_resolve_declared_type_key(source_file.header.module_name, name, source_file.header.imports, declared_types) or { '' }
 		if type_key != '' && declared_kinds[type_key] == .enum_ {
 			return '${fastc_c_declared_type_name(type_key)}__${member}', start + 3
 		}
@@ -2706,6 +2766,18 @@ fn fastc_generate_enum_string_helpers(infos []FastcEnumInfo) ([]string, []string
 		print_out.writeln('')
 		names << 'v_fastc_print_enum_${info.c_name}'
 		texts << print_out.str()
+		mut from_out := strings.new_builder(256)
+		// `Enum.from_string(s)` maps a field-name string back to its value, returning
+		// `?Enum` (none when no field name matches).
+		from_out.writeln('static Option ${info.c_name}__from_string(string __v_fastc_from) {')
+		for field in info.fields {
+			from_out.writeln('\tif (builtin__string_eq(__v_fastc_from, _S("${field}"))) { ${info.c_name} __v_fastc_value = ${info.c_name}__${field}; return (Option){.data=v_fastc_interface_box(&__v_fastc_value, sizeof(${info.c_name})), .state=0}; }')
+		}
+		from_out.writeln('\treturn (Option){.state=2};')
+		from_out.writeln('}')
+		from_out.writeln('')
+		names << '${info.c_name}__from_string'
+		texts << from_out.str()
 	}
 	return names, texts
 }
@@ -2727,7 +2799,7 @@ fn fastc_emit_interface_declaration(mut scan scanner.Scanner, source_file FastcS
 	return tok
 }
 
-fn fastc_emit_alias_declaration(mut scan scanner.Scanner, source_file FastcSourceFile, declared_types map[string]bool, declared_kinds map[string]FastcDeclaredTypeKind, allow_short_placeholders bool, mut struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, mut alias_base_types map[string]string, mut sum_types map[string]bool, mut sum_type_variants map[string]bool, mut out strings.Builder) !token.Token {
+fn fastc_emit_alias_declaration(mut scan scanner.Scanner, source_file FastcSourceFile, declared_types map[string]bool, declared_kinds map[string]FastcDeclaredTypeKind, allow_short_placeholders bool, mut struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, mut alias_base_types map[string]string, mut fn_alias_return_types map[string]string, mut sum_types map[string]bool, mut sum_type_variants map[string]bool, mut out strings.Builder) !token.Token {
 	mut tok := scan.scan()
 	if tok != .name {
 		return error('fastc parser does not support type alias in ${source_file.path}')
@@ -2761,12 +2833,9 @@ fn fastc_emit_alias_declaration(mut scan scanner.Scanner, source_file FastcSourc
 	}
 	tok = scan.scan()
 	if tok == .key_fn {
-		return fastc_emit_function_alias(mut scan, source_file, declared_types,
-			allow_short_placeholders, c_name, mut out)
+		return fastc_emit_function_alias(mut scan, source_file, declared_types, allow_short_placeholders, c_name, mut fn_alias_return_types, mut out)
 	}
-	base, next_token := fastc_scan_type(mut scan, tok, source_file.path,
-		source_file.header.module_name, source_file.header.imports, declared_types,
-		allow_short_placeholders) or { return error('fastc type `${name}`: ${err.msg()}') }
+	base, next_token := fastc_scan_type(mut scan, tok, source_file.path, source_file.header.module_name, source_file.header.imports, declared_types, allow_short_placeholders) or { return error('fastc type `${name}`: ${err.msg()}') }
 	tok = next_token
 	if tok == .semicolon {
 		tok = scan.scan()
@@ -2779,9 +2848,7 @@ fn fastc_emit_alias_declaration(mut scan scanner.Scanner, source_file FastcSourc
 		sum_type_variants['${c_name}|${base.trim_right('*')}'] = true
 		for tok == .pipe {
 			tok = scan.scan()
-			variant, variant_next := fastc_scan_type(mut scan, tok, source_file.path,
-				source_file.header.module_name, source_file.header.imports, declared_types,
-				allow_short_placeholders) or { return error('fastc type `${name}`: ${err.msg()}') }
+			variant, variant_next := fastc_scan_type(mut scan, tok, source_file.path, source_file.header.module_name, source_file.header.imports, declared_types, allow_short_placeholders) or { return error('fastc type `${name}`: ${err.msg()}') }
 			sum_type_variants['${c_name}|${variant.trim_right('*')}'] = true
 			tok = variant_next
 			if tok == .semicolon {
@@ -2824,7 +2891,7 @@ fn fastc_emit_alias_declaration(mut scan scanner.Scanner, source_file FastcSourc
 	return tok
 }
 
-fn fastc_emit_function_alias(mut scan scanner.Scanner, source_file FastcSourceFile, declared_types map[string]bool, allow_short_placeholders bool, c_name string, mut out strings.Builder) !token.Token {
+fn fastc_emit_function_alias(mut scan scanner.Scanner, source_file FastcSourceFile, declared_types map[string]bool, allow_short_placeholders bool, c_name string, mut fn_alias_return_types map[string]string, mut out strings.Builder) !token.Token {
 	mut tok := scan.scan()
 	if tok != .lpar {
 		return error('fastc parser does not support function type `${c_name}` in ${source_file.path}')
@@ -2850,9 +2917,7 @@ fn fastc_emit_function_alias(mut scan scanner.Scanner, source_file FastcSourceFi
 		}
 		if has_parameter_name {
 			tok = scan.scan()
-			parameter_type, next_token := fastc_scan_type(mut scan, tok, source_file.path,
-				source_file.header.module_name, source_file.header.imports, declared_types,
-				allow_short_placeholders)!
+			parameter_type, next_token := fastc_scan_type(mut scan, tok, source_file.path, source_file.header.module_name, source_file.header.imports, declared_types, allow_short_placeholders)!
 			parameter_types << if parameter_is_mut && !parameter_type.ends_with('*') {
 				parameter_type + '*'
 			} else {
@@ -2860,9 +2925,7 @@ fn fastc_emit_function_alias(mut scan scanner.Scanner, source_file FastcSourceFi
 			}
 			tok = next_token
 		} else {
-			parameter_type, next_token := fastc_scan_type(mut scan, tok, source_file.path,
-				source_file.header.module_name, source_file.header.imports, declared_types,
-				allow_short_placeholders)!
+			parameter_type, next_token := fastc_scan_type(mut scan, tok, source_file.path, source_file.header.module_name, source_file.header.imports, declared_types, allow_short_placeholders)!
 			parameter_types << if parameter_is_mut && !parameter_type.ends_with('*') {
 				parameter_type + '*'
 			} else {
@@ -2879,20 +2942,19 @@ fn fastc_emit_function_alias(mut scan scanner.Scanner, source_file FastcSourceFi
 		return_type = 'Option'
 		tok = scan.scan()
 		if tok in [.name, .amp, .and, .mul, .lsbr, .key_fn, .question, .not] {
-			_, tok = fastc_scan_type(mut scan, tok, source_file.path,
-				source_file.header.module_name, source_file.header.imports, declared_types,
-				allow_short_placeholders)!
+			_, tok = fastc_scan_type(mut scan, tok, source_file.path, source_file.header.module_name, source_file.header.imports, declared_types, allow_short_placeholders)!
 		}
 	} else if tok !in [.semicolon, .eof] {
-		return_type, tok = fastc_scan_type(mut scan, tok, source_file.path,
-			source_file.header.module_name, source_file.header.imports, declared_types,
-			allow_short_placeholders)!
+		return_type, tok = fastc_scan_type(mut scan, tok, source_file.path, source_file.header.module_name, source_file.header.imports, declared_types, allow_short_placeholders)!
 	}
 	out.writeln('typedef ${return_type} (*${c_name})(${if parameter_types.len == 0 {
 		'void'
 	} else {
 		parameter_types.join(', ')
 	}});')
+	// Record the alias's return type so a call through a value of this fn type
+	// (`resolver(path)` where `resolver SomeFnAlias`) can infer its result type.
+	fn_alias_return_types[c_name] = return_type
 	if tok == .semicolon {
 		tok = scan.scan()
 	}

--- a/vlib/v3/gen/fastc/expr.v
+++ b/vlib/v3/gen/fastc/expr.v
@@ -97,9 +97,9 @@ fn fastc_or_operand_token_start(tokens []FastcExpressionToken) int {
 			}
 			.lpar {
 				if depth == 0 {
-					if i > 0 && tokens[i - 1].tok == .name && fastc_primitive_c_type(tokens[i - 1].lit) != none {
-						return 0
-					}
+					// An unbalanced `(` at depth 0 opens the operand's enclosing group. Even a
+					// primitive cast (`u8(parse(s) or {…})`) scopes the `or` to the value INSIDE the
+					// cast, so return the position after `(` and let the cast prefix be re-emitted.
 					return if nearest_comma >= 0 { nearest_comma + 1 } else { i + 1 }
 				}
 				depth--
@@ -117,6 +117,11 @@ fn fastc_or_operand_token_start(tokens []FastcExpressionToken) int {
 			}
 			.plus, .minus, .mul, .div, .mod, .amp, .pipe, .xor, .left_shift, .right_shift, .right_shift_unsigned, .eq, .ne, .gt, .lt, .ge, .le, .and, .logical_or {
 				if depth == 0 {
+					// A leading `&`, `*`, `+` or `-` belongs to the option-producing operand
+					// (`&m[k] or { nil }`); it is not the binary separator before it.
+					if tokens[i].tok in [.amp, .and, .mul, .plus, .minus] && fastc_token_is_prefix_operator(tokens, i) {
+						continue
+					}
 					return i + 1
 				}
 			}
@@ -162,6 +167,45 @@ fn (mut g Parser) read_condition_expression(stops []token.Token) !string {
 	return g.read_expression_with_prefix_mode('', stops, false, true)
 }
 
+// condition_brace_opens_struct_literal reports whether a `{` reached while reading an
+// if/for condition opens a struct literal (`if pos == Pos{}`) rather than the block that
+// terminates the condition. The distinction is the token preceding the type reference: a
+// value operator (`==`, `(`, …) precedes a struct literal, whereas `is`/`as` precede the
+// block that follows a smart-cast target (`if x is Ident {`).
+fn (g &Parser) condition_brace_opens_struct_literal(tokens []FastcExpressionToken, previous_token token.Token, previous_lit string) bool {
+	if previous_token != .name {
+		return false
+	}
+	mut type_resolves := false
+	mut before_index := tokens.len - 2
+	if tokens.len >= 3 && tokens[tokens.len - 2].tok == .dot && tokens[tokens.len - 3].tok == .name {
+		module_alias := tokens[tokens.len - 3].lit
+		if imported_module := g.imports[module_alias] {
+			type_key := fastc_type_key(imported_module, previous_lit)
+			type_resolves = type_key in g.declared_types
+		}
+		before_index = tokens.len - 4
+	} else if previous_lit in g.locals {
+		// A local variable whose name shadows a type (e.g. the loop variable `array`,
+		// which also names the builtin `array` type) is a value, so `array {` opens the
+		// loop/if block, not a struct literal.
+		return false
+	} else if tokens.len >= 2 && tokens[tokens.len - 2].tok == .dot {
+		// A dotted name that is not a module-qualified type is an enum shorthand
+		// (`sym.kind == .array {`) or member access, not a bare struct-literal type.
+		return false
+	} else {
+		type_resolves = g.resolve_declared_type_key(previous_lit) != none
+	}
+	if !type_resolves {
+		return false
+	}
+	if before_index >= 0 && tokens[before_index].tok in [.key_is, .not_is, .key_as] {
+		return false
+	}
+	return true
+}
+
 fn (mut g Parser) read_statement_expression(stops []token.Token) !string {
 	return g.read_expression_with_prefix_mode('', stops, true, false)
 }
@@ -186,7 +230,16 @@ fn (mut g Parser) read_expression_with_prefix_mode(prefix string, stops []token.
 			g.type_memo.clear()
 		}
 	}
+	// `ok && x.field` where `ok := x is Variant && …`: pre-register the bool's implied member
+	// smart-casts so the streamed `x.field` reads the narrowed variant, then drop them after.
+	mut bool_implied := []string{}
+	if g.selfhost && g.expression_depth == 1 && prefix == '' {
+		bool_implied = g.apply_bool_implication_smartcasts(stops)
+	}
 	defer {
+		for implied_name in bool_implied {
+			g.member_smartcasts.delete(implied_name)
+		}
 		g.expression_depth--
 	}
 	return g.read_expression_with_prefix_mode_impl(prefix, stops, allow_mutation_statement, allow_declaration_guard)
@@ -207,7 +260,11 @@ fn (mut g Parser) lower_higher_order_expression(mut result strings.Builder, mut 
 		&& lookahead.scan() == .lpar {
 		receiver_start := fastc_method_receiver_start(expression_tokens, expression_tokens.len)
 		receiver_tokens := expression_tokens[receiver_start..].clone()
-		receiver_type := g.infer_expression_type(receiver_tokens) or { '' }
+		// Array aliases (`strings.Builder = []u8`) share the array layout and support
+		// the same compiler-magic methods as plain arrays.
+		receiver_type := fastc_normalize_inferred_type(g.underlying_alias_type(g.infer_expression_type(receiver_tokens) or {
+			''
+		}))
 		// Array-literal receivers (`[.a, .b].map(...)`) do not round-trip
 		// through the receiver renderer yet; leave them to the normal path.
 		if receiver_type.starts_with('Array_') {
@@ -221,7 +278,6 @@ fn (mut g Parser) lower_higher_order_expression(mut result strings.Builder, mut 
 			// context to resolve `.enum` shorthand elements.
 			mut receiver_source := ''
 			if receiver_tokens[0].tok == .lsbr && receiver_tokens.last().tok == .rsbr {
-				raw := g.render_raw_expression_tokens(receiver_tokens) or { '' }
 				items := fastc_expression_list_items(receiver_tokens, 1, receiver_tokens.len - 1) or {
 					return g.unsupported('`.${higher_order_method}` array-literal receiver')
 				}
@@ -240,7 +296,11 @@ fn (mut g Parser) lower_higher_order_expression(mut result strings.Builder, mut 
 				if receiver_start == 0 {
 					result.str()
 				} else {
-					result.go_back(raw.len)
+					prefix := g.render_raw_expression_tokens(expression_tokens[..receiver_start]) or {
+						return g.unsupported('`.${higher_order_method}` expression prefix')
+					}
+					result.go_back(result.len)
+					result.write_string(prefix)
 				}
 			} else {
 				resolved := g.render_method_receiver_expression(receiver_tokens) or {
@@ -250,28 +310,57 @@ fn (mut g Parser) lower_higher_order_expression(mut result strings.Builder, mut 
 				if receiver_start == 0 {
 					result.str()
 				} else {
-					raw := g.render_raw_expression_tokens(receiver_tokens) or {
-						return g.unsupported('`.${higher_order_method}` receiver')
+					prefix := g.render_raw_expression_tokens(expression_tokens[..receiver_start]) or {
+						return g.unsupported('`.${higher_order_method}` expression prefix')
 					}
-					result.go_back(raw.len)
+					result.go_back(result.len)
+					result.write_string(prefix)
 				}
 			}
 			g.next() // `.`
 			g.next() // method name
 			g.next() // `(`
-			had_it := 'it' in g.locals
-			saved_it := g.locals['it'] or { FastcLocal{} }
+			mut it_name := 'it'
+			if g.tok == .pipe {
+				// An explicit closure header (`arr.filter(|item| item.ok)`) names the
+				// element in place of the implicit `it` local.
+				g.next()
+				if g.tok != .name {
+					return g.unsupported('`.${higher_order_method}` closure parameter')
+				}
+				it_name = g.lit
+				g.next()
+				if g.tok != .pipe {
+					return g.unsupported('`.${higher_order_method}` closure `|param|` header')
+				}
+				g.next()
+			}
+			had_it := it_name in g.locals
+			saved_it := g.locals[it_name] or { FastcLocal{} }
 			g.type_memo.clear()
-			g.locals['it'] = FastcLocal{
+			g.locals[it_name] = FastcLocal{
 				typ: element_type
 			}
-			closure := g.read_expression([token.Token.rpar])!
-			closure_type := g.last_expression_type
+			// The closure type is independent of the surrounding assignment type.
+			saved_closure_expected := g.expected_expression_type
+			g.expected_expression_type = ''
+			mut closure := g.read_expression([token.Token.rpar])!
+			g.expected_expression_type = saved_closure_expected
+			mut closure_type := g.last_expression_type
+			// A bare function is applied to each element (`items.map(convert)`).
+			if g.last_expression.len == 1 && g.last_expression[0].tok == .name
+				&& g.last_expression[0].lit != it_name {
+				function_key := g.unqualified_function_key(g.last_expression[0].lit)
+				if signature := g.functions[function_key] {
+					closure = '${closure}(${it_name})'
+					closure_type = signature.return_type
+				}
+			}
 			if had_it {
 				g.type_memo.clear()
-				g.locals['it'] = saved_it
+				g.locals[it_name] = saved_it
 			} else {
-				g.locals.delete('it')
+				g.locals.delete(it_name)
 			}
 			g.next() // `)`
 			if closure_type == '' {
@@ -282,16 +371,24 @@ fn (mut g Parser) lower_higher_order_expression(mut result strings.Builder, mut 
 			idx := g.temporary_name('index')
 			elem := g.temporary_name('element')
 			mut lowered := ''
-			mut result_type := receiver_type
+			// A mutable array local has pointer type; iterate over a value copy of its
+			// header while retaining the shared data buffer.
+			collection_type := receiver_type.trim_right('*')
+			collection_source := if receiver_type.ends_with('*') {
+				'*(${receiver_source})'
+			} else {
+				receiver_source
+			}
+			mut result_type := collection_type
 			if higher_order_method == 'map' {
 				result_type = fastc_array_c_type(closure_type)
 				fastc_register_composite_type(result_type, mut g.composite_types)
-				lowered = '({ ${receiver_type} ${src} = (${receiver_source}); ${result_type} ${dst} = (${result_type})builtin____new_array(0, ${src}.len, sizeof(${closure_type})); for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} it = ((${element_type} *)${src}.data)[${idx}]; ${closure_type} ${elem} = (${closure}); builtin__array_push((array *)&${dst}, &${elem}); } ${dst}; })'
+				lowered = '({ ${collection_type} ${src} = (${collection_source}); ${result_type} ${dst} = (${result_type})builtin____new_array(0, ${src}.len, sizeof(${closure_type})); for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} ${it_name} = ((${element_type} *)${src}.data)[${idx}]; ${closure_type} ${elem} = (${closure}); builtin__array_push((array *)&${dst}, &${elem}); } ${dst}; })'
 			} else if higher_order_method == 'filter' {
-				lowered = '({ ${receiver_type} ${src} = (${receiver_source}); ${receiver_type} ${dst} = (${receiver_type})builtin____new_array(0, ${src}.len, sizeof(${element_type})); for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} it = ((${element_type} *)${src}.data)[${idx}]; if (${closure}) { builtin__array_push((array *)&${dst}, &it); } } ${dst}; })'
+				lowered = '({ ${collection_type} ${src} = (${collection_source}); ${collection_type} ${dst} = (${collection_type})builtin____new_array(0, ${src}.len, sizeof(${element_type})); for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} ${it_name} = ((${element_type} *)${src}.data)[${idx}]; if (${closure}) { builtin__array_push((array *)&${dst}, &${it_name}); } } ${dst}; })'
 			} else if higher_order_method == 'count' {
 				result_type = 'int'
-				lowered = '({ ${receiver_type} ${src} = (${receiver_source}); int ${dst} = 0; for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} it = ((${element_type} *)${src}.data)[${idx}]; if (${closure}) { ${dst}++; } } ${dst}; })'
+				lowered = '({ ${collection_type} ${src} = (${collection_source}); int ${dst} = 0; for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} ${it_name} = ((${element_type} *)${src}.data)[${idx}]; if (${closure}) { ${dst}++; } } ${dst}; })'
 			} else {
 				result_type = 'bool'
 				initial := if higher_order_method == 'all' { 'true' } else { 'false' }
@@ -301,7 +398,7 @@ fn (mut g Parser) lower_higher_order_expression(mut result strings.Builder, mut 
 					closure
 				}
 				matched := if higher_order_method == 'all' { 'false' } else { 'true' }
-				lowered = '({ ${receiver_type} ${src} = (${receiver_source}); bool ${dst} = ${initial}; for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} it = ((${element_type} *)${src}.data)[${idx}]; if (${condition}) { ${dst} = ${matched}; break; } } ${dst}; })'
+				lowered = '({ ${collection_type} ${src} = (${collection_source}); bool ${dst} = ${initial}; for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} ${it_name} = ((${element_type} *)${src}.data)[${idx}]; if (${condition}) { ${dst} = ${matched}; break; } } ${dst}; })'
 			}
 			result.write_string(lowered)
 			expression_tokens = expression_tokens[..receiver_start].clone()
@@ -335,10 +432,11 @@ fn (mut g Parser) lower_higher_order_expression(mut result strings.Builder, mut 
 			if receiver_start == 0 {
 				result.str()
 			} else {
-				raw := g.render_raw_expression_tokens(receiver_tokens) or {
-					return g.unsupported('`.sort` receiver')
+				prefix := g.render_raw_expression_tokens(expression_tokens[..receiver_start]) or {
+					return g.unsupported('`.sort` expression prefix')
 				}
-				result.go_back(raw.len)
+				result.go_back(result.len)
+				result.write_string(prefix)
 			}
 			g.next() // `.`
 			g.next() // `sort`
@@ -419,6 +517,7 @@ fn (mut g Parser) lower_or_expression(mut result strings.Builder, mut expression
 	mut value_type := g.expected_expression_type
 	mut option_tokens := expression_tokens.clone()
 	mut assignment_prefix := ''
+	mut assignment_suffix := ''
 	mut scoped_operand_prefix := ''
 	mut scoped_or_operand := false
 	mut assignment_depth := 0
@@ -456,12 +555,40 @@ fn (mut g Parser) lower_or_expression(mut result strings.Builder, mut expression
 		}
 	}
 	for i, assignment_token in expression_tokens {
+		if in_struct_field {
+			// The enclosing assignment must not re-scope an `or` that already belongs
+			// to a struct field value.
+			break
+		}
 		if assignment_token.tok in [.lpar, .lsbr, .lcbr] {
 			assignment_depth++
 		} else if assignment_token.tok in [.rpar, .rsbr, .rcbr] {
 			assignment_depth--
 		} else if assignment_depth == 0 && assignment_token.tok.is_assignment() && i > 0 && i + 1 < expression_tokens.len {
 			left_tokens := expression_tokens[..i].clone()
+			mut rhs_paren_depth := 0
+			for rhs_token in expression_tokens[i + 1..] {
+				match rhs_token.tok {
+					.lpar { rhs_paren_depth++ }
+					.rpar { rhs_paren_depth-- }
+					else {}
+				}
+			}
+			if rhs_paren_depth != 0 {
+				// A parenthesized RHS operand is handled by operand scoping below.
+				continue
+			}
+			if assignment_token.tok == .assign {
+				if map_wrap := g.render_map_index_assignment_wrapping(left_tokens) {
+					assignment_prefix = map_wrap.prefix
+					assignment_suffix = map_wrap.suffix
+					value_type = map_wrap.value_type
+					option_tokens = expression_tokens[i + 1..].clone()
+					option_expression = g.render_call_argument_expression(option_tokens, value_type) or { '' }
+					wrapper_parens = 0
+					break
+				}
+			}
 			left_type := g.infer_expression_type(left_tokens) or { '' }
 			if left_type != '' {
 				left_source := g.render_membership_candidate(left_tokens, left_type) or {
@@ -494,7 +621,24 @@ fn (mut g Parser) lower_or_expression(mut result strings.Builder, mut expression
 				option_expression
 			}
 			separator := expression_tokens[operand_start - 1].tok
-			if separator !in [.lpar, .lsbr, .comma] {
+			// A grouping `(` after an operator is not rebuilt as a call/index prefix.
+			mut grouping_prefix := false
+			if separator == .lpar {
+				is_call_paren := operand_start >= 2 && expression_tokens[operand_start - 2].tok in [
+					.name,
+					.rpar,
+					.rsbr,
+				]
+				mut before_content := false
+				for prefix_token in expression_tokens[..operand_start - 1] {
+					if prefix_token.tok != .lpar {
+						before_content = true
+						break
+					}
+				}
+				grouping_prefix = !is_call_paren && before_content
+			}
+			if separator !in [.lpar, .lsbr, .comma] || grouping_prefix {
 				scoped_operand_prefix = g.render_raw_expression_tokens(struct_field_prefix_tokens) or {
 					''
 				}
@@ -563,6 +707,9 @@ fn (mut g Parser) lower_or_expression(mut result strings.Builder, mut expression
 	if map_lookup := g.render_map_lookup_option_expression(option_tokens) {
 		option_expression = map_lookup.source
 		option_value_type = map_lookup.typ
+	} else if slice_option := g.render_slice_option_expression(option_tokens) {
+		option_expression = slice_option.source
+		option_value_type = slice_option.typ
 	} else if array_lookup := g.render_array_lookup_option_expression(option_tokens) {
 		option_expression = array_lookup.source
 		option_value_type = array_lookup.typ
@@ -580,6 +727,10 @@ fn (mut g Parser) lower_or_expression(mut result strings.Builder, mut expression
 	} else if method_call := g.render_method_call_expression(option_tokens, option_expression) {
 		option_expression = method_call.source
 		option_value_type = g.option_value_type_for_expression(option_tokens)
+	}
+	// The `or` result is the option payload, not the enclosing expression's type.
+	if g.selfhost && option_value_type != '' && option_value_type != value_type {
+		value_type = option_value_type
 	}
 	if pointer_members := g.render_pointer_member_access_expression(option_tokens, option_expression) {
 		option_expression = pointer_members.source
@@ -677,6 +828,7 @@ fn (mut g Parser) lower_or_expression(mut result strings.Builder, mut expression
 		result.write_string(assignment_prefix)
 		result.write_string(scoped_operand_prefix)
 		result.write_string(or_expr_body)
+		result.write_string(assignment_suffix)
 		if in_struct_field {
 			expression_tokens = struct_field_prefix_tokens.clone()
 			expression_tokens << FastcExpressionToken{
@@ -703,7 +855,7 @@ fn (mut g Parser) lower_or_expression(mut result strings.Builder, mut expression
 					lit: '='
 				}
 			}
-			if assignment_prefix != '' {
+			if assignment_prefix != '' && assignment_suffix == '' {
 				expression_tokens << FastcExpressionToken{
 					tok: .assign
 					lit: '='
@@ -756,8 +908,14 @@ fn (mut g Parser) lower_or_expression(mut result strings.Builder, mut expression
 	// A multiline final expression gets a scanner-inserted semicolon before
 	// the block's `}`. Keep it out of the expression tokens so composite
 	// literals retain their inferred type.
+	// Supply the option payload type so bare `[]`/`{}` fallbacks are typed.
+	previous_fallback_expected := g.expected_expression_type
+	if g.selfhost && option_value_type != '' {
+		g.expected_expression_type = option_value_type
+	}
 	mut fallback := g.read_expression([token.Token.semicolon, token.Token.rcbr])!
-	fallback_type := fastc_normalize_inferred_type(g.last_expression_type)
+	g.expected_expression_type = previous_fallback_expected
+	mut fallback_type := fastc_normalize_inferred_type(g.last_expression_type)
 	if fallback == '' {
 		fallback = '0'
 	} else if fallback_type.starts_with('Map_') && fallback.contains('){}') {
@@ -766,6 +924,13 @@ fn (mut g Parser) lower_or_expression(mut result strings.Builder, mut expression
 		}
 		hash_fn, eq_fn, clone_fn, free_fn := g.map_runtime_functions(key_type)
 		fallback = '(builtin__new_map(sizeof(${fastc_runtime_c_type(key_type)}), sizeof(${fastc_runtime_c_type(map_value_type)}), &${hash_fn}, &${eq_fn}, &${clone_fn}, &${free_fn}))'
+	}
+	// A concrete variant fallback must be boxed to match the option payload.
+	if g.selfhost && option_value_type != '' && fallback_type != ''
+		&& fallback_type != option_value_type
+		&& g.should_box_variant(option_value_type, fallback_type) {
+		fallback = g.interface_value_expression(option_value_type, fallback_type, fallback)
+		fallback_type = option_value_type
 	}
 	if had_err {
 		g.type_memo.clear()
@@ -836,7 +1001,7 @@ fn (mut g Parser) lower_or_expression(mut result strings.Builder, mut expression
 		// `return result_call() or { error(...) }`: the IError is a replacement
 		// result failure, not a value of the result payload type.
 		'({ Option ${temporary} = (${option_expression}); if (${temporary}.state) { return (Option){.err = (${fallback}), .state = 1}; } ${success_value}; })'
-	} else if value_type != 'void' && fallback_type in ['', 'void'] {
+	} else if value_type == 'void' || fallback_type in ['', 'void'] {
 		'({ Option ${temporary} = (${option_expression}); if (${temporary}.state) { ${fallback}; } ${success_value}; })'
 	} else {
 		'({ Option ${temporary} = (${option_expression}); ${temporary}.state ? (${fallback}) : ${success_value}; })'
@@ -848,6 +1013,7 @@ fn (mut g Parser) lower_or_expression(mut result strings.Builder, mut expression
 	result.write_string(scoped_operand_prefix)
 	result.write_string('('.repeat(wrapper_parens))
 	result.write_string(or_expr_body)
+	result.write_string(assignment_suffix)
 	if in_struct_field {
 		expression_tokens = struct_field_prefix_tokens.clone()
 		expression_tokens << FastcExpressionToken{
@@ -880,7 +1046,7 @@ fn (mut g Parser) lower_or_expression(mut result strings.Builder, mut expression
 				lit: '='
 			}
 		}
-		if assignment_prefix != '' {
+		if assignment_prefix != '' && assignment_suffix == '' {
 			expression_tokens << FastcExpressionToken{
 				tok: .assign
 				lit: '='
@@ -900,10 +1066,10 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 	if g.selfhost && prefix == '' && g.tok == .arrow {
 		return g.read_channel_receive(stops)!
 	}
-	if prefix == '' && g.tok == .key_if {
+	if prefix == '' && g.tok == .key_if && !g.selfhost {
 		return g.read_if_expression()!
 	}
-	if prefix == '' && g.tok == .key_match {
+	if prefix == '' && g.tok == .key_match && !g.selfhost {
 		return g.read_match_expression()!
 	}
 	if prefix == '' && g.tok == .dollar {
@@ -949,6 +1115,9 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 	mut previous_token_end := g.s.pos
 	mut previous_module_separator := false
 	mut unsafe_expression_depth := 0
+	// The brace_depth at which each still-open unsafe/lock block was opened, so a `}` is matched
+	// to the innermost open construct (a nested struct literal vs. the unsafe block itself).
+	mut unsafe_open_brace_depths := []int{}
 	mut struct_types := []string{}
 	mut struct_depths := []int{}
 	mut struct_paren_depths := []int{}
@@ -971,6 +1140,57 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 		if g.selfhost && g.tok == .semicolon && g.semicolon_continues_expression() {
 			g.next()
 			continue
+		}
+		if g.selfhost && g.tok == .semicolon && struct_depths.len > 0 && brace_depth == struct_depths.last() && paren_depth == struct_paren_depths.last() && previous_token in [
+			.lcbr,
+			.comma,
+		] {
+			// A newline right after a struct-literal `{` (or a field separator) auto-inserts a `;`
+			// (the preceding `Struct{`/`,` leaves the scanner's insert-semi flag set). It precedes
+			// the first/next field, so it is spurious — skip it. A `;` following a rendered field
+			// VALUE is instead converted to `,` by the struct-field handling further below.
+			g.next()
+			continue
+		}
+		// `$res(N)` (the Nth function result, referenced in a defer to record the return value
+		// for debugging) is a comptime construct the V3 backend does not support. The defer body
+		// is gated by a runtime flag, so render a zero value of the Nth return type: valid C that
+		// keeps the surrounding function compiling and linking.
+		if g.tok == .dollar {
+			mut res_lookahead := g.s
+			if res_lookahead.scan() == .name && res_lookahead.lit == 'res' {
+				g.next() // `$`
+				g.next() // `res`
+				g.expect(.lpar)!
+				mut res_index := 0
+				if g.tok == .number {
+					res_index = g.lit.int()
+					g.next()
+				}
+				g.expect(.rpar)!
+				res_type := if g.return_types.len > res_index {
+					g.return_types[res_index]
+				} else if g.return_type !in ['', 'void', 'MultiReturn'] {
+					g.return_type
+				} else {
+					'int'
+				}
+				res_value := '(${fastc_normalize_inferred_type(res_type)}){0}'
+				if result.len > 0 && fastc_needs_space(result.last(), res_value) {
+					result.write_u8(` `)
+				}
+				result.write_string(res_value)
+				expression_tokens << FastcExpressionToken{
+					tok: .name
+					lit: res_value
+					typ: fastc_normalize_inferred_type(res_type)
+				}
+				previous_token = .name
+				previous_lit = res_value
+				previous_module_separator = false
+				previous_token_end = g.s.pos
+				continue
+			}
 		}
 		// `$d('key', default)` may appear mid-expression (e.g. `int($d(...))`).
 		// Lower it inline to its default value.
@@ -1052,12 +1272,38 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			}
 			unsafe_expression_depth++
 			g.unsafe_depth += 1
+			unsafe_open_brace_depths << brace_depth
 			g.next()
 			continue
 		}
-		if unsafe_expression_depth > 0 && g.tok == .rcbr {
+		if (g.tok == .key_lock || g.tok == .key_rlock) && previous_token != .dot {
+			// `rlock x { value }` yields the block's value. FastC does no real locking,
+			// so skip the lock targets and treat the block transparently, exactly like an
+			// `unsafe { value }` expression. A `.lock`/`.rlock` after `.` is a method name
+			// (`mutex.lock()`), not the keyword, so it is excluded.
+			g.next()
+			for g.tok != .lcbr && g.tok != .eof {
+				g.next()
+			}
+			if g.tok != .lcbr {
+				return g.unsupported('lock expression without a block')
+			}
+			unsafe_expression_depth++
+			g.unsafe_depth += 1
+			unsafe_open_brace_depths << brace_depth
+			g.next()
+			continue
+		}
+		if unsafe_expression_depth > 0 && g.tok == .rcbr && unsafe_open_brace_depths.len > 0 && unsafe_open_brace_depths.last() == brace_depth {
+			// This `}` matches the innermost open unsafe/lock block. A `}` at a deeper brace_depth
+			// belongs to a nested struct/array literal opened inside the block
+			// (`unsafe { U64F64{ f: value }.u }`); leaving it to the brace-depth handler preserves
+			// the member access after the literal. Conversely, an unsafe block opened as a struct
+			// field value (`string{ str: unsafe { m() } }`) sits at the literal's brace_depth and
+			// was opened later, so it still closes here.
 			unsafe_expression_depth--
 			g.unsafe_depth -= 1
+			unsafe_open_brace_depths.delete_last()
 			g.next()
 			if unsafe_expression_depth == 0 {
 				continue
@@ -1068,7 +1314,9 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			continue
 		}
 		if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0 && g.tok in stops {
-			break
+			if !(g.selfhost && g.tok == .lcbr && g.condition_brace_opens_struct_literal(expression_tokens, previous_token, previous_lit)) {
+				break
+			}
 		}
 		if paren_depth == 0 && bracket_depth == 0 && brace_depth == 0 && g.tok == .comma {
 			// V's top-level commas form simultaneous multi-target assignments.
@@ -1091,6 +1339,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 				tok: .string
 				lit: literal
 				source: interpolation
+				typ: 'string'
 			}
 			previous_token = .string
 			previous_lit = literal
@@ -1121,7 +1370,9 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			.comma,
 			.semicolon,
 		]
-		if g.tok == .key_shared && shared_classification.is_identifier && !shared_is_struct_field {
+		if g.tok == .key_shared && shared_classification.is_identifier && !shared_is_struct_field && enum_shorthand_type == '' {
+			// A `.shared` enum shorthand (member named with the `shared` keyword) is resolved
+			// against the pending `enum_shorthand_type` below, not treated as a `shared` local.
 			expression_tokens << FastcExpressionToken{
 				tok: .name
 				lit: g.lit
@@ -1152,8 +1403,19 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			}
 			continue
 		}
-		if g.tok in [.key_mut, .key_shared] && !shared_is_struct_field {
+		if g.tok in [.key_mut, .key_shared] && !shared_is_struct_field && enum_shorthand_type == '' {
+			consumed_mut := g.tok == .key_mut
 			g.next()
+			if g.selfhost && consumed_mut && allow_declaration_guard && g.tok == .name {
+				mut probe := g.s
+				if probe.scan() in [token.Token.key_is, token.Token.not_is] {
+					// `if mut x is T`: the `mut` only marks the smart-cast subject mutable;
+					// it must not emit an address-of. Preserve that marker on the name token
+					// so parse_if can expose the boxed payload by reference in the branch.
+					next_token_is_mut_argument = true
+					continue
+				}
+			}
 			if g.tok in [.amp, .and] {
 				next_token_is_mut_argument = true
 				continue
@@ -1184,6 +1446,19 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			previous_expected_type := g.expected_expression_type
 			if expected_struct_field_type != '' {
 				g.expected_expression_type = expected_struct_field_type
+			} else if paren_depth > 0 {
+				// A parenthesized if-expression — a call argument (`f(if c {…} else {…})`) or a
+				// A parenthesized if-expression — a call argument (`f(if c {…} else {…})`) or a
+				// grouped operand — takes its type from its own branches, not the surrounding
+				// expected type (which describes the whole call), so clear it to avoid boxing an
+				// `int` argument into the outer sum type. But propagate an ENUM parameter type so
+				// branch `.member` shorthands (`f(if c { .arrow } else { .dot })`) resolve.
+				arg_type := g.streaming_call_argument_type(expression_tokens)
+				if arg_type != '' && g.declared_kinds[g.semantic_type_key(arg_type)] == .enum_ {
+					g.expected_expression_type = arg_type
+				} else {
+					g.expected_expression_type = ''
+				}
 			}
 			conditional := g.read_if_expression()!
 			conditional_type := g.last_expression_type
@@ -1222,7 +1497,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			continue
 		}
 		if g.selfhost && g.tok == .key_fn {
-			anon := g.reject_anonymous_function()!
+			anon := g.parse_anonymous_function()!
 			if result.len > 0 && fastc_needs_space(result.last(), anon) && !previous_module_separator {
 				result.write_u8(` `)
 			}
@@ -1238,7 +1513,23 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			previous_token_end = g.s.pos
 			continue
 		}
-		if g.selfhost && g.tok == .key_spawn {
+		mut spawn_is_field_name := false
+		if g.selfhost && g.tok == .key_spawn && previous_token != .dot {
+			mut spawn_probe := g.s
+			// `spawn:` (a struct-field/map key named `spawn`) is a field name, not the
+			// `spawn` keyword.
+			spawn_is_field_name = spawn_probe.scan() == .colon
+		}
+		// A struct-literal field may be named with a word that is also a keyword
+		// (`MonomorphCacheSpec{ module: … }`). At a field-name position (right after `{`,
+		// `,` or `;` inside the struct's braces) a keyword followed by `:` is that field's
+		// name, not the keyword.
+		mut keyword_is_field_name := false
+		if g.selfhost && g.tok.is_keyword() && previous_token in [.lcbr, .comma, .semicolon] && struct_depths.len > 0 && brace_depth == struct_depths.last() && paren_depth == struct_paren_depths.last() {
+			mut keyword_field_probe := g.s
+			keyword_is_field_name = keyword_field_probe.scan() == .colon
+		}
+		if g.selfhost && g.tok == .key_spawn && previous_token != .dot && !spawn_is_field_name {
 			spawned := g.read_spawn_expression()!
 			spawned_type := g.last_expression_type
 			if result.len > 0 && fastc_needs_space(result.last(), spawned) && !previous_module_separator {
@@ -1346,7 +1637,12 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			// levels and also orders + and - above &. Reject ambiguous token streams.
 			return g.unsupported('mixed operator precedence')
 		}
-		if g.tok.is_assignment() || g.tok in [.inc, .dec] {
+		value_context := paren_depth != 0 || bracket_depth != 0 || brace_depth != 0 || unsafe_expression_depth != 0
+		if g.selfhost && g.tok in [.inc, .dec] && value_context && source_token_count > 0 {
+			// A post-increment/decrement used as a value (`Node{ id: c.x++ }`) is a valid C
+			// post-fix expression with matching semantics, so append it as an operand
+			// rather than treating it as a statement mutation.
+		} else if g.tok.is_assignment() || g.tok in [.inc, .dec] {
 			is_declaration_guard := allow_declaration_guard && g.tok == .decl_assign && source_token_count == 1
 			if (!allow_mutation_statement && !is_declaration_guard) || paren_depth != 0 || bracket_depth != 0 || brace_depth != 0 || unsafe_expression_depth != 0 {
 				return g.unsupported('mutation `${g.token_source()}` inside an expression')
@@ -1378,7 +1674,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 		// A word that is also a keyword (`conn.select(...)`, `x.lock`) is a member
 		// name, not a keyword, once it follows `.`; store it as a plain name so the
 		// method-call and inference paths recognize it like any other member.
-		stored_tok := if (previous_token == .dot && g.tok.is_keyword()) || shared_is_struct_field {
+		stored_tok := if (previous_token == .dot && g.tok.is_keyword()) || shared_is_struct_field || spawn_is_field_name || keyword_is_field_name {
 			token.Token.name
 		} else {
 			g.tok
@@ -1447,7 +1743,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 		if g.tok == .name && expression_tokens.len >= 3 && expression_tokens[expression_tokens.len - 2].tok == .dot && expression_tokens[expression_tokens.len - 3].tok == .name && expression_tokens[expression_tokens.len - 3].lit == 'C' {
 			piece = g.lit
 		}
-		if g.selfhost && brace_depth > 0 && g.tok == .name {
+		if g.selfhost && brace_depth > 0 && (g.tok == .name || keyword_is_field_name) {
 			mut field_lookahead := g.s
 			if field_lookahead.scan() == .colon {
 				piece = g.lit
@@ -1512,10 +1808,25 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 				qualified_key := fastc_type_key(g.imports[module_lit], previous_lit)
 				if qualified_key in g.declared_types {
 					cast_type := fastc_c_declared_type_name(qualified_key)
-					result.go_back(cast_type.len + pointer_prefix_len)
-					piece = '((${cast_type}${pointer_suffix})('
+					// The pointer prefix (`&mod.Type(x)` / `&&mod.Type(x)`) sits BEFORE the module
+					// name (`… & ast . File (`), i.e. at len-5, not the len-3 the bare-type case
+					// checks — there len-3 is the `.` of the qualification.
+					qual_pointer_token := if expression_tokens.len >= 5 && fastc_token_is_prefix_operator(expression_tokens, expression_tokens.len - 5) {
+						expression_tokens[expression_tokens.len - 5].tok
+					} else {
+						token.Token.unknown
+					}
+					qual_pointer_count := if qual_pointer_token == .and {
+						2
+					} else if qual_pointer_token == .amp {
+						1
+					} else {
+						0
+					}
+					result.go_back(cast_type.len + qual_pointer_count)
+					piece = '((${cast_type}${'*'.repeat(qual_pointer_count)})('
 					cast_depths << paren_depth + 1
-					if pointer_cast {
+					if qual_pointer_count > 0 {
 						pointer_cast_depths << paren_depth + 1
 					}
 				}
@@ -1639,7 +1950,7 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			pending_field_value_mark = true
 		} else if g.selfhost && struct_depths.len > 0 && brace_depth == struct_depths.last() && paren_depth == struct_paren_depths.last() && g.tok == .semicolon {
 			piece = ','
-		} else if g.selfhost && struct_depths.len > 0 && brace_depth == struct_depths.last() && paren_depth == struct_paren_depths.last() && (g.tok == .name || shared_is_struct_field) && previous_token in [
+		} else if g.selfhost && struct_depths.len > 0 && brace_depth == struct_depths.last() && paren_depth == struct_paren_depths.last() && (g.tok == .name || shared_is_struct_field || spawn_is_field_name || keyword_is_field_name) && previous_token in [
 			.lcbr,
 			.comma,
 			.semicolon,
@@ -1650,7 +1961,14 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 				expected_struct_field_type = ''
 			}
 			piece = '.${piece}'
-		} else if g.selfhost && g.tok == .dot && fastc_token_is_prefix_operator(expression_tokens, expression_tokens.len - 1) {
+		} else if g.selfhost && g.tok == .dot && (fastc_token_is_prefix_operator(expression_tokens, expression_tokens.len - 1) || (expression_tokens.len > 0 && expression_tokens.last().tok in [
+			.xor,
+			.pipe,
+			.amp,
+		])) {
+			// `.member` right after a value would be a field access, but after a binary flag
+			// operator (`~Show.zero() ^ .name`, `a | .b`) it is an enum-shorthand operand, which
+			// fastc_token_is_prefix_operator misses (it inspects the token BEFORE the operator).
 			mut contextual_type := if expected_struct_field_type != '' {
 				expected_struct_field_type
 			} else {
@@ -1667,6 +1985,13 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 						contextual_type = g.infer_expression_type(expression_tokens[..i]) or { '' }
 						break
 					}
+				}
+			}
+			if contextual_type != '' {
+				// An unqualified same-module field type (`Show`) must resolve to its declared C
+				// type so the shorthand becomes `flag__Show__name`, not a raw unqualified name.
+				if resolved_enum_key := g.resolve_declared_type_key(contextual_type.trim_right('*')) {
+					contextual_type = fastc_c_declared_type_name(resolved_enum_key)
 				}
 			}
 			if g.declared_kinds[g.semantic_type_key(contextual_type)] != .enum_ {
@@ -1694,6 +2019,12 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 						operand_depth++
 					} else if expression_tokens[i].tok in [.lpar, .lsbr, .lcbr] {
 						operand_depth--
+						if operand_depth < 0 {
+							// Reached the enclosing `(`/`[`/`{` (`int(l.mode == .x)`); the left
+							// operand begins just after it, not at the whole expression.
+							operand_start = i + 1
+							break
+						}
 					} else if operand_depth == 0 && expression_tokens[i].tok in [.and, .logical_or] {
 						operand_start = i + 1
 						break
@@ -1785,8 +2116,69 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 		g.validate_expression_calls(expression_tokens)!
 	}
 	mut rendered_expression := fastc_take_trimmed(mut result)
+	if g.selfhost && expression_tokens.len > 1 && expression_tokens.last().tok == .question {
+		// A trailing `?` propagates an option exactly like `!` propagates a result.
+		// FastC represents both with one `Option` type, so normalize `?` to the `!`
+		// handling used everywhere below.
+		last_token := expression_tokens.last()
+		expression_tokens[expression_tokens.len - 1] = FastcExpressionToken{
+			tok: .not
+			source: last_token.source
+			unsafe_depth: last_token.unsafe_depth
+			is_mut_argument: last_token.is_mut_argument
+			is_statement: last_token.is_statement
+			lit: last_token.lit
+			typ: last_token.typ
+		}
+	}
+	// A boolean `is` expression with a flow-sensitive `&&` narrowing is handled first, on the
+	// original tokens: its operands (including any `(x as T).field`) must render with the
+	// narrowing active, which the general as-cast rewrite below cannot do. A top-level
+	// assignment (`x = a is T && …`) is left to render_assignment_expression, which routes its
+	// RHS through the same narrowing renderer; handling the whole `x = …` here would mis-split
+	// at the `=` and register a stale smart-cast that the RHS then re-applies (double unwrap).
+	if g.selfhost && !fastc_tokens_have_top_level_assignment(expression_tokens) {
+		if narrowed := g.render_narrowing_boolean_expression(expression_tokens) {
+			g.last_expression_type = 'bool'
+			g.last_expression = expression_tokens
+			return g.render_constant_references(expression_tokens, narrowed)
+		}
+	}
+	if g.selfhost {
+		if rewritten := g.rewrite_embedded_as_casts(expression_tokens) {
+			expression_tokens = rewritten.clone()
+			rendered_expression = g.render_raw_expression_tokens(expression_tokens) or {
+				rendered_expression
+			}
+		}
+	}
+	if g.selfhost && expression_tokens.len > 1 && expression_tokens.last().tok == .not && rendered_expression.ends_with('?') {
+		rendered_expression = rendered_expression[..rendered_expression.len - 1] + '!'
+	}
 	rendered_expression = g.render_enum_alias_member_references(expression_tokens, rendered_expression)
 	rendered_expression = g.render_constant_references(expression_tokens, rendered_expression)
+	if g.selfhost {
+		// `m[k].field = value`: a map value is not a C lvalue, so assign the field through a
+		// mutable pointer to the entry rather than the map-read spelling render_special yields.
+		if map_field := g.render_map_value_field_assignment(expression_tokens) {
+			g.last_expression_type = map_field.typ
+			g.last_expression = expression_tokens
+			return g.render_constant_references(expression_tokens, map_field.source)
+		}
+		// `m[k].field++` / `m[k].field--`: same lvalue problem, incremented through the entry.
+		if map_field := g.render_map_value_field_inc_dec(expression_tokens) {
+			g.last_expression_type = map_field.typ
+			g.last_expression = expression_tokens
+			return g.render_constant_references(expression_tokens, map_field.source)
+		}
+		// `x.field = value` where `field` is common to every variant of the boxed sum type `x`:
+		// dispatch on the runtime tag and write through the matched variant, not the box.
+		if common_assign := g.render_sumtype_common_field_assignment(expression_tokens) {
+			g.last_expression_type = common_assign.typ
+			g.last_expression = expression_tokens
+			return g.render_constant_references(expression_tokens, common_assign.source)
+		}
+	}
 	if special := g.render_special_expression(expression_tokens, rendered_expression) {
 		g.last_expression_type = special.typ
 		g.last_expression = expression_tokens
@@ -1812,6 +2204,7 @@ fn (g &Parser) reference_local_value_piece(name string, piece string, previous_t
 }
 
 fn (g &Parser) reference_local_value_piece_for_local(local FastcLocal, piece string, previous_token token.Token, expression_tokens []FastcExpressionToken, stops []token.Token) string {
+	local_piece := if local.c_name != '' { local.c_name } else { piece }
 	mut lookahead := g.s
 	next_token := lookahead.scan()
 	is_single_value := expression_tokens.len == 1 && (next_token in stops || next_token == .eof)
@@ -1830,9 +2223,9 @@ fn (g &Parser) reference_local_value_piece_for_local(local FastcLocal, piece str
 		.dot,
 		.lsbr,
 	] && !is_single_value && !is_deref_prefix && !is_pointer_cast_operand {
-		return '(*(${piece}))'
+		return '(*(${local_piece}))'
 	}
-	return piece
+	return local_piece
 }
 
 fn fastc_shared_modifier_operand_start(tok token.Token) bool {
@@ -2086,6 +2479,39 @@ fn fastc_replace_c_root_identifier(source string, identifier string, replacement
 	return out.str()
 }
 
+// fastc_replace_call_needle replaces a method-call needle (`receiver.method(`, ending in `(`)
+// only where its START is not preceded by an identifier char or `.` — so a needle like
+// `return_type.clear(` does not match the suffix of a longer chain `fn_decl.return_type.clear(`
+// (whose real receiver is the whole `fn_decl.return_type`). The trailing `(` is its own boundary,
+// so (unlike fastc_replace_c_identifier) no end-boundary check is applied.
+fn fastc_replace_call_needle(source string, needle string, replacement string) string {
+	if needle == '' || needle == replacement || !source.contains(needle) {
+		return source
+	}
+	mut out := strings.new_builder(source.len + replacement.len)
+	mut start := 0
+	for start < source.len {
+		remaining := source[start..]
+		relative := remaining.index(needle) or {
+			out.write_string(remaining)
+			break
+		}
+		index := start + relative
+		before_blocks := index > 0 && (source[index - 1].is_alnum() || source[index - 1] in [
+			`_`,
+			`.`,
+		])
+		out.write_string(source[start..index])
+		if before_blocks {
+			out.write_string(needle)
+		} else {
+			out.write_string(replacement)
+		}
+		start = index + needle.len
+	}
+	return out.str()
+}
+
 fn fastc_replace_c_identifier(source string, identifier string, replacement string) string {
 	if identifier == '' || identifier == replacement || !fastc_contains(source, identifier) {
 		return source
@@ -2112,6 +2538,77 @@ fn fastc_replace_c_identifier(source string, identifier string, replacement stri
 	return out.str()
 }
 
+// fastc_token_continues_expression reports whether a token appearing right after an
+// auto-inserted `;` continues the previous expression (a binary/postfix operator),
+// so the `;` is a line continuation rather than a statement boundary. The token
+// equivalent of semicolon_continues_expression, used where only a lookahead scanner
+// (not the source cursor) is available.
+// streaming_call_argument_type returns the declared parameter type of the call argument the
+// streaming reader is currently inside (the innermost unmatched `(` whose preceding token is a
+// function/method name), or '' when the enclosing `(` is a grouping paren or the callee is
+// unknown. Used to give an if/match-expression argument its parameter type mid-stream.
+fn (g &Parser) streaming_call_argument_type(tokens []FastcExpressionToken) string {
+	mut depth := 0
+	mut open := -1
+	for i := tokens.len - 1; i >= 0; i-- {
+		match tokens[i].tok {
+			.rpar, .rsbr, .rcbr {
+				depth++
+			}
+			.lpar, .lsbr, .lcbr {
+				if depth == 0 {
+					open = i
+					break
+				}
+				depth--
+			}
+			else {}
+		}
+	}
+	if open <= 0 || tokens[open].tok != .lpar || tokens[open - 1].tok != .name {
+		return ''
+	}
+	mut arg_index := 0
+	mut inner := 0
+	for i := open + 1; i < tokens.len; i++ {
+		match tokens[i].tok {
+			.lpar, .lsbr, .lcbr { inner++ }
+			.rpar, .rsbr, .rcbr { inner-- }
+			.comma {
+				if inner == 0 { arg_index++ }
+			}
+			else {}
+		}
+	}
+	name := tokens[open - 1].lit
+	if open >= 2 && tokens[open - 2].tok == .dot {
+		// `recv.method(…)`: resolve on the receiver's type; parameter_types[0] is the receiver.
+		receiver_start := fastc_method_receiver_start(tokens, open - 2)
+		receiver_tokens := tokens[receiver_start..open - 2]
+		receiver_type := g.infer_expression_type(receiver_tokens) or { return '' }
+		method_key, _ := g.resolve_method(receiver_type, name)
+		signature := g.functions[method_key] or { return '' }
+		idx := arg_index + 1
+		return if idx < signature.parameter_types.len { signature.parameter_types[idx] } else { '' }
+	}
+	function_key := g.unqualified_function_key(name)
+	signature := g.functions[function_key] or { return '' }
+	return if arg_index < signature.parameter_types.len {
+		signature.parameter_types[arg_index]
+	} else {
+		''
+	}
+}
+
+fn fastc_token_continues_expression(tok token.Token) bool {
+	// `.mul`/`.plus`/`.minus`/`.amp` are omitted: a leading `*`/`+`/`-`/`&` after an auto-`;`
+	// is a unary prefix starting a new statement (deref/sign/address-of), not a binary
+	// continuation. `.and` (`&&`) stays — it can only be binary.
+	return tok in [.dot, .div, .mod, .and, .pipe, .logical_or, .xor, .lt, .le, .gt, .ge, .eq, .ne,
+		.left_shift, .right_shift, .right_shift_unsigned, .question, .rpar, .key_or, .key_in, .key_is,
+		.key_as]
+}
+
 fn (g &Parser) semicolon_continues_expression() bool {
 	mut offset := g.s.offset
 	for offset < g.s.src.len && g.s.src[offset] in [` `, `\t`, `\r`, `\n`] {
@@ -2130,8 +2627,18 @@ fn (g &Parser) semicolon_continues_expression() bool {
 		// The next `.field` starts the following map entry, not a member chain.
 		return false
 	}
-	return g.s.src[offset] in [`.`, `+`, `-`, `*`, `/`, `%`, `&`, `|`, `^`, `<`, `>`, `=`, `?`,
-		`)`]
+	next := g.s.src[offset]
+	if next in [`*`, `-`, `+`] {
+		// A leading `*`/`-`/`+` after an auto-inserted `;` is a unary prefix (deref, sign)
+		// beginning a NEW statement (`record(err)\n*default`), not a binary continuation — V
+		// requires a binary operator at the previous line's END to continue.
+		return false
+	}
+	if next == `&` {
+		// `&&` continues a logical expression; a lone `&` is unary address-of (new statement).
+		return offset + 1 < g.s.src.len && g.s.src[offset + 1] == `&`
+	}
+	return next in [`.`, `/`, `%`, `|`, `^`, `<`, `>`, `=`, `?`, `)`]
 }
 
 fn fastc_runtime_c_type(typ string) string {
@@ -2470,6 +2977,521 @@ fn (g &Parser) guarded_logical_expression(tokens []FastcExpressionToken, flags F
 	return g.render_logical_expression(tokens)
 }
 
+// fastc_strip_paren_tokens removes fully-matching outer parentheses from a token slice.
+fn fastc_strip_paren_tokens(tokens []FastcExpressionToken) []FastcExpressionToken {
+	mut start := 0
+	mut end := tokens.len
+	for end - start >= 2 && tokens[start].tok == .lpar && tokens[end - 1].tok == .rpar {
+		mut depth := 0
+		mut matches := true
+		for i := start; i < end; i++ {
+			if tokens[i].tok == .lpar {
+				depth++
+			} else if tokens[i].tok == .rpar {
+				depth--
+				if depth == 0 && i != end - 1 {
+					matches = false
+					break
+				}
+			}
+		}
+		if !matches {
+			break
+		}
+		start++
+		end--
+	}
+	return tokens[start..end]
+}
+
+// render_boolean_is_expression renders a boolean expression built from `is`/`!is` type
+// tests whose left operand is not a bare name (`unalias(x) is Alias`, and `&&`/`||`
+// combinations of such), which the simple `name is T` renderer cannot handle. Returns
+// none for anything without such a test, leaving other renderers unaffected.
+fn (g &Parser) render_boolean_is_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	mut has_is := false
+	for item in tokens {
+		if item.tok in [.key_is, .not_is] {
+			has_is = true
+			break
+		}
+	}
+	if !has_is {
+		return none
+	}
+	inner := fastc_strip_paren_tokens(tokens)
+	if inner.len < 3 {
+		return none
+	}
+	mut depth := 0
+	for i, item in inner {
+		match item.tok {
+			.lpar, .lsbr, .lcbr {
+				depth++
+			}
+			.rpar, .rsbr, .rcbr {
+				depth--
+			}
+			.and, .logical_or, .eq, .ne {
+				if depth == 0 && i > 0 && i + 1 < inner.len {
+					// `==`/`!=` only combine boolean `is` tests when an operand actually holds one
+					// (`(a is T) != (b is T)`); a plain value comparison is left to the numeric/
+					// enum/struct comparison paths.
+					if item.tok in [.eq, .ne] && !fastc_expression_tokens_contain(inner[..i], .key_is) && !fastc_expression_tokens_contain(inner[..i], .not_is) && !fastc_expression_tokens_contain(inner[i + 1..], .key_is) && !fastc_expression_tokens_contain(inner[i + 1..], .not_is) {
+						continue
+					}
+					left := g.render_boolean_is_operand(inner[..i]) or { return none }
+					mut right := g.render_boolean_is_operand(inner[i + 1..]) or { return none }
+					op := match item.tok {
+						.and { '&&' }
+						.logical_or { '||' }
+						.eq { '==' }
+						else { '!=' }
+					}
+					// `<call>() is T && … <call>().field …`: a smart-cast on a method-call
+					// result cannot be tracked as a member path (detect_member_smartcasts owns
+					// only names/chains), so narrow the SAME rendered call in the right conjunct
+					// by reading its fields through the concrete variant's `_object`.
+					if item.tok == .and {
+						right = g.apply_call_is_narrowing(inner[..i], right)
+					}
+					return FastcRenderedExpression{
+						source: '((${left}) ${op} (${right}))'
+						typ: 'bool'
+					}
+				}
+			}
+			else {}
+		}
+	}
+	depth = 0
+	mut is_idx := -1
+	for i, item in inner {
+		match item.tok {
+			.lpar, .lsbr, .lcbr { depth++ }
+			.rpar, .rsbr, .rcbr { depth-- }
+			.key_is, .not_is {
+				if depth == 0 && is_idx < 0 {
+					is_idx = i
+				}
+			}
+			else {}
+		}
+	}
+	if is_idx <= 1 {
+		// A bare-name left operand (`x is T`) is handled by the simpler renderer.
+		return none
+	}
+	lhs_tokens := inner[..is_idx]
+	// A call (`unalias(x) is T`), a member chain (`e.expr is T`, e.g. inside a match-arm
+	// boolean value) or an indexed element (`ptypes[0] is T`, e.g. `arr.len > 0 && arr[0]
+	// is T`) left operand is a plain boolean tag test here. A bare-name left operand
+	// (`x is T`) is a smart-cast subject owned by detect_member_smartcasts, so leave it.
+	mut lhs_is_boolean_test := false
+	for item in lhs_tokens {
+		if item.tok in [.lpar, .dot, .lsbr] {
+			lhs_is_boolean_test = true
+			break
+		}
+	}
+	if !lhs_is_boolean_test {
+		return none
+	}
+	lhs_type := fastc_normalize_inferred_type(g.infer_expression_type(lhs_tokens) or { return none })
+	if !g.is_boxed_type(lhs_type) {
+		return none
+	}
+	mut variant_c := ''
+	if is_idx + 2 == inner.len && inner[is_idx + 1].tok == .name {
+		if type_key := g.resolve_declared_type_key(inner[is_idx + 1].lit) {
+			variant_c = fastc_c_declared_type_name(type_key)
+		} else if fastc_primitive_c_type(inner[is_idx + 1].lit) != none {
+			variant_c = inner[is_idx + 1].lit
+		}
+	} else if resolved := g.type_from_expression_tokens(inner[is_idx + 1..]) {
+		variant_c = fastc_normalize_inferred_type(resolved).trim_right('*')
+	}
+	if variant_c == '' {
+		return none
+	}
+	lhs_source := g.render_call_argument_expression(lhs_tokens, lhs_type) or { return none }
+	access := if lhs_type.ends_with('*') { '->' } else { '.' }
+	operator := if inner[is_idx].tok == .key_is { '==' } else { '!=' }
+	return FastcRenderedExpression{
+		source: '(((${lhs_source})${access}_typ) ${operator} __v_typeid_${variant_c})'
+		typ: 'bool'
+	}
+}
+
+fn (g &Parser) render_boolean_is_operand(tokens []FastcExpressionToken) ?string {
+	if boolean_is := g.render_boolean_is_expression(tokens) {
+		return boolean_is.source
+	}
+	return g.render_call_argument_expression(tokens, 'bool')
+}
+
+struct FastcCallIsNarrowing {
+	box     string
+	variant string
+}
+
+// render_call_is_narrowing returns the boxed subject render and concrete variant for a positive
+// `<call>() is T` operand — a smart-cast whose subject is a method-call result, which the
+// name/member-chain paths (detect_member_smartcasts) do not own. Returns none for `!is`, a
+// pointer subject, or a bare-name/pure-member-chain subject.
+fn (g &Parser) render_call_is_narrowing(tokens []FastcExpressionToken) ?FastcCallIsNarrowing {
+	inner := fastc_strip_paren_tokens(tokens)
+	mut depth := 0
+	mut is_idx := -1
+	for i, item in inner {
+		match item.tok {
+			.lpar, .lsbr, .lcbr { depth++ }
+			.rpar, .rsbr, .rcbr { depth-- }
+			.key_is {
+				if depth == 0 && is_idx < 0 {
+					is_idx = i
+				}
+			}
+			.not_is {
+				if depth == 0 {
+					return none
+				}
+			}
+			else {}
+		}
+	}
+	if is_idx <= 0 || is_idx + 1 >= inner.len {
+		return none
+	}
+	lhs_tokens := inner[..is_idx]
+	if fastc_indexed_member_chain_path(lhs_tokens) != none {
+		return none
+	}
+	mut has_call := false
+	for it in lhs_tokens {
+		if it.tok == .lpar {
+			has_call = true
+			break
+		}
+	}
+	if !has_call {
+		return none
+	}
+	lhs_type := fastc_normalize_inferred_type(g.infer_expression_type(lhs_tokens) or { return none })
+	if !g.is_boxed_type(lhs_type) || lhs_type.ends_with('*') {
+		return none
+	}
+	mut variant_c := ''
+	if is_idx + 2 == inner.len && inner[is_idx + 1].tok == .name {
+		if type_key := g.resolve_declared_type_key(inner[is_idx + 1].lit) {
+			variant_c = fastc_c_declared_type_name(type_key)
+		} else if fastc_primitive_c_type(inner[is_idx + 1].lit) != none {
+			variant_c = inner[is_idx + 1].lit
+		}
+	} else if resolved := g.type_from_expression_tokens(inner[is_idx + 1..]) {
+		variant_c = fastc_normalize_inferred_type(resolved).trim_right('*')
+	}
+	if variant_c == '' {
+		return none
+	}
+	box := g.render_call_argument_expression(lhs_tokens, lhs_type) or { return none }
+	return FastcCallIsNarrowing{
+		box: box
+		variant: variant_c
+	}
+}
+
+// apply_call_is_narrowing rewrites field reads of the boxed call subject of a `<call>() is T`
+// left operand in the already-rendered `right` conjunct so they read the concrete variant `T`
+// through `_object`. Returns `right` unchanged when the left is not such a narrowing.
+fn (g &Parser) apply_call_is_narrowing(left_tokens []FastcExpressionToken, right string) string {
+	narrowing := g.render_call_is_narrowing(left_tokens) or { return right }
+	needle := '${narrowing.box}.'
+	if !right.contains(needle) {
+		return right
+	}
+	return right.replace(needle, '((${narrowing.variant} *)(${narrowing.box}._object))->')
+}
+
+// has_call_is_narrowing reports (shape-only, no rendering) whether `tokens` is a positive
+// `<call>() is T` on a boxed value subject — the flavour of narrowing apply_call_is_narrowing
+// handles. Used to gate the narrowing-boolean renderer on.
+fn (g &Parser) has_call_is_narrowing(tokens []FastcExpressionToken) bool {
+	inner := fastc_strip_paren_tokens(tokens)
+	mut depth := 0
+	mut is_idx := -1
+	for i, item in inner {
+		match item.tok {
+			.lpar, .lsbr, .lcbr { depth++ }
+			.rpar, .rsbr, .rcbr { depth-- }
+			.key_is {
+				if depth == 0 && is_idx < 0 {
+					is_idx = i
+				}
+			}
+			.not_is {
+				if depth == 0 {
+					return false
+				}
+			}
+			else {}
+		}
+	}
+	if is_idx <= 0 {
+		return false
+	}
+	lhs := inner[..is_idx]
+	if fastc_indexed_member_chain_path(lhs) != none {
+		return false
+	}
+	mut has_call := false
+	for it in lhs {
+		if it.tok == .lpar {
+			has_call = true
+			break
+		}
+	}
+	if !has_call {
+		return false
+	}
+	lhs_type := fastc_normalize_inferred_type(g.infer_expression_type(lhs) or { return false })
+	return g.is_boxed_type(lhs_type) && !lhs_type.ends_with('*')
+}
+
+// fastc_top_level_boolean_split returns the first index of `op` (`&&` / `||`) that sits at
+// bracket depth zero, or none when the operator does not appear at the top level.
+fn fastc_top_level_boolean_split(tokens []FastcExpressionToken, op token.Token) ?int {
+	mut depth := 0
+	for i, item in tokens {
+		match item.tok {
+			.lpar, .lsbr, .lcbr { depth++ }
+			.rpar, .rsbr, .rcbr { depth-- }
+			else {
+				if depth == 0 && item.tok == op && i > 0 && i + 1 < tokens.len {
+					return i
+				}
+			}
+		}
+	}
+	return none
+}
+
+// conjunction_narrowing describes the smart-cast a positive `subject is T` conjunct imposes
+// on the conjuncts to its right within an `&&` chain.
+struct FastcConjunctionNarrowing {
+	path      string
+	smartcast FastcMemberSmartcast
+}
+
+// conjunction_narrowing returns the subject narrowing implied by a lone `subject is T`
+// operand (`subject` a bare local or member chain), or none when the operand is not such a
+// narrowing. `!is`, calls, and compound operands never narrow.
+fn (g &Parser) conjunction_narrowing(tokens []FastcExpressionToken) ?FastcConjunctionNarrowing {
+	inner := fastc_strip_paren_tokens(tokens)
+	mut depth := 0
+	mut is_idx := -1
+	for i, item in inner {
+		match item.tok {
+			.lpar, .lsbr, .lcbr { depth++ }
+			.rpar, .rsbr, .rcbr { depth-- }
+			.key_is {
+				if depth == 0 && is_idx < 0 {
+					is_idx = i
+				}
+			}
+			.not_is, .and, .logical_or {
+				if depth == 0 {
+					return none
+				}
+			}
+			else {}
+		}
+	}
+	if is_idx < 1 {
+		return none
+	}
+	subject_tokens := inner[..is_idx]
+	mut has_index := false
+	for item in subject_tokens {
+		if item.tok == .lsbr {
+			has_index = true
+			break
+		}
+	}
+	// The narrowed subject may be an indexed member chain (`node.args[0].expr is CallExpr`);
+	// key it with the same `[]` markers render_member_receiver uses so the smart-cast is found
+	// when `.is_method`/`.name` on that chain are rendered later.
+	path := if has_index {
+		fastc_indexed_member_chain_path(subject_tokens) or { return none }
+	} else {
+		for item in subject_tokens {
+			if item.tok !in [.name, .dot] {
+				return none
+			}
+		}
+		fastc_member_chain_path(subject_tokens, 0, subject_tokens.len) or { return none }
+	}
+	mut subject_type := g.infer_expression_type(subject_tokens) or { '' }
+	if member_type := g.infer_member_access_type(subject_tokens, 0, subject_tokens.len) {
+		subject_type = member_type
+	}
+	if subject_type == '' {
+		return none
+	}
+	if !g.is_boxed_type(fastc_normalize_inferred_type(subject_type)) {
+		return none
+	}
+	mut variant_c := ''
+	if is_idx + 2 == inner.len && inner[is_idx + 1].tok == .name {
+		if type_key := g.resolve_declared_type_key(inner[is_idx + 1].lit) {
+			variant_c = fastc_c_declared_type_name(type_key)
+		} else if fastc_primitive_c_type(inner[is_idx + 1].lit) != none {
+			variant_c = inner[is_idx + 1].lit
+		}
+	} else if resolved := g.type_from_expression_tokens(inner[is_idx + 1..]) {
+		variant_c = fastc_normalize_inferred_type(resolved).trim_right('*')
+	}
+	if variant_c == '' {
+		return none
+	}
+	// Render the subject WITHOUT any smart-cast already registered for this exact path, so a
+	// re-evaluation (`x.left is Ident && … && x.left.method()` narrowed more than once) does not
+	// wrap the subject in its own variant unwrap and produce a double `((T*)((T*)…_object)._object)`.
+	mut w := unsafe { &Parser(g) }
+	had_self := path in g.member_smartcasts
+	saved_self := g.member_smartcasts[path] or { FastcMemberSmartcast{} }
+	if had_self {
+		w.member_smartcasts.delete(path)
+	}
+	subject_source := g.render_member_receiver(subject_tokens) or {
+		if had_self {
+			w.member_smartcasts[path] = saved_self
+		}
+		return none
+	}
+	if had_self {
+		w.member_smartcasts[path] = saved_self
+	}
+	access := if subject_type.ends_with('*') { '->' } else { '.' }
+	return FastcConjunctionNarrowing{
+		path: path
+		smartcast: FastcMemberSmartcast{
+			typ: variant_c + '*'
+			source: '((${variant_c} *)(${subject_source})${access}_object)'
+		}
+	}
+}
+
+// boolean_expression_has_narrowing reports whether a boolean `is` expression contains a
+// top-level `&&` whose left conjunct narrows a subject (`x is T && x.f is U`), which the
+// per-operand rendering cannot express because the right conjunct must see the narrowing.
+fn (g &Parser) boolean_expression_has_narrowing(tokens []FastcExpressionToken) bool {
+	inner := fastc_strip_paren_tokens(tokens)
+	if inner.len < 3 {
+		return false
+	}
+	if inner[0].tok == .not {
+		return g.boolean_expression_has_narrowing(inner[1..])
+	}
+	if idx := fastc_top_level_boolean_split(inner, .logical_or) {
+		return g.boolean_expression_has_narrowing(inner[..idx]) || g.boolean_expression_has_narrowing(inner[idx + 1..])
+	}
+	if idx := fastc_top_level_boolean_split(inner, .and) {
+		// The left conjunct itself may be a parenthesized boolean that narrows internally
+		// (`(k != .b || !(x.info is Struct && x.info.is_anon)) && …`), so recurse into it too —
+		// not only test whether it is a bare `subject is T` narrowing.
+		if g.conjunction_narrowing(inner[..idx]) != none || g.has_call_is_narrowing(inner[..idx]) || g.boolean_expression_has_narrowing(inner[..idx]) {
+			return true
+		}
+		return g.boolean_expression_has_narrowing(inner[idx + 1..])
+	}
+	return false
+}
+
+// render_narrowing_boolean_expression lowers a boolean `is` expression whose `&&` chains
+// carry flow-sensitive smart-casts (`e is UnsafeExpr && e.expr is Nil`). Each narrowing left
+// conjunct registers a temporary member smart-cast so the operands to its right — rendered
+// through the ordinary non-mutating renderers — resolve the narrowed subject. Returns none
+// when no such narrowing is present, leaving the plain boolean path untouched.
+fn (mut g Parser) render_narrowing_boolean_expression(tokens []FastcExpressionToken) ?string {
+	mut has_is := false
+	for item in tokens {
+		if item.tok in [.key_is, .not_is] {
+			has_is = true
+			break
+		}
+	}
+	if !has_is || !g.boolean_expression_has_narrowing(tokens) {
+		return none
+	}
+	return g.render_narrowing_boolean_impl(tokens)
+}
+
+fn (mut g Parser) render_narrowing_boolean_operand(tokens []FastcExpressionToken) ?string {
+	if compound := g.render_narrowing_boolean_impl(tokens) {
+		return compound
+	}
+	// A `(subject as T).field` operand reads the narrowed subject through the concrete
+	// variant; render it directly so the member `as` cast is not left for the raw renderer.
+	if tokens.len > 0 && tokens[0].tok == .lpar {
+		if as_member := g.render_as_cast_member_access(tokens) {
+			return as_member.source
+		}
+	}
+	// Any other embedded `(x as T)` cast in this operand (e.g. a method-call receiver
+	// `(x as T).m()`) is lowered with the current narrowing active before the fallback.
+	if rewritten := g.rewrite_embedded_as_casts(tokens) {
+		return g.render_boolean_is_operand(rewritten)
+	}
+	return g.render_boolean_is_operand(tokens)
+}
+
+fn (mut g Parser) render_narrowing_boolean_impl(tokens []FastcExpressionToken) ?string {
+	inner := fastc_strip_paren_tokens(tokens)
+	if inner.len > 1 && inner[0].tok == .not && fastc_top_level_boolean_split(inner, .and) == none && fastc_top_level_boolean_split(inner, .logical_or) == none {
+		// `!(a is T && a.f == …)`: the negation wraps the WHOLE expression (no top-level
+		// `&&`/`||` sits outside it), and the `&&` inside still narrows its own right operand,
+		// so recurse through the `!`. A `!x && y` (where `!` binds tighter than `&&`) is left to
+		// the boolean split below, so the negation is not spread across the whole conjunction.
+		operand := g.render_narrowing_boolean_impl(inner[1..]) or { return none }
+		return '(!(${operand}))'
+	}
+	if idx := fastc_top_level_boolean_split(inner, .logical_or) {
+		left := g.render_narrowing_boolean_operand(inner[..idx]) or { return none }
+		right := g.render_narrowing_boolean_operand(inner[idx + 1..]) or { return none }
+		return '((${left}) || (${right}))'
+	}
+	if idx := fastc_top_level_boolean_split(inner, .and) {
+		left_tokens := inner[..idx]
+		left := g.render_narrowing_boolean_operand(left_tokens) or { return none }
+		if narrowing := g.conjunction_narrowing(left_tokens) {
+			had := narrowing.path in g.member_smartcasts
+			saved := g.member_smartcasts[narrowing.path] or { FastcMemberSmartcast{} }
+			g.member_smartcasts[narrowing.path] = narrowing.smartcast
+			right := g.render_narrowing_boolean_operand(inner[idx + 1..]) or {
+				if had {
+					g.member_smartcasts[narrowing.path] = saved
+				} else {
+					g.member_smartcasts.delete(narrowing.path)
+				}
+				return none
+			}
+			if had {
+				g.member_smartcasts[narrowing.path] = saved
+			} else {
+				g.member_smartcasts.delete(narrowing.path)
+			}
+			return '((${left}) && (${right}))'
+		}
+		mut right := g.render_narrowing_boolean_operand(inner[idx + 1..]) or { return none }
+		// A `<call>() is T` left operand narrows the SAME call in the right operand (a smart-cast
+		// on a method-call result, which conjunction_narrowing does not own).
+		right = g.apply_call_is_narrowing(left_tokens, right)
+		return '((${left}) && (${right}))'
+	}
+	return none
+}
+
 fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered_expression string) ?FastcRenderedExpression {
 	if tokens.len == 1 {
 		if tokens[0].tok == .name {
@@ -2536,7 +3558,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 				has_left_shift = true
 				has_binary = true
 			}
-			.minus, .mul, .div, .mod, .amp, .pipe, .xor, .right_shift {
+			.minus, .mul, .div, .mod, .amp, .pipe, .xor, .right_shift, .right_shift_unsigned {
 				has_binary = true
 			}
 			.and, .logical_or {
@@ -2605,6 +3627,36 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			return string_print
 		}
 	}
+	// A common sum-type field read (`node.pos`, present in every variant) must be tried
+	// before the member-smart-cast short-circuit below: when the receiver itself is a
+	// smart-cast subject, render_member_receiver would otherwise splice a raw `.pos`
+	// access onto the boxed sum-type struct, which has no such field.
+	if g.selfhost && has_dot && tokens.len >= 3 && tokens.last().tok == .name && tokens[tokens.len - 2].tok == .dot {
+		if common_field := g.render_sumtype_common_field_access(tokens) {
+			return common_field
+		}
+	}
+	// `&x.field` where `x.field` reads through a member smart-cast: the address must point at
+	// the concrete-variant object (`(Var *)subject._object`), not the raw boxed field. Without
+	// this the reference decays to `&subject.field`, a `ScopeObject *`, and later `obj.typ`
+	// reads a field the box lacks. A member smart-cast already represents the narrowed field as
+	// a pointer into the box (`typ` ends with `*`), so its read source IS the field's address —
+	// return it directly; only a value-typed narrowing needs an explicit `&`.
+	if g.selfhost && tokens.len > 2 && tokens[0].tok == .amp && has_dot && g.expression_uses_member_smartcast(tokens[1..]) {
+		if member_source := g.render_member_receiver(tokens[1..]) {
+			member_type := g.infer_member_access_type(tokens[1..], 0, tokens.len - 1) or { '' }
+			if member_type.ends_with('*') {
+				return FastcRenderedExpression{
+					source: member_source
+					typ: member_type
+				}
+			}
+			return FastcRenderedExpression{
+				source: '&(${member_source})'
+				typ: if member_type != '' { member_type + '*' } else { 'voidptr' }
+			}
+		}
+	}
 	if g.selfhost && has_dot && g.expression_uses_member_smartcast(tokens) {
 		if source := g.render_member_receiver(tokens) {
 			if typ := g.infer_member_access_type(tokens, 0, tokens.len) {
@@ -2615,17 +3667,101 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			}
 		}
 	}
+	// A member access cast (`x.f as T`) must be lowered here, before the pointer /
+	// method-access branches below claim the member chain — otherwise a cast whose
+	// target shares a name with a FastC builtin (`MultiReturn`, `Chan`, ...) never
+	// reaches the general `as` handling.
+	if g.selfhost && has_as && has_dot {
+		if as_expression := g.render_as_cast_expression(tokens) {
+			return as_expression
+		}
+		// `(x as T).field`: the cast is parenthesized, then a field chain follows.
+		if as_member := g.render_as_cast_member_access(tokens) {
+			return as_member
+		}
+	}
+	// An Option is represented by the generic C `Option` struct, so equality with
+	// `none` must compare its state before generic binary/struct comparisons can
+	// claim the expression and emit an invalid C struct comparison.
+	if has_comparison && fastc_top_level_boolean_split(tokens, .and) == none
+		&& fastc_top_level_boolean_split(tokens, .logical_or) == none {
+		if option_comparison := g.render_option_none_comparison(tokens) {
+			return option_comparison
+		}
+	}
 	if has_binary {
 		if overloaded_binary := g.guarded_overloaded_binary_expression(tokens, flags) {
 			return overloaded_binary
 		}
 	}
+	if g.selfhost && has_assignment && has_comparison && !has_lsbr {
+		// `x.f = a == b` is an assignment whose RHS is a comparison. Assignment binds looser
+		// than comparison, so split at the top-level `=` before the comparison handlers below
+		// claim the `==` and emit `(x.f = a) == b`. Restricted to the assignment+comparison
+		// case (and excluding index targets, which route through the map/array assignment
+		// lowering) so ordinary assignments keep their existing handling.
+		if assignment := g.render_assignment_expression(tokens) {
+			return assignment
+		}
+	}
 	if has_comparison {
+		// A comparison whose operand reads a NESTED member smart-cast (`x.expr.obj.generic_typ
+		// == 0`, where both `x.expr` and `x.expr.obj` are narrowed) must render its operands
+		// through render_guard_comparison, whose render_comparison_operand walks the full chain
+		// via render_member_receiver — the integer/struct comparison paths below only apply the
+		// first-level narrowing spliced by the streaming reader. A call-bearing operand is left
+		// to those paths (render_comparison_operand's pointer-member handling mis-lowers it).
+		if g.selfhost && g.expression_uses_member_smartcast(tokens) && !fastc_expression_tokens_contain(tokens, .lpar) && fastc_top_level_boolean_split(tokens, .and) == none && fastc_top_level_boolean_split(tokens, .logical_or) == none {
+			if guard := g.render_guard_comparison(tokens) {
+				return FastcRenderedExpression{
+					source: guard
+					typ: 'bool'
+				}
+			}
+		}
+		// Render indexed comparison operands independently. Besides chained accesses
+		// (`fields[0][0] == \`0\``), this ensures both sides of `s[i] > a[i]` use the
+		// direct-array-access lowering instead of leaving the second string index raw.
+		if g.selfhost && has_lsbr && !has_assignment && fastc_top_level_boolean_split(tokens, .and) == none && fastc_top_level_boolean_split(tokens, .logical_or) == none {
+			if guard := g.render_guard_comparison(tokens) {
+				return FastcRenderedExpression{
+					source: guard
+					typ: 'bool'
+				}
+			}
+		}
+		// A parenthesized membership used as a comparison operand (`(key in m) != known`)
+		// must be lowered before the raw comparison renderer leaves V's `in` in C.
+		if g.selfhost && has_membership && fastc_top_level_boolean_split(tokens, .and) == none
+			&& fastc_top_level_boolean_split(tokens, .logical_or) == none {
+			if guard := g.render_guard_comparison(tokens) {
+				return FastcRenderedExpression{
+					source: guard
+					typ: 'bool'
+				}
+			}
+		}
+		// A comparison whose call operand propagates a result/option in one of its arguments
+		// (`f(g()!) == 0`) must render that operand through render_guard_comparison so the
+		// nested `!` is unwrapped rather than emitted as a raw C `!` on the returned Option.
+		if g.selfhost && fastc_tokens_contain_nested_propagation(tokens) && fastc_top_level_boolean_split(tokens, .and) == none && fastc_top_level_boolean_split(tokens, .logical_or) == none {
+			if guard := g.render_guard_comparison(tokens) {
+				return FastcRenderedExpression{
+					source: guard
+					typ: 'bool'
+				}
+			}
+		}
 		if struct_comparison := g.guarded_struct_comparison_expression(tokens, flags) {
 			return struct_comparison
 		}
 		if integer_comparison := g.guarded_mixed_integer_comparison_expression(tokens, flags) {
 			return integer_comparison
+		}
+		if g.selfhost {
+			if common_field_comparison := g.render_common_field_comparison_expression(tokens) {
+				return common_field_comparison
+			}
 		}
 	}
 	if !g.selfhost {
@@ -2670,6 +3806,14 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			}
 		}
 		if tokens.len > 1 && tokens.last().tok == .not {
+			// A string concatenation whose operands are `?`/`!`-propagated (`a()? + b()?`) must
+			// lower through string_plus first; the generic nested-propagation replace below only
+			// unwraps the trailing operand and would leave a raw C `+` between two strings.
+			if has_plus {
+				if concatenation := g.render_composed_string_concatenation(tokens) {
+					return concatenation
+				}
+			}
 			if nested_propagation := g.guarded_nested_option_propagation(tokens, rendered_expression, flags) {
 				return nested_propagation
 			}
@@ -2695,8 +3839,55 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			}
 		}
 		if has_lsbr {
+			if g.selfhost && has_as {
+				// `arr[i] as T`: the `as` cast on an array-element (or map-value) receiver must
+				// lower here, before the array/map-read branches below claim the `[…]` and leave
+				// the trailing `as T` as raw C.
+				if as_expression := g.render_as_cast_expression(tokens) {
+					return as_expression
+				}
+			}
+			if g.selfhost && tokens.len >= 2 && tokens[0].tok == .lsbr {
+				// An array LITERAL whose element embeds a map read (`[m[k]]`) must lower as a whole
+				// `new_array`; render_embedded_map_reads below would rewrite only the inner read and
+				// leave the outer `[…]` as invalid raw C. render_array_literal_argument returns none
+				// unless the tokens truly are `[ … ]`, so it is safe to try before the map paths.
+				mut array_type := g.infer_expression_type(tokens) or { '' }
+				if !array_type.starts_with('Array_') && !array_type.starts_with('FixedArray_') && (g.expected_expression_type.starts_with('Array_') || g.expected_expression_type.starts_with('FixedArray_')) {
+					array_type = fastc_trim_pointer_suffix(g.expected_expression_type)
+				}
+				if array_literal := g.render_array_literal_argument(tokens, array_type) {
+					return array_literal
+				}
+			}
+			if tokens.last().tok in [.inc, .dec] {
+				if map_inc := g.render_map_index_inc_dec_expression(tokens) {
+					return map_inc
+				}
+			}
 			if map_expression := g.guarded_map_expression(tokens, flags) {
 				return map_expression
+			}
+			// An outer array/string index whose INDEX is itself a map read (`arr[m[k]]`) must be
+			// lowered as a whole array access — its index renderer already lowers the inner map
+			// read to a value. render_embedded_map_reads below would otherwise rewrite only the
+			// inner read and leave the outer `arr[…]` as a raw C index on the array struct.
+			// render_array_access returns none unless the whole expression is such an access.
+			if array_access := g.render_array_access_expression(tokens) {
+				return array_access
+			}
+			if has_comparison {
+				// `m[k] == .enum_`: resolve the enum-shorthand comparison against the map value type
+				// here — render_embedded_map_reads below would rewrite only the `m[k]` read and leave
+				// the raw `.enum_` shorthand as invalid C.
+				if enum_comparison := g.render_enum_comparison_expression(tokens) {
+					return enum_comparison
+				}
+			}
+			if !has_assignment && !has_membership && !has_logical {
+				if embedded_map := g.render_embedded_map_reads(tokens) {
+					return embedded_map
+				}
 			}
 		}
 		if has_lcbr {
@@ -2722,6 +3913,15 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 				return assignment
 			}
 		}
+		if has_dot && has_lpar && tokens.last().tok == .rpar {
+			// `arr.map/filter/any/all/count(it…)` used as a sub-expression (call argument,
+			// membership collection, struct-field value): the streaming reader only lowers
+			// these magic closure methods when they front the whole statement, so lower a
+			// trailing one here too instead of leaving a raw `array_map(arr, it.f)`.
+			if higher_order := g.render_higher_order_method_expression(tokens) {
+				return higher_order
+			}
+		}
 		if has_dot && has_lpar && (tokens.len == 0 || tokens.last().tok != .not) {
 			if static_call := g.render_static_call_expression(tokens, rendered_expression) {
 				return static_call
@@ -2740,19 +3940,50 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			}
 		}
 		if has_comparison {
-			if option_comparison := g.render_option_none_comparison(tokens) {
-				return option_comparison
+			if g.selfhost {
+				if nil_comparison := g.render_nil_comparison(tokens) {
+					return nil_comparison
+				}
 			}
 			if enum_comparison := g.guarded_enum_comparison_expression(tokens, flags) {
 				return enum_comparison
 			}
+			// `f(x) is Variant` (a call left operand, possibly combined with `&&`/`||`) is a
+			// boolean tag test, not something the smart-cast reader can shadow.
+			if boolean_is := g.render_boolean_is_expression(tokens) {
+				return boolean_is
+			}
 			if string_comparison := g.render_string_comparison_expression(tokens) {
 				return string_comparison
 			}
+			// A comparison whose operand is a plain call (`node_kind_id(child) != 75`) must be
+			// lowered through render_guard_comparison so the call's arguments receive their
+			// value/pointer coercions (auto-deref of a `&T` argument for a by-value parameter);
+			// the raw fallback below would stream the call verbatim and leave the mismatch.
+			if g.selfhost && fastc_comparison_operand_is_plain_call(tokens) && !g.expression_uses_member_smartcast(tokens) && fastc_top_level_boolean_split(tokens, .and) == none && fastc_top_level_boolean_split(tokens, .logical_or) == none {
+				if guard := g.render_guard_comparison(tokens) {
+					return FastcRenderedExpression{
+						source: guard
+						typ: 'bool'
+					}
+				}
+			}
 		}
-		if has_plus {
+		if has_plus && !has_membership {
+			// `+` binds tighter than `in`, so a top-level membership (`'@' + name in tokens`) owns the
+			// whole expression; without this gate the concat renderer wrongly splits at `+` and treats
+			// `name in tokens` (a bool) as a string operand. The membership handler below renders the
+			// concatenated subject itself.
 			if concatenation := g.guarded_composed_string_concatenation(tokens, flags) {
 				return concatenation
+			}
+		}
+		if g.selfhost {
+			// `x()?.field` / `x()?.method(a)`: the `?`/`!` propagates the option and the trailing
+			// member chain applies to the unwrapped value, so lower it before the raw fallback
+			// leaves a stray C `?`/`!` between the call and the member access.
+			if propagation_member := g.render_propagation_before_member(tokens) {
+				return propagation_member
 			}
 		}
 		if tokens.len > 1 && tokens.last().tok == .not && rendered_expression.ends_with('!') && !fastc_trailing_not_marks_fixed_array_literal(tokens) {
@@ -2790,6 +4021,19 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			}
 		}
 		if has_membership {
+			// A fully-parenthesized membership (`(x in m)`, as in `for (candidate in used) {`)
+			// keeps its `in` at paren depth 1 where the depth-0 scan below misses it; render the
+			// stripped inner expression so the membership lowers, then restore the grouping.
+			stripped := fastc_strip_paren_tokens(tokens)
+			if stripped.len < tokens.len && (fastc_expression_tokens_contain(stripped, .key_in) || fastc_expression_tokens_contain(stripped, .not_in)) {
+				raw_stripped := g.render_raw_expression_tokens(stripped) or { rendered_expression }
+				if inner := g.render_special_expression(stripped, raw_stripped) {
+					return FastcRenderedExpression{
+						source: '(${inner.source})'
+						typ: inner.typ
+					}
+				}
+			}
 			mut depth := 0
 			for i, item in tokens {
 				if item.tok in [.lpar, .lsbr, .lcbr] {
@@ -2799,8 +4043,55 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 				} else if depth == 0 && item.tok in [.key_in, .not_in] && i > 0 && i + 1 < tokens.len {
 					temporary_namespace := g.temporary_namespace('membership')
 					right_tokens := tokens[i + 1..]
-					right_type := g.infer_expression_type(right_tokens) or { return none }
-					if g.underlying_alias_type(right_type) == 'string' {
+					// `x in [Type1, Type2, …]` where `x` is a boxed sum type is a membership
+					// over the runtime type tag (V's `x is Type1 || x is Type2 || …`), not a
+					// value search. The list elements are declared type names, not values.
+					left_boxed_type := fastc_normalize_inferred_type(g.infer_expression_type(tokens[..i]) or {
+						''
+					})
+					if g.is_boxed_type(left_boxed_type) && right_tokens.len >= 2 && right_tokens[0].tok == .lsbr && right_tokens.last().tok == .rsbr {
+						if elements := fastc_expression_list_items(right_tokens, 1, right_tokens.len - 1) {
+							mut type_ids := []string{}
+							for element in elements {
+								type_key := g.type_from_expression_tokens(element) or { break }
+								type_ids << fastc_normalize_inferred_type(type_key).trim_right('*')
+							}
+							if type_ids.len == elements.len && type_ids.len > 0 {
+								subject := g.render_call_argument_expression(tokens[..i], left_boxed_type) or {
+									return none
+								}
+								access := if left_boxed_type.ends_with('*') { '->' } else { '.' }
+								subject_name := '${temporary_namespace}_subject'
+								mut checks := []string{}
+								for type_id in type_ids {
+									checks << '(${subject_name}${access}_typ == __v_typeid_${type_id})'
+								}
+								joined := checks.join(' || ')
+								predicate := if item.tok == .not_in {
+									'!(${joined})'
+								} else {
+									'(${joined})'
+								}
+								return FastcRenderedExpression{
+									source: '({ ${left_boxed_type} ${subject_name} = (${subject}); ${predicate}; })'
+									typ: 'bool'
+								}
+							}
+						}
+					}
+					right_type := g.infer_expression_type(right_tokens) or {
+						// A bare array literal of enum shorthands (`x !in [.a, .b]`) can be
+						// impossible to infer on its own: with the full builtin loaded several
+						// enums share member names like `struct`/`interface`, so the list has
+						// no unambiguous element type. Fall through to the array-literal path
+						// below, which derives the element type from the left operand instead.
+						if right_tokens.len >= 2 && right_tokens[0].tok == .lsbr && right_tokens.last().tok == .rsbr {
+							''
+						} else {
+							return none
+						}
+					}
+					if right_type != '' && g.underlying_alias_type(right_type) == 'string' {
 						left_type := g.infer_expression_type(tokens[..i]) or { return none }
 						if g.underlying_alias_type(left_type) != 'string' {
 							return none
@@ -2858,17 +4149,33 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 						} else {
 							'${collection_name}${access}len'
 						}
-						comparison := if g.underlying_alias_type(element_type).trim_right('*') == 'string' {
-							'builtin__string_eq(${item_name}, ((${element_type} *)${collection_name}${access}data)[${index_name}])'
-						} else {
-							'(${item_name} == ((${element_type} *)${collection_name}${access}data)[${index_name}])'
+						right_element := '((${element_type} *)${collection_name}${access}data)[${index_name}]'
+						mut comparison := '(${item_name} == ${right_element})'
+						if g.underlying_alias_type(element_type).trim_right('*') == 'string' {
+							comparison = 'builtin__string_eq(${item_name}, ${right_element})'
+						} else if fastc_trim_pointer_suffix(g.underlying_alias_type(element_type)).starts_with('Array_') {
+							// Array elements (`types in [][]Type`) cannot be compared with C `==`;
+							// compare the two arrays element-wise inline.
+							comparison = g.fastc_inline_array_element_equality(element_type, item_name, right_element) or { return none }
+						} else if g.struct_equality_is_supported(element_type, []) {
+							// Struct elements (`typ in []StrType`) cannot be compared with C `==`; compare them
+							// field-wise, like `struct == struct`.
+							comparison = g.struct_equality_source(item_name, right_element, element_type, [])
 						}
 						// A hoisted predicate keeps this interpolation flat: the FastC
 						// selfhost parser renders nested `${if ... { '${...}' }}` blocks
 						// literally, corrupting the emitted membership expression.
 						predicate := if item.tok == .not_in { '!${found_name}' } else { found_name }
+						// A collection lowered to a `({ … for … })` statement-expression (e.g.
+						// `arr.map(it.f)`) cannot be `__typeof__`'d by TinyCC; name its known array
+						// type directly instead.
+						collection_c_type := if collection.starts_with('({') {
+							right_type
+						} else {
+							'__typeof__((${collection}))'
+						}
 						return FastcRenderedExpression{
-							source: '({ ${element_type} ${item_name} = (${candidate}); __typeof__((${collection})) ${collection_name} = (${collection}); bool ${found_name} = false; for (int ${index_name} = 0; ${index_name} < ${collection_length}; ${index_name}++) { if (${comparison}) { ${found_name} = true; break; } } ${predicate}; })'
+							source: '({ ${element_type} ${item_name} = (${candidate}); ${collection_c_type} ${collection_name} = (${collection}); bool ${found_name} = false; for (int ${index_name} = 0; ${index_name} < ${collection_length}; ${index_name}++) { if (${comparison}) { ${found_name} = true; break; } } ${predicate}; })'
 							typ: 'bool'
 						}
 					}
@@ -2931,9 +4238,36 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 			if array_access := g.render_array_access_expression(tokens) {
 				return array_access
 			}
+			// An index embedded in a larger expression (`node.items()[0].field > 0`)
+			// must be lowered before pointer-member rewriting can return the partially
+			// rewritten method call with raw C indexing still attached.
+			if nested_array := g.render_nested_array_access_expression(tokens, rendered_expression) {
+				mut nested_source := nested_array.source
+				mut nested_type := nested_array.typ
+				if has_dot && has_lpar {
+					if method_expression := g.render_method_call_expression(tokens, nested_array.source) {
+						nested_source = method_expression.source
+						nested_type = method_expression.typ
+					}
+				}
+				if has_dot {
+					if pointer_members := g.render_pointer_member_access_expression(tokens, nested_source) {
+						return pointer_members
+					}
+				}
+				return FastcRenderedExpression{
+					source: nested_source
+					typ: nested_type
+				}
+			}
 		}
 		if has_dot {
 			if pointer_members := g.render_pointer_member_access_expression(tokens, rendered_expression) {
+				if has_lsbr {
+					if nested_array := g.render_nested_array_access_expression(tokens, pointer_members.source) {
+						return nested_array
+					}
+				}
 				return pointer_members
 			}
 		}
@@ -2971,11 +4305,27 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 		.key_is,
 		.not_is,
 	] {
-		lhs_type := g.infer_expression_type(tokens[..1]) or { return none }
+		// `x is T` tests the boxed subject's tag, so the `._typ`/`->_typ` access is
+		// decided by the local's own (boxed) type — never a member smart-cast that a
+		// sibling guard in the same condition registered on the same name. A folded
+		// `(x as T).field` group arrives as a synthetic token carrying its C text in `.source`
+		// and its type in `.typ` (an empty `.lit`), so read those directly for it.
+		is_synth_subject := tokens[0].source != ''
+		lhs_type := if is_synth_subject && tokens[0].typ != '' {
+			fastc_normalize_inferred_type(tokens[0].typ)
+		} else if local := g.locals[tokens[0].lit] {
+			local.typ
+		} else {
+			g.infer_expression_type(tokens[..1]) or { return none }
+		}
 		mut variant_c := ''
 		if tokens.len == 3 && tokens[2].tok == .name {
 			if type_key := g.resolve_declared_type_key(tokens[2].lit) {
 				variant_c = fastc_c_declared_type_name(type_key)
+			} else if fastc_primitive_c_type(tokens[2].lit) != none {
+				// A primitive sum-type variant (`v is u64`) is not a declared type; its
+				// own spelling is the `__v_typeid_` suffix (see decl.v's primitive ids).
+				variant_c = tokens[2].lit
 			}
 		} else if resolved_target := g.type_from_expression_tokens(tokens[2..]) {
 			// Qualified (`err is io.Eof`) and composite (`x is []string`) targets both
@@ -2988,8 +4338,9 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 		}
 		access := if lhs_type.ends_with('*') { '->' } else { '.' }
 		operator := if tokens[1].tok == .key_is { '==' } else { '!=' }
+		subject := if is_synth_subject { tokens[0].source } else { tokens[0].lit }
 		return FastcRenderedExpression{
-			source: '((${tokens[0].lit}${access}_typ) ${operator} __v_typeid_${variant_c})'
+			source: '((${subject}${access}_typ) ${operator} __v_typeid_${variant_c})'
 			typ: 'bool'
 		}
 	}
@@ -3046,6 +4397,17 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 		tokens.len
 	}
 	if g.selfhost && array_end == 2 && tokens[0].tok == .lsbr && tokens[1].tok == .rsbr && g.expected_expression_type.trim_right('*').starts_with('Array_') {
+		// A dynamic empty array needs a real header carrying `element_size`, otherwise a later
+		// `<<` push copies `len * 0` bytes into a NULL buffer and silently drops the elements.
+		array_type := fastc_trim_pointer_suffix(g.expected_expression_type)
+		if element_type := g.array_element_type(array_type) {
+			mut w := unsafe { &Parser(g) }
+			fastc_register_composite_type(array_type, mut w.composite_types)
+			return FastcRenderedExpression{
+				source: '((${array_type})builtin____new_array(0, 0, sizeof(${fastc_normalize_inferred_type(element_type)})))'
+				typ: g.expected_expression_type
+			}
+		}
 		return FastcRenderedExpression{
 			source: '(${g.expected_expression_type}){0}'
 			typ: g.expected_expression_type
@@ -3149,17 +4511,43 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 }
 
 fn (g &Parser) expression_uses_member_smartcast(tokens []FastcExpressionToken) bool {
-	if g.member_smartcasts.len == 0 || tokens.len < 3 || tokens[0].tok != .name {
+	if g.member_smartcasts.len == 0 {
 		return false
 	}
-	mut path := tokens[0].lit
-	mut index := 1
-	for index + 1 < tokens.len && tokens[index].tok == .dot && tokens[index + 1].tok == .name {
-		path += '.' + tokens[index + 1].lit
+	// A smart-cast subject can appear anywhere in the expression, not only at its start
+	// (`!left.is_blank()`, `a && x.f`). Scan every chain-start name (one not preceded by a
+	// `.`) and its member chain.
+	for i, item in tokens {
+		if item.tok != .name || (i > 0 && tokens[i - 1].tok == .dot) {
+			continue
+		}
+		mut path := item.lit
 		if path in g.member_smartcasts {
 			return true
 		}
-		index += 2
+		mut index := i + 1
+		for index < tokens.len {
+			if tokens[index].tok == .lsbr {
+				// An array index segment keys as the `[]` marker, matching render_member_receiver
+				// (`right.args[0].expr` → `right.args[].expr`).
+				close := fastc_matching_delimiter(tokens, index, .lsbr, .rsbr) or { break }
+				path += '[]'
+				if path in g.member_smartcasts {
+					return true
+				}
+				index = close + 1
+				continue
+			}
+			if index + 1 < tokens.len && tokens[index].tok == .dot && tokens[index + 1].tok == .name {
+				path += '.' + tokens[index + 1].lit
+				if path in g.member_smartcasts {
+					return true
+				}
+				index += 2
+				continue
+			}
+			break
+		}
 	}
 	return false
 }

--- a/vlib/v3/gen/fastc/expr.v
+++ b/vlib/v3/gen/fastc/expr.v
@@ -337,9 +337,11 @@ fn (mut g Parser) lower_higher_order_expression(mut result strings.Builder, mut 
 			}
 			had_it := it_name in g.locals
 			saved_it := g.locals[it_name] or { FastcLocal{} }
+			it_c_name := fastc_c_identifier(it_name)
 			g.type_memo.clear()
 			g.locals[it_name] = FastcLocal{
 				typ: element_type
+				c_name: it_c_name
 			}
 			// The closure type is independent of the surrounding assignment type.
 			saved_closure_expected := g.expected_expression_type
@@ -352,7 +354,7 @@ fn (mut g Parser) lower_higher_order_expression(mut result strings.Builder, mut 
 				&& g.last_expression[0].lit != it_name {
 				function_key := g.unqualified_function_key(g.last_expression[0].lit)
 				if signature := g.functions[function_key] {
-					closure = '${closure}(${it_name})'
+					closure = '${closure}(${it_c_name})'
 					closure_type = signature.return_type
 				}
 			}
@@ -383,12 +385,12 @@ fn (mut g Parser) lower_higher_order_expression(mut result strings.Builder, mut 
 			if higher_order_method == 'map' {
 				result_type = fastc_array_c_type(closure_type)
 				fastc_register_composite_type(result_type, mut g.composite_types)
-				lowered = '({ ${collection_type} ${src} = (${collection_source}); ${result_type} ${dst} = (${result_type})builtin____new_array(0, ${src}.len, sizeof(${closure_type})); for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} ${it_name} = ((${element_type} *)${src}.data)[${idx}]; ${closure_type} ${elem} = (${closure}); builtin__array_push((array *)&${dst}, &${elem}); } ${dst}; })'
+				lowered = '({ ${collection_type} ${src} = (${collection_source}); ${result_type} ${dst} = (${result_type})builtin____new_array(0, ${src}.len, sizeof(${closure_type})); for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} ${it_c_name} = ((${element_type} *)${src}.data)[${idx}]; ${closure_type} ${elem} = (${closure}); builtin__array_push((array *)&${dst}, &${elem}); } ${dst}; })'
 			} else if higher_order_method == 'filter' {
-				lowered = '({ ${collection_type} ${src} = (${collection_source}); ${collection_type} ${dst} = (${collection_type})builtin____new_array(0, ${src}.len, sizeof(${element_type})); for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} ${it_name} = ((${element_type} *)${src}.data)[${idx}]; if (${closure}) { builtin__array_push((array *)&${dst}, &${it_name}); } } ${dst}; })'
+				lowered = '({ ${collection_type} ${src} = (${collection_source}); ${collection_type} ${dst} = (${collection_type})builtin____new_array(0, ${src}.len, sizeof(${element_type})); for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} ${it_c_name} = ((${element_type} *)${src}.data)[${idx}]; if (${closure}) { builtin__array_push((array *)&${dst}, &${it_c_name}); } } ${dst}; })'
 			} else if higher_order_method == 'count' {
 				result_type = 'int'
-				lowered = '({ ${collection_type} ${src} = (${collection_source}); int ${dst} = 0; for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} ${it_name} = ((${element_type} *)${src}.data)[${idx}]; if (${closure}) { ${dst}++; } } ${dst}; })'
+				lowered = '({ ${collection_type} ${src} = (${collection_source}); int ${dst} = 0; for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} ${it_c_name} = ((${element_type} *)${src}.data)[${idx}]; if (${closure}) { ${dst}++; } } ${dst}; })'
 			} else {
 				result_type = 'bool'
 				initial := if higher_order_method == 'all' { 'true' } else { 'false' }
@@ -398,7 +400,7 @@ fn (mut g Parser) lower_higher_order_expression(mut result strings.Builder, mut 
 					closure
 				}
 				matched := if higher_order_method == 'all' { 'false' } else { 'true' }
-				lowered = '({ ${collection_type} ${src} = (${collection_source}); bool ${dst} = ${initial}; for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} ${it_name} = ((${element_type} *)${src}.data)[${idx}]; if (${condition}) { ${dst} = ${matched}; break; } } ${dst}; })'
+				lowered = '({ ${collection_type} ${src} = (${collection_source}); bool ${dst} = ${initial}; for (int ${idx} = 0; ${idx} < ${src}.len; ${idx}++) { ${element_type} ${it_c_name} = ((${element_type} *)${src}.data)[${idx}]; if (${condition}) { ${dst} = ${matched}; break; } } ${dst}; })'
 			}
 			result.write_string(lowered)
 			expression_tokens = expression_tokens[..receiver_start].clone()

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -259,9 +259,11 @@ static inline bool v_fastc_us_le(u64 a, i64 b) { return b >= 0 && a <= (u64)b; }
 // Keep source identifiers distinct from C keywords while preserving the same
 // spelling used by the conventional C generator.
 const fastc_c_reserved_identifiers = {
+	'array':    true
 	'asm':      true
 	'auto':     true
 	'break':    true
+	'map':      true
 	'case':     true
 	'char':     true
 	'const':    true
@@ -309,7 +311,7 @@ fn fastc_c_identifier(name string) string {
 	}
 	first := name[0]
 	// Bitset of the initial letters used by the reserved-identifier table (`a` is bit 0).
-	if first < `a` || first > `w` || (u32(8_259_967) & (u32(1) << (first - `a`))) == 0 {
+	if first < `a` || first > `w` || (u32(8_264_063) & (u32(1) << (first - `a`))) == 0 {
 		return name
 	}
 	return if name in fastc_c_reserved_identifiers {
@@ -331,6 +333,42 @@ typedef _Bool bool;
 #include <string.h>
 #ifndef _WIN32
 #include <pthread.h>
+#endif
+
+/* `C.__V_architecture` (pref.get_host_arch) resolves the host arch at C-compile time;
+ * its numeric values match pref.Arch (amd64=1, arm64=2, …). */
+#ifndef __V_architecture
+#define __V_architecture 0
+#if defined(__x86_64__) || defined(_M_AMD64)
+#undef __V_architecture
+#define __V_architecture 1
+#endif
+#if defined(__aarch64__) || defined(__arm64__) || defined(_M_ARM64)
+#undef __V_architecture
+#define __V_architecture 2
+#endif
+#if defined(__arm__) || defined(_M_ARM)
+#undef __V_architecture
+#define __V_architecture 3
+#endif
+#if defined(__riscv) && __riscv_xlen == 64
+#undef __V_architecture
+#define __V_architecture 4
+#endif
+#if defined(__riscv) && __riscv_xlen == 32
+#undef __V_architecture
+#define __V_architecture 5
+#endif
+#if defined(__i386__) || defined(_M_IX86)
+#undef __V_architecture
+#define __V_architecture 6
+#endif
+#endif
+
+/* `C.V_COMMIT_HASH` (util.vhash) is normally injected by the build; keep the same
+ * placeholder the C backend uses when it is absent. */
+#ifndef V_COMMIT_HASH
+#define V_COMMIT_HASH "@@@"
 #endif
 
 typedef int8_t i8;
@@ -647,6 +685,19 @@ static void builtin__array_sort(array *values) {
 	}
 }
 
+static array builtin__array_sorted(array *values) {
+	array result = *values;
+	if (values != NULL && values->len > 0) {
+		size_t bytes = (size_t)values->len * (size_t)values->element_size;
+		result.data = malloc(bytes);
+		if (result.data != NULL && values->data != NULL) memcpy(result.data, values->data, bytes);
+		result.offset = 0;
+		result.cap = values->len;
+	}
+	builtin__array_sort(&result);
+	return result;
+}
+
 '
 
 enum FastcDeclaredTypeKind {
@@ -667,6 +718,7 @@ struct FastcFunctionSignature {
 	last_parameter_is_params bool
 	is_public                bool
 	is_disabled              bool
+	is_c_extern              bool
 	module_name              string
 	path                     string
 }
@@ -712,6 +764,11 @@ struct FastcLocal {
 	is_mut       bool
 	is_reference bool
 	typ          string
+	// A smart-cast that narrows a local to a concrete variant may store the narrowed value
+	// in a uniquely named C temporary rather than shadowing the local's own C name, so a
+	// later `defer` body (rendered at function scope) still binds the original name. When set,
+	// the local's spelling resolves to this name instead of `fastc_c_identifier(name)`.
+	c_name string
 	// For a variable declared with an option type (`b ?bool`), the C `typ` is the
 	// type-erased `Option`; this keeps the wrapped value type so an `if x := b`
 	// guard on the bare variable can unwrap it.
@@ -724,12 +781,30 @@ struct FastcLocal {
 	// For a channel local (`ch chan T` / `ch := chan T{…}`), the C `typ` is the erased
 	// `chan`; this keeps the element C type so `<-ch` recovers the received value type.
 	chan_element_type string
+	// For a bare-local `is` smart-cast whose `typ` is the narrowed variant, this records the
+	// original boxed sum-type/interface type. A method defined on the whole sum type (`fn (e
+	// Expr) pos()`) is not on the variant, so it dispatches on the still-live boxed original.
+	smartcast_origin_type string
+	// C expression that still names the original boxed value while this local is narrowed.
+	// Mutable calls accepting the sum type must receive this storage, not the concrete payload
+	// pointer, because their ABI expects the sum-type tag/object wrapper.
+	smartcast_origin_source string
+	// For a bool local assigned a top-level `&&` chain of `is` tests (`ok := x is A && y is B`),
+	// the member smart-casts implied when the bool is true. A later `ok && x.field` then narrows
+	// `x`/`y` for the rest of that `&&` chain. Scoped with the local, so it never leaks between
+	// functions that reuse the bool's name.
+	bool_implications []FastcBoolImplication
 }
 
 struct FastcLocalScopeChange {
 	name         string
 	previous     FastcLocal
 	had_previous bool
+}
+
+struct FastcFunctionDeferBlock {
+	flag  string
+	lines []string
 }
 
 struct FastcExpressionToken {
@@ -768,9 +843,13 @@ struct FastcStructField {
 	is_skip              bool
 	is_function          bool
 	is_optional_function bool
-	module_name          string
-	path                 string
-	default_source       string
+	// Shared map fields keep pointer identity even though FastC currently erases locking.
+	// Without this, copying their containing struct detaches subsequent map header updates.
+	is_shared_pointer bool
+	module_name       string
+	path              string
+	imports           map[string]string
+	default_source    string
 mut:
 	default_value string
 	storage_path  []string
@@ -1009,11 +1088,12 @@ struct FastcComptimeBlock {
 }
 
 struct FastcDeclarationAttribute {
-	tok        token.Token
-	is_enabled bool
-	is_flag    bool
-	is_params  bool
-	is_typedef bool
+	tok         token.Token
+	is_enabled  bool
+	is_flag     bool
+	is_params   bool
+	is_typedef  bool
+	is_c_extern bool
 }
 
 struct FastcEnumInfo {
@@ -1032,7 +1112,13 @@ struct FastcTypeDeclarations {
 	enum_helper_names []string
 	enum_helper_texts []string
 	alias_base_types  map[string]string
-	enum_field_types  map[string]string
+	// Return type (C spelling) declared by each `type Name = fn (...) Ret` alias,
+	// keyed by the alias C name. Lets a call through such a value infer its result.
+	fn_alias_return_types map[string]string
+	enum_field_types      map[string]string
+	// Value names declared by each enum, keyed by the enum's C name, in source
+	// order. Used to unroll `$for x in Enum.values { ... }`.
+	enum_field_names map[string][]string
 	// Declared C names of sum types (`type X = A | B`). They share the boxed
 	// `{void*_object; u32 _typ;}` layout with interfaces; construction boxes a
 	// variant and `match` dispatches on `_typ`.
@@ -1052,8 +1138,19 @@ struct FastcLoopBlockResult {
 // member cannot be shadowed under its qualified source spelling, so member-chain rendering
 // consults this table while the branch is active.
 struct FastcMemberSmartcast {
-	typ    string
-	source string
+	typ           string
+	source        string
+	variants      []string
+	tag_source    string
+	object_source string
+}
+
+// FastcBoolImplication records that a bool local (assigned a top-level `&&` chain of `is` tests,
+// `enum_operands := lhs is Enum && rhs is Enum`) implies a member smart-cast on `subject` whenever
+// the bool is true — so a later `enum_operands && lhs.field` narrows `lhs` for the rest of the `&&`.
+struct FastcBoolImplication {
+	subject   string
+	smartcast FastcMemberSmartcast
 }
 
 struct Parser {
@@ -1079,7 +1176,9 @@ struct Parser {
 	declared_kinds         map[string]FastcDeclaredTypeKind
 	enum_flags             map[string]bool
 	enum_field_types       map[string]string
+	enum_field_names       map[string][]string
 	alias_base_types       map[string]string
+	fn_alias_return_types  map[string]string
 	sum_types              map[string]bool
 	// Declared variants of each sum type, keyed `"${sum_type_c_name}|${variant_c_name}"`.
 	// Lets an append distinguish push-many (`[]T << []T`) from boxing an array-valued
@@ -1151,21 +1250,26 @@ mut:
 	current_method_is_static bool
 	expected_expression_type string
 	capturing_defer          bool
+	// next_declaration_is_unsafe records a `@[unsafe]` attribute seen just before a
+	// top-level declaration, so a function so marked parses its body as unsafe.
+	next_declaration_is_unsafe bool
 	// While parsing an `or { ... }` block that yields a value, a trailing bare value
 	// expression is captured here (typed by `or_value_expected_type`) instead of being
 	// rejected as a value-only statement.
-	or_value_capture        bool
-	or_value_captured       string
-	or_value_expected_type  string
-	defer_depth             int
-	captured_defer_lines    []string
-	deferred_lines          []string
-	deferred_block_starts   []int
-	loop_defer_block_starts []int
-	loop_has_breaks         []bool
-	statement_reachable     bool
-	last_expression_type    string
-	last_expression         []FastcExpressionToken
+	or_value_capture            bool
+	or_value_captured           string
+	or_value_expected_type      string
+	defer_depth                 int
+	captured_defer_lines        []string
+	deferred_lines              []string
+	deferred_block_starts       []int
+	function_defer_blocks       []FastcFunctionDeferBlock
+	function_defer_declarations []string
+	loop_defer_block_starts     []int
+	loop_has_breaks             []bool
+	statement_reachable         bool
+	last_expression_type        string
+	last_expression             []FastcExpressionToken
 	// Conditional expressions have no flat token list after their branches are
 	// parsed. Preserve an Option payload type for their consuming declaration.
 	last_option_value_type  string
@@ -1343,7 +1447,9 @@ struct FastcFileGenContext {
 	declared_kinds            map[string]FastcDeclaredTypeKind
 	enum_flags                map[string]bool
 	enum_field_types          map[string]string
+	enum_field_names          map[string][]string
 	alias_base_types          map[string]string
+	fn_alias_return_types     map[string]string
 	sum_types                 map[string]bool
 	sum_type_variants         map[string]bool
 	struct_fields             map[string]map[string]string
@@ -1461,7 +1567,9 @@ fn fastc_generate_single_file(ctx &FastcFileGenContext, source_file FastcSourceF
 		declared_kinds: ctx.declared_kinds
 		enum_flags: ctx.enum_flags
 		enum_field_types: ctx.enum_field_types
+		enum_field_names: ctx.enum_field_names
 		alias_base_types: ctx.alias_base_types
+		fn_alias_return_types: ctx.fn_alias_return_types
 		sum_types: ctx.sum_types
 		sum_type_variants: ctx.sum_type_variants
 		struct_fields: ctx.struct_fields
@@ -1657,17 +1765,43 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	for source_file in sources {
 		source_imports[source_file.path] = source_file.header.imports.clone()
 	}
+	if fastc_field_defaults_reference_constants(struct_field_info, constants) {
+		seed_ctx := FastcConstantGenContext{
+			prefs: unsafe { prefs }
+			declared_types: declared_types
+			declared_type_c_names: declared_type_c_names
+			declared_type_key_by_name: declared_type_key_by_name
+			fastc_prefixed_c_names: fastc_prefixed_c_names
+			has_c_functions: fastc_functions_declare_c(functions)
+			declared_kinds: declared_kinds
+			enum_flags: enum_flags
+			enum_field_types: enum_field_types
+			alias_base_types: type_output.alias_base_types
+			struct_fields: struct_fields
+			struct_field_info: struct_field_info
+			sum_types: type_output.sum_types
+			sum_type_variants: type_output.sum_type_variants
+			functions: functions
+			constants: constants
+			public_constants: public_constants
+			globals: globals
+			public_globals: public_globals
+		}
+		constant_candidates := fastc_constant_candidates(ordered_sources, constant_sources, constant_spans)
+		fastc_seed_constant_types(&seed_ctx, constant_candidates, mut constant_types)
+	}
 	// The struct field defaults render on a worker while the constants are
 	// pre-parsed; a constant file that consulted them is re-parsed after.
-	mut pending_defaults := fastc_start_field_defaults(source_imports, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info, functions, constants, public_constants, constant_types, globals, public_globals, global_types, type_output.sum_types)
-	constant_output := fastc_generate_constant_declarations(ordered_sources, constant_sources, constant_spans, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info, mut pending_defaults, functions, constants, public_constants, globals, public_globals, mut constant_types)!
+	mut pending_defaults := fastc_start_field_defaults(source_imports, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.enum_field_names, type_output.alias_base_types, struct_fields, struct_field_info, functions, constants, public_constants, constant_types, globals, public_globals, global_types, type_output.sum_types)
+	constant_output := fastc_generate_constant_declarations(ordered_sources, constant_sources, constant_spans, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info, type_output.sum_types, type_output.sum_type_variants, mut pending_defaults, functions, constants, public_constants, globals, public_globals, mut constant_types)!
 	struct_field_info = constant_output.struct_field_info.clone()
 	timer.mark('constant_declarations')
 	for name, _ in constant_output.composite_types {
 		composite_types[name] = true
 	}
-	header_free := prefs.building_v
-		&& fastc_c_abi_supported(prefs.target.os, prefs.target.arch, fastc_host_uses_glibc())
+	// The fixed ABI prelude covers the bootstrap compiler. The real-builtin
+	// path reaches the wider C API used by cmd/v and must retain its headers.
+	header_free := prefs.building_v && 'fastc_real_builtin' !in prefs.user_defines && fastc_c_abi_supported(prefs.target.os, prefs.target.arch, fastc_host_uses_glibc())
 	global_output := fastc_generate_global_declarations(ordered_sources, global_sources, prefs, header_free, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info, functions, constants, constant_output.compile_time_values, public_constants, constant_types, globals, public_globals, mut global_types)!
 	timer.mark('global_declarations')
 	for name, _ in global_output.composite_types {
@@ -1733,7 +1867,9 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 		declared_kinds: declared_kinds
 		enum_flags: enum_flags
 		enum_field_types: enum_field_types
+		enum_field_names: type_output.enum_field_names
 		alias_base_types: type_output.alias_base_types
+		fn_alias_return_types: type_output.fn_alias_return_types
 		sum_types: type_output.sum_types
 		sum_type_variants: type_output.sum_type_variants
 		struct_fields: struct_fields
@@ -1860,6 +1996,16 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	}
 	interface_dispatches := fastc_wait_interface_dispatches(mut pending_interface_dispatches)
 	timer.mark('wait_interface_dispatches')
+	// Fixed arrays that occur only in declarations or signatures are not seen by
+	// the expression renderer, so register their raw markers before emitting typedefs.
+	fastc_collect_referenced_fixed_array_types(type_output.declarations_head, mut fixed_array_types)
+	fastc_collect_referenced_fixed_array_types(type_declarations, mut fixed_array_types)
+	for prototype_piece in prototype_pieces {
+		fastc_collect_referenced_fixed_array_types(prototype_piece, mut fixed_array_types)
+	}
+	for body_piece in body_pieces {
+		fastc_collect_referenced_fixed_array_types(body_piece, mut fixed_array_types)
+	}
 	fixed_array_declarations := fastc_generate_fixed_array_declarations(fixed_array_types)
 	preamble := if header_free {
 		c_selfhost_preamble.replace(c_selfhost_preamble_includes, fastc_c_abi_prelude(prefs.target.os, prefs.target.arch, ''))
@@ -1971,17 +2117,14 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	if prefs.building_v {
 		pieces << fastc_piece(c_selfhost_post_directives)
 	}
-	if spawn_typedefs.len > 0 && !header_free {
-		pieces << fastc_piece(c_spawn_runtime)
-		pieces << '\n'
-	}
-	pieces << fastc_piece(constant_output.macros)
-	pieces << fastc_piece(type_output.declarations_head)
-	pieces << fastc_piece(composite_typedefs)
-	pieces << fastc_piece(type_declarations)
-	pieces << late_composite_declarations.str()
-	pieces << fastc_piece(fixed_array_declarations)
 	if spawn_typedefs.len > 0 {
+		if !header_free {
+			pieces << fastc_piece(c_spawn_runtime)
+			pieces << '\n'
+		}
+		// A `thread` handle can appear as a struct field, so its typedef must precede the
+		// aggregate type declarations that embed it (and the `Array_`/typeid composites
+		// derived from it), not follow them.
 		mut thread_type_names := spawn_typedefs.keys()
 		thread_type_names.sort()
 		for thread_type_name in thread_type_names {
@@ -1990,6 +2133,13 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 		}
 		pieces << '\n'
 	}
+	pieces << fastc_piece(constant_output.macros)
+	pieces << fastc_piece(type_output.declarations_head)
+	pieces << fastc_piece(composite_typedefs)
+	pieces << fastc_piece(type_declarations)
+	pieces << late_composite_declarations.str()
+	pieces << fastc_piece(fixed_array_declarations)
+	pieces << fastc_c_extern_prototypes(functions)
 	mut extern_indexes := []int{}
 	mut extern_texts := []string{}
 	mut define_texts := []string{}
@@ -2001,6 +2151,16 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	extern_texts << fastc_extern_declarations(global_output.declarations, true)
 	define_texts << fastc_extern_declarations(global_output.declarations, false)
 	pieces << fastc_piece(global_output.declarations)
+	// Generated formatting helpers can be registered while parsing a function
+	// that reachability later removes, even though another live helper calls
+	// them. Keep their declarations outside the per-function prototype ranges.
+	mut spawn_helper_names := spawn_helpers.keys()
+	spawn_helper_names.sort()
+	mut spawn_helper_prototypes := strings.new_builder(256)
+	for spawn_helper_name in spawn_helper_names {
+		spawn_helper_prototypes.write_string(fastc_definition_prototypes(spawn_helpers[spawn_helper_name]))
+	}
+	pieces << fastc_take_string(mut spawn_helper_prototypes)
 	fastc_collect_c_piece_ranges(mut pieces, prototype_pieces, kept_proto_ranges)
 	if startup_initializers.len > 0 {
 		pieces << 'static void v_fastc_init_globals(void);'
@@ -2016,8 +2176,6 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	}
 	fastc_collect_c_piece_ranges(mut pieces, type_output.enum_helper_texts, kept_helper_ranges)
 	if spawn_helpers.len > 0 {
-		mut spawn_helper_names := spawn_helpers.keys()
-		spawn_helper_names.sort()
 		for spawn_helper_name in spawn_helper_names {
 			pieces << spawn_helpers[spawn_helper_name]
 			pieces << '\n'
@@ -2065,11 +2223,11 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	// program with any keeps a single unit.
 	mut unit_starts := []int{cap: outputs.len + 2}
 	if kept_conditional_ranges.len == 0 && outputs.len > 0 {
-		for i, output in outputs {
+		for i, _ in outputs {
 			window_start := output_body_offsets[i]
 			window_end := if i + 1 < outputs.len { output_body_offsets[i + 1] } else { body_len }
 			unit_starts << pieces.len
-			fastc_collect_c_piece_ranges(mut pieces, body_pieces, fastc_window_ranges(kept_body_ranges, window_start, window_end, output.body.len == 0))
+			fastc_collect_c_piece_ranges(mut pieces, body_pieces, fastc_window_ranges(kept_body_ranges, window_start, window_end))
 		}
 	} else {
 		fastc_collect_c_piece_ranges(mut pieces, body_pieces, kept_body_ranges)
@@ -2109,14 +2267,39 @@ fn fastc_definition_prototypes(text string) string {
 	return out.str()
 }
 
-// fastc_window_ranges returns the parts of the ascending [start, end)
-// `ranges` inside [window_start, window_end). An empty body contributes
-// nothing; `empty` short-circuits the search for it.
-fn fastc_window_ranges(ranges []int, window_start int, window_end int, empty bool) []int {
-	mut out := []int{}
-	if empty {
-		return out
+// fastc_c_extern_prototypes emits declarations explicitly requested with `@[c_extern]`.
+// Such symbols come from linked system libraries rather than an included header, so C99 must
+// see their V-declared ABI before a call (matching the main C backend's behavior).
+fn fastc_c_extern_prototypes(functions map[string]FastcFunctionSignature) string {
+	mut keys := functions.keys()
+	keys.sort()
+	mut out := strings.new_builder(128)
+	for key in keys {
+		signature := functions[key]
+		if !key.starts_with('C.') || !signature.is_c_extern || signature.is_disabled {
+			continue
+		}
+		name := key.all_after_first('C.')
+		mut parameters := []string{cap: signature.parameter_types.len + 1}
+		for parameter_type in signature.parameter_types {
+			parameters << parameter_type
+		}
+		if signature.is_variadic {
+			parameters << '...'
+		} else if parameters.len == 0 {
+			parameters << 'void'
+		}
+		out.writeln('#ifndef ${name}')
+		out.writeln('extern ${signature.return_type} ${name}(${parameters.join(', ')});')
+		out.writeln('#endif')
 	}
+	return out.str()
+}
+
+// fastc_window_ranges returns the parts of the ascending [start, end)
+// `ranges` inside [window_start, window_end).
+fn fastc_window_ranges(ranges []int, window_start int, window_end int) []int {
+	mut out := []int{}
 	for i := 0; i + 1 < ranges.len; i += 2 {
 		start := ranges[i]
 		end := ranges[i + 1]

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -2501,6 +2501,39 @@ fn main() {
 	assert plain_enum_array_source.contains('typedef array Array_Space;'), plain_enum_array_source
 }
 
+fn test_higher_order_lowering_handles_pointer_receivers_callbacks_and_keyword_parameters() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn convert(value int) int {
+	return value + 1
+}
+
+fn consume(values []int) int {
+	return values.len
+}
+
+fn apply(mut values []int) int {
+	streamed := values.map(|short| short + 1)
+	return streamed.len + consume(values.map(convert)) + consume(values.map(|short| short + 2))
+}
+
+fn main() {
+	mut values := [1, 2]
+	_ := apply(mut values)
+}
+', 'higher_order_nested_regressions.v', prefs) or { panic(err) }
+	// Mutable array receivers are pointers in C. Both lowerers iterate a value copy of the
+	// header, nested bare callbacks are invoked, and legal V names are escaped for C.
+	assert c_source.contains('Array_int __v_fastc_collection_'), c_source
+	assert c_source.contains('= (*(values));'), c_source
+	assert !c_source.contains('Array_int* __v_fastc_collection_'), c_source
+	assert c_source.contains('convert(it)'), c_source
+	assert c_source.count('int __v_fastc_keyword_short =') == 2, c_source
+	assert !c_source.contains('int short ='), c_source
+}
+
 fn test_real_builtin_path_keyword_identifiers_enum_casts_and_dollar_d() {
 	mut prefs := pref.new_preferences()
 	prefs.building_v = true
@@ -5844,8 +5877,39 @@ fn main() {
 ', 'valid_parallel_assignment.v', prefs) or { panic(err) }
 	assert c_source.contains('first = __v_fastc_parallel_'), c_source
 	assert c_source.contains('second = __v_fastc_parallel_'), c_source
-	assert c_source.contains('memcpy(&first, __v_fastc_multi_return_'), c_source
-	assert c_source.contains('memcpy(&second, __v_fastc_multi_return_'), c_source
+	assert c_source.contains('memcpy(&first, V_FASTC_MULTI_SOURCE(__v_fastc_multi_return_'), c_source
+	assert c_source.contains('memcpy(&second, V_FASTC_MULTI_SOURCE(__v_fastc_multi_return_'), c_source
+}
+
+fn test_parallel_member_assignment_uses_pointer_backed_multi_return_storage() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Large {
+	bytes [40]u8
+}
+
+struct Holder {
+mut:
+	value Large
+}
+
+fn pair() (int, Large) {
+	return 1, Large{}
+}
+
+fn assign(mut holder Holder) {
+	_, holder.value = pair()
+}
+
+fn main() {
+	mut holder := Holder{}
+	assign(mut holder)
+}
+', 'parallel_member_large_multi_return.v', prefs) or { panic(err) }
+	assert c_source.contains('memcpy(&holder->value, V_FASTC_MULTI_SOURCE(__v_fastc_multi_return_'), c_source
+	assert !c_source.contains('.values[1].data, sizeof(holder->value)'), c_source
 }
 
 fn test_selfhost_parallel_assignment_accepts_aggregate_targets() {
@@ -8086,6 +8150,40 @@ fn main() {}
 	assert c_source.contains('->value=2'), c_source
 }
 
+fn test_condition_loop_smartcast_subject_is_evaluated_once() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct CallExpr {}
+struct NameExpr {}
+type Expr = CallExpr | NameExpr
+
+struct Argument {
+	expr Expr
+}
+
+fn next_index() int {
+	return 0
+}
+
+fn scan(args []Argument) {
+	for args[next_index()].expr is CallExpr {
+		break
+	}
+}
+
+fn main() {
+	scan([Argument{ expr: CallExpr{} }])
+}
+', 'condition_loop_smartcast_once.v', prefs) or { panic(err) }
+	// The rewritten type-test conjunct owns evaluation of the subject. Its temporary must not
+	// evaluate the indexed expression again in the per-iteration prelude.
+	assert c_source.contains('Expr __v_fastc_smartcast_subject_'), c_source
+	assert c_source.contains('= (Expr){0};'), c_source
+	assert c_source.count('next_index()') == 1, c_source
+}
+
 fn test_mut_sum_type_smartcast_passes_original_box_to_mut_sum_type_parameter() {
 	mut prefs := pref.new_preferences()
 	prefs.building_v = true
@@ -9830,6 +9928,38 @@ fn main() {
 	assert c_source.contains('MultiReturn'), c_source
 	assert c_source.contains('.values[0], sizeof('), c_source
 	assert c_source.contains('.values[1], sizeof('), c_source
+}
+
+fn test_if_expression_multi_return_guard_uses_pointer_backed_storage() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Large {
+	bytes [40]u8
+}
+
+fn pair(ok bool) ?(Large, int) {
+	if !ok {
+		return none
+	}
+	return Large{}, 1
+}
+
+fn choose(ok bool) Large {
+	return if value, _ := pair(ok) {
+		value
+	} else {
+		Large{}
+	}
+}
+
+fn main() {
+	_ := choose(true)
+}
+', 'if_expression_large_multi_return_guard.v', prefs) or { panic(err) }
+	assert c_source.contains('memcpy(&value, V_FASTC_MULTI_SOURCE(__v_fastc_multi_return_'), c_source
+	assert !c_source.contains('.values[0].data, sizeof(value)'), c_source
 }
 
 fn test_selfhost_if_multi_return_option_guard_with_shared_bindings() {

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -423,8 +423,36 @@ fn main() {
 	println(shared)
 }
 ', 'selfhost_static_shared_local.v', prefs) or { panic(err) }
-	assert c_source.contains('i64 shared = (1);'), c_source
+	assert c_source.contains('static ${fastc_platform_int_c_type} shared;'), c_source
+	assert c_source.contains('static bool __v_fastc_static_init_'), c_source
+	assert c_source.contains('shared = (1);'), c_source
 	assert c_source.contains('println(shared)'), c_source
+}
+
+fn test_selfhost_mut_static_pointer_survives_later_calls() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Item {}
+
+fn retained(value &Item) &Item {
+	mut static saved := unsafe { &Item(nil) }
+	if value != unsafe { nil } {
+		saved = value
+	}
+	return saved
+}
+
+fn main() {
+	item := &Item{}
+	_ = retained(item)
+	_ = retained(unsafe { nil })
+}
+', 'selfhost_mut_static_pointer.v', prefs) or { panic(err) }
+	assert c_source.contains('static __typeof__((((Item*)(NULL)))) saved;'), c_source
+	assert c_source.contains('static bool __v_fastc_static_init_'), c_source
+	assert c_source.contains('saved = (((Item*)(NULL)));'), c_source
 }
 
 fn test_selfhost_unsafe_contextual_shared_local_mutation() {
@@ -464,6 +492,35 @@ fn main() {
 ', 'selfhost_contextual_shared_struct_field.v', prefs) or { panic(err) }
 	assert c_source.contains('(Box){.shared='), c_source
 	assert !c_source.contains('(Box){shared='), c_source
+}
+
+fn test_selfhost_shared_map_field_keeps_identity_across_struct_copy() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Registry {
+	values shared map[string]int
+}
+
+fn insert(copy Registry) {
+	lock copy.values {
+		copy.values["answer"] = 42
+	}
+}
+
+fn main() {
+	registry := Registry{}
+	insert(registry)
+	rlock registry.values {
+		println(registry.values["answer"])
+	}
+}
+', 'selfhost_shared_map_field.v', prefs) or { panic(err) }
+	assert c_source.contains('Map_string_int* values;'), c_source
+	assert c_source.contains('*(copy.values)'), c_source
+	assert c_source.contains('*(registry.values)'), c_source
+	assert c_source.contains('(Map_string_int*)v_fastc_interface_box'), c_source
 }
 
 fn test_fastc_chunk_bounds_reserve_files_for_later_workers() {
@@ -562,6 +619,41 @@ fn test_fastc_split_rewrites_prealloc_tls_global_linkage() {
 	definition := 'static _Thread_local VMemoryBlock* g_memory_block;\n'
 	assert fastc_extern_declarations(definition, false) == '_Thread_local VMemoryBlock* g_memory_block;\n'
 	assert fastc_extern_declarations(definition, true) == 'extern _Thread_local VMemoryBlock* g_memory_block;\n'
+}
+
+fn test_fastc_window_ranges_keeps_content_appended_after_empty_file() {
+	// An empty final source can still own a non-empty window when generated generic
+	// or anonymous-function definitions are appended after that source's body.
+	assert fastc_window_ranges([0, 20], 10, 20) == [10, 20]
+	assert fastc_window_ranges([0, 10], 10, 10) == []
+}
+
+fn test_fastc_emits_explicit_c_extern_prototype() {
+	functions := {
+		'C.external_api': FastcFunctionSignature{
+			parameter_types: ['int', 'voidptr']
+			return_type: 'int'
+			is_c_extern: true
+		}
+	}
+	assert fastc_c_extern_prototypes(functions) == '#ifndef external_api\nextern int external_api(int, voidptr);\n#endif\n'
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct ExternalUsage {
+	value u64
+}
+
+@[c_extern]
+fn C.external_api(pid int, usage &ExternalUsage) int
+
+fn main() {
+	mut usage := ExternalUsage{}
+	_ = C.external_api(1, &usage)
+}
+', 'selfhost_c_extern.v', prefs) or { panic(err) }
+	assert c_source.contains('#ifndef external_api\nextern int external_api(int, ExternalUsage*);\n#endif'), c_source
 }
 
 fn test_fastc_tcc_job_count_respects_parallel_controls() {
@@ -2210,6 +2302,37 @@ fn main() {
 ', 'method_value.v', prefs) or { panic(err) }
 	assert source.contains('Service_handle'), source
 	assert !source.contains('service.handle'), source
+}
+
+fn test_selfhost_selector_at_end_of_binary_expression_is_not_method_value() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	source := generate('module main
+
+enum Kind {
+	other
+	str
+}
+
+struct Node {
+	kind      Kind
+	is_method bool
+}
+
+fn accepts_str_method(node Node) bool {
+	return node.is_method && node.kind == .str
+}
+
+fn same_storage(left string, right string) bool {
+	return left.len == right.len && unsafe { left.str == right.str }
+}
+
+fn main() {}
+', 'selector_after_binary.v', prefs) or { panic(err) }
+	assert !source.contains('&builtin__bool_str'), source
+	assert source.contains('Kind__str'), source
+	assert source.contains('left.str'), source
+	assert source.contains('right.str'), source
 }
 
 fn test_selfhost_embedded_option_method_recovers_payload_type() {
@@ -4309,6 +4432,23 @@ fn main() {
 	assert interpolation_source.contains('static string v_fastc_enum_str_Permissions(Permissions value)'), interpolation_source
 	assert interpolation_source.contains('_S("Permissions{")'), interpolation_source
 	assert interpolation_source.contains('v_fastc_enum_str_Permissions(permissions)'), interpolation_source
+
+	custom_str_source := generate(r"module main
+
+enum Kind {
+	assign
+}
+
+fn (kind Kind) str() string {
+	return '='
+}
+
+fn main() {
+	println(Kind.assign.str())
+	println('${Kind.assign}')
+}
+", 'enum_custom_str_interpolation.v', selfhost_prefs) or { panic(err) }
+	assert custom_str_source.contains('Kind_str(Kind__assign)'), custom_str_source
 }
 
 fn test_invalid_enum_printing_matches_interpolation() {
@@ -7711,15 +7851,17 @@ fn main() {
 	assert c_source.contains('typedef struct { void *_object; u32 _typ; void *_methods; } Animal;'), c_source
 	// Construction boxes the concrete variant with its type id.
 	assert c_source.contains('._typ=__v_typeid_Dog'), c_source
-	assert c_source.contains('__v_fastc_box_value = ((Dog){'), c_source
+	assert c_source.contains('Dog __v_fastc_box_value ='), c_source
 	assert !c_source.contains('Dog{sound:'), c_source
 	// `match` dispatches on the boxed `_typ` tag rather than comparing structs.
 	assert c_source.contains('_typ == __v_typeid_Dog'), c_source
 	assert c_source.contains('_typ == __v_typeid_Cat'), c_source
 	// The matched branch smart-casts the subject to the concrete variant so field
-	// access (`a.sound`) resolves.
-	assert c_source.contains('Dog a = *(Dog *)'), c_source
-	assert c_source.contains('Cat a = *(Cat *)'), c_source
+	// access (`a.sound`) resolves through the uniquely named narrowed temporary.
+	assert c_source.contains('Dog __v_fastc_match_cast_'), c_source
+	assert c_source.contains('Cat __v_fastc_match_cast_'), c_source
+	assert c_source.contains('return __v_fastc_match_cast_'), c_source
+	assert !c_source.contains('return a.sound'), c_source
 }
 
 fn test_sum_type_primitive_variants() {
@@ -7889,6 +8031,216 @@ fn main() {
 	// `Plain` has no array variant, so `[]Plain << []Plain` stays a push-many append
 	// that copies each element, matching the main C backend.
 	assert c_source.contains('builtin__array_push_many'), c_source
+}
+
+fn test_sum_type_smartcast_variant_append_is_boxed() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Item {
+	value int
+}
+
+type Node = Item | string
+
+fn retain_items(nodes []Node) []Node {
+	mut result := []Node{}
+	for node in nodes {
+		if node is Item {
+			result << node
+		}
+	}
+	return result
+}
+
+fn main() {}
+', 'sum_type_smartcast_append.v', prefs) or { panic(err) }
+	assert c_source.contains('main__Node __v_fastc_push_value_'), c_source
+	assert c_source.contains('__v_typeid_main__Item'), c_source
+	assert c_source.contains('builtin__array_push((array *)&result'), c_source
+}
+
+fn test_mut_sum_type_smartcast_mutates_boxed_payload() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Item {
+mut:
+	value int
+}
+
+type Node = Item | string
+
+fn update(node Node) {
+	mut current := node
+	if mut current is Item {
+		current.value = 2
+	}
+}
+
+fn main() {}
+', 'mut_sum_type_smartcast.v', prefs) or { panic(err) }
+	assert c_source.contains('Item* __v_fastc_if_cast_'), c_source
+	assert c_source.contains('->value=2'), c_source
+}
+
+fn test_mut_sum_type_smartcast_passes_original_box_to_mut_sum_type_parameter() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Item {
+mut:
+	value int
+}
+
+type Node = Item | string
+
+fn inspect(mut node Node) {
+	if mut node is Item {
+		node.value++
+		inspect(mut node)
+	}
+}
+
+fn main() {}
+', 'mut_sum_type_smartcast_argument.v', prefs) or { panic(err) }
+	assert c_source.contains('inspect(__v_fastc_smartcast_subject_'), c_source
+	assert !c_source.contains('inspect(__v_fastc_if_cast_'), c_source
+}
+
+fn test_mut_match_sum_type_smartcast_passes_original_box_to_mut_parameter() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Item {
+mut:
+	value int
+}
+
+type Node = Item | string
+
+fn inspect(mut node Node) {
+	match mut node {
+		Item {
+			node.value++
+			inspect(mut node)
+		}
+		else {}
+	}
+}
+
+fn main() {}
+', 'mut_match_sum_type_smartcast_argument.v', prefs) or { panic(err) }
+	assert c_source.contains('inspect(node)'), c_source
+	assert !c_source.contains('inspect(__v_fastc_match_cast_'), c_source
+}
+
+fn test_selfhost_string_array_index_uses_value_equality() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn locate(names []string, wanted string) (int, int) {
+	return names.index(wanted), names.last_index(wanted)
+}
+
+fn main() {}
+', 'string_array_index.v', prefs) or { panic(err) }
+	assert c_source.count('builtin__string_eq(__v_fastc_index_item') == 2, c_source
+	assert c_source.contains('int __v_fastc_index_cursor = 0;'), c_source
+	assert c_source.contains('int __v_fastc_index_cursor = __v_fastc_index_collection.len - 1;'), c_source
+}
+
+fn test_mut_match_member_smartcast_reads_current_boxed_payload() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct First {
+	value int
+}
+
+struct Second {
+	value int
+}
+
+type Info = First | Second
+
+struct Holder {
+mut:
+	info Info
+}
+
+fn refresh(mut holder Holder) {
+	holder.info = First{ value: 2 }
+}
+
+fn value(mut holder Holder) int {
+	match mut holder.info {
+		First {
+			refresh(mut holder)
+			return holder.info.value
+		}
+		else {
+			return 0
+		}
+	}
+}
+
+fn main() {}
+', 'mut_match_current_payload.v', prefs) or { panic(err) }
+	assert c_source.contains('((First *)__v_fastc_match_'), c_source
+	assert c_source.contains('->_object)->value'), c_source
+}
+
+fn test_reference_to_boxed_interface_has_heap_lifetime() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+interface Value {}
+
+struct Item {}
+
+fn boxed_pointer() &Value {
+	return &Value(Item{})
+}
+
+fn main() {}
+', 'boxed_interface_pointer.v', prefs) or { panic(err) }
+	assert c_source.contains('(Value *)v_fastc_interface_box(&__v_fastc_iface_ref, sizeof(Value))'), c_source
+	assert !c_source.contains('&__v_fastc_iface_ref;'), c_source
+}
+
+fn test_boxed_address_payload_has_heap_lifetime() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Item {
+	value int
+}
+
+struct Other {}
+
+type Value = Item | Other
+
+fn boxed(value Item) Value {
+	return Value(&value)
+}
+
+fn conditionally_boxed(value Item, flag bool) &Value {
+	return if flag { &Value(Other{}) } else { &Value(&value) }
+}
+
+fn main() {}
+', 'boxed_address_payload.v', prefs) or { panic(err) }
+	assert c_source.contains('v_fastc_interface_box((const void*)(&(value)), sizeof(Item))'), c_source
+	assert c_source.contains('v_fastc_interface_box((const void*)(&value), sizeof(Item))'), c_source
 }
 
 fn test_generic_monomorphization() {
@@ -8074,6 +8426,33 @@ fn main() {
 	// empty array (element_size set), not a zeroed one, so `s.items << x` copies the
 	// element. `X{}` gets the field default applied.
 	assert c_source.contains('.items=(((Array_int)builtin____new_array(0, 0, sizeof(int))))'), c_source
+}
+
+fn test_struct_array_alias_field_default_initializes_element_size() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+type ByteBuilder = []u8
+
+struct Output {
+mut:
+	bytes ByteBuilder
+}
+
+fn (mut o Output) write(x u8) {
+	o.bytes << x
+}
+
+fn main() {
+	mut out := Output{}
+	out.write(3)
+	_ := out
+}
+', 'struct_array_alias_default.v', prefs) or { panic(err) }
+	// An omitted array-alias field still needs a typed empty array. In particular,
+	// strings.Builder fields otherwise start with element_size 0 and corrupt writes.
+	assert c_source.contains('.bytes=(((ByteBuilder)builtin____new_array(0, 0, sizeof(u8))))'), c_source
 }
 
 fn test_struct_map_field_default_initializes_runtime() {
@@ -8268,6 +8647,34 @@ fn main() {
 	// variant struct which is not assignable to the boxed `{_object,_typ,_methods}`.
 	assert c_source.contains('.value=('), c_source
 	assert c_source.contains('._typ=__v_typeid_Null'), c_source
+}
+
+fn test_selfhost_sum_type_constant_field_default_is_not_reboxed() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Empty {
+	value int = 1
+}
+
+type Expr = Empty | int
+
+const empty_expr = Expr(Empty{})
+
+struct Holder {
+	expr Expr = empty_expr
+}
+
+fn main() {
+	_ = Holder{}
+}
+', 'selfhost_sum_constant_field_default.v', prefs) or { panic(err) }
+	assert c_source.contains('__v_fastc_struct_default.expr=(main__empty_expr);'), c_source
+	assert !c_source.contains('__v_fastc_box_value = (main__empty_expr)'), c_source
+	assert c_source.contains('static Expr main__empty_expr;'), c_source
+	assert c_source.contains('main__empty_expr = (Expr){._object='), c_source
+	assert c_source.contains('._typ=__v_typeid_Empty'), c_source
 }
 
 fn test_selfhost_interface_method_named_like_keyword() {
@@ -8864,6 +9271,12 @@ fn main() {
 	// The field labels appear in the generated str() body.
 	assert c_source.contains('    x: '), c_source
 	assert c_source.contains('    y: '), c_source
+	prototype := 'string v_fastc_default_str_Point(Point it);'
+	definition := 'string v_fastc_default_str_Point(Point it) {'
+	prototype_index := c_source.index(prototype) or { -1 }
+	definition_index := c_source.index(definition) or { -1 }
+	assert prototype_index >= 0, c_source
+	assert prototype_index < definition_index, c_source
 }
 
 fn test_selfhost_explicit_default_struct_str_method() {
@@ -8882,6 +9295,314 @@ fn main() {
 ', 'selfhost_struct_str_method.v', prefs) or { panic(err) }
 	assert c_source.contains('v_fastc_default_str_Point('), c_source
 	assert !c_source.contains('.str()'), c_source
+}
+
+fn test_direct_array_access_does_not_rewrite_a_lowered_member_suffix() {
+	source := 'builtin__u8_is_digit(((str).str[i]))'
+	assert fastc_replace_c_root_identifier(source, 'str[i]', '((str).str[i])') == source
+}
+
+fn test_direct_array_access_lowers_both_indexed_comparison_operands() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+@[direct_array_access]
+fn compare(s string, a string, i int) bool {
+	return s[i] > a[i]
+}
+
+fn main() {
+	_ = compare("a", "b", 0)
+}
+', 'direct_array_access_comparison.v', prefs) or { panic(err) }
+	assert c_source.contains('((s).str[i])'), c_source
+	assert c_source.contains('((a).str[i])'), c_source
+	assert !c_source.contains('>a[i]'), c_source
+}
+
+fn test_selfhost_parenthesized_membership_comparison_operand_is_lowered() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct State {
+	values map[string]string
+}
+
+fn check(name string, state State, known bool) bool {
+	return (name in state.values) != known
+}
+
+fn main() {
+	_ = check("x", State{}, false)
+}
+', 'selfhost_membership_comparison_operand.v', prefs) or { panic(err) }
+	assert c_source.contains('builtin__map_get_check'), c_source
+	assert !c_source.contains('name in state'), c_source
+}
+
+fn test_direct_array_access_lowers_indexed_method_receiver_once() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn (c u8) is_digit() bool {
+	return c >= `0` && c <= `9`
+}
+
+@[direct_array_access]
+fn check(str string, i int) bool {
+	return (str[i] != `-` && str[i] != `+`) && !str[i].is_digit()
+}
+
+fn main() {
+	_ = check("0", 0)
+}
+', 'direct_array_access_method.v', prefs) or { panic(err) }
+	assert c_source.contains('u8_is_digit(((str).str[i]))'), c_source
+	assert !c_source.contains('(str).((str).str[i])'), c_source
+}
+
+fn test_direct_string_index_builtin_method_receiver_is_lowered() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+@[direct_array_access]
+fn character(str string, i int) string {
+	return str[i].ascii_str()
+}
+
+fn main() {
+	_ = character("0", 0)
+}
+', 'direct_string_index_builtin_method.v', prefs) or { panic(err) }
+	assert c_source.contains('builtin__u8_ascii_str(((str).str[i]))'), c_source
+	assert !c_source.contains('str[i]).ascii_str'), c_source
+}
+
+fn test_pointer_global_array_field_index_before_member_is_lowered() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Item {
+	name string
+}
+
+struct Table {
+	items []&Item
+}
+
+__global table &Table
+
+fn lookup(i int) string {
+	return if i >= 0 && i < table.items.len {
+		table.items[i].name
+	} else {
+		""
+	}
+}
+
+fn main() {
+	_ = lookup(0)
+}
+', 'pointer_global_array_field_index.v', prefs) or { panic(err) }
+	assert c_source.contains('builtin__array_get'), c_source
+	assert !c_source.contains('table->items[i]'), c_source
+	assert c_source.contains('))->name'), c_source
+	assert !c_source.contains(')).name'), c_source
+}
+
+fn test_pointer_member_array_field_index_before_member_is_lowered() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Item {
+	kind int
+}
+
+struct Ast {
+	items []Item
+}
+
+struct Gen {
+	a &Ast
+}
+
+fn lookup(g &Gen, i i64) int {
+	return g.a.items[int(i)].kind
+}
+
+fn main() {
+	_ = lookup(&Gen{}, 0)
+}
+', 'pointer_member_array_field_index.v', prefs) or { panic(err) }
+	assert c_source.contains('builtin__array_get'), c_source
+	assert !c_source.contains('items[((int)'), c_source
+}
+
+fn test_pointer_member_array_indexed_by_array_element_is_lowered() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Node {
+	kind int
+}
+
+struct Ast {
+	nodes []Node
+}
+
+struct Parser {
+	a &Ast
+}
+
+fn lookup(p &Parser, ids []int, i int) bool {
+	return p.a.nodes[int(ids[i])].kind != 1
+}
+
+fn main() {
+	_ = lookup(&Parser{}, [], 0)
+}
+', 'pointer_member_array_nested_index.v', prefs) or { panic(err) }
+	assert c_source.count('builtin__array_get') >= 2, c_source
+	assert !c_source.contains('p->a->nodes['), c_source
+}
+
+fn test_pointer_member_array_indexed_by_method_call_is_lowered() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Node {
+	kind int
+}
+
+struct Ast {
+	nodes []Node
+}
+
+fn (a &Ast) child(i int) int {
+	return i
+}
+
+struct Transformer {
+	a &Ast
+}
+
+fn is_first(t &Transformer, i int) bool {
+	return t.a.nodes[int(t.a.child(i))].kind == 1
+}
+
+fn main() {
+	_ = is_first(&Transformer{}, 0)
+}
+', 'pointer_member_array_method_index.v', prefs) or { panic(err) }
+	assert c_source.contains('builtin__array_get'), c_source
+	assert !c_source.contains('t->a->nodes['), c_source
+}
+
+fn test_indexed_struct_pointer_field_chain_is_lowered() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Scope {
+	parent &Scope
+}
+
+struct Branch {
+	scope &Scope
+}
+
+struct Tree {
+	branches []Branch
+}
+
+fn parent(tree &Tree, i int) &Scope {
+	mut continuation_scope := tree.branches[i].scope.parent
+	return continuation_scope
+}
+
+fn main() {
+	_ = parent(&Tree{}, 0)
+}
+', 'indexed_struct_pointer_field_chain.v', prefs) or { panic(err) }
+	assert c_source.contains('builtin__array_get'), c_source
+	assert c_source.contains('))->scope->parent'), c_source
+	assert !c_source.contains('.scope.parent'), c_source
+}
+
+fn test_mut_map_index_field_in_if_expression_is_lowered() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Info {
+	module_name string
+}
+
+fn existing_module(mut needed map[string]Info, name string) string {
+	return if name in needed {
+		needed[name].module_name
+	} else {
+		""
+	}
+}
+
+fn main() {
+	mut needed := map[string]Info{}
+	_ = existing_module(mut needed, "x")
+}
+', 'mut_map_index_field_if_expression.v', prefs) or { panic(err) }
+	assert c_source.contains('builtin__map_get'), c_source
+	assert !c_source.contains('(needed)[name]'), c_source
+}
+
+fn test_map_index_comparison_in_logical_expression_is_lowered() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn before(values map[int]int, key int, offset int) bool {
+	return key !in values || offset < values[key]
+}
+
+fn main() {
+	_ = before(map[int]int{}, 0, 0)
+}
+', 'map_index_logical_comparison.v', prefs) or { panic(err) }
+	assert c_source.contains('builtin__map_get'), c_source
+	assert !c_source.contains('(values)[key]'), c_source
+}
+
+fn test_method_array_result_index_before_member_is_lowered() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Node {
+	params []string
+}
+
+fn (node &Node) generic_params() []string {
+	return node.params
+}
+
+fn has_generic(node Node) bool {
+	return node.generic_params().len > 0 && node.generic_params()[0].len > 0
+}
+
+fn main() {
+	_ = has_generic(Node{})
+}
+', 'method_array_result_index.v', prefs) or { panic(err) }
+	assert c_source.contains('builtin__array_get'), c_source
+	assert !c_source.contains('Node_generic_params(&(node))[0]'), c_source
 }
 
 fn test_selfhost_or_in_array_literal_element() {
@@ -9390,6 +10111,26 @@ fn main() {
 	assert !c_source.contains('Option __v_fastc_option_0 = (main__labels[kind])'), c_source
 }
 
+fn test_selfhost_address_of_map_lookup_or_returns_stored_value_pointer() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Item {
+	value int
+}
+
+fn find_ptr(items map[string]Item, key string) &Item {
+	return unsafe { &items[key] or { nil } }
+}
+
+fn main() {}
+', 'selfhost_map_lookup_address.v', prefs) or { panic(err) }
+	assert c_source.contains('Item *__v_fastc_map_value'), c_source
+	assert c_source.contains('Item* __v_fastc_box_value = (__v_fastc_map_value)'), c_source
+	assert !c_source.contains('&({ Option'), c_source
+}
+
 fn test_selfhost_mut_alias_struct_boxes_as_underlying_interface_implementer() {
 	mut prefs := pref.new_preferences()
 	prefs.building_v = true
@@ -9771,6 +10512,152 @@ fn main() {
 	assert c_source.contains('*((Kind *)value._object)'), c_source
 	assert c_source.contains('Kind__one'), c_source
 	assert !c_source.contains('value==.one'), c_source
+}
+
+fn test_selfhost_enum_shorthand_in_smartcast_conjunction() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+enum Op {
+	mul
+}
+
+struct PrefixExpr {
+	op Op
+}
+
+type Expr = PrefixExpr | int
+
+fn check(left Expr) bool {
+	return left is PrefixExpr && left.op == .mul
+}
+
+fn main() {
+	_ = check(1)
+}
+', 'selfhost_smartcast_enum_shorthand.v', prefs) or { panic(err) }
+	assert c_source.contains('Op__mul'), c_source
+	assert !c_source.contains('== (.mul)'), c_source
+}
+
+fn test_selfhost_enum_shorthand_in_parenthesized_smartcast_guard() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+enum Language {
+	v
+	c
+}
+
+struct Ident {
+	language Language
+	obj int
+}
+
+type Expr = Ident | int
+
+struct Arg {
+	expr Expr
+}
+
+struct Table {}
+
+fn (t &Table) is_interface_smartcast(obj int) bool {
+	return obj != 0
+}
+
+struct Gen {
+	table &Table
+}
+
+fn check(g &Gen, arg Arg) bool {
+	if arg.expr is Ident && (arg.expr.language == .c || g.table.is_interface_smartcast(arg.expr.obj)) {
+		return true
+	}
+	return false
+}
+
+fn main() {
+	_ = check(&Gen{}, Arg{})
+}
+', 'selfhost_smartcast_parenthesized_enum_guard.v', prefs) or { panic(err) }
+	assert c_source.contains('Language__c'), c_source
+	assert !c_source.contains('language==.c'), c_source
+}
+
+fn test_selfhost_method_call_in_smartcast_conjunction() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+enum Flag {
+	generic
+}
+
+type Type = u64
+
+fn (t Type) has_flag(flag Flag) bool {
+	return t & u64(flag) != 0
+}
+
+struct StructInit {
+	unresolved bool
+	typ Type
+}
+
+type Expr = StructInit | int
+
+fn check(right &Expr) bool {
+	return right is StructInit && right.unresolved && right.typ.has_flag(.generic)
+}
+
+fn main() {
+	value := Expr(1)
+	_ = check(&value)
+}
+', 'selfhost_smartcast_method_conjunction.v', prefs) or { panic(err) }
+	assert c_source.contains('Type_has_flag(((StructInit *)'), c_source
+	assert !c_source.contains('right.typ.has_flag'), c_source
+}
+
+fn test_selfhost_nested_member_smartcasts_with_mutable_first_subject() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Var {}
+
+type ScopeObject = Var | int
+
+struct Ident {
+	obj ScopeObject
+}
+
+type Expr = Ident | int
+
+struct Selector {
+mut:
+	left Expr
+}
+
+fn check(mut selector Selector) bool {
+	return if mut selector.left is Ident && selector.left.obj is Var {
+		true
+	} else {
+		false
+	}
+}
+
+fn main() {
+	mut selector := Selector{}
+	_ = check(mut selector)
+}
+', 'selfhost_nested_member_smartcasts.v', prefs) or { panic(err) }
+	assert c_source.contains('__v_typeid_Ident'), c_source
+	assert c_source.contains('__v_typeid_Var'), c_source
+	assert !c_source.contains('selector->left.obj is'), c_source
 }
 
 fn test_selfhost_flag_define_directive() {
@@ -11259,6 +12146,39 @@ fn main() {
 	assert c_source.contains('take((Option){.data='), c_source
 	assert c_source.contains('sizeof(Array_u8)'), c_source
 	assert c_source.contains('take((Option){.state=2})'), c_source
+}
+
+fn test_selfhost_option_returning_method_call_compared_with_none() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Checker {}
+
+fn (c &Checker) find(name string, values []string) ?int {
+	_ = c
+	_ = name
+	_ = values
+	return none
+}
+
+fn has_value(c &Checker) bool {
+	return c.find("value", []string{}) != none
+}
+
+fn has_named_value(c &Checker, name string) bool {
+	return name.len > 0 && c.find(name, []string{}) != none
+}
+
+fn main() {
+	checker := &Checker{}
+	_ := has_value(checker)
+	_ := has_named_value(checker, "value")
+}
+', 'option_method_call_none_comparison.v', prefs) or { panic(err) }
+	assert c_source.contains(').state != 2)'), c_source
+	assert !c_source.contains('!= ((Option){.state=2})'), c_source
+	assert !c_source.contains('v_fastc_box_value'), c_source
 }
 
 fn test_selfhost_anonymous_function_is_rejected() {

--- a/vlib/v3/gen/fastc/fn.v
+++ b/vlib/v3/gen/fastc/fn.v
@@ -114,6 +114,7 @@ fn (mut g Parser) parse_top_level_items(stop_at_block_end bool) ! {
 		}
 		mut item_enabled := true
 		g.pending_direct_array_access = false
+		g.next_declaration_is_unsafe = false
 		for g.tok == .attribute {
 			item_enabled = g.skip_attribute()! && item_enabled
 			g.skip_semicolons()
@@ -395,6 +396,10 @@ fn (mut g Parser) skip_attribute() !bool {
 		}
 		if depth == 1 && g.tok == .name && g.lit == 'direct_array_access' {
 			g.pending_direct_array_access = true
+		}
+		if depth == 1 && at_item_start && g.tok == .key_unsafe {
+			// `@[unsafe]` marks the whole function body as an unsafe region.
+			g.next_declaration_is_unsafe = true
 		}
 		if depth == 1 && g.tok == .semicolon {
 			at_item_start = true
@@ -768,14 +773,6 @@ fn (mut g Parser) parse_function(enabled bool) ! {
 			return
 		}
 	}
-	if g.selfhost && g.open_block_contains_select_statement() {
-		// The self-host reachability prepass deliberately groups overloaded methods
-		// by name. Omit an unsupported overload that only became reachable through
-		// that conservative grouping. A real reference remains undefined and makes
-		// C validation fail instead of emitting select with changed semantics.
-		g.skip_balanced(.lcbr, .rcbr)!
-		return
-	}
 	if g.selfhost && !is_fastc_source && receiver_type != '' && g.method_uses_undefined_receiver() {
 		// A method reaching an undefined identifier as a method-call receiver is broken
 		// dead code, kept only because its name collides with a genuinely-used method on
@@ -799,6 +796,22 @@ fn (mut g Parser) parse_function(enabled bool) ! {
 		params.join(', ')
 	}
 	g.protos.writeln('${c_return_type} ${c_name}(${c_params});')
+	if g.selfhost && g.open_block_contains_select_statement() {
+		// `select { … }` (channel multiplexing) has no C lowering. Emit a trivial stub rather
+		// than skipping the function, so a genuinely referenced select-using function (the
+		// parallel `Pool.run`) still links. FastC channels are erased, so the select path is
+		// dead and a caller reaching this falls back to its synchronous branch.
+		g.write_line('${c_return_type} ${c_name}(${c_params}) {')
+		g.indent++
+		if return_type != 'void' {
+			g.write_line('return (${return_type}){0};')
+		}
+		g.indent--
+		g.write_line('}')
+		g.out.writeln('')
+		g.skip_balanced(.lcbr, .rcbr)!
+		return
+	}
 	if !enabled {
 		g.write_line('${c_return_type} ${c_name}(${c_params}) {')
 		g.indent++
@@ -839,9 +852,23 @@ fn (mut g Parser) parse_function(enabled bool) ! {
 	previous_method_is_static := g.current_method_is_static
 	previous_deferred_lines := g.deferred_lines.clone()
 	previous_deferred_block_starts := g.deferred_block_starts.clone()
+	previous_function_defer_blocks := g.function_defer_blocks.clone()
+	previous_function_defer_declarations := g.function_defer_declarations.clone()
 	previous_loop_defer_block_starts := g.loop_defer_block_starts.clone()
 	previous_loop_has_breaks := g.loop_has_breaks.clone()
 	previous_statement_reachable := g.statement_reachable
+	previous_unsafe_depth := g.unsafe_depth
+	// Defer-capture state must never span function boundaries; a render path that reads a
+	// block value speculatively (and swallows an error) can otherwise leave
+	// `capturing_defer` set, which would misroute a later function's statements.
+	previous_capturing_defer := g.capturing_defer
+	previous_captured_defer_lines := g.captured_defer_lines.clone()
+	previous_defer_depth := g.defer_depth
+	if g.next_declaration_is_unsafe {
+		// `@[unsafe]` makes the entire body an unsafe region (`nil`, pointer
+		// arithmetic, ...), matching V's semantics for the attribute.
+		g.unsafe_depth = 1
+	}
 	g.in_main = is_main
 	g.return_type = return_type
 	g.return_types = return_types.clone()
@@ -851,9 +878,15 @@ fn (mut g Parser) parse_function(enabled bool) ! {
 	g.current_method_is_static = is_static_method
 	g.deferred_lines.clear()
 	g.deferred_block_starts.clear()
+	g.function_defer_blocks.clear()
+	g.function_defer_declarations.clear()
 	g.loop_defer_block_starts.clear()
 	g.loop_has_breaks.clear()
+	g.capturing_defer = false
+	g.captured_defer_lines.clear()
+	g.defer_depth = 0
 	g.statement_reachable = true
+	function_body_start := g.out.len
 	mut terminates := false
 	if is_generic {
 		// Locate the end of the body (the matching `}`) so a failed placeholder
@@ -890,10 +923,11 @@ fn (mut g Parser) parse_function(enabled bool) ! {
 			// A struct literal on an unbound type parameter (`T{...}`, as in orm's
 			// `map_row`'s `mut instance := T{}`): the placeholder lowering can miscount
 			// the literal's `}` and end the body early, leaking a stray statement to the
-			// top level. Type-parameter reflection (`T.name`, `T.fields`, ...) likewise
-			// has no valid C spelling until this function is monomorphized. Force the
-			// whole placeholder body to stub in either case.
-			if prev_was_type_param && body_tok in [.lcbr, .dot] {
+			// top level. Type-parameter reflection (`T.name`, `T.fields`, ...) and a cast
+			// or construction on the type parameter (`T(x)`, as in sync.pool's
+			// `*(&T(items[idx]))`) likewise have no valid C spelling until this function is
+			// monomorphized. Force the whole placeholder body to stub in every case.
+			if prev_was_type_param && body_tok in [.lcbr, .dot, .lpar] {
 				force_stub = true
 			}
 			prev_was_lsbr = body_tok == .lsbr
@@ -906,18 +940,9 @@ fn (mut g Parser) parse_function(enabled bool) ! {
 	} else {
 		terminates = g.parse_block_body()!
 	}
-	g.in_main = previous_in_main
-	g.return_type = previous_return_type
-	g.return_types = previous_return_types.clone()
-	g.option_return_type = previous_option_return_type
-	g.current_function = previous_function
-	g.current_receiver = previous_receiver
-	g.current_method_is_static = previous_method_is_static
-	g.deferred_lines = previous_deferred_lines.clone()
-	g.deferred_block_starts = previous_deferred_block_starts.clone()
-	g.loop_defer_block_starts = previous_loop_defer_block_starts.clone()
-	g.loop_has_breaks = previous_loop_has_breaks.clone()
-	g.statement_reachable = previous_statement_reachable
+	if !terminates {
+		g.write_function_deferred_blocks()
+	}
 	if return_type != 'void' && !terminates {
 		if !g.selfhost {
 			return g.unsupported('non-void function `${name}` that can fall through')
@@ -930,6 +955,29 @@ fn (mut g Parser) parse_function(enabled bool) ! {
 	if is_main {
 		g.write_line('return 0;')
 	}
+	function_body := g.out.cut_to(function_body_start)
+	for declaration in g.function_defer_declarations {
+		g.write_line(declaration)
+	}
+	g.out.write_string(function_body)
+	g.in_main = previous_in_main
+	g.return_type = previous_return_type
+	g.return_types = previous_return_types.clone()
+	g.option_return_type = previous_option_return_type
+	g.current_function = previous_function
+	g.current_receiver = previous_receiver
+	g.current_method_is_static = previous_method_is_static
+	g.deferred_lines = previous_deferred_lines.clone()
+	g.deferred_block_starts = previous_deferred_block_starts.clone()
+	g.function_defer_blocks = previous_function_defer_blocks.clone()
+	g.function_defer_declarations = previous_function_defer_declarations.clone()
+	g.loop_defer_block_starts = previous_loop_defer_block_starts.clone()
+	g.loop_has_breaks = previous_loop_has_breaks.clone()
+	g.capturing_defer = previous_capturing_defer
+	g.captured_defer_lines = previous_captured_defer_lines.clone()
+	g.defer_depth = previous_defer_depth
+	g.statement_reachable = previous_statement_reachable
+	g.unsafe_depth = previous_unsafe_depth
 	g.indent--
 	g.write_line('}')
 	g.out.writeln('')
@@ -970,6 +1018,8 @@ fn (mut g Parser) emit_generic_body_stub(out_checkpoint int, saved_indent int, b
 	}
 	g.indent = saved_indent
 	g.capturing_defer = false
+	g.function_defer_blocks.clear()
+	g.function_defer_declarations.clear()
 	g.s = body_end
 	g.next()
 	if return_type != 'void' {
@@ -1109,6 +1159,7 @@ fn (mut g Parser) parse_script() ! {
 
 fn (mut g Parser) parse_parameters() ![]string {
 	mut params := []string{}
+	mut blank_index := 0
 	g.skip_semicolons()
 	for g.tok != .rpar {
 		mut is_mut := false
@@ -1140,7 +1191,15 @@ fn (mut g Parser) parse_parameters() ![]string {
 			type_name += '*'
 		}
 		for parameter_name in names {
-			c_name := fastc_c_identifier(parameter_name)
+			// Two blank `_` parameters (`fn f(_ A, _ B)`) would both render as the C name
+			// `_`, which C rejects as a redeclaration. `_` is never referenced in the body,
+			// so give each a distinct throwaway name.
+			c_name := if parameter_name == '_' {
+				blank_index++
+				'_fastc_unused_${blank_index}'
+			} else {
+				fastc_c_identifier(parameter_name)
+			}
 			if is_fn_pointer {
 				// Declare a real function pointer with unspecified args so `f(x)`
 				// compiles as a direct call; the return C type is recovered above.

--- a/vlib/v3/gen/fastc/for.v
+++ b/vlib/v3/gen/fastc/for.v
@@ -157,7 +157,7 @@ fn (mut g Parser) parse_for() !bool {
 					g.write_line('${map_value_type} ${fastc_c_identifier(value_name)} = ((${map_value_type} *)${values_name}.data)[${index_name}];')
 					g.locals[value_name] = FastcLocal{
 						is_mut: value_is_mut
-						typ:    map_value_type
+						typ: map_value_type
 					}
 				}
 				_ = g.parse_loop_block_body()!
@@ -180,9 +180,7 @@ fn (mut g Parser) parse_for() !bool {
 				''
 			}
 			is_fixed_array := fixed_length != ''
-			is_raw_fixed_array := is_fixed_array && (start_expression.len > 1
-				|| (start_expression.len == 1
-				&& fastc_global_key(g.module_name, start_expression[0].lit) in g.globals))
+			is_raw_fixed_array := is_fixed_array && (start_expression.len > 1 || (start_expression.len == 1 && fastc_global_key(g.module_name, start_expression[0].lit) in g.globals))
 			g.next()
 			collection_name := g.temporary_name('collection')
 			is_ordinary_string := !g.selfhost && collection_layout_type == 'string'
@@ -229,21 +227,24 @@ fn (mut g Parser) parse_for() !bool {
 			actual_value_name := if value_name == '' { name } else { value_name }
 			if actual_value_name != '_' {
 				c_value_name := fastc_c_identifier(actual_value_name)
-				if item_is_mut {
+				// `for i, mut x in arr` makes the value variable a mutable reference to the
+				// element exactly like `for mut x in arr`; the `mut` is just carried on the
+				// second binding (`value_is_mut`) instead of the first.
+				if item_is_mut || value_is_mut {
 					if element_type.ends_with('*') {
 						// Pointer elements are already references to mutable values. Taking the
 						// array slot's address here would incorrectly bind `x` as `&&T`.
 						g.write_line('${element_type} ${c_value_name} = ((${element_type} *)${collection_data})[${index_name}];')
 						g.locals[actual_value_name] = FastcLocal{
 							is_mut: true
-							typ:    element_type
+							typ: element_type
 						}
 					} else {
 						g.write_line('${element_type} *${c_value_name} = &(((${element_type} *)${collection_data})[${index_name}]);')
 						g.locals[actual_value_name] = FastcLocal{
-							is_mut:       true
+							is_mut: true
 							is_reference: true
-							typ:          element_type + '*'
+							typ: element_type + '*'
 						}
 					}
 				} else if is_ordinary_string {
@@ -251,8 +252,7 @@ fn (mut g Parser) parse_for() !bool {
 					g.locals[actual_value_name] = FastcLocal{
 						typ: 'u8'
 					}
-				} else if !is_fixed_array && collection_layout_type.ends_with('*')
-					&& collection_layout_type.trim_right('*') != 'string' {
+				} else if !is_fixed_array && collection_layout_type.ends_with('*') && collection_layout_type.trim_right('*') != 'string' {
 					g.write_line('${element_type} *${c_value_name} = &(((${element_type} *)${collection_data})[${index_name}]);')
 					g.locals[actual_value_name] = FastcLocal{
 						typ: element_type + '*'
@@ -298,7 +298,7 @@ fn (mut g Parser) parse_for() !bool {
 			if is_declaration {
 				g.locals[name] = FastcLocal{
 					is_mut: true
-					typ:    initial_type
+					typ: initial_type
 				}
 			}
 			condition := g.read_expression([token.Token.semicolon])!
@@ -322,7 +322,11 @@ fn (mut g Parser) parse_for() !bool {
 		}
 		g.validate_expression_name(name, .unknown)!
 		condition := g.read_expression_with_prefix(name, [token.Token.lcbr])!
+		condition_tokens := g.last_expression.clone()
 		g.expect(.lcbr)!
+		if g.write_condition_loop(condition, condition_tokens)! {
+			return false
+		}
 		g.write_line('while (${condition}) {')
 		g.indent++
 		_ = g.parse_loop_block_body()!
@@ -331,7 +335,11 @@ fn (mut g Parser) parse_for() !bool {
 		return false
 	}
 	condition := g.read_expression([token.Token.lcbr])!
+	condition_tokens := g.last_expression.clone()
 	g.expect(.lcbr)!
+	if g.write_condition_loop(condition, condition_tokens)! {
+		return false
+	}
 	g.write_line('while (${condition}) {')
 	g.indent++
 	_ = g.parse_loop_block_body()!
@@ -340,13 +348,66 @@ fn (mut g Parser) parse_for() !bool {
 	return false
 }
 
+// write_condition_loop emits a `for <cond> { … }` loop whose condition narrows a boxed member
+// (`for x.f is T { … x.f.field … }`), keeping the smart-cast live through the body exactly as
+// an `if` does. Because the condition is re-checked each iteration (its tag test reads a
+// per-iteration temp), the loop is emitted as `while (1) { <boxed temps>; if (!cond) break;
+// <member ptrs>; body }`. Returns false (emitting nothing) when the condition has no member
+// smart-cast, so the caller falls back to a plain `while (cond)`.
+fn (mut g Parser) write_condition_loop(condition string, condition_tokens []FastcExpressionToken) !bool {
+	if !g.selfhost {
+		return false
+	}
+	plans, rewritten_condition := g.detect_member_smartcasts(condition_tokens, condition)
+	if plans.len == 0 {
+		return false
+	}
+	loop_condition := if rewritten_condition != '' { rewritten_condition } else { condition }
+	g.write_line('while (1) {')
+	g.indent++
+	for plan in plans {
+		g.write_line('${plan.boxed_type} ${plan.boxed_tmp} = ${plan.source};')
+	}
+	g.write_line('if (!(${loop_condition})) { break; }')
+	mut previous_member_smartcasts := map[string]FastcMemberSmartcast{}
+	mut had_member_smartcasts := map[string]bool{}
+	for plan in plans {
+		plan_access := if plan.boxed_type.ends_with('*') { '->' } else { '.' }
+		g.write_line('${plan.type_c} *${plan.member_tmp} = (${plan.type_c} *)${plan.boxed_tmp}${plan_access}_object;')
+		if plan.path !in previous_member_smartcasts {
+			had_member_smartcasts[plan.path] = plan.path in g.member_smartcasts
+			previous_member_smartcasts[plan.path] = g.member_smartcasts[plan.path] or {
+				FastcMemberSmartcast{}
+			}
+		}
+		g.member_smartcasts[plan.path] = FastcMemberSmartcast{
+			typ: plan.type_c + '*'
+			source: plan.member_tmp
+		}
+	}
+	_ = g.parse_loop_block_body()!
+	for path, present in had_member_smartcasts {
+		if present {
+			g.member_smartcasts[path] = previous_member_smartcasts[path]
+		} else {
+			g.member_smartcasts.delete(path)
+		}
+	}
+	g.indent--
+	g.write_line('}')
+	return true
+}
+
 fn (g &Parser) mutable_collection_expression(tokens []FastcExpressionToken) bool {
 	for item in tokens {
 		if item.tok != .name {
 			continue
 		}
 		if local := g.locals[item.lit] {
-			return local.is_mut || (item.unsafe_depth > 0 && fastc_is_pointer_type(local.typ))
+			// An `unsafe { … }` collection is the programmer's explicit assertion that
+			// mutable iteration is intended (`for mut f in unsafe { s.fields }`); the
+			// array's data is shared regardless, so the mutation reaches the source.
+			return local.is_mut || item.unsafe_depth > 0
 		}
 		global_key := fastc_global_key(g.module_name, item.lit)
 		return item.unsafe_depth > 0 && global_key in g.globals

--- a/vlib/v3/gen/fastc/for.v
+++ b/vlib/v3/gen/fastc/for.v
@@ -366,7 +366,12 @@ fn (mut g Parser) write_condition_loop(condition string, condition_tokens []Fast
 	g.write_line('while (1) {')
 	g.indent++
 	for plan in plans {
-		g.write_line('${plan.boxed_type} ${plan.boxed_tmp} = ${plan.source};')
+		boxed_zero := if plan.boxed_type.ends_with('*') {
+			'NULL'
+		} else {
+			'(${plan.boxed_type}){0}'
+		}
+		g.write_line('${plan.boxed_type} ${plan.boxed_tmp} = ${boxed_zero};')
 	}
 	g.write_line('if (!(${loop_condition})) { break; }')
 	mut previous_member_smartcasts := map[string]FastcMemberSmartcast{}

--- a/vlib/v3/gen/fastc/if.v
+++ b/vlib/v3/gen/fastc/if.v
@@ -41,13 +41,305 @@ fn (g &Parser) or_block_has_statements() bool {
 			depth--
 		} else if depth == 0 && tok == .key_return {
 			return true
+		} else if depth == 0 && (tok.is_assignment() || tok in [.inc, .dec]) {
+			// A top-level assignment or `++`/`--` makes the block a statement block
+			// (`or { x = '' }`), not a trailing value expression.
+			return true
 		} else if depth == 0 && tok == .semicolon {
 			next_token := lookahead.scan()
+			if fastc_token_continues_expression(next_token) {
+				// A `;` auto-inserted mid multi-line expression (`a\n || b`) is a
+				// continuation, not a statement boundary; keep scanning past it.
+				tok = lookahead.scan()
+				continue
+			}
 			return next_token != .rcbr
 		}
 		tok = lookahead.scan()
 	}
 	return false
+}
+
+// parse_if_prescan_leading_smartcasts registers a temporary member smart-cast for each
+// leading `[mut] local is Variant` conjunct of an if-condition (simple boxed-local
+// subjects, single-name variants, joined by top-level `&&`), so a following guard or the
+// interpolation inside one reads the narrowed field while the condition is (re)rendered.
+// It does not consume input (a probe scanner walks ahead) and returns the names it
+// registered so the caller can drop them afterwards.
+fn (mut g Parser) parse_if_prescan_leading_smartcasts() []string {
+	mut registered := []string{}
+	mut probe := g.s
+	mut tok := g.tok
+	mut lit := g.lit
+	// Buffer the whole condition's tokens (bounded by the block `{` / `;`), tracking bracket
+	// depth so only TOP-LEVEL operators split the boolean structure.
+	mut toks := []token.Token{}
+	mut lits := []string{}
+	mut depth := 0
+	mut has_top_and := false
+	mut has_top_or := false
+	for {
+		if depth == 0 && tok in [token.Token.lcbr, .eof] {
+			break
+		}
+		if depth == 0 && tok == .semicolon {
+			// An auto-inserted `;` at a line break before a binary continuation (`x is A\n || …`)
+			// is not the condition's end; skip it so the whole multi-line condition is scanned.
+			// Missing this would treat `x is A` as the whole condition and wrongly narrow `x`.
+			next := probe.scan()
+			next_lit := probe.lit
+			if !fastc_token_continues_expression(next) {
+				break
+			}
+			tok = next
+			lit = next_lit
+			continue
+		}
+		if depth == 0 && tok == .and {
+			has_top_and = true
+		}
+		if depth == 0 && tok == .logical_or {
+			has_top_or = true
+		}
+		if tok in [.lpar, .lsbr, .lcbr] {
+			depth++
+		} else if tok in [.rpar, .rsbr, .rcbr] {
+			if depth > 0 {
+				depth--
+			}
+		}
+		toks << tok
+		lits << lit
+		tok = probe.scan()
+		lit = probe.lit
+	}
+	// A mix of top-level `&&` and `||` has no single short-circuit guarantee across the whole
+	// condition, so no prescan narrowing is safe.
+	if has_top_and && has_top_or {
+		return []string{}
+	}
+	// A subject also read through an explicit `right as SI` in the same condition is narrowed by
+	// that cast (with the conjunction narrowing) already; a prescan member smart-cast on the same
+	// name would collide with the `as` rendering, so exclude those names.
+	mut as_names := map[string]bool{}
+	for i in 0 .. toks.len - 1 {
+		if toks[i] == .name && toks[i + 1] == .key_as {
+			as_names[lits[i]] = true
+		}
+	}
+	// A top-level `||` chain narrows on NEGATED `is`: `x !is T || … x …` evaluates a later operand
+	// only when `x !is T` was false, i.e. `x` IS `T` there. A `&&` chain (or a single conjunct)
+	// narrows on positive `is`: `x is T && … x …`. Either way a member read buried in a later
+	// operand's `or`-block synthetic (`tc.structs[field_type.name]`) then narrows correctly.
+	split_tok := if has_top_or { token.Token.logical_or } else { token.Token.and }
+	is_tok := if has_top_or { token.Token.not_is } else { token.Token.key_is }
+	mut start := 0
+	mut d := 0
+	for i, item in toks {
+		if item in [.lpar, .lsbr, .lcbr] {
+			d++
+			continue
+		}
+		if item in [.rpar, .rsbr, .rcbr] {
+			if d > 0 {
+				d--
+			}
+			continue
+		}
+		if d == 0 && item == split_tok {
+			g.prescan_register_is_conjunct(toks[start..i], lits[start..i], as_names, is_tok, mut registered)
+			start = i + 1
+		}
+	}
+	g.prescan_register_is_conjunct(toks[start..], lits[start..], as_names, is_tok, mut registered)
+	return registered
+}
+
+// prescan_register_is_conjunct registers a member smart-cast when the conjunct is exactly a bare
+// `[mut] [&] name <is_tok> Variant`; any other shape (a call, a `!` test, a member `is`) is skipped.
+fn (mut g Parser) prescan_register_is_conjunct(toks []token.Token, lits []string, as_names map[string]bool, is_tok token.Token, mut registered []string) {
+	mut i := 0
+	for i < toks.len && toks[i] in [.key_mut, .amp] {
+		i++
+	}
+	if i + 3 != toks.len || toks[i] != .name || toks[i + 1] != is_tok || toks[i + 2] != .name {
+		return
+	}
+	subject := lits[i]
+	if subject in as_names {
+		return
+	}
+	variant_name := lits[i + 2]
+	if local := g.locals[subject] {
+		boxed := fastc_normalize_inferred_type(local.typ)
+		if g.is_boxed_type(boxed) && subject !in g.member_smartcasts {
+			if variant_key := g.resolve_declared_type_key(variant_name) {
+				variant_c := fastc_c_declared_type_name(variant_key)
+				access := if boxed.ends_with('*') { '->' } else { '.' }
+				g.member_smartcasts[subject] = FastcMemberSmartcast{
+					typ: variant_c + '*'
+					source: '((${variant_c} *)${g.local_c_name(subject)}${access}_object)'
+				}
+				registered << subject
+			}
+		}
+	}
+}
+
+// compute_bool_is_implications returns the member smart-casts a bool local would imply when true,
+// given the tokens of its RHS. Only a top-level `&&` chain (no top-level `||`) qualifies: a true
+// bool then guarantees every `is` conjunct held. Bare `subject is Variant` conjuncts contribute a
+// smart-cast; a bare bool-local conjunct inherits its own recorded implications.
+fn (g &Parser) compute_bool_is_implications(tokens []FastcExpressionToken) []FastcBoolImplication {
+	mut depth := 0
+	for t in tokens {
+		match t.tok {
+			.lpar, .lsbr, .lcbr { depth++ }
+			.rpar, .rsbr, .rcbr { depth-- }
+			.logical_or {
+				if depth == 0 {
+					return []
+				}
+			}
+			else {}
+		}
+	}
+	mut implications := []FastcBoolImplication{}
+	for conjunct in fastc_split_top_level_and(tokens) {
+		if imp := g.bool_conjunct_implication(conjunct) {
+			implications << imp
+		} else if conjunct.len == 1 && conjunct[0].tok == .name {
+			if inherited := g.locals[conjunct[0].lit] {
+				for inner in inherited.bool_implications {
+					implications << inner
+				}
+			}
+		}
+	}
+	return implications
+}
+
+// bool_conjunct_implication returns the smart-cast a lone `[mut] name is Variant` conjunct implies.
+fn (g &Parser) bool_conjunct_implication(conjunct []FastcExpressionToken) ?FastcBoolImplication {
+	mut i := 0
+	for i < conjunct.len && conjunct[i].tok in [.key_mut, .amp] {
+		i++
+	}
+	if i + 3 != conjunct.len || conjunct[i].tok != .name || conjunct[i + 1].tok != .key_is || conjunct[i + 2].tok != .name {
+		return none
+	}
+	subject := conjunct[i].lit
+	variant_name := conjunct[i + 2].lit
+	local := g.locals[subject] or { return none }
+	boxed := fastc_normalize_inferred_type(local.typ)
+	if !g.is_boxed_type(boxed) {
+		return none
+	}
+	variant_key := g.resolve_declared_type_key(variant_name) or { return none }
+	variant_c := fastc_c_declared_type_name(variant_key)
+	access := if boxed.ends_with('*') { '->' } else { '.' }
+	return FastcBoolImplication{
+		subject: subject
+		smartcast: FastcMemberSmartcast{
+			typ: variant_c + '*'
+			source: '((${variant_c} *)${g.local_c_name(subject)}${access}_object)'
+		}
+	}
+}
+
+// apply_bool_implication_smartcasts, when the expression about to be read starts with `boolvar &&`
+// where `boolvar` is a bool local carrying `is` implications and the chain has no top-level `||`,
+// registers those implied member smart-casts and returns the names to delete after the read — so
+// `ok && x.field` reads `x`'s narrowed variant field. See [[fastc-compile-cmd-v]].
+fn (mut g Parser) apply_bool_implication_smartcasts(stops []token.Token) []string {
+	if g.tok != .name {
+		return []
+	}
+	local := g.locals[g.lit] or { return [] }
+	if local.bool_implications.len == 0 {
+		return []
+	}
+	mut probe := g.s
+	mut tok := g.tok
+	mut depth := 0
+	mut saw_top_and := false
+	for {
+		if depth == 0 && tok == .semicolon {
+			// Skip an auto-inserted `;` before a binary continuation (`ok\n && x.field`); checked
+			// before `stops` (which includes `.semicolon`) so a line-wrapped chain is not cut short.
+			next := probe.scan()
+			if !fastc_token_continues_expression(next) {
+				break
+			}
+			tok = next
+			continue
+		}
+		if depth == 0 && (tok in stops || tok == .eof) {
+			break
+		}
+		if depth == 0 && tok == .logical_or {
+			return []
+		}
+		if depth == 0 && tok == .and {
+			saw_top_and = true
+		}
+		if tok in [.lpar, .lsbr, .lcbr] {
+			depth++
+		} else if tok in [.rpar, .rsbr, .rcbr] {
+			if depth > 0 {
+				depth--
+			}
+		}
+		tok = probe.scan()
+	}
+	if !saw_top_and {
+		return []
+	}
+	mut registered := []string{}
+	for imp in local.bool_implications {
+		if imp.subject !in g.member_smartcasts {
+			g.member_smartcasts[imp.subject] = imp.smartcast
+			registered << imp.subject
+		}
+	}
+	return registered
+}
+
+// detect_option_none_narrowings returns the option locals a condition guarantees to be
+// non-none inside the then-branch: each top-level `name != none` conjunct (the caller
+// having already excluded a top-level `||`), where `name` is an option-typed local. Such
+// a local is stored as the erased `Option`, so its wrapped value is reached through
+// `*((Base *)name.data)` — the source a member smart-cast then rewrites `name.field` onto.
+fn (g &Parser) detect_option_none_narrowings(cond_tokens []FastcExpressionToken) []string {
+	mut names := []string{}
+	mut depth := 0
+	for i := 0; i + 2 < cond_tokens.len; i++ {
+		tok := cond_tokens[i].tok
+		if tok in [.lpar, .lsbr, .lcbr] {
+			depth++
+			continue
+		}
+		if tok in [.rpar, .rsbr, .rcbr] {
+			depth--
+			continue
+		}
+		if depth != 0 {
+			continue
+		}
+		if tok == .name && cond_tokens[i + 1].tok == .ne && cond_tokens[i + 2].tok == .key_none {
+			if i > 0 && cond_tokens[i - 1].tok == .dot {
+				// `x.f != none` narrows a member, not the bare local — out of scope here.
+				continue
+			}
+			name := cond_tokens[i].lit
+			if local := g.locals[name] {
+				if local.option_value_type != '' && name !in names {
+					names << name
+				}
+			}
+		}
+	}
+	return names
 }
 
 fn (mut g Parser) parse_if() !bool {
@@ -77,7 +369,31 @@ fn (mut g Parser) parse_if() !bool {
 			return g.parse_if_multi_return_guard(guard_names)
 		}
 	}
-	mut condition := g.read_condition_expression([token.Token.semicolon, token.Token.lcbr])!
+	// A guard (or an interpolation inside one) may read a field of a subject narrowed by
+	// an earlier `is` in the SAME condition (`if x is T && '${x.field}' !in m`). The streaming
+	// reader renders that field — including ones buried in an `or`-block synthetic like
+	// `(m[x.field] or {})` that later top-level narrowing can no longer reach into — before any
+	// smart-cast is known. So narrow the leading `is` subjects UP FRONT for the read; on failure
+	// (a subject the prescan cannot narrow) retry once without them.
+	saved_s := g.s
+	saved_tok := g.tok
+	saved_lit := g.lit
+	mut prescan_registered := g.parse_if_prescan_leading_smartcasts()
+	mut condition := g.read_condition_expression([token.Token.semicolon, token.Token.lcbr]) or {
+		for prescan_name in prescan_registered {
+			g.member_smartcasts.delete(prescan_name)
+		}
+		prescan_registered = []string{}
+		g.s = saved_s
+		g.tok = saved_tok
+		g.lit = saved_lit
+		g.read_condition_expression([token.Token.semicolon, token.Token.lcbr])!
+	}
+	// The narrowing was only needed while rendering the condition; drop it so the ordinary
+	// per-branch smart-cast setup below owns it.
+	for prescan_name in prescan_registered {
+		g.member_smartcasts.delete(prescan_name)
+	}
 	if condition.len == 0 {
 		return g.unsupported('empty if condition')
 	}
@@ -89,24 +405,96 @@ fn (mut g Parser) parse_if() !bool {
 	mut smartcast_type := ''
 	mut smartcast_tmp := ''
 	mut smartcast_boxed_type := ''
-	if cond_tokens.len >= 3 && cond_tokens[0].tok == .name && cond_tokens[1].tok == .key_is {
-		if local := g.locals[cond_tokens[0].lit] {
+	mut smartcast_negated := false
+	mut local_start := 0
+	if cond_tokens.len > 0 && cond_tokens[0].tok in [.key_mut, .amp] {
+		// `if mut local is Variant`: the `mut` renders as a leading `&`/`mut` token.
+		local_start = 1
+	}
+	// A top-level `||` (`x is A || x is B`) means no single variant is guaranteed in the
+	// branch, so `x` must not be shadowed to the first tested variant.
+	mut condition_has_top_level_or := false
+	// A top-level `&&` matters for the negated `!is` fall-through narrowing: `x !is A && x !is B`
+	// exits only when `x` is neither, so past the block `x` is `A` OR `B`, not a single variant.
+	mut condition_has_top_level_and := false
+	mut or_scan_depth := 0
+	for item in cond_tokens {
+		match item.tok {
+			.lpar, .lsbr, .lcbr { or_scan_depth++ }
+			.rpar, .rsbr, .rcbr { or_scan_depth-- }
+			.logical_or {
+				if or_scan_depth == 0 {
+					condition_has_top_level_or = true
+				}
+			}
+			.and {
+				if or_scan_depth == 0 {
+					condition_has_top_level_and = true
+				}
+			}
+			else {}
+		}
+	}
+	first_is_negated := cond_tokens.len >= local_start + 2 && cond_tokens[local_start + 1].tok == .not_is
+	// A top-level `||` forbids the positive in-branch shadow (`x is A || x is B` guarantees no
+	// single variant in the then-branch). But a NEGATED first operand with a terminating block
+	// narrows in the FALL-THROUGH instead: `x !is A || … { return }` reaches past the block only
+	// when `x` IS `A` (De Morgan), so allow detection there — only the after-block narrowing (which
+	// requires `smartcast_negated`) consumes it; the positive shadows stay gated off.
+	if (!condition_has_top_level_or || first_is_negated) && cond_tokens.len >= local_start + 3 && cond_tokens[local_start].tok == .name && cond_tokens[local_start + 1].tok in [
+		.key_is,
+		.not_is,
+	] {
+		smartcast_negated = cond_tokens[local_start + 1].tok == .not_is
+		if local := g.locals[cond_tokens[local_start].lit] {
 			boxed := fastc_normalize_inferred_type(local.typ)
 			if g.is_boxed_type(boxed) {
-				if cond_tokens.len == 3 && cond_tokens[2].tok == .name {
-					if variant_key := g.resolve_declared_type_key(cond_tokens[2].lit) {
-						smartcast_name = cond_tokens[0].lit
+				// The variant type spans from just after `is` up to the first top-level
+				// `&&`/`||`; a trailing boolean guard (`x is T && cond`) must not be handed
+				// to the type resolver, which would otherwise reject the whole slice.
+				mut type_end := cond_tokens.len
+				mut guard_depth := 0
+				for i := local_start + 2; i < cond_tokens.len; i++ {
+					match cond_tokens[i].tok {
+						.lpar, .lsbr, .lcbr { guard_depth++ }
+						.rpar, .rsbr, .rcbr { guard_depth-- }
+						.and, .logical_or {
+							if guard_depth == 0 {
+								type_end = i
+								break
+							}
+						}
+						else {}
+					}
+				}
+				if type_end == local_start + 3 && cond_tokens[local_start + 2].tok == .name {
+					if variant_key := g.resolve_declared_type_key(cond_tokens[local_start + 2].lit) {
+						smartcast_name = cond_tokens[local_start].lit
 						smartcast_type = fastc_c_declared_type_name(variant_key)
 						smartcast_boxed_type = local.typ
 						smartcast_tmp = g.temporary_name('smartcast_subject')
+					} else if fastc_primitive_c_type(cond_tokens[local_start + 2].lit) != none {
+						// A primitive sum-type variant (`if v is u64`) narrows to that
+						// primitive; its own spelling is the smart-cast C type and tag.
+						smartcast_name = cond_tokens[local_start].lit
+						smartcast_type = cond_tokens[local_start + 2].lit
+						smartcast_boxed_type = local.typ
+						smartcast_tmp = g.temporary_name('smartcast_subject')
 					}
-				} else if resolved_target := g.type_from_expression_tokens(cond_tokens[2..]) {
-					// Composite variant target (`x is []string` / `x is map[K]V`): the
-					// type spans several tokens and lowers to a generated composite type.
+				} else if resolved_target := g.type_from_expression_tokens(cond_tokens[local_start + 2..type_end]) {
+					// A variant target that spans several tokens: a composite type
+					// (`x is []string` / `x is map[K]V`) or a module-qualified variant
+					// (`x is ast.IfExpr`). Composites must be registered; a qualified
+					// variant already resolves to its declared C type.
 					target := fastc_normalize_inferred_type(resolved_target)
 					if target.starts_with('Array_') || target.starts_with('Map_') {
 						fastc_register_composite_type(target, mut g.composite_types)
-						smartcast_name = cond_tokens[0].lit
+						smartcast_name = cond_tokens[local_start].lit
+						smartcast_type = target
+						smartcast_boxed_type = local.typ
+						smartcast_tmp = g.temporary_name('smartcast_subject')
+					} else if target != '' {
+						smartcast_name = cond_tokens[local_start].lit
 						smartcast_type = target
 						smartcast_boxed_type = local.typ
 						smartcast_tmp = g.temporary_name('smartcast_subject')
@@ -115,58 +503,19 @@ fn (mut g Parser) parse_if() !bool {
 			}
 		}
 	}
-	// A boxed member (`if mut holder.writer is File`) needs the same concrete view as
-	// a boxed local, but its qualified source spelling cannot be shadowed. Keep a
-	// branch-scoped member-path rewrite instead, backed by a pointer to the boxed object.
-	mut member_smartcast_path := ''
-	mut member_smartcast_type := ''
-	mut member_smartcast_boxed_type := ''
-	mut member_smartcast_source := ''
-	mut member_smartcast_boxed_tmp := ''
-	mut member_smartcast_tmp := ''
-	mut is_index := -1
-	for i, item in cond_tokens {
-		if item.tok == .key_is {
-			is_index = i
-			break
-		}
+	if smartcast_name != '' && local_start == 1 {
+		// `if mut x is T`: the leading `mut`/`&` defeats the general `is` rendering, so
+		// build the runtime tag check explicitly here.
+		access := if smartcast_boxed_type.ends_with('*') { '->' } else { '.' }
+		condition = '((${g.local_c_name(smartcast_name)}${access}_typ) == __v_typeid_${smartcast_type})'
 	}
-	mut member_start := 0
-	if cond_tokens.len > 0 && cond_tokens[0].tok in [.key_mut, .amp] {
-		member_start = 1
-	}
-	if is_index > member_start + 1 && is_index + 1 < cond_tokens.len {
-		left_tokens := cond_tokens[member_start..is_index]
-		mut is_member_chain := left_tokens.len >= 3 && left_tokens[0].tok == .name
-		mut path := if is_member_chain { left_tokens[0].lit } else { '' }
-		mut index := 1
-		for is_member_chain && index < left_tokens.len {
-			if index + 1 >= left_tokens.len || left_tokens[index].tok != .dot
-				|| left_tokens[index + 1].tok != .name {
-				is_member_chain = false
-				break
-			}
-			path += '.' + left_tokens[index + 1].lit
-			index += 2
-		}
-		if is_member_chain {
-			left_type := fastc_normalize_inferred_type(g.infer_expression_type(left_tokens) or {
-				''
-			})
-			target_type := g.type_from_expression_tokens(cond_tokens[is_index + 1..]) or { '' }
-			if left_type != '' && target_type != '' && g.is_boxed_type(left_type) {
-				left_source := g.render_member_receiver(left_tokens) or { '' }
-				if left_source != '' {
-					member_smartcast_path = path
-					member_smartcast_type = fastc_normalize_inferred_type(target_type)
-					member_smartcast_boxed_type = left_type
-					member_smartcast_source = left_source
-					member_smartcast_boxed_tmp = g.temporary_name('smartcast_subject')
-					member_smartcast_tmp = g.temporary_name('smartcast_member')
-					condition = '((${member_smartcast_boxed_tmp}._typ) == __v_typeid_${member_smartcast_type})'
-				}
-			}
-		}
+	// A boxed member (`if mut holder.writer is File`, or a conjunction such as
+	// `a.x is T && b.y is U`) needs the same concrete view as a boxed local, but its
+	// qualified source spelling cannot be shadowed. Keep a branch-scoped member-path
+	// rewrite per test instead, backed by a pointer to each boxed object.
+	member_smartcast_plans, member_smartcast_condition := g.detect_member_smartcasts(cond_tokens, condition)
+	if member_smartcast_condition != '' {
+		condition = member_smartcast_condition
 	}
 	mut guard_name := ''
 	mut guard_type := ''
@@ -178,15 +527,15 @@ fn (mut g Parser) parse_if() !bool {
 	// `if mut x := opt {` / `if mut x := map[k] {`: the leading `mut` (which renders to
 	// a `&` token here) shifts the name one token to the right. `& <name> :=` at the
 	// start of an if condition can only come from such a `mut` guard.
-	guard_name_index := if g.selfhost && g.last_expression.len >= 1
-		&& g.last_expression[0].tok in [token.Token.key_mut, token.Token.amp] {
+	guard_name_index := if g.selfhost && g.last_expression.len >= 1 && g.last_expression[0].tok in [
+		token.Token.key_mut,
+		token.Token.amp,
+	] {
 		1
 	} else {
 		0
 	}
-	if g.selfhost && g.last_expression.len >= guard_name_index + 3
-		&& g.last_expression[guard_name_index].tok == .name
-		&& g.last_expression[guard_name_index + 1].tok == .decl_assign {
+	if g.selfhost && g.last_expression.len >= guard_name_index + 3 && g.last_expression[guard_name_index].tok == .name && g.last_expression[guard_name_index + 1].tok == .decl_assign {
 		right_tokens := g.last_expression[guard_name_index + 2..]
 		if function_field := g.optional_function_field_for_expression(right_tokens) {
 			guard_name = g.last_expression[guard_name_index].lit
@@ -206,6 +555,16 @@ fn (mut g Parser) parse_if() !bool {
 			g.write_line('Option ${guard_option} = (${map_lookup.source});')
 			condition = '${guard_option}.state == 0'
 			g.last_expression_type = 'bool'
+		} else if array_lookup := g.render_array_lookup_option_expression(right_tokens) {
+			// `if x := arr[i] {` succeeds only when the index is in bounds, so the array
+			// access must lower to the bounds-checked Option form, not a raw element read.
+			guard_name = g.last_expression[guard_name_index].lit
+			guard_type = array_lookup.typ
+			guard_is_mut = guard_name_index == 1
+			guard_option = g.temporary_name('if_guard')
+			g.write_line('Option ${guard_option} = (${array_lookup.source});')
+			condition = '${guard_option}.state == 0'
+			g.last_expression_type = 'bool'
 		} else {
 			option_type := g.option_value_type_for_expression(right_tokens)
 			if option_type != '' {
@@ -223,13 +582,18 @@ fn (mut g Parser) parse_if() !bool {
 	}
 	g.skip_semicolons()
 	g.expect(.lcbr)!
-	if smartcast_name != '' {
+	if smartcast_name != '' && !smartcast_negated {
 		// Copy the boxed value out before the branch so the shadowing cast below
 		// does not reference its own uninitialized declaration.
-		g.write_line('${smartcast_boxed_type} ${smartcast_tmp} = ${fastc_c_identifier(smartcast_name)};')
+		g.write_line('${smartcast_boxed_type} ${smartcast_tmp} = ${g.local_c_name(smartcast_name)};')
 	}
-	if member_smartcast_path != '' {
-		g.write_line('${member_smartcast_boxed_type} ${member_smartcast_boxed_tmp} = ${member_smartcast_source};')
+	for plan in member_smartcast_plans {
+		boxed_zero := if plan.boxed_type.ends_with('*') {
+			'NULL'
+		} else {
+			'(${plan.boxed_type}){0}'
+		}
+		g.write_line('${plan.boxed_type} ${plan.boxed_tmp} = ${boxed_zero};')
 	}
 	g.write_line('if (${condition}) {')
 	g.indent++
@@ -250,9 +614,9 @@ fn (mut g Parser) parse_if() !bool {
 			name := fastc_c_identifier(guard_name)
 			g.write_line('${return_type} (*${name})(${parameters}) = (${return_type} (*)(${parameters}))(${guard_function_source});')
 			g.locals[guard_name] = FastcLocal{
-				is_mut:               guard_is_mut
-				typ:                  'voidptr'
-				fn_return_type:       return_type
+				is_mut: guard_is_mut
+				typ: 'voidptr'
+				fn_return_type: return_type
 				fn_option_value_type: guard_function.fn_option_value_type
 			}
 		} else if guard_erased_generic {
@@ -264,37 +628,116 @@ fn (mut g Parser) parse_if() !bool {
 			}
 			g.locals[guard_name] = FastcLocal{
 				is_mut: guard_is_mut
-				typ:    guard_type
+				typ: guard_type
 			}
 		} else {
 			function_alias := g.functions[guard_type] or { FastcFunctionSignature{} }
 			g.write_line('${guard_type} ${fastc_c_identifier(guard_name)} = *((${guard_type} *)${guard_option}.data);')
 			g.locals[guard_name] = FastcLocal{
-				is_mut:               guard_is_mut
-				typ:                  guard_type
-				fn_return_type:       function_alias.return_type
+				is_mut: guard_is_mut
+				typ: guard_type
+				fn_return_type: function_alias.return_type
 				fn_option_value_type: function_alias.option_type
 			}
 		}
 	}
 	previous_smartcast := g.locals[smartcast_name] or { FastcLocal{} }
 	had_smartcast := smartcast_name in g.locals
-	if smartcast_name != '' {
-		g.write_line('${smartcast_type} ${fastc_c_identifier(smartcast_name)} = *((${smartcast_type} *)${smartcast_tmp}._object);')
+	if smartcast_name != '' && !smartcast_negated {
+		// A pointer subject (`node &ast.Node`) reaches its boxed payload through `->`.
+		tmp_access := if smartcast_boxed_type.ends_with('*') { '->' } else { '.' }
+		smartcast_is_reference := local_start == 1 || smartcast_boxed_type.ends_with('*') || cond_tokens[local_start].is_mut_argument
+		// The narrowed value goes into a UNIQUELY named temporary, not a shadow of the subject's
+		// own C name, so a `defer` body (rendered at function scope) still binds the original.
+		branch_cast := g.temporary_name('if_cast')
+		branch_type := if smartcast_is_reference { smartcast_type + '*' } else { smartcast_type }
+		branch_value := if smartcast_is_reference {
+			'(${smartcast_type} *)${smartcast_tmp}${tmp_access}_object'
+		} else {
+			'*((${smartcast_type} *)${smartcast_tmp}${tmp_access}_object)'
+		}
+		g.write_line('${branch_type} ${branch_cast} = ${branch_value};')
 		g.locals[smartcast_name] = FastcLocal{
 			is_mut: previous_smartcast.is_mut
-			typ:    smartcast_type
+			is_reference: smartcast_is_reference
+			typ: branch_type
+			c_name: branch_cast
+			smartcast_origin_type: smartcast_boxed_type
+			smartcast_origin_source: smartcast_tmp
 		}
 	}
-	previous_member_smartcast := g.member_smartcasts[member_smartcast_path] or {
-		FastcMemberSmartcast{}
+	mut previous_member_smartcasts := map[string]FastcMemberSmartcast{}
+	mut had_member_smartcasts := map[string]bool{}
+	mut previous_local_plans := map[string]FastcLocal{}
+	mut had_local_plans := map[string]bool{}
+	for plan in member_smartcast_plans {
+		if plan.path == smartcast_name {
+			// The bare local is also shadowed as a concrete-variant value below, which
+			// already covers both `${name}` and `${name}.field`; a member-path pointer
+			// rewrite would instead expose it as a pointer to later statements.
+			continue
+		}
+		plan_access := if plan.boxed_type.ends_with('*') { '->' } else { '.' }
+		if plan.path in g.locals && !plan.path.contains('.') && !plan.path.contains('[') {
+			// A second bare local narrowed in the same condition (`a is X && b is Y`) must be
+			// shadowed as a concrete-variant VALUE, exactly like the primary subject above.
+			// A member-smartcast pointer is only consulted by member-access reads, so plain
+			// reads of the local (an arithmetic operand, a cast) would otherwise keep the raw
+			// boxed value.
+			if plan.path !in previous_local_plans {
+				had_local_plans[plan.path] = plan.path in g.locals
+				previous_local_plans[plan.path] = g.locals[plan.path] or { FastcLocal{} }
+			}
+			plan_shadow := g.temporary_name('if_cast')
+			plan_is_reference := plan.boxed_type.ends_with('*')
+			plan_type := if plan_is_reference { plan.type_c + '*' } else { plan.type_c }
+			plan_value := if plan_is_reference {
+				'(${plan.type_c} *)${plan.boxed_tmp}${plan_access}_object'
+			} else {
+				'*((${plan.type_c} *)${plan.boxed_tmp}${plan_access}_object)'
+			}
+			g.write_line('${plan_type} ${plan_shadow} = ${plan_value};')
+			previous_plan_local := g.locals[plan.path] or { FastcLocal{} }
+			g.locals[plan.path] = FastcLocal{
+				is_mut: previous_plan_local.is_mut
+				is_reference: plan_is_reference
+				typ: plan_type
+				c_name: plan_shadow
+				smartcast_origin_type: plan.boxed_type
+				smartcast_origin_source: plan.boxed_tmp
+			}
+			continue
+		}
+		if plan.path !in previous_member_smartcasts {
+			had_member_smartcasts[plan.path] = plan.path in g.member_smartcasts
+			previous_member_smartcasts[plan.path] = g.member_smartcasts[plan.path] or {
+				FastcMemberSmartcast{}
+			}
+		}
+		g.write_line('${plan.type_c} *${plan.member_tmp} = (${plan.type_c} *)${plan.boxed_tmp}${plan_access}_object;')
+		g.member_smartcasts[plan.path] = FastcMemberSmartcast{
+			typ: plan.type_c + '*'
+			source: plan.member_tmp
+		}
 	}
-	had_member_smartcast := member_smartcast_path in g.member_smartcasts
-	if member_smartcast_path != '' {
-		g.write_line('${member_smartcast_type} *${member_smartcast_tmp} = (${member_smartcast_type} *)${member_smartcast_boxed_tmp}._object;')
-		g.member_smartcasts[member_smartcast_path] = FastcMemberSmartcast{
-			typ:    member_smartcast_type + '*'
-			source: member_smartcast_tmp
+	// `if opt != none { opt.field }`: narrow each option local guaranteed non-none in the
+	// branch to its wrapped value, read through the erased `Option`'s `.data` payload.
+	if !condition_has_top_level_or {
+		for opt_name in g.detect_option_none_narrowings(cond_tokens) {
+			if opt_name == smartcast_name || opt_name in previous_member_smartcasts {
+				continue
+			}
+			if local := g.locals[opt_name] {
+				base := local.option_value_type
+				had_member_smartcasts[opt_name] = opt_name in g.member_smartcasts
+				previous_member_smartcasts[opt_name] = g.member_smartcasts[opt_name] or {
+					FastcMemberSmartcast{}
+				}
+				g.member_smartcasts[opt_name] = FastcMemberSmartcast{
+					typ: base
+					source: '(*((${base} *)${fastc_c_identifier(opt_name)}.data))'
+				}
+			}
 		}
 	}
 	then_terminates := g.parse_block_body()!
@@ -312,16 +755,40 @@ fn (mut g Parser) parse_if() !bool {
 			g.locals.delete(smartcast_name)
 		}
 	}
-	if member_smartcast_path != '' {
-		if had_member_smartcast {
-			g.member_smartcasts[member_smartcast_path] = previous_member_smartcast
+	for path, present in had_member_smartcasts {
+		if present {
+			g.member_smartcasts[path] = previous_member_smartcasts[path]
 		} else {
-			g.member_smartcasts.delete(member_smartcast_path)
+			g.member_smartcasts.delete(path)
+		}
+	}
+	for path, present in had_local_plans {
+		if present {
+			g.locals[path] = previous_local_plans[path]
+		} else {
+			g.locals.delete(path)
 		}
 	}
 	g.indent--
 	if g.tok != .key_else {
 		g.write_line('}')
+		if smartcast_negated && smartcast_name != '' && then_terminates && !condition_has_top_level_and && !previous_smartcast.is_mut {
+			// `if x !is Variant { return }`: reaching past the block proves `x` IS the
+			// variant, so narrow it to a value shadow scoped to the rest of the block,
+			// mirroring the positive `is` branch but in the fall-through path. A `mut`
+			// subject is excluded: a later `x = …` reassignment widens the smart-cast in V,
+			// but the value shadow would keep pointing at the stale narrowed variant.
+			access := if smartcast_boxed_type.ends_with('*') { '->' } else { '.' }
+			branch_cast := g.temporary_name('if_cast')
+			g.write_line('${smartcast_type} ${branch_cast} = *((${smartcast_type} *)${g.local_c_name(smartcast_name)}${access}_object);')
+			g.set_scoped_local(smartcast_name, FastcLocal{
+				is_mut: previous_smartcast.is_mut
+				typ: smartcast_type
+				c_name: branch_cast
+				smartcast_origin_type: smartcast_boxed_type
+				smartcast_origin_source: g.local_c_name(smartcast_name)
+			})
+		}
 		return false
 	}
 	g.next()
@@ -448,9 +915,24 @@ fn (g &Parser) if_starts_final_block_expression() bool {
 	mut lookahead := scanner.new_scanner(g.prefs, .normal)
 	lookahead.init(g.s.current_file(), g.s.src)
 	lookahead.offset = g.s.offset
+	mut prev := token.Token.unknown
 	mut tok := lookahead.scan()
 	for {
-		for tok !in [.lcbr, .eof] {
+		// Scan to the block-opening `{`, skipping any `unsafe { … }` that appears in the
+		// condition itself (`if x != unsafe { nil } { … }`), whose brace would otherwise
+		// be mistaken for the block.
+		for tok != .eof {
+			if tok == .lcbr {
+				if prev == .key_unsafe {
+					tok = fastc_skip_balanced_tokens(mut lookahead, tok, .lcbr, .rcbr) or {
+						return false
+					}
+					prev = .rcbr
+					continue
+				}
+				break
+			}
+			prev = tok
 			tok = lookahead.scan()
 		}
 		if tok != .lcbr {
@@ -468,6 +950,7 @@ fn (g &Parser) if_starts_final_block_expression() bool {
 			tok = lookahead.scan()
 		}
 		if tok == .key_if {
+			prev = .key_if
 			tok = lookahead.scan()
 			continue
 		}
@@ -483,6 +966,389 @@ fn (g &Parser) if_starts_final_block_expression() bool {
 	return tok == .rcbr
 }
 
+// FastcMemberSmartcastPlan is one `member.path is Type` test detected in an `if`
+// condition. A condition may carry several (`a.x is T && b.y is U`); each one gets
+// its boxed subject captured before the branch and a concrete pointer inside it.
+struct FastcMemberSmartcastPlan {
+	path       string
+	type_c     string
+	boxed_type string
+	source     string
+	boxed_tmp  string
+	member_tmp string
+}
+
+// fastc_strip_outer_parens removes fully-matching outer parentheses from a rendered C
+// expression (the streaming reader wraps a whole condition in one pair), so its top-level
+// operators become visible to a split.
+fn fastc_strip_outer_parens(source string) string {
+	mut s := source.trim_space()
+	for s.len >= 2 && s[0] == `(` && s[s.len - 1] == `)` {
+		mut depth := 0
+		mut quote := u8(0)
+		mut escaped := false
+		mut matches := true
+		for i := 0; i < s.len; i++ {
+			c := s[i]
+			if quote != 0 {
+				if escaped {
+					escaped = false
+				} else if c == `\\` {
+					escaped = true
+				} else if c == quote {
+					quote = 0
+				}
+				continue
+			}
+			if c == `'` || c == `"` {
+				quote = c
+			} else if c == `(` {
+				depth++
+			} else if c == `)` {
+				depth--
+				if depth == 0 && i != s.len - 1 {
+					matches = false
+					break
+				}
+			}
+		}
+		if !matches {
+			break
+		}
+		s = s[1..s.len - 1].trim_space()
+	}
+	return s
+}
+
+// fastc_split_top_level_c_and splits a rendered C condition on its top-level `&&`
+// operators, respecting parentheses/brackets/braces and string and char literals, so a
+// guard conjunct can reuse its already-rendered spelling.
+fn fastc_split_top_level_c_and(source string) []string {
+	mut parts := []string{}
+	mut start := 0
+	mut depth := 0
+	mut quote := u8(0)
+	mut escaped := false
+	for i := 0; i < source.len; i++ {
+		c := source[i]
+		if quote != 0 {
+			if escaped {
+				escaped = false
+			} else if c == `\\` {
+				escaped = true
+			} else if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		if c == `'` || c == `"` {
+			quote = c
+		} else if c in [`(`, `[`, `{`] {
+			depth++
+		} else if c in [`)`, `]`, `}`] {
+			depth--
+		} else if depth == 0 && c == `&` && i + 1 < source.len && source[i + 1] == `&` {
+			parts << source[start..i]
+			i++
+			start = i + 1
+		}
+	}
+	parts << source[start..]
+	return parts
+}
+
+// fastc_split_top_level_and splits condition tokens on top-level `&&` operators.
+fn fastc_split_top_level_and(tokens []FastcExpressionToken) [][]FastcExpressionToken {
+	mut parts := [][]FastcExpressionToken{}
+	mut depth := 0
+	mut start := 0
+	for i, item in tokens {
+		match item.tok {
+			.lpar, .lsbr, .lcbr { depth++ }
+			.rpar, .rsbr, .rcbr { depth-- }
+			.and {
+				if depth == 0 {
+					parts << tokens[start..i]
+					start = i + 1
+				}
+			}
+			else {}
+		}
+	}
+	parts << tokens[start..]
+	return parts
+}
+
+// fastc_first_top_level_is returns the index of the first top-level `is` in tokens.
+fn fastc_first_top_level_is(tokens []FastcExpressionToken) int {
+	mut depth := 0
+	for i, item in tokens {
+		match item.tok {
+			.lpar, .lsbr, .lcbr { depth++ }
+			.rpar, .rsbr, .rcbr { depth-- }
+			.key_is {
+				if depth == 0 {
+					return i
+				}
+			}
+			else {}
+		}
+	}
+	return -1
+}
+
+// render_guard_boolean_expression lowers a compound boolean guard conjunct (`(op == .decl
+// && x.is_mut) || op == .assign`) that reads narrowed subjects and enum shorthands. Splitting
+// on the top-level `||`/`&&` lets each leaf resolve through render_guard_comparison (which
+// applies the enum-shorthand type) or render_member_receiver (the smart-cast pointer), which
+// the raw renderer alone loses when re-rendering the conjunct outside the streaming reader.
+fn (g &Parser) render_guard_boolean_expression(tokens []FastcExpressionToken) ?string {
+	inner := fastc_strip_paren_tokens(tokens)
+	if inner.len == 0 {
+		return none
+	}
+	if idx := fastc_top_level_boolean_split(inner, .logical_or) {
+		left := g.render_guard_boolean_expression(inner[..idx]) or { return none }
+		right := g.render_guard_boolean_expression(inner[idx + 1..]) or { return none }
+		return '((${left}) || (${right}))'
+	}
+	if idx := fastc_top_level_boolean_split(inner, .and) {
+		left := g.render_guard_boolean_expression(inner[..idx]) or { return none }
+		right := g.render_guard_boolean_expression(inner[idx + 1..]) or { return none }
+		return '((${left}) && (${right}))'
+	}
+	if inner[0].tok == .not {
+		operand := g.render_guard_boolean_expression(inner[1..]) or { return none }
+		return '(!(${operand}))'
+	}
+	if comparison := g.render_guard_comparison(inner) {
+		return comparison
+	}
+	if boolean_is := g.render_boolean_is_expression(inner) {
+		return boolean_is.source
+	}
+	if member := g.render_member_receiver(inner) {
+		return member
+	}
+	if raw := g.render_raw_expression_tokens(inner) {
+		if special := g.render_special_expression(inner, raw) {
+			return special.source
+		}
+		return raw
+	}
+	return none
+}
+
+// detect_member_smartcasts finds every `member.path is Type` test in a (possibly
+// `&&`-conjoined) condition, records a plan per test, and rewrites `condition` to
+// the conjunction of the runtime type checks plus any boolean guards. Returns an
+// empty list (leaving `condition` untouched) when the condition is not a member
+// smartcast, so simple-local smartcasts and ordinary conditions are unaffected.
+fn (mut g Parser) detect_member_smartcasts(cond_tokens []FastcExpressionToken, rendered_condition string) ([]FastcMemberSmartcastPlan, string) {
+	conjuncts := fastc_split_top_level_and(cond_tokens)
+	rendered_conjuncts := fastc_split_top_level_c_and(fastc_strip_outer_parens(rendered_condition))
+	aligned := rendered_conjuncts.len == conjuncts.len
+	mut plans := []FastcMemberSmartcastPlan{}
+	mut condition_parts := []string{}
+	mut previous := map[string]FastcMemberSmartcast{}
+	mut previously_present := map[string]bool{}
+	mut ok := true
+	for i, conjunct in conjuncts {
+		mut cstart := 0
+		if conjunct.len > 0 && conjunct[0].tok in [.key_mut, .amp] {
+			cstart = 1
+		}
+		is_idx := fastc_first_top_level_is(conjunct)
+		if is_idx > cstart && is_idx + 1 < conjunct.len {
+			left_tokens := conjunct[cstart..is_idx]
+			// A member/local subject (`x.f is T`, `x is T`, or an indexed chain
+			// `right.args[0].expr is T`) is a smart-cast; a non-chain left operand
+			// (`unalias(x) is T`) is instead a boolean guard, handled below.
+			if path := fastc_indexed_member_chain_path(left_tokens) {
+				mut left_type := fastc_normalize_inferred_type(g.infer_expression_type(left_tokens) or {
+					''
+				})
+				if member_type := g.infer_member_access_type(left_tokens, 0, left_tokens.len) {
+					left_type = fastc_normalize_inferred_type(member_type)
+				}
+				target_type := g.type_from_expression_tokens(conjunct[is_idx + 1..]) or { '' }
+				if left_type != '' && target_type != '' && g.is_boxed_type(left_type) {
+					if left_source := g.render_member_receiver(left_tokens) {
+						normalized_target := fastc_normalize_inferred_type(target_type)
+						boxed_tmp := g.temporary_name('smartcast_subject')
+						member_tmp := g.temporary_name('smartcast_member')
+						// A pointer subject (`node &ast.Node`, or a nested variant already
+						// narrowed to `Variant*`) reaches its boxed `_typ`/`_object` through
+						// `->`, not `.`.
+						access := if left_type.ends_with('*') { '->' } else { '.' }
+						plans << FastcMemberSmartcastPlan{
+							path: path
+							type_c: normalized_target
+							boxed_type: left_type
+							source: left_source
+							boxed_tmp: boxed_tmp
+							member_tmp: member_tmp
+						}
+						// Assign the boxed temporary inside this conjunct. Hoisting the member read
+						// before the whole condition would violate short-circuiting for guards such
+						// as `args.len == 1 && args[0].expr is CallExpr`.
+						condition_parts << '(((${boxed_tmp} = (${left_source}))${access}_typ) == __v_typeid_${normalized_target})'
+						// Register temporarily so a following guard conjunct reads the
+						// concrete variant; restored below before the caller sets it up.
+						if path !in previous {
+							previously_present[path] = path in g.member_smartcasts
+							previous[path] = g.member_smartcasts[path] or { FastcMemberSmartcast{} }
+						}
+						g.member_smartcasts[path] = FastcMemberSmartcast{
+							typ: normalized_target + '*'
+							source: '((${normalized_target} *)${boxed_tmp}${access}_object)'
+						}
+						continue
+					}
+				}
+				ok = false
+				break
+			}
+		}
+		// A parenthesized group that itself narrows (`(x.f is T && x.f.g !in [...])`) must be
+		// rendered through the flow-sensitive narrowing renderer so its own left `is` conjunct
+		// registers the smart-cast its right operand reads. render_boolean_is_expression below
+		// splits the group but cannot register that narrowing (it is non-mut), leaving the
+		// membership/comparison subject read through the boxed value.
+		if g.boolean_expression_has_narrowing(conjunct[cstart..]) {
+			if guard := g.render_narrowing_boolean_expression(conjunct[cstart..]) {
+				condition_parts << '(${guard})'
+				continue
+			}
+		}
+		// A guard built from `is` tests on non-name operands (`unalias(x) is Array`),
+		// possibly combined with `&&`/`||`, reads through the earlier smart-casts. The
+		// streaming reader cannot render such a test, so try it before reusing the reader's
+		// aligned rendering.
+		if guard := g.render_boolean_is_expression(conjunct[cstart..]) {
+			condition_parts << '(${guard.source})'
+			continue
+		}
+		// A non-`is` conjunct is a boolean guard. When it does NOT touch a narrowed
+		// subject, the streaming reader's own rendering of this conjunct (which already
+		// resolved enum shorthands and constants) is reused by splitting the rendered
+		// condition the same way as the tokens.
+		uses_smartcast := g.expression_uses_member_smartcast(conjunct[cstart..])
+		if !uses_smartcast && aligned {
+			condition_parts << '(${rendered_conjuncts[i].trim_space()})'
+			continue
+		}
+		// A comparison guard that reads a narrowed subject through a plain member/index chain
+		// (`x.args[0].expr.typ > 0`) must be rendered before the general member receiver path.
+		// Besides indexed chains, this resolves an enum shorthand such as
+		// `left is PrefixExpr && left.op == .mul` against the narrowed field's enum type.
+		// A call-bearing operand (`sym(x).kind != .placeholder`) is left to the raw/special path,
+		// whose call handling the comparison renderer does not reproduce.
+		if uses_smartcast && !fastc_expression_tokens_contain(conjunct[cstart..], .lpar) {
+			if guard := g.render_guard_comparison(conjunct[cstart..]) {
+				condition_parts << '(${guard})'
+				continue
+			}
+		}
+		// A method call on a narrowed member (`right.typ.has_flag(.generic)`) needs
+		// both method lowering and the active smartcast receiver. The general member
+		// renderer below only handles the receiver chain and can leave the call raw.
+		if uses_smartcast && fastc_tokens_are_plain_call(fastc_strip_paren_tokens(conjunct[cstart..]))
+			&& !fastc_expression_tokens_contain(conjunct[cstart..], .key_as) {
+			if raw := g.render_raw_expression_tokens(conjunct[cstart..]) {
+				if special := g.render_special_expression(conjunct[cstart..], raw) {
+					condition_parts << '(${special.source})'
+					continue
+				}
+			}
+		}
+		// A guard that reads the narrowed subject (`expr.kind == .constant`) must be
+		// re-rendered so that access goes through the concrete-variant pointer: a plain
+		// member chain (`x.f.g`), a parenthesized cast field access (`(x.f as T).g`), or
+		// the general expression path (a call/comparison).
+		if guard := g.render_member_receiver(conjunct[cstart..]) {
+			condition_parts << '(${guard})'
+			continue
+		}
+		if guard := g.render_as_cast_member_access(conjunct[cstart..]) {
+			condition_parts << '(${guard.source})'
+			continue
+		}
+		// An embedded `(x as T)` cast in the guard (a method-call receiver `(x as T).m()`)
+		// is lowered to a synthetic atom first so the `as` does not reach the raw renderer.
+		if rewritten := g.rewrite_embedded_as_casts(conjunct[cstart..]) {
+			if raw := g.render_raw_expression_tokens(rewritten) {
+				if special := g.render_special_expression(rewritten, raw) {
+					condition_parts << '(${special.source})'
+				} else {
+					condition_parts << '(${raw})'
+				}
+				continue
+			}
+		}
+		// A compound boolean guard (`(op == .decl && x.is_mut) || op == .assign`) must be
+		// split so each leaf resolves its enum shorthand and narrowed field reads; the raw
+		// path below would leave `.decl` and the boxed member access unresolved.
+		strip := fastc_strip_paren_tokens(conjunct[cstart..])
+		if fastc_top_level_boolean_split(strip, .logical_or) != none || fastc_top_level_boolean_split(strip, .and) != none {
+			if guard := g.render_guard_boolean_expression(conjunct[cstart..]) {
+				condition_parts << '(${guard})'
+				continue
+			}
+		}
+		if raw := g.render_raw_expression_tokens(conjunct[cstart..]) {
+			if special := g.render_special_expression(conjunct[cstart..], raw) {
+				condition_parts << '(${special.source})'
+				continue
+			}
+		}
+		if guard := g.render_guard_comparison(conjunct[cstart..]) {
+			condition_parts << '(${guard})'
+			continue
+		}
+		if aligned {
+			condition_parts << '(${rendered_conjuncts[i].trim_space()})'
+			continue
+		}
+		ok = false
+		break
+	}
+	for path, present in previously_present {
+		if present {
+			g.member_smartcasts[path] = previous[path]
+		} else {
+			g.member_smartcasts.delete(path)
+		}
+	}
+	if !ok || plans.len == 0 {
+		return []FastcMemberSmartcastPlan{}, ''
+	}
+	return plans, condition_parts.join(' && ')
+}
+
+// match_starts_final_block_expression reports whether a `match` at the current
+// token is the final expression of the enclosing block (its `{ ... }` body is
+// immediately followed by the block's closing `}`), so it is a value rather than a
+// standalone statement. Mirrors if_starts_final_block_expression for `match`.
+fn (g &Parser) match_starts_final_block_expression() bool {
+	mut lookahead := scanner.new_scanner(g.prefs, .normal)
+	lookahead.init(g.s.current_file(), g.s.src)
+	lookahead.offset = g.s.offset
+	mut tok := lookahead.scan()
+	// Skip the match subject up to the opening `{` of the match body.
+	for tok !in [.lcbr, .eof] {
+		tok = lookahead.scan()
+	}
+	if tok != .lcbr {
+		return false
+	}
+	tok = fastc_skip_balanced_tokens(mut lookahead, tok, .lcbr, .rcbr) or { return false }
+	for tok == .semicolon {
+		tok = lookahead.scan()
+	}
+	return tok == .rcbr
+}
+
 fn fastc_option_success_expression(value_type string, expression string) string {
 	base := fastc_normalize_inferred_type(value_type)
 	return '(Option){.data=${fastc_box_expression(base, expression)}, .state=0}'
@@ -490,6 +1356,121 @@ fn fastc_option_success_expression(value_type string, expression string) string 
 
 fn fastc_box_expression(value_type string, expression string) string {
 	return '({ ${value_type} __v_fastc_box_value = (${expression}); v_fastc_interface_box(&__v_fastc_box_value, sizeof(${value_type})); })'
+}
+
+// read_if_expression_multi_return_guard lowers `if a, b := opt_multi() { x } else { y }`
+// used as an expression: the option is unwrapped, its multi-return components bound in
+// the then-branch, and the selected branch's value produced as a statement-expression.
+fn (mut g Parser) read_if_expression_multi_return_guard(names []string, branch_expected_type string, outer_expected_type string) !string {
+	for g.tok != .decl_assign && g.tok != .eof {
+		g.next()
+	}
+	g.expect(.decl_assign)!
+	rhs := g.read_expression([token.Token.semicolon, token.Token.lcbr])!
+	component_types := g.multi_return_types_for_expression(g.last_expression)
+	if component_types.len < names.len {
+		return g.unsupported('multi-return option guard component types')
+	}
+	g.skip_semicolons()
+	g.expect(.lcbr)!
+	guard_option := g.temporary_name('if_guard')
+	multi_return := g.temporary_name('multi_return')
+	mut binds := 'MultiReturn ${multi_return} = *((MultiReturn *)${guard_option}.data); '
+	mut previous_locals := []FastcLocal{}
+	mut had_locals := []bool{}
+	for i, name in names {
+		had_locals << (name in g.locals)
+		previous_locals << (g.locals[name] or { FastcLocal{} })
+		if name == '_' {
+			continue
+		}
+		component_type := fastc_normalize_inferred_type(component_types[i])
+		c_name := fastc_c_identifier(name)
+		binds += '${component_type} ${c_name} = (${component_type}){0}; memcpy(&${c_name}, ${multi_return}.values[${i}].data, sizeof(${c_name})); '
+		g.locals[name] = FastcLocal{
+			typ: component_type
+		}
+	}
+	g.expected_expression_type = branch_expected_type
+	then_expr := if g.tok == .key_return {
+		g.read_return_expression_branch()!
+	} else {
+		g.read_block_expression_value()!
+	}
+	then_type := g.last_expression_type
+	for i, name in names {
+		if had_locals[i] {
+			g.locals[name] = previous_locals[i]
+		} else {
+			g.locals.delete(name)
+		}
+	}
+	g.skip_semicolons()
+	g.expect(.rcbr)!
+	if g.tok != .key_else {
+		return g.unsupported('if expression without `else`')
+	}
+	g.next()
+	g.expected_expression_type = branch_expected_type
+	mut else_expr := ''
+	if g.tok == .key_if {
+		else_expr = g.read_if_expression()!
+	} else {
+		g.expect(.lcbr)!
+		else_expr = if g.tok == .key_return {
+			g.read_return_expression_branch()!
+		} else {
+			g.read_block_expression_value()!
+		}
+		g.skip_semicolons()
+		g.expect(.rcbr)!
+	}
+	else_type := g.last_expression_type
+	result_type := if then_type != '' {
+		fastc_normalize_inferred_type(then_type)
+	} else if else_type != '' {
+		fastc_normalize_inferred_type(else_type)
+	} else if outer_expected_type != '' {
+		outer_expected_type
+	} else {
+		'int'
+	}
+	g.last_expression_type = result_type
+	g.expected_expression_type = outer_expected_type
+	g.last_expression = []FastcExpressionToken{}
+	result_var := g.temporary_name('if_result')
+	return '({ Option ${guard_option} = (${rhs}); ${result_type} ${result_var}; if (${guard_option}.state == 0) { ${binds}${result_var} = (${then_expr}); } else { ${result_var} = (${else_expr}); } ${result_var}; })'
+}
+
+// fastc_plan_is_bare_local reports whether a member-smart-cast plan narrows a bare local
+// variable (not a member/indexed chain), which is shadowed as a concrete-variant VALUE rather
+// than exposed as a member-smart-cast pointer.
+fn (g &Parser) fastc_plan_is_bare_local(plan FastcMemberSmartcastPlan) bool {
+	return plan.path in g.locals && !plan.path.contains('.') && !plan.path.contains('[')
+}
+
+// fastc_common_sum_type returns a declared sum type that has BOTH `a` and `b` among its leaf
+// variants (used to unify differing if/match branch variants into one boxed value), or none.
+fn (g &Parser) fastc_common_sum_type(a string, b string) ?string {
+	an := fastc_trim_pointer_suffix(fastc_normalize_inferred_type(a))
+	bn := fastc_trim_pointer_suffix(fastc_normalize_inferred_type(b))
+	if an == '' || bn == '' || an == bn {
+		return none
+	}
+	// Only unify DECLARED struct/enum variants. Two primitive branches (`abs64(x)` vs `u32(0)`)
+	// can share a numeric sum type in the builtin, but boxing them without an explicit expected
+	// type would corrupt ordinary numeric if-expressions.
+	if an in ['bool', 'string', 'rune', 'voidptr', 'char'] || bn in ['bool', 'string', 'rune',
+		'voidptr', 'char'] || fastc_is_numeric_expression_type(an) || fastc_is_numeric_expression_type(bn) {
+		return none
+	}
+	for sum_type, _ in g.sum_types {
+		leaves := g.sum_type_leaf_variants(sum_type)
+		if an in leaves && bn in leaves {
+			return sum_type
+		}
+	}
+	return none
 }
 
 fn (mut g Parser) read_if_expression() !string {
@@ -502,14 +1483,37 @@ fn (mut g Parser) read_if_expression() !string {
 		''
 	}
 	g.expect(.key_if)!
+	// `pos := if a, _, _ := opt_multi() { … } else { … }`: a multi-return option guard
+	// used as an if-expression value.
+	if g.tok == .name {
+		mut probe := g.s
+		mut guard_names := [g.lit]
+		mut is_multi_guard := false
+		for {
+			t := probe.scan()
+			if t == .comma {
+				if probe.scan() !in [.name, .key_shared] {
+					break
+				}
+				guard_names << probe.lit
+			} else if t == .decl_assign {
+				is_multi_guard = guard_names.len >= 2
+				break
+			} else {
+				break
+			}
+		}
+		if is_multi_guard {
+			return g.read_if_expression_multi_return_guard(guard_names, branch_expected_type, outer_expected_type)
+		}
+	}
 	g.expected_expression_type = ''
 	mut condition := g.read_condition_expression([token.Token.semicolon, token.Token.lcbr])!
 	mut guard_name := ''
 	mut guard_type := ''
 	mut guard_option := ''
 	mut guard_source := ''
-	if g.selfhost && g.last_expression.len >= 3 && g.last_expression[0].tok == .name
-		&& g.last_expression[1].tok == .decl_assign {
+	if g.selfhost && g.last_expression.len >= 3 && g.last_expression[0].tok == .name && g.last_expression[1].tok == .decl_assign {
 		right_tokens := g.last_expression[2..]
 		if map_lookup := g.render_map_lookup_option_expression(right_tokens) {
 			guard_name = g.last_expression[0].lit
@@ -529,6 +1533,28 @@ fn (mut g Parser) read_if_expression() !string {
 			g.last_expression_type = 'bool'
 		}
 	}
+	// A boxed-member smart-cast in an if-*expression* condition (`if sym.info is FnType {
+	// &sym.info.func }`) needs the same concrete-variant view as the statement form; the
+	// tmp declarations are emitted inline in the wrapping statement-expression below.
+	member_smartcast_plans, member_smartcast_condition := g.detect_member_smartcasts(g.last_expression, condition)
+	use_member_smartcasts := guard_name == '' && member_smartcast_condition != ''
+	mut smartcast_decls := ''
+	if use_member_smartcasts {
+		condition = member_smartcast_condition
+		for plan in member_smartcast_plans {
+			// A pointer subject (`mut node ast.TypeDecl` is `TypeDecl*`) reaches its boxed
+			// payload through `->`, not `.`.
+			plan_access := if plan.boxed_type.ends_with('*') { '->' } else { '.' }
+			if g.fastc_plan_is_bare_local(plan) {
+				// A bare-local subject is shadowed as a concrete-variant VALUE, so a whole-value
+				// read of the local (`if x is T { x }` returning it) yields the variant — not the
+				// raw boxed subject, which would mis-box on the way out.
+				smartcast_decls += '${plan.boxed_type} ${plan.boxed_tmp} = ${plan.source}; ${plan.type_c} ${plan.member_tmp} = *((${plan.type_c} *)${plan.boxed_tmp}${plan_access}_object); '
+			} else {
+				smartcast_decls += '${plan.boxed_type} ${plan.boxed_tmp} = ${plan.source}; ${plan.type_c} *${plan.member_tmp} = (${plan.type_c} *)${plan.boxed_tmp}${plan_access}_object; '
+			}
+		}
+	}
 	g.skip_semicolons()
 	g.expect(.lcbr)!
 	previous_guard := g.locals[guard_name] or { FastcLocal{} }
@@ -539,10 +1565,57 @@ fn (mut g Parser) read_if_expression() !string {
 		}
 	}
 	g.expected_expression_type = branch_expected_type
+	mut previous_member_smartcasts := map[string]FastcMemberSmartcast{}
+	mut had_member_smartcasts := map[string]bool{}
+	mut previous_local_shadows := map[string]FastcLocal{}
+	mut had_local_shadows := map[string]bool{}
+	if use_member_smartcasts {
+		for plan in member_smartcast_plans {
+			if g.fastc_plan_is_bare_local(plan) {
+				if plan.path !in previous_local_shadows {
+					had_local_shadows[plan.path] = plan.path in g.locals
+					previous_local_shadows[plan.path] = g.locals[plan.path] or { FastcLocal{} }
+				}
+				previous_plan_local := g.locals[plan.path] or { FastcLocal{} }
+				g.locals[plan.path] = FastcLocal{
+					is_mut: previous_plan_local.is_mut
+					typ: plan.type_c
+					c_name: plan.member_tmp
+				}
+				continue
+			}
+			if plan.path !in previous_member_smartcasts {
+				had_member_smartcasts[plan.path] = plan.path in g.member_smartcasts
+				previous_member_smartcasts[plan.path] = g.member_smartcasts[plan.path] or {
+					FastcMemberSmartcast{}
+				}
+			}
+			g.member_smartcasts[plan.path] = FastcMemberSmartcast{
+				typ: plan.type_c + '*'
+				source: plan.member_tmp
+			}
+		}
+	}
 	mut then_expression := if g.tok == .key_return {
 		g.read_return_expression_branch()!
 	} else {
 		g.read_block_expression_value()!
+	}
+	if use_member_smartcasts {
+		for path, present in had_local_shadows {
+			if present {
+				g.locals[path] = previous_local_shadows[path]
+			} else {
+				g.locals.delete(path)
+			}
+		}
+		for path, present in had_member_smartcasts {
+			if present {
+				g.member_smartcasts[path] = previous_member_smartcasts[path]
+			} else {
+				g.member_smartcasts.delete(path)
+			}
+		}
 	}
 	if guard_name != '' {
 		then_expression = '({ ${guard_type} ${fastc_c_identifier(guard_name)} = *((${guard_type} *)${guard_option}.data); ${then_expression}; })'
@@ -575,14 +1648,25 @@ fn (mut g Parser) read_if_expression() !string {
 	mut else_expression := ''
 	mut else_type := ''
 	mut else_option_value_type := ''
+	// With no outer expected type (`x := if … {} else {}`), the then branch's inferred type is
+	// the best expected type for the else branch, so a bare `[]` / `{}` there lowers to a typed
+	// empty collection instead of raw C (which the `else_type == ''` fallback would wrap in an
+	// invalid `(void)([])`).
+	else_branch_expected := if branch_expected_type != '' {
+		branch_expected_type
+	} else if then_type !in ['', 'Option'] {
+		fastc_normalize_inferred_type(then_type)
+	} else {
+		''
+	}
 	if g.tok == .key_if {
-		g.expected_expression_type = branch_expected_type
+		g.expected_expression_type = else_branch_expected
 		else_expression = g.read_if_expression()!
 		else_type = g.last_expression_type
 		else_option_value_type = g.last_option_value_type
 	} else {
 		g.expect(.lcbr)!
-		g.expected_expression_type = branch_expected_type
+		g.expected_expression_type = else_branch_expected
 		else_expression = if g.tok == .key_return {
 			g.read_return_expression_branch()!
 		} else {
@@ -645,14 +1729,23 @@ fn (mut g Parser) read_if_expression() !string {
 		then_type = resolved_type
 		else_type = resolved_type
 	}
+	// A member smart-cast branch (`if x.obj is Var { x.obj } else { Var{…} }`) reads the narrowed
+	// member as a variant POINTER, while the other branch is a by-value variant; deref the pointer
+	// branch so the ternary selects between two value-typed branches.
+	if g.selfhost && then_type.ends_with('*') && else_type != '' && then_type.trim_right('*') == else_type {
+		then_expression = '*(${then_expression})'
+		then_type = else_type
+	} else if g.selfhost && else_type.ends_with('*') && then_type != '' && else_type.trim_right('*') == then_type {
+		else_expression = '*(${else_expression})'
+		else_type = then_type
+	}
 	if then_type == else_type {
 		g.last_expression_type = then_type
 	} else if g.selfhost && then_type == '' {
 		g.last_expression_type = else_type
 	} else if g.selfhost && else_type == '' {
 		g.last_expression_type = then_type
-	} else if g.selfhost && fastc_is_integer_expression_type(then_type)
-		&& fastc_is_integer_expression_type(else_type) {
+	} else if g.selfhost && fastc_is_integer_expression_type(then_type) && fastc_is_integer_expression_type(else_type) {
 		g.last_expression_type = if then_type == 'integer literal' { else_type } else { then_type }
 	} else {
 		g.last_expression_type = if outer_expected_type != '' {
@@ -663,19 +1756,62 @@ fn (mut g Parser) read_if_expression() !string {
 			else_type
 		}
 	}
-	g.last_option_value_type = if g.last_expression_type == 'Option' && then_option_value_type != ''
-		&& then_option_value_type == else_option_value_type {
+	g.last_option_value_type = if g.last_expression_type == 'Option' && then_option_value_type != '' && then_option_value_type == else_option_value_type {
 		then_option_value_type
 	} else {
 		''
 	}
+	// When the if-expression's value is a boxed sum type / interface, its branches may be
+	// DIFFERENT variants (`if x is T { x } else { empty }`), which C cannot select between in one
+	// ternary. Box each variant branch into the boxed type so the ternary picks between two
+	// identically-typed boxes. The target box is the expected type when known, else the sum type
+	// that has both branch variants — recovered here because a call-argument if-expression is
+	// read before its parameter type is applied, so the caller would otherwise box the whole
+	// mismatched ternary.
+	if g.selfhost && then_type != '' && else_type != '' {
+		then_norm := fastc_normalize_inferred_type(then_type)
+		else_norm := fastc_normalize_inferred_type(else_type)
+		mut expected_box := ''
+		if outer_expected_type != '' && g.is_boxed_type(fastc_normalize_inferred_type(outer_expected_type)) {
+			expected_box = fastc_normalize_inferred_type(outer_expected_type)
+		} else if then_norm != else_norm {
+			// One branch may already BE the sum type (`ast.empty_expr` is an `Expr`) while the
+			// other is a bare variant; box the variant into that sum type. Otherwise fall back to
+			// a sum type that has both as variants.
+			if g.is_boxed_type(else_norm) && g.should_box_variant(else_norm, then_type) {
+				expected_box = else_norm
+			} else if g.is_boxed_type(then_norm) && g.should_box_variant(then_norm, else_type) {
+				expected_box = then_norm
+			} else {
+				expected_box = g.fastc_common_sum_type(then_type, else_type) or { '' }
+			}
+		}
+		if expected_box != '' {
+			if fastc_normalize_inferred_type(then_type) != expected_box && g.should_box_variant(expected_box, then_type) {
+				then_expression = g.interface_value_expression(expected_box, then_type, then_expression)
+				then_type = expected_box
+			}
+			if fastc_normalize_inferred_type(else_type) != expected_box && g.should_box_variant(expected_box, else_type) {
+				else_expression = g.interface_value_expression(expected_box, else_type, else_expression)
+				else_type = expected_box
+			}
+			if then_type == expected_box || else_type == expected_box {
+				g.last_expression_type = expected_box
+			}
+		}
+	}
 	g.expected_expression_type = outer_expected_type
 	g.last_expression = []FastcExpressionToken{}
 	conditional := '((${condition}) ? (${then_expression}) : (${else_expression}))'
-	return if guard_option == '' {
-		conditional
+	wrapped := if smartcast_decls != '' {
+		'({ ${smartcast_decls}${conditional}; })'
 	} else {
-		'({ Option ${guard_option} = (${guard_source}); ${conditional}; })'
+		conditional
+	}
+	return if guard_option == '' {
+		wrapped
+	} else {
+		'({ Option ${guard_option} = (${guard_source}); ${wrapped}; })'
 	}
 }
 
@@ -694,8 +1830,7 @@ fn (mut g Parser) read_return_expression_branch() !string {
 	if g.return_type.trim_right('*') == 'MultiReturn' {
 		mut values := []string{}
 		for {
-			value :=
-				g.read_expression([token.Token.comma, token.Token.semicolon, token.Token.rcbr])!
+			value := g.read_expression([token.Token.comma, token.Token.semicolon, token.Token.rcbr])!
 			values << 'V_FASTC_MULTI_VALUE((${value}))'
 			if g.tok != .comma {
 				break
@@ -708,16 +1843,26 @@ fn (mut g Parser) read_return_expression_branch() !string {
 		return '({ return ${fastc_multi_return_literal(values)}; 0; })'
 	}
 	value := g.read_expression([token.Token.semicolon, token.Token.rcbr])!
+	value_type := g.last_expression_type
 	g.consume_statement_end()
-	g.last_expression_type = ''
 	g.last_expression = []FastcExpressionToken{}
-	return '({ return ${value}; 0; })'
+	// This `return` propagates out of the enclosing function, so coerce its value to that
+	// function's return type exactly as parse_return does — an `IError` becomes the error state of
+	// an `Option`, and a bare value is wrapped into the success state — rather than emitting a raw
+	// `return <IError>` that TinyCC rejects.
+	mut return_value := value
+	if g.selfhost && g.return_type == 'Option' && value_type.trim_right('*') == 'IError' {
+		return_value = '(Option){.err=${value}, .state=1}'
+	} else if g.selfhost && g.return_type == 'Option' && value_type !in ['', 'Option'] {
+		value_base := fastc_normalize_inferred_type(value_type)
+		return_value = '(Option){.data=${fastc_box_expression(value_base, value)}, .state=0}'
+	}
+	g.last_expression_type = ''
+	return '({ return ${return_value}; 0; })'
 }
 
 fn (g &Parser) expected_enum_shorthand_expression() ?string {
-	if !g.selfhost || g.last_expression_type != '' || g.last_expression.len != 2
-		|| g.last_expression[0].tok != .dot || g.last_expression[1].tok != .name
-		|| g.declared_kinds[g.semantic_type_key(g.return_type)] != .enum_ {
+	if !g.selfhost || g.last_expression_type != '' || g.last_expression.len != 2 || g.last_expression[0].tok != .dot || g.last_expression[1].tok != .name || g.declared_kinds[g.semantic_type_key(g.return_type)] != .enum_ {
 		return none
 	}
 	return '${g.return_type.trim_right('*')}__${g.last_expression[1].lit}'

--- a/vlib/v3/gen/fastc/if.v
+++ b/vlib/v3/gen/fastc/if.v
@@ -1386,7 +1386,7 @@ fn (mut g Parser) read_if_expression_multi_return_guard(names []string, branch_e
 		}
 		component_type := fastc_normalize_inferred_type(component_types[i])
 		c_name := fastc_c_identifier(name)
-		binds += '${component_type} ${c_name} = (${component_type}){0}; memcpy(&${c_name}, ${multi_return}.values[${i}].data, sizeof(${c_name})); '
+		binds += '${component_type} ${c_name} = (${component_type}){0}; memcpy(&${c_name}, V_FASTC_MULTI_SOURCE(${multi_return}.values[${i}], sizeof(${c_name})), sizeof(${c_name})); '
 		g.locals[name] = FastcLocal{
 			typ: component_type
 		}

--- a/vlib/v3/gen/fastc/link.v
+++ b/vlib/v3/gen/fastc/link.v
@@ -15,7 +15,7 @@ mut:
 // fastc_prepare_link initializes the in-process TinyCC linker on macOS. Other
 // platforms retain the executable-based linker and only record its arguments.
 pub fn fastc_prepare_link(program string, tcc_lib string, base_args []string) FastcPreparedLink {
-	$if macos && !fastc_selfhost ? {
+	$if macos && !fastc_selfhost ?&& !v3_backend ? {
 		return fastc_prepare_libtcc_link(program, tcc_lib, base_args)
 	} $else {
 		return FastcPreparedLink{
@@ -28,7 +28,7 @@ pub fn fastc_prepare_link(program string, tcc_lib string, base_args []string) Fa
 // fastc_prepared_link_skips_codesign reports whether the prepared linker
 // suppresses TinyCC's codesign subprocess and needs in-process signing.
 pub fn fastc_prepared_link_skips_codesign(link &FastcPreparedLink) bool {
-	$if macos && !fastc_selfhost ? {
+	$if macos && !fastc_selfhost ?&& !v3_backend ? {
 		return !isnil(link.state)
 	} $else {
 		return false
@@ -38,7 +38,7 @@ pub fn fastc_prepared_link_skips_codesign(link &FastcPreparedLink) bool {
 // fastc_finish_link adds the compiled inputs to a prepared linker and writes
 // the executable. `final_args` contains libraries and other link-only flags.
 pub fn fastc_finish_link(mut link FastcPreparedLink, input_paths []string, final_args []string, output string) os.Result {
-	$if macos && !fastc_selfhost ? {
+	$if macos && !fastc_selfhost ?&& !v3_backend ? {
 		return fastc_finish_libtcc_link(mut link, input_paths, final_args, output)
 	} $else {
 		mut args := link.base_args.clone()
@@ -51,7 +51,7 @@ pub fn fastc_finish_link(mut link FastcPreparedLink, input_paths []string, final
 
 // fastc_discard_link releases a prepared linker after unit compilation fails.
 pub fn fastc_discard_link(mut link FastcPreparedLink) {
-	$if macos && !fastc_selfhost ? {
+	$if macos && !fastc_selfhost ?&& !v3_backend ? {
 		fastc_discard_libtcc_link(mut link)
 	}
 }

--- a/vlib/v3/gen/fastc/match.v
+++ b/vlib/v3/gen/fastc/match.v
@@ -29,24 +29,44 @@ fn (mut g Parser) read_match_expression() !string {
 	outer_expected_type := g.expected_expression_type
 	g.expect(.key_match)!
 	g.expected_expression_type = ''
+	// `read_expression` consumes the `mut` modifier and keeps only the referenced
+	// name in `last_expression`, so remember it before parsing the subject.
+	subject_is_mut := g.tok == .key_mut
 	subject := g.read_expression([token.Token.lcbr])!
 	subject_type := g.last_expression_type
 	if subject == '' || subject_type == '' {
 		return g.unsupported('unverifiable match expression subject')
 	}
 	subject_tokens := g.last_expression.clone()
+	smartcast_is_reference := subject_is_mut || subject_type.ends_with('*')
 	// A sum-type / interface subject dispatches on the boxed `_typ` tag; each branch
 	// names a variant type and (for a plain-local subject) is smart-cast inside its
 	// value expression.
 	is_boxed := g.is_boxed_type(fastc_normalize_inferred_type(subject_type))
 	boxed_access := if subject_type.ends_with('*') { '->' } else { '.' }
 	mut subject_local := ''
-	if is_boxed && subject_tokens.len == 1 && subject_tokens[0].tok == .name
-		&& subject_tokens[0].lit in g.locals {
+	if is_boxed && subject_tokens.len == 1 && subject_tokens[0].tok == .name && subject_tokens[0].lit in g.locals {
 		subject_local = subject_tokens[0].lit
-	} else if is_boxed && subject_tokens.len == 2 && subject_tokens[0].tok in [.key_mut, .amp]
-		&& subject_tokens[1].tok == .name && subject_tokens[1].lit in g.locals {
+	} else if is_boxed && subject_tokens.len == 2 && subject_tokens[0].tok in [
+		.key_mut,
+		.amp,
+	] && subject_tokens[1].tok == .name && subject_tokens[1].lit in g.locals {
 		subject_local = subject_tokens[1].lit
+	}
+	// A boxed member subject (`match sym.info { ast.Struct { sym.info.name } }`, or
+	// `match mut sym.info { … }`) cannot be shadowed like a plain local, so each branch
+	// narrows the member path through the same branch-scoped rewrite the `if x.f is T`
+	// smart-casts use. A leading `mut`/`&` renders away, so skip it before the chain scan.
+	member_start := if subject_tokens.len > 0 && subject_tokens[0].tok in [.key_mut, .amp] {
+		1
+	} else {
+		0
+	}
+	mut subject_member_path := ''
+	if is_boxed && subject_local == '' {
+		if path := fastc_member_chain_path(subject_tokens, member_start, subject_tokens.len) {
+			subject_member_path = path
+		}
 	}
 	g.expect(.lcbr)!
 	temporary := g.temporary_name('match')
@@ -103,8 +123,7 @@ fn (mut g Parser) read_match_expression() !string {
 					g.next()
 					finish := g.read_expression([token.Token.comma, token.Token.lcbr])!
 					finish_tokens := g.last_expression.clone()
-					case_key = 'range:${case_key}..${g.normalized_match_case_key(finish_tokens,
-						finish)}'
+					case_key = 'range:${case_key}..${g.normalized_match_case_key(finish_tokens, finish)}'
 					case_source = '${start}..${finish}'
 					branch_conditions << '((${temporary}) >= (${start}) && (${temporary}) <= (${finish}))'
 				} else {
@@ -137,32 +156,76 @@ fn (mut g Parser) read_match_expression() !string {
 			'array'
 		} else if common_numeric_type != '' {
 			common_numeric_type
+		} else if branch_variants.len > 0 {
+			// Several struct variants in one arm (`SizeOf, IsRefType { x.is_type }`) may
+			// only touch fields common to every variant, which V lays out compatibly, so
+			// reading them through the first variant is correct.
+			branch_variants[0]
 		} else {
 			''
 		}
+		multi_struct_smartcast := branch_variants.len > 1 && !branch_all_arrays && common_numeric_type == ''
 		mut smartcast_saved := FastcLocal{}
-		smartcast_active := is_boxed && !is_else && smartcast_type != '' && subject_local != ''
+		smartcast_active := is_boxed && !is_else && smartcast_type != '' && subject_local != '' && !multi_struct_smartcast
 		if smartcast_active {
 			smartcast_saved = g.locals[subject_local] or { FastcLocal{} }
 			g.locals[subject_local] = FastcLocal{
 				is_mut: smartcast_saved.is_mut
-				typ:    smartcast_type
+				is_reference: smartcast_is_reference
+				typ: if smartcast_is_reference {
+					smartcast_type + '*'} else {
+					smartcast_type}
+			}
+		}
+		projection_path := if subject_member_path != '' {
+			subject_member_path
+		} else if multi_struct_smartcast {
+			subject_local
+		} else {
+			''
+		}
+		member_smartcast_active := is_boxed && !is_else && smartcast_type != '' && projection_path != ''
+		mut member_smartcast_saved := FastcMemberSmartcast{}
+		mut member_smartcast_present := false
+		if member_smartcast_active {
+			member_smartcast_present = projection_path in g.member_smartcasts
+			member_smartcast_saved = g.member_smartcasts[projection_path] or {
+				FastcMemberSmartcast{}
+			}
+			g.member_smartcasts[projection_path] = FastcMemberSmartcast{
+				typ: smartcast_type + '*'
+				source: '((${smartcast_type} *)${temporary}${boxed_access}_object)'
+				variants: if multi_struct_smartcast { branch_variants.clone() } else { [] }
+				tag_source: '${temporary}${boxed_access}_typ'
+				object_source: '${temporary}${boxed_access}_object'
 			}
 		}
 		mut value := g.read_match_block_expression_value()!
 		mut value_type := g.last_expression_type
+		if member_smartcast_active {
+			if member_smartcast_present {
+				g.member_smartcasts[projection_path] = member_smartcast_saved
+			} else {
+				g.member_smartcasts.delete(projection_path)
+			}
+		}
 		if smartcast_active {
 			g.locals[subject_local] = smartcast_saved
-			smartcast_value := if common_numeric_type != '' {
-				fastc_match_multi_variant_value(temporary, boxed_access, branch_variants,
-					common_numeric_type)
+			smartcast_value := if smartcast_is_reference {
+				'(${smartcast_type} *)${temporary}${boxed_access}_object'
+			} else if common_numeric_type != '' {
+				fastc_match_multi_variant_value(temporary, boxed_access, branch_variants, common_numeric_type)
 			} else {
 				'*(${smartcast_type} *)${temporary}${boxed_access}_object'
 			}
-			value = '({ ${smartcast_type} ${fastc_c_identifier(subject_local)} = ${smartcast_value}; (${value}); })'
+			declaration_type := if smartcast_is_reference {
+				smartcast_type + '*'
+			} else {
+				smartcast_type
+			}
+			value = '({ ${declaration_type} ${fastc_c_identifier(subject_local)} = ${smartcast_value}; (${value}); })'
 		}
-		if g.selfhost && value_type != '' && outer_expected_type != ''
-			&& g.should_box_variant(outer_expected_type, value_type) {
+		if g.selfhost && value_type != '' && outer_expected_type != '' && g.should_box_variant(outer_expected_type, value_type) {
 			// A branch value whose type is a variant of the match's (boxed) expected
 			// type must be boxed, so every branch shares the ternary's result type
 			// (e.g. a `[]Primitive` branch returning the smart-cast array as a `Primitive`).
@@ -198,12 +261,15 @@ fn (mut g Parser) read_match_expression() !string {
 			}
 			result_type = 'Option'
 		}
-		if g.selfhost && value_type == '' && result_type != '' {
+		if g.selfhost && value_type in ['', 'void'] && result_type != '' {
+			// A diverging arm (a `@[noreturn]` call such as `eprintln_exit(...)`) yields no
+			// usable value; run it, then fall through to a zeroed result so the branch still
+			// matches the ternary's result type.
 			zero_type := fastc_normalize_inferred_type(result_type)
 			value = '({ (void)(${value}); (${zero_type}){0}; })'
 			value_type = result_type
 		}
-		if result_type == '' && value_type != '' {
+		if result_type == '' && value_type !in ['', 'void'] {
 			if g.selfhost {
 				zero_type := fastc_normalize_inferred_type(value_type)
 				for i, previous_value in values {
@@ -258,6 +324,11 @@ fn (g &Parser) normalized_match_case_key(tokens []FastcExpressionToken, rendered
 }
 
 fn (mut g Parser) read_match_block_expression_value() !string {
+	if g.tok == .dollar && g.dollar_keyword_is('if') {
+		// A `$if … { value } $else { value }` arm is a compile-time expression: select
+		// the taken branch's value rather than executing it as a statement.
+		return g.read_comptime_if_expression()!
+	}
 	if g.tok == .key_if || g.or_block_has_statements() {
 		return g.read_block_expression_value()!
 	}
@@ -287,6 +358,11 @@ fn (mut g Parser) read_match_block_expression_value() !string {
 
 fn (mut g Parser) read_block_expression_value() !string {
 	g.skip_semicolons()
+	if g.tok == .dollar && g.dollar_keyword_is('if') {
+		// `$if … { value } $else { value }` as the block's value: select the taken
+		// branch's value rather than executing it as a statement.
+		return g.read_comptime_if_expression()!
+	}
 	if g.tok == .key_if && g.if_starts_final_block_expression() {
 		return g.read_if_expression()!
 	}
@@ -315,16 +391,23 @@ fn (mut g Parser) read_block_expression_value() !string {
 	previous_lines := g.captured_defer_lines.clone()
 	g.capturing_defer = true
 	g.captured_defer_lines = []string{}
+	// Restore through a defer so a `parse_statement` error that a speculative caller
+	// swallows cannot leave `capturing_defer` set for the rest of the function.
+	defer {
+		g.capturing_defer = previous_capture
+		g.captured_defer_lines = previous_lines.clone()
+	}
 	for g.or_block_has_statements() {
 		if g.tok == .key_if && g.if_starts_final_block_expression() {
+			break
+		}
+		if g.tok == .key_match && g.match_starts_final_block_expression() {
 			break
 		}
 		_ = g.parse_statement()!
 		g.skip_semicolons()
 	}
 	statements := g.captured_defer_lines.clone()
-	g.capturing_defer = previous_capture
-	g.captured_defer_lines = previous_lines
 	if g.tok == .rcbr {
 		g.last_expression_type = ''
 		g.last_expression = []FastcExpressionToken{}
@@ -334,8 +417,8 @@ fn (mut g Parser) read_block_expression_value() !string {
 	mut value := if g.tok == .name {
 		prefix := g.lit
 		g.next()
-		g.read_expression_with_prefix(prefix,
-			[token.Token.comma, token.Token.semicolon, token.Token.rcbr])!
+		g.read_expression_with_prefix(prefix, [token.Token.comma, token.Token.semicolon,
+			token.Token.rcbr])!
 	} else {
 		g.read_expression([token.Token.comma, token.Token.semicolon, token.Token.rcbr])!
 	}
@@ -370,8 +453,8 @@ fn (mut g Parser) read_block_expression_value() !string {
 	if g.tok == .name {
 		prefix := g.lit
 		g.next()
-		final_value := g.read_expression_with_prefix(prefix,
-			[token.Token.semicolon, token.Token.rcbr])!
+		final_value := g.read_expression_with_prefix(prefix, [token.Token.semicolon,
+			token.Token.rcbr])!
 		value = if value.trim_space() in ['', ';'] {
 			final_value
 		} else {

--- a/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
@@ -109,9 +109,9 @@ mut:
 	result FastcFieldDefaultsResult
 }
 
-fn fastc_start_field_defaults(source_imports map[string]map[string]string, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, global_types map[string]string, sum_types map[string]bool) FastcPendingFieldDefaults {
+fn fastc_start_field_defaults(source_imports map[string]map[string]string, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, enum_field_names map[string][]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, global_types map[string]string, sum_types map[string]bool) FastcPendingFieldDefaults {
 	return FastcPendingFieldDefaults{
-		result: fastc_run_field_defaults(source_imports, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, alias_base_types, struct_fields, struct_field_info, functions, constants, public_constants, constant_types, globals, public_globals, global_types, sum_types)
+		result: fastc_run_field_defaults(source_imports, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, enum_field_names, alias_base_types, struct_fields, struct_field_info, functions, constants, public_constants, constant_types, globals, public_globals, global_types, sum_types)
 	}
 }
 

--- a/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
@@ -861,15 +861,15 @@ mut:
 	result  FastcFieldDefaultsResult
 }
 
-fn fastc_start_field_defaults(source_imports map[string]map[string]string, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, global_types map[string]string, sum_types map[string]bool) FastcPendingFieldDefaults {
+fn fastc_start_field_defaults(source_imports map[string]map[string]string, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, enum_field_names map[string][]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, global_types map[string]string, sum_types map[string]bool) FastcPendingFieldDefaults {
 	if fastc_parallel_worker_limit(prefs) <= 1 {
 		return FastcPendingFieldDefaults{
-			result: fastc_run_field_defaults(source_imports, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, alias_base_types, struct_fields, struct_field_info, functions, constants, public_constants, constant_types, globals, public_globals, global_types, sum_types)
+			result: fastc_run_field_defaults(source_imports, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, enum_field_names, alias_base_types, struct_fields, struct_field_info, functions, constants, public_constants, constant_types, globals, public_globals, global_types, sum_types)
 		}
 	}
 	return FastcPendingFieldDefaults{
 		workers: [
-			spawn fastc_run_field_defaults(source_imports, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, alias_base_types, struct_fields, struct_field_info, functions, constants, public_constants, constant_types, globals, public_globals, global_types, sum_types),
+			spawn fastc_run_field_defaults(source_imports, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, enum_field_names, alias_base_types, struct_fields, struct_field_info, functions, constants, public_constants, constant_types, globals, public_globals, global_types, sum_types),
 		]
 	}
 }

--- a/vlib/v3/gen/fastc/render.v
+++ b/vlib/v3/gen/fastc/render.v
@@ -38,10 +38,80 @@ fn fastc_builtin_type_idx(type_name string) ?int {
 	}
 }
 
+// fastc_resolve_flag_enum_statics rewrites a flag enum's compiler-magic static methods that FastC
+// leaves as calls to non-existent functions: `Enum.zero()` (the empty flag, value 0) and
+// `Enum.all()` (every member OR-ed together). Only applied for a flag enum.
+fn (g &Parser) fastc_resolve_flag_enum_statics(source string, enum_c string) string {
+	if g.flag_enum_type_key(enum_c) == none {
+		return source
+	}
+	mut out := source.replace('${enum_c}__zero()', '((${enum_c})0)')
+	if out.contains('${enum_c}__all()') {
+		if members := g.enum_field_names[enum_c] {
+			mut parts := []string{cap: members.len}
+			for member in members {
+				parts << '${enum_c}__${member}'
+			}
+			if parts.len > 0 {
+				out = out.replace('${enum_c}__all()', '((${enum_c})(${parts.join(' | ')}))')
+			}
+		}
+	}
+	return out
+}
+
+// fastc_resolve_enum_shorthands_in_source rewrites `.member` enum shorthands that appear in a
+// value position (the `.` is not preceded by an identifier byte, so a real `.field` access is
+// left alone) into their `Enum__member` C constant. String literals are skipped so a `.member`
+// inside `_S("…")` is never rewritten.
+fn fastc_resolve_enum_shorthands_in_source(source string, enum_c string, fields []string) string {
+	mut out := ''
+	mut i := 0
+	for i < source.len {
+		c := source[i]
+		if c == `"` {
+			out += c.ascii_str()
+			i++
+			for i < source.len {
+				out += source[i].ascii_str()
+				if source[i] == `\\` && i + 1 < source.len {
+					out += source[i + 1].ascii_str()
+					i += 2
+					continue
+				}
+				if source[i] == `"` {
+					i++
+					break
+				}
+				i++
+			}
+			continue
+		}
+		if c == `.` && (i == 0 || !fastc_identifier_byte(source[i - 1])) && i + 1 < source.len && fastc_identifier_byte(source[i + 1]) {
+			mut j := i + 1
+			for j < source.len && fastc_identifier_byte(source[j]) {
+				j++
+			}
+			member := source[i + 1..j]
+			if member in fields {
+				out += '${enum_c}__${member}'
+				i = j
+				continue
+			}
+		}
+		out += c.ascii_str()
+		i++
+	}
+	return out
+}
+
 fn (g &Parser) render_map_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
 	if lookup := g.render_map_lookup_option_expression(tokens) {
+		// The Option temp uses the reserved `__v_fastc_` prefix, NOT a plain name like `lookup`: a
+		// source variable of that name used in the key (`m[lookup]`) would otherwise be shadowed by
+		// this declaration and read uninitialized inside its own initializer.
 		return FastcRenderedExpression{
-			source: '({ Option lookup = (${lookup.source}); lookup.state ? (${lookup.typ}){0} : *((${lookup.typ} *)lookup.data); })'
+			source: '({ Option __v_fastc_map_lookup = (${lookup.source}); __v_fastc_map_lookup.state ? (${lookup.typ}){0} : *((${lookup.typ} *)__v_fastc_map_lookup.data); })'
 			typ: lookup.typ
 		}
 	}
@@ -142,6 +212,286 @@ fn (g &Parser) render_map_expression(tokens []FastcExpressionToken) ?FastcRender
 		}
 	}
 	return none
+}
+
+// render_map_value_field_assignment lowers `m[k].field = value` (a struct field of a map
+// value). A map value is not a C lvalue, so a mutable pointer to the entry is taken (inserting
+// a zero default when absent) and the field assigned through it.
+fn (g &Parser) render_map_value_field_assignment(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	mut depth := 0
+	mut assign_idx := -1
+	for i, item in tokens {
+		match item.tok {
+			.lpar, .lsbr, .lcbr { depth++ }
+			.rpar, .rsbr, .rcbr { depth-- }
+			.assign {
+				if depth == 0 {
+					assign_idx = i
+					break
+				}
+			}
+			else {}
+		}
+	}
+	if assign_idx <= 0 || assign_idx + 1 >= tokens.len {
+		return none
+	}
+	lhs := tokens[..assign_idx]
+	if lhs.len < 5 || lhs.last().tok != .name {
+		return none
+	}
+	// The last top-level `]` must be followed by a pure `.name` chain (the fields).
+	mut close := -1
+	mut bracket_depth := 0
+	for i, item in lhs {
+		match item.tok {
+			.lsbr { bracket_depth++ }
+			.rsbr {
+				bracket_depth--
+				if bracket_depth == 0 {
+					close = i
+				}
+			}
+			else {}
+		}
+	}
+	if close <= 0 || close + 1 >= lhs.len || lhs[close + 1].tok != .dot {
+		return none
+	}
+	map_index_tokens := lhs[..close + 1]
+	field_tokens := lhs[close + 1..]
+	if field_tokens.len < 2 || field_tokens.len % 2 != 0 {
+		return none
+	}
+	for i := 0; i < field_tokens.len; i += 2 {
+		if field_tokens[i].tok != .dot || field_tokens[i + 1].tok != .name {
+			return none
+		}
+	}
+	ptr := g.render_mutable_map_value_pointer(map_index_tokens) or { return none }
+	value_type := ptr.typ
+	mut current_type := value_type
+	mut field_access := ''
+	for i := 0; i < field_tokens.len; i += 2 {
+		field := g.struct_field_metadata(current_type, field_tokens[i + 1].lit) or { return none }
+		separator := if i == 0 { '->' } else { '.' }
+		field_access += separator + fastc_c_identifier(field.name)
+		current_type = field.typ
+	}
+	value_source := g.render_call_argument_expression(tokens[assign_idx + 1..], current_type) or {
+		return none
+	}
+	return FastcRenderedExpression{
+		source: '({ ${value_type} *__v_fastc_map_field_ptr = (${ptr.source}); __v_fastc_map_field_ptr${field_access} = (${value_source}); (void)0; })'
+		typ: 'void'
+	}
+}
+
+// render_map_value_field_inc_dec lowers `m[k].field++` / `m[k].field--` (a struct field of a map
+// value). Like the assignment form, the map value is not a C lvalue, so a mutable pointer to the
+// entry (inserting a zero default when absent) is taken and the field incremented through it.
+fn (g &Parser) render_map_value_field_inc_dec(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	if tokens.len < 6 || tokens.last().tok !in [.inc, .dec] {
+		return none
+	}
+	op := if tokens.last().tok == .inc { '++' } else { '--' }
+	lhs := tokens[..tokens.len - 1]
+	if lhs.last().tok != .name {
+		return none
+	}
+	mut close := -1
+	mut bracket_depth := 0
+	for i, item in lhs {
+		match item.tok {
+			.lsbr { bracket_depth++ }
+			.rsbr {
+				bracket_depth--
+				if bracket_depth == 0 {
+					close = i
+				}
+			}
+			else {}
+		}
+	}
+	if close <= 0 || close + 1 >= lhs.len || lhs[close + 1].tok != .dot {
+		return none
+	}
+	map_index_tokens := lhs[..close + 1]
+	field_tokens := lhs[close + 1..]
+	if field_tokens.len < 2 || field_tokens.len % 2 != 0 {
+		return none
+	}
+	for i := 0; i < field_tokens.len; i += 2 {
+		if field_tokens[i].tok != .dot || field_tokens[i + 1].tok != .name {
+			return none
+		}
+	}
+	ptr := g.render_mutable_map_value_pointer(map_index_tokens) or { return none }
+	value_type := ptr.typ
+	mut current_type := value_type
+	mut field_access := ''
+	for i := 0; i < field_tokens.len; i += 2 {
+		field := g.struct_field_metadata(current_type, field_tokens[i + 1].lit) or { return none }
+		separator := if i == 0 { '->' } else { '.' }
+		field_access += separator + fastc_c_identifier(field.name)
+		current_type = field.typ
+	}
+	return FastcRenderedExpression{
+		source: '({ ${value_type} *__v_fastc_map_field_ptr = (${ptr.source}); __v_fastc_map_field_ptr${field_access}${op}; (void)0; })'
+		typ: 'void'
+	}
+}
+
+struct FastcMapAssignmentWrap {
+	prefix     string
+	suffix     string
+	value_type string
+}
+
+// render_embedded_map_reads lowers each `name[key]` map-index READ that appears as a
+// sub-expression of a larger expression (`m[k] + 1`, `if … { m[k] } …`) into the
+// `builtin__map_get` form, which a bare-read only receives when it is the whole
+// expression. Only bare-name map bases are rewritten; the caller must exclude assignment
+// targets so `m[k] = …` still routes through the map-set lowering.
+fn (g &Parser) render_embedded_map_reads(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	mut rewritten := []FastcExpressionToken{}
+	mut i := 0
+	mut found := false
+	// A map read nested in a call's argument list or a struct-literal field (`f(m[k])`,
+	// `sb.write(m[k])`, `T{ x: m[k] }`) is lowered by the call/literal renderer, so leave it
+	// alone. But a cast's parens (`int(m[k])`) and plain grouping (`(m[k]) + 1`) do not lower
+	// their contents, so those map reads must still be rewritten here. Track, per open
+	// bracket, whether it introduces a call/braces scope to skip.
+	mut skip_stack := []bool{}
+	for i < tokens.len {
+		if tokens[i].tok == .lpar {
+			// A call's `(` follows a function/method name; a cast's follows a type name and
+			// grouping follows an operator/`(`.
+			is_call := i > 0 && tokens[i - 1].tok == .name && fastc_primitive_c_type(tokens[i - 1].lit) == none && g.resolve_declared_type_key(tokens[i - 1].lit) == none
+			skip_stack << is_call
+			rewritten << tokens[i]
+			i++
+			continue
+		}
+		if tokens[i].tok == .lcbr {
+			skip_stack << true
+			rewritten << tokens[i]
+			i++
+			continue
+		}
+		if tokens[i].tok in [.rpar, .rcbr] {
+			if skip_stack.len > 0 {
+				skip_stack.pop()
+			}
+			rewritten << tokens[i]
+			i++
+			continue
+		}
+		inside_skip := skip_stack.any(it)
+		if !inside_skip && tokens[i].tok == .name && i + 1 < tokens.len && tokens[i + 1].tok == .lsbr && (i == 0 || tokens[i - 1].tok != .dot) {
+			close := fastc_matching_delimiter(tokens, i + 1, .lsbr, .rsbr) or { -1 }
+			if close > i + 1 {
+				map_type := g.infer_expression_type(tokens[i..i + 1]) or { '' }
+				is_assign_target := close + 1 < tokens.len && tokens[close + 1].tok.is_assignment()
+				// A map value that is itself indexed or has a field taken (`m[k][i]`,
+				// `m[k].f`) is the base of a larger access; leave the whole chain to the
+				// array/member renderers rather than rewriting just the map read.
+				followed_by_access := close + 1 < tokens.len && tokens[close + 1].tok in [
+					.lsbr,
+					.dot,
+				]
+				if map_type != '' && !is_assign_target && !followed_by_access {
+					if g.map_key_value_types(map_type) != none {
+						if read := g.render_map_expression(tokens[i..close + 1]) {
+							rewritten << FastcExpressionToken{
+								tok: .name
+								lit: read.source
+								source: read.source
+								typ: read.typ
+							}
+							i = close + 1
+							found = true
+							continue
+						}
+					} else if array_read := g.render_array_access_expression(tokens[i..close + 1]) {
+						// An array read (`a[i]`) sharing an expression with a rewritten map read
+						// (`a[i] < m[k]`) must also be lowered, or the raw renderer would index the
+						// array header struct directly. This does not itself set `found`, so a
+						// map-free array expression still returns none and keeps its usual path.
+						rewritten << FastcExpressionToken{
+							tok: .name
+							lit: array_read.source
+							source: array_read.source
+							typ: array_read.typ
+						}
+						i = close + 1
+						continue
+					}
+				}
+			}
+		}
+		rewritten << tokens[i]
+		i++
+	}
+	if !found {
+		return none
+	}
+	source := g.render_raw_expression_tokens(rewritten) or { return none }
+	return FastcRenderedExpression{
+		source: source
+		typ: g.infer_expression_type(tokens) or { '' }
+	}
+}
+
+// render_map_index_assignment_wrapping lowers the target of `m[k] = <value>` into a
+// `builtin__map_set` wrapper split around the value, so an assignment whose RHS cannot be a
+// plain C lvalue operand (notably `m[k] = rhs or { … }`, where the RHS is a statement
+// expression) still stores through the map runtime. The caller splices the rendered value
+// between `.prefix` and `.suffix`.
+fn (g &Parser) render_map_index_assignment_wrapping(left_tokens []FastcExpressionToken) ?FastcMapAssignmentWrap {
+	if left_tokens.len < 4 || left_tokens.last().tok != .rsbr {
+		return none
+	}
+	close := left_tokens.len - 1
+	mut open := -1
+	mut bracket_depth := 0
+	for i := close; i >= 0; i-- {
+		if left_tokens[i].tok == .rsbr {
+			bracket_depth++
+		} else if left_tokens[i].tok == .lsbr {
+			bracket_depth--
+			if bracket_depth == 0 {
+				open = i
+				break
+			}
+		}
+	}
+	if open <= 0 {
+		return none
+	}
+	base_tokens := left_tokens[..open]
+	map_type := g.infer_expression_type(base_tokens) or { return none }
+	key_type, value_type := g.map_key_value_types(map_type) or { return none }
+	key_source := g.render_call_argument_expression(left_tokens[open + 1..close], key_type) or {
+		return none
+	}
+	mut map_address := ''
+	if nested := g.render_mutable_map_value_pointer(base_tokens) {
+		if nested.typ != map_type.trim_right('*') {
+			return none
+		}
+		map_address = nested.source
+	} else {
+		map_source := g.render_member_receiver(base_tokens) or {
+			g.render_raw_expression_tokens(base_tokens) or { return none }
+		}
+		map_address = if map_type.ends_with('*') { map_source } else { '&${map_source}' }
+	}
+	return FastcMapAssignmentWrap{
+		prefix: '({ ${key_type} __v_fastc_map_key = (${key_source}); ${value_type} __v_fastc_map_value = ('
+		suffix: '); builtin__map_set((map *)${map_address}, &__v_fastc_map_key, &__v_fastc_map_value); __v_fastc_map_value; })'
+		value_type: value_type
+	}
 }
 
 fn (g &Parser) render_bool_print_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
@@ -322,10 +672,11 @@ fn (g &Parser) render_empty_struct_initializer(c_type string) string {
 	// re-parses a file that did so after they are ready.
 	fastc_note_field_defaults_use(g)
 	for field in g.struct_field_info[layout_type] {
-		if field.default_value == '' {
+		field_default := g.struct_field_initializer_default(field)
+		if field_default == '' {
 			continue
 		}
-		rendered_field := '.${fastc_c_identifier(field.name)}=(${field.default_value})'
+		rendered_field := '.${fastc_c_identifier(field.name)}=(${field_default})'
 		rendered_fields << rendered_field
 		rendered_fields_by_name[field.name] = rendered_field
 	}
@@ -337,6 +688,41 @@ fn (g &Parser) render_empty_struct_initializer(c_type string) string {
 	}
 	empty_initializers := []string{}
 	return g.render_struct_literal_with_defaults(c_type, layout_type, empty_initializers, rendered_fields, rendered_fields_by_name).source
+}
+
+fn (g &Parser) struct_field_initializer_default(field FastcStructField) string {
+	mut value := ''
+	if field.default_value != '' {
+		value = field.default_value
+	} else if !field.typ.ends_with('*') && g.struct_type_has_initializer_defaults(field.typ) {
+		value = g.render_empty_struct_initializer(field.typ)
+	}
+	if value == '' {
+		return ''
+	}
+	if !field.is_shared_pointer {
+		return value
+	}
+	return '({ ${field.typ} __v_fastc_shared_field_value = (${value}); (${field.typ}*)v_fastc_interface_box(&__v_fastc_shared_field_value, sizeof(${field.typ})); })'
+}
+
+fn (g &Parser) struct_type_has_initializer_defaults(c_type string) bool {
+	if c_type.ends_with('*') {
+		return false
+	}
+	layout_type := fastc_trim_pointer_suffix(g.underlying_alias_type(c_type))
+	if layout_type !in g.struct_field_info {
+		return false
+	}
+	for field in g.struct_field_info[layout_type] {
+		if field.default_value != '' {
+			return true
+		}
+		if field.typ != c_type && g.struct_type_has_initializer_defaults(field.typ) {
+			return true
+		}
+	}
+	return false
 }
 
 // fastc_type_is_declared_struct reports whether `c_type` names a declared struct/union.
@@ -501,25 +887,51 @@ fn (g &Parser) render_assignment_expression(tokens []FastcExpressionToken) ?Fast
 		return none
 	}
 	mut left := ''
-	if array_access := g.render_array_access_expression(left_tokens) {
-		left = array_access.source
-	} else if member := g.render_member_receiver(left_tokens) {
-		left = member
-	} else {
-		raw := g.render_raw_expression_tokens(left_tokens) or { return none }
-		left = if pointer_members := g.render_pointer_member_access_expression(left_tokens, raw) {
-			pointer_members.source
+	if left_tokens.len >= 4 && left_tokens.last().tok == .name && left_tokens[left_tokens.len - 2].tok == .dot && left_tokens[left_tokens.len - 3].tok == .rpar {
+		// `recv.method(args).field = value`: the target is a field of a method-call result (a
+		// pointer receiver like `table.sym(id)`), which the member-receiver renderer cannot spell.
+		receiver_tokens := left_tokens[..left_tokens.len - 2]
+		field := left_tokens.last().lit
+		raw_receiver := g.render_raw_expression_tokens(receiver_tokens) or { '' }
+		if call := g.render_method_call_expression(receiver_tokens, raw_receiver) {
+			access := if call.typ.ends_with('*') { '->' } else { '.' }
+			left = '(${call.source})${access}${field}'
+		}
+	}
+	if left == '' {
+		if array_access := g.render_array_access_expression(left_tokens) {
+			left = array_access.source
+		} else if member := g.render_member_receiver(left_tokens) {
+			left = member
 		} else {
-			raw
+			raw := g.render_raw_expression_tokens(left_tokens) or { return none }
+			left = if pointer_members := g.render_pointer_member_access_expression(left_tokens, raw) {
+				pointer_members.source
+			} else {
+				raw
+			}
 		}
 	}
 	rhs_tokens := tokens[assignment_index + 1..]
 	mut right := ''
 	if rhs_tokens.len == 2 && rhs_tokens[0].tok == .lsbr && rhs_tokens[1].tok == .rsbr && fastc_trim_pointer_suffix(left_type).starts_with('Array_') {
 		// An empty array literal `[]` has no element type of its own; assigned to an
-		// array target it lowers to a typed empty array from the target's type (the
-		// standalone `x = []` case is handled where `expected_expression_type` is set).
-		right = '(${left_type}){0}'
+		// array target it lowers to a typed empty array from the target's type. The
+		// header must retain the element size so a later `<<` copies actual elements.
+		array_type := fastc_trim_pointer_suffix(left_type)
+		element_type := g.array_element_type(array_type) or { return none }
+		right = '((${array_type})builtin____new_array(0, 0, sizeof(${fastc_normalize_inferred_type(element_type)})))'
+	} else if g.selfhost && g.boolean_expression_has_narrowing(rhs_tokens) {
+		// `x.f = a is T && a.g …`: the RHS is a flow-sensitive narrowing boolean, whose right
+		// conjuncts read the smart-cast the left `is` registers. render_call_argument_expression
+		// cannot register that (it is non-mut); route through the narrowing renderer, which
+		// saves/restores the temporary member smart-casts itself.
+		mut w := unsafe { &Parser(g) }
+		if narrowed := w.render_narrowing_boolean_expression(rhs_tokens) {
+			right = narrowed
+		} else {
+			right = g.render_call_argument_expression(rhs_tokens, left_type) or { return none }
+		}
 	} else {
 		right = g.render_call_argument_expression(rhs_tokens, left_type) or { return none }
 	}
@@ -531,11 +943,40 @@ fn (g &Parser) render_assignment_expression(tokens []FastcExpressionToken) ?Fast
 			if fastc_trim_pointer_suffix(rhs_type) == 'IError' {
 				right = '(Option){.err=${right}, .state=1}'
 			} else {
-				payload := g.render_call_argument_expression(rhs_tokens, option_payload_type) or {
+				// `right` already holds the fully lowered RHS; for a narrowing boolean it
+				// carries the member smart-cast that a re-render through
+				// render_call_argument_expression would drop, so reuse it as the payload.
+				payload := if g.boolean_expression_has_narrowing(rhs_tokens) {
 					right
+				} else {
+					g.render_call_argument_expression(rhs_tokens, option_payload_type) or {
+						right
+					}
 				}
 				right = fastc_option_success_expression(option_payload_type, payload)
 			}
+		}
+	}
+	if g.selfhost && operator == .assign && left_type.contains('_FASTC_ARRAY_OF_') && g.fixed_array_uses_raw_storage(left_tokens) {
+		// `s.arr = [N]T{}` zeroes a raw-storage fixed array; the empty `[N]T{}` literal is not
+		// lowered to a value, so memset rather than memcpy from an unrendered right-hand side.
+		if fastc_is_empty_fixed_array_literal(rhs_tokens) {
+			return FastcRenderedExpression{
+				source: 'memset(${left}, 0, sizeof(${left}))'
+				typ: left_type
+			}
+		}
+		// The target is a raw-storage fixed-array member/global (a C `T[N]` array, which cannot be
+		// assigned); copy the source array's bytes instead. A by-value wrapper source keeps its
+		// array in `.data`, while another raw-storage source is already a bare array.
+		right_data := if g.fixed_array_uses_raw_storage(rhs_tokens) {
+			right
+		} else {
+			'(${right}).data'
+		}
+		return FastcRenderedExpression{
+			source: 'memcpy(${left}, ${right_data}, sizeof(${left}))'
+			typ: left_type
 		}
 	}
 	source := if operator == .plus_assign && g.underlying_alias_type(left_type) == 'string' {
@@ -594,12 +1035,12 @@ fn (g &Parser) render_unsigned_right_shift_assignment(target string, value strin
 
 fn fastc_overloaded_binary_precedence(tok token.Token) int {
 	return match tok {
-		.pipe { 1 }
-		.xor { 2 }
-		.amp { 3 }
-		.left_shift, .right_shift { 4 }
-		.plus, .minus { 5 }
-		.mul, .div, .mod { 6 }
+		// Keep these groups aligned with V's binding powers, not C's. In V,
+		// `+ - | ^` share one level and `* / % << >> >>> &` share the next.
+		// Parenthesizing the recursively rendered operands below then preserves
+		// both V's grouping and left associativity in the generated C.
+		.pipe, .xor, .plus, .minus { 1 }
+		.amp, .left_shift, .right_shift, .right_shift_unsigned, .mul, .div, .mod { 2 }
 		else { 0 }
 	}
 }
@@ -612,6 +1053,20 @@ fn fastc_has_top_level_assignment(tokens []FastcExpressionToken) bool {
 		} else if item.tok in [.rpar, .rsbr, .rcbr] {
 			depth--
 		} else if depth == 0 && item.tok.is_assignment() {
+			return true
+		}
+	}
+	return false
+}
+
+fn fastc_has_top_level_bitwise_operator(tokens []FastcExpressionToken) bool {
+	mut depth := 0
+	for i, item in tokens {
+		if item.tok in [.lpar, .lsbr, .lcbr] {
+			depth++
+		} else if item.tok in [.rpar, .rsbr, .rcbr] {
+			depth--
+		} else if depth == 0 && i > 0 && i + 1 < tokens.len && item.tok in [.amp, .pipe, .xor] {
 			return true
 		}
 	}
@@ -654,6 +1109,13 @@ fn (g &Parser) render_overloaded_comparison_expression(left_tokens []FastcExpres
 	receiver_tokens := if reverse_arguments { right_tokens } else { left_tokens }
 	argument_tokens := if reverse_arguments { left_tokens } else { right_tokens }
 	receiver_type := g.infer_expression_type(receiver_tokens) or { return none }
+	argument_type := g.infer_expression_type(argument_tokens) or { '' }
+	// Equality against `nil` is pointer identity even when the pointee type has
+	// overloaded `==`. Calling that overload would pass NULL as the second
+	// receiver and dereference it (for example `&ast.Scope == unsafe { nil }`).
+	if operator in [.eq, .ne] && (receiver_type == 'nil' || argument_type == 'nil') {
+		return none
+	}
 	method_key := g.method_function_key(receiver_type, method_operator)
 	if method_key !in g.functions {
 		return none
@@ -780,8 +1242,26 @@ fn (g &Parser) render_overloaded_binary_expression(tokens []FastcExpressionToken
 		left_tokens := tokens[..boolean_index]
 		right_tokens := tokens[boolean_index + 1..]
 		operator := tokens[boolean_index].tok
+		if operator in [.key_in, .not_in] {
+			// Membership is not a C binary operator; splitting here would emit a raw `(x) in (y)`.
+			// Bail so the dedicated membership handler lowers it (its subject renders any concat).
+			return none
+		}
 		if comparison := g.render_overloaded_comparison_expression(left_tokens, right_tokens, operator) {
 			return comparison
+		}
+		// V's bitwise operators bind tighter than comparisons, while C's `&`, `|`,
+		// and `^` bind looser. Preserve the V parse explicitly; otherwise
+		// `x & 1 == 0` becomes `x & (1 == 0)` in C.
+		if operator in [.eq, .ne, .lt, .le, .gt, .ge] && (fastc_has_top_level_bitwise_operator(left_tokens) || fastc_has_top_level_bitwise_operator(right_tokens)) {
+			left_type := g.infer_expression_type(left_tokens) or { return none }
+			right_type := g.infer_expression_type(right_tokens) or { return none }
+			left := g.render_call_argument_expression(left_tokens, left_type) or { return none }
+			right := g.render_call_argument_expression(right_tokens, right_type) or { return none }
+			return FastcRenderedExpression{
+				source: '((${left})${operator.str()}(${right}))'
+				typ: 'bool'
+			}
 		}
 		mut left_special := FastcRenderedExpression{}
 		if rendered := g.render_overloaded_binary_expression(left_tokens) {
@@ -847,6 +1327,11 @@ fn (g &Parser) render_overloaded_binary_expression(tokens []FastcExpressionToken
 	left_type := g.infer_expression_type(left_tokens) or { return none }
 	operator := tokens[operator_index].tok.str()
 	method_key := g.method_function_key(left_type, operator)
+	if tokens[operator_index].tok == .left_shift && fastc_trim_pointer_suffix(g.underlying_alias_type(left_type)).starts_with('Array_') {
+		// `arr << x` is an append (render_append_expression), not a C left-shift;
+		// splitting here would emit an invalid `(arr) << (x)`.
+		return none
+	}
 	if method_key !in g.functions {
 		mut left_special := FastcRenderedExpression{}
 		if rendered := g.render_overloaded_binary_expression(left_tokens) {
@@ -869,6 +1354,15 @@ fn (g &Parser) render_overloaded_binary_expression(tokens []FastcExpressionToken
 			right_special.source
 		} else {
 			g.render_call_argument_expression(right_tokens, right_type) or { return none }
+		}
+		// A `+` whose operands are strings is concatenation, not C pointer arithmetic. When
+		// one side is itself a lowered string expression (`a + s[..n] + b`), the recursive
+		// step above already rendered it, so the joining operator must still be string_plus.
+		if operator == '+' && (fastc_trim_pointer_suffix(g.underlying_alias_type(left_type)) == 'string' || fastc_trim_pointer_suffix(g.underlying_alias_type(right_type)) == 'string') {
+			return FastcRenderedExpression{
+				source: 'builtin__string_plus((${left}),(${right}))'
+				typ: 'string'
+			}
 		}
 		return FastcRenderedExpression{
 			source: '((${left})${operator}(${right}))'
@@ -919,6 +1413,37 @@ fn fastc_contains_method_marker(rendered string, name string) bool {
 	return false
 }
 
+// fastc_replace_member_chain replaces every occurrence of `needle` in `source` that is a whole
+// token (not preceded or followed by an identifier character), so replacing a member chain such
+// as `node.expr` does not corrupt a sibling field like `node.expr_type` that merely shares its
+// prefix. A needle ending in `.` deliberately replaces a member-chain prefix.
+fn fastc_replace_member_chain(source string, needle string, replacement string) string {
+	if needle == '' {
+		return source
+	}
+	mut result := ''
+	mut i := 0
+	for i < source.len {
+		if i + needle.len <= source.len && source[i..i + needle.len] == needle {
+			before_ok := i == 0 || !fastc_is_chain_identifier_char(source[i - 1])
+			after_ok := needle.ends_with('.') || i + needle.len == source.len
+				|| !fastc_is_chain_identifier_char(source[i + needle.len])
+			if before_ok && after_ok {
+				result += replacement
+				i += needle.len
+				continue
+			}
+		}
+		result += source[i].ascii_str()
+		i++
+	}
+	return result
+}
+
+fn fastc_is_chain_identifier_char(c u8) bool {
+	return c.is_letter() || c.is_digit() || c == `_`
+}
+
 fn (g &Parser) render_pointer_member_access_expression(tokens []FastcExpressionToken, rendered_expression string) ?FastcRenderedExpression {
 	if tokens.len < 3 {
 		return none
@@ -946,9 +1471,7 @@ fn (g &Parser) render_pointer_member_access_expression(tokens []FastcExpressionT
 		}
 		root_type := g.infer_expression_type(tokens[start..start + 1]) or { continue }
 		root_is_reference := if local := g.locals[item.lit] { local.is_reference } else { false }
-		if !root_type.ends_with('*') && !root_is_reference {
-			continue
-		}
+		root_is_pointer := root_type.ends_with('*') || root_is_reference
 		mut end := start + 1
 		for end + 1 < tokens.len && tokens[end].tok == .dot && tokens[end + 1].tok == .name {
 			if end + 2 < tokens.len && tokens[end + 2].tok == .lpar {
@@ -962,6 +1485,15 @@ fn (g &Parser) render_pointer_member_access_expression(tokens []FastcExpressionT
 		chain_tokens := tokens[start..end]
 		raw_chain := g.render_raw_expression_tokens(chain_tokens) or { continue }
 		promoted_chain := g.render_member_receiver(chain_tokens) or { continue }
+		// A value-rooted chain needs no `.`→`->` deref rewrite (the second loop below handles
+		// pointer fields), but it still needs embedded-field promotion (`err.pos` →
+		// `err.__embedded_0.pos`) when a field is reached through an embed, OR a correction when
+		// the raw render spuriously deref'd a FIELD that shadows a pointer local (`node.left.len`
+		// inside `for mut left in node.left` → `node.left->len`); in that case the raw and
+		// member-receiver renders disagree, so proceed to replace the raw with the correct chain.
+		if !root_is_pointer && !promoted_chain.contains('__embedded_') && raw_chain == promoted_chain {
+			continue
+		}
 		mut needle := raw_chain
 		if !rendered.contains(needle) {
 			root_source := g.resolved_expression_name(item.lit, .unknown)
@@ -970,9 +1502,17 @@ fn (g &Parser) render_pointer_member_access_expression(tokens []FastcExpressionT
 				needle = pointer_chain
 			}
 		}
-		if promoted_chain != needle && rendered.contains(needle) {
-			rendered = rendered.replace(needle, promoted_chain)
-			changed = true
+		if promoted_chain != needle && rendered.contains(needle) && !(promoted_chain.contains(needle) && rendered.contains(promoted_chain)) {
+			// A whole-word replace: the chain `node.expr` must not match the prefix of a longer
+			// identifier such as the sibling field `node.expr_type`. Skip when the promoted form
+			// (which itself contains the raw chain, e.g. a smart-cast `((T*)(x.f)._object)`) is
+			// already present — a method-call receiver render applied it, so replacing the raw
+			// chain surviving inside it would double-wrap.
+			replaced := fastc_replace_member_chain(rendered, needle, promoted_chain)
+			if replaced != rendered {
+				rendered = replaced
+				changed = true
+			}
 		}
 	}
 	for i in 1 .. tokens.len - 1 {
@@ -984,7 +1524,18 @@ fn (g &Parser) render_pointer_member_access_expression(tokens []FastcExpressionT
 		}
 		receiver_start := fastc_method_receiver_start(tokens, i)
 		receiver_tokens := tokens[receiver_start..i]
-		receiver_type := g.infer_expression_type(receiver_tokens) or { continue }
+		mut receiver_type := g.infer_expression_type(receiver_tokens) or { continue }
+		mut lowered_array_receiver := ''
+		if receiver_tokens.len > 0 {
+			if array_receiver := g.render_indexed_member_receiver(receiver_tokens) {
+				lowered_array_receiver = array_receiver.source
+				// General member inference can erase the reference marker from an
+				// indexed `[]&T` element. The array lowering retains its exact type.
+				if array_receiver.typ.ends_with('*') {
+					receiver_type = array_receiver.typ
+				}
+			}
+		}
 		if tokens[i + 1].lit in ['len', 'cap'] {
 			if fixed_length := fastc_fixed_array_length(receiver_type.trim_right('*')) {
 				raw_receiver := g.render_raw_expression_tokens(receiver_tokens) or { continue }
@@ -1003,8 +1554,12 @@ fn (g &Parser) render_pointer_member_access_expression(tokens []FastcExpressionT
 		if !receiver_type.ends_with('*') {
 			continue
 		}
-		receiver_source := g.render_member_receiver(receiver_tokens) or {
-			g.render_membership_candidate(receiver_tokens, '') or { continue }
+		receiver_source := if lowered_array_receiver != '' {
+			lowered_array_receiver
+		} else {
+			g.render_member_receiver(receiver_tokens) or {
+				g.render_membership_candidate(receiver_tokens, '') or { continue }
+			}
 		}
 		needle := '${receiver_source}.${tokens[i + 1].lit}'
 		replaced := fastc_replace_c_identifier(rendered, needle, '${receiver_source}->${tokens[i + 1].lit}')
@@ -1015,7 +1570,9 @@ fn (g &Parser) render_pointer_member_access_expression(tokens []FastcExpressionT
 		}
 		raw_receiver := g.render_raw_expression_tokens(receiver_tokens) or { '' }
 		raw_needle := '${raw_receiver}.${tokens[i + 1].lit}'
-		raw_replaced := fastc_replace_c_identifier(rendered, raw_needle, '${raw_receiver}->${tokens[i + 1].lit}')
+		// Use the smartcast receiver (`member->…`) as the replacement base, not the
+		// raw member spelling (`x.f->…`, which derefs a non-pointer).
+		raw_replaced := fastc_replace_c_identifier(rendered, raw_needle, '${receiver_source}->${tokens[i + 1].lit}')
 		if raw_receiver != '' && raw_replaced != rendered {
 			rendered = raw_replaced
 			changed = true
@@ -1066,6 +1623,29 @@ fn (g &Parser) render_chained_array_access_expression(tokens []FastcExpressionTo
 			if fastc_contains(rendered, raw_lookup) {
 				rendered = fastc_replace(rendered, raw_lookup, lookup.source)
 				changed = true
+				continue
+			}
+			// The raw render leaves the key's method/function calls un-lowered, so it may not
+			// match the buffer (`m[f(x)]` streams as `m[F(x)]`); rebuild the needle with the key
+			// rendered the way the buffer holds it.
+			// render_member_receiver spells the base the way the buffer holds it (a pointer field
+			// derefs with `->`, which render_raw misses); pair it with the lowered key.
+			base_src := if member := g.render_member_receiver(base_tokens) {
+				member
+			} else {
+				g.render_raw_expression_tokens(base_tokens) or { continue }
+			}
+			key_source := g.render_membership_candidate(tokens[open + 1..close], '') or { continue }
+			for lowered_needle in [
+				'${base_src}[${key_source}]',
+				'(${base_src})[${key_source}]',
+				'(*(${base_src}))[${key_source}]',
+			] {
+				if rendered.contains(lowered_needle) {
+					rendered = rendered.replace(lowered_needle, lookup.source)
+					changed = true
+					break
+				}
 			}
 			continue
 		}
@@ -1100,13 +1680,61 @@ fn (g &Parser) render_chained_array_access_expression(tokens []FastcExpressionTo
 			array_value := if base_type.ends_with('*') { '*(${base_source})' } else { base_source }
 			'(*(${element_type} *)builtin__array_get(${array_value}, ${index_source}))'
 		}
-		mut needle := '${base_source}[${index_source}]'
+		// The buffer holds the render_raw spelling of the base, so match that first; using the
+		// member-receiver `base_source` as the primary needle lets a shorter un-mangled name
+		// (`short[0]`) match INSIDE the mangled buffer text (`__v_fastc_keyword_short[0]`) and
+		// splice the replacement after the keyword prefix.
+		mut needle := '${raw_base}[${index_source}]'
 		if !fastc_contains(rendered, needle) {
-			needle = '${raw_base}[${index_source}]'
+			needle = '${base_source}[${index_source}]'
 		}
-		if fastc_contains(rendered, needle) {
-			rendered = fastc_replace(rendered, needle, replacement)
+		if !fastc_contains(rendered, needle) {
+			// The streamed index can retain a source-level cast spelling (`int(i)`) while
+			// render_membership_candidate has already normalized it to the platform C type.
+			// Try that exact streamed spelling when locating the access to replace. If
+			// the streamed index contains another array access (`int(ids[i])`), lower that
+			// inner access while retaining the outer cast's streamed C spelling.
+			if raw_index := g.render_raw_expression_tokens(tokens[open + 1..close]) {
+				mut streamed_indexes := [raw_index]
+				// The streaming reader can already have lowered a method nested in the
+				// index (`nodes[int(a.child(i))]`). Match that intermediate spelling too.
+				if method_index := g.render_method_call_expression(tokens[open + 1..close], raw_index) {
+					streamed_indexes << method_index.source
+				}
+				if nested_index := g.render_nested_array_access_expression(tokens[open + 1..close], raw_index) {
+					streamed_indexes << nested_index.source
+				}
+				for streamed_index in streamed_indexes {
+					raw_needle := '${raw_base}[${streamed_index}]'
+					member_needle := '${base_source}[${streamed_index}]'
+					if fastc_contains(rendered, raw_needle) {
+						needle = raw_needle
+						break
+					} else if fastc_contains(rendered, member_needle) {
+						needle = member_needle
+						break
+					}
+				}
+			}
+		}
+		// An element that is itself a pointer (`[]&TypeSymbol`) auto-dereferences on the
+		// following member access, so `arr[i].field` lowers to `(elem)->field`, not `.field`.
+		if element_type.ends_with('*') && fastc_contains(rendered, '${needle}.') {
+			rendered = fastc_replace_member_chain(rendered, '${needle}.', '${replacement}->')
 			changed = true
+		} else if fastc_contains(rendered, needle) {
+			// For a root name, do not match the same text inside an already-lowered
+			// string member access: lowering `str[i]` inside `((str).str[i])` again
+			// produces the invalid `((str).((str).str[i]))`.
+			replaced := if base_tokens.len == 1 && base_tokens[0].tok == .name {
+				fastc_replace_c_root_identifier(rendered, needle, replacement)
+			} else {
+				fastc_replace_member_chain(rendered, needle, replacement)
+			}
+			if replaced != rendered {
+				rendered = replaced
+				changed = true
+			}
 		}
 	}
 	inferred_type := g.infer_expression_type(tokens) or { '' }
@@ -1429,7 +2057,28 @@ fn (g &Parser) render_struct_comparison_expression_impl(tokens []FastcExpression
 						typ: 'bool'
 					}
 				}
+				// Two sum-type VALUES (`node.stmt != ast.empty_stmt`, neither a variant cast):
+				// compare the runtime tag, then the concrete variant's contents.
+				if sum_eq := g.render_sum_type_value_equality(left_tokens, right_tokens, left_layout) {
+					source := if item.tok == .ne { '!(${sum_eq})' } else { sum_eq }
+					return FastcRenderedExpression{
+						source: source
+						typ: 'bool'
+					}
+				}
 				return none
+			}
+			if left_layout == right_layout && left_layout.starts_with('Map_') {
+				// `m1 == m2` deep-compares maps; C `==` on the erased `map` struct is
+				// invalid, so route through the builtin key/value comparison.
+				left := g.render_comparison_operand(left_tokens, left_type) or { return none }
+				right := g.render_comparison_operand(right_tokens, right_type) or { return none }
+				equality := 'builtin__map_map_eq((${left}), (${right}))'
+				result := if item.tok == .ne { '!(${equality})' } else { equality }
+				return FastcRenderedExpression{
+					source: result
+					typ: 'bool'
+				}
 			}
 			left_key := g.semantic_type_key(left_layout)
 			if left_layout != right_layout || left_key !in g.declared_kinds || g.declared_kinds[left_key] != .struct_ || !g.struct_equality_is_supported(left_type, []string{}) {
@@ -1493,12 +2142,214 @@ fn (g &Parser) render_sum_type_equality(left_tokens []FastcExpressionToken, righ
 	return '({ ${sum_type} ${left_temp} = (${left}); ${comparison}; })'
 }
 
+// render_sum_type_value_equality lowers `a == b` where both `a` and `b` are values of the same
+// sum type (`node.stmt == ast.empty_stmt`). The boxed `{_object,_typ,_methods}` struct cannot be
+// compared with C `==`, so the tags are compared first and, when equal, the concrete variant's
+// contents through a switch. A variant whose element-wise equality is not expressible (e.g. it
+// holds an option/map/further sum type) falls back to a tag-only match.
+fn (g &Parser) render_sum_type_value_equality(left_tokens []FastcExpressionToken, right_tokens []FastcExpressionToken, sum_type string) ?string {
+	left := g.render_comparison_operand(left_tokens, sum_type) or { return none }
+	right := g.render_comparison_operand(right_tokens, sum_type) or { return none }
+	a := '__v_fastc_sv_a'
+	b := '__v_fastc_sv_b'
+	mut cases := []string{}
+	for variant in g.sum_type_leaf_variants(sum_type) {
+		mut concrete := 'true'
+		if g.struct_equality_is_supported(variant, []string{}) {
+			left_value := '(*(${variant} *)${a}._object)'
+			right_value := '(*(${variant} *)${b}._object)'
+			concrete = g.struct_equality_source(left_value, right_value, variant, []string{})
+		} else if fastc_primitive_c_type(variant) != none {
+			concrete = '(*(${variant} *)${a}._object == *(${variant} *)${b}._object)'
+		}
+		cases << 'case __v_typeid_${variant}: __v_fastc_sv_eq = (${concrete}); break;'
+	}
+	if cases.len == 0 {
+		return none
+	}
+	return '({ ${sum_type} ${a} = (${left}); ${sum_type} ${b} = (${right}); bool __v_fastc_sv_eq; if (${a}._typ != ${b}._typ) { __v_fastc_sv_eq = false; } else { switch (${a}._typ) { ${cases.join(' ')} default: __v_fastc_sv_eq = true; break; } } __v_fastc_sv_eq; })'
+}
+
 // render_as_cast_expression lowers `<boxed> as Type`. A boxed sum-type / interface
 // value shares the `{_object, _typ, _methods}` layout and dispatches by `_typ`, so a
 // downcast to ANOTHER interface / sum type just re-boxes the same object under the
 // target type, and a cast to a CONCRETE type unboxes the stored object. Returns none
 // unless `as` is the top-level operator, the right side is a declared type, and the
 // left operand is a boxed value.
+// render_as_cast_member_access renders `(X as T).field.field…` — a parenthesized
+// `as` cast followed by a member-field chain. The cast target supplies the type for
+// each field lookup. Method calls / index accesses on the cast result are left to
+// the other renderers (returns none).
+fn (g &Parser) render_as_cast_member_access(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	if tokens.len < 3 || tokens[0].tok != .lpar {
+		return none
+	}
+	close := fastc_matching_rpar(tokens, 0) or { return none }
+	if close + 1 >= tokens.len {
+		return none
+	}
+	inner := tokens[1..close]
+	as_index := fastc_bare_as_cast_index(inner, 0, inner.len) or { return none }
+	cast := g.render_as_cast_expression(inner) or { return none }
+	mut source := '(${cast.source})'
+	mut current_type := cast.typ
+	// Track the equivalent plain member path (`subject.field…`, dropping the redundant `as T`
+	// cast) so a member smart-cast registered on it — `subject.field is Variant`, narrowing the
+	// field to a variant whose method the cast's un-narrowed field type lacks — overrides the
+	// cast's field read.
+	mut member_path := fastc_member_chain_path(inner, 0, as_index) or { '' }
+	mut i := close + 1
+	for i < tokens.len {
+		if tokens[i].tok == .lsbr {
+			// A trailing element index on the cast member chain (`(x as T).val[0]`): the base
+			// `(x as T).val` is rendered above; lower the string byte / dynamic-array element
+			// access here so it does not reach the raw renderer as a mangled `.valbuiltin_…`.
+			close_index := fastc_matching_delimiter(tokens, i, .lsbr, .rsbr) or { return none }
+			if close_index != tokens.len - 1 || close_index <= i + 1 || fastc_expression_tokens_contain(tokens[i + 1..close_index], .dotdot) {
+				return none
+			}
+			index_source := g.render_membership_candidate(tokens[i + 1..close_index], 'int') or {
+				return none
+			}
+			layout := fastc_trim_pointer_suffix(g.underlying_alias_type(current_type))
+			if layout == 'string' {
+				string_source := if current_type.ends_with('*') { '*(${source})' } else { source }
+				return FastcRenderedExpression{
+					source: 'builtin__string_at(${string_source}, ${index_source})'
+					typ: 'u8'
+				}
+			}
+			if layout.starts_with('Array_') {
+				element_type := g.array_element_type(current_type) or { return none }
+				array_value := if current_type.ends_with('*') { '*(${source})' } else { source }
+				return FastcRenderedExpression{
+					source: '(*(${element_type} *)builtin__array_get(${array_value}, ${index_source}))'
+					typ: element_type
+				}
+			}
+			return none
+		}
+		if i + 1 >= tokens.len || tokens[i].tok != .dot || tokens[i + 1].tok != .name {
+			return none
+		}
+		if i + 2 < tokens.len && tokens[i + 2].tok == .lpar {
+			return none
+		}
+		field := g.struct_field_metadata(current_type, tokens[i + 1].lit) or { return none }
+		for storage_name in field.storage_path {
+			separator := if current_type.ends_with('*') { '->' } else { '.' }
+			source += separator + fastc_c_identifier(storage_name)
+			current_type = g.struct_direct_member_type(current_type, storage_name)
+			if current_type == '' {
+				return none
+			}
+		}
+		separator := if current_type.ends_with('*') { '->' } else { '.' }
+		field_source := source + separator + fastc_c_identifier(field.name)
+		source = if field.is_shared_pointer { '*(${field_source})' } else { field_source }
+		current_type = field.typ
+		if member_path != '' {
+			member_path += '.' + tokens[i + 1].lit
+			if smartcast := g.member_smartcasts[member_path] {
+				source = smartcast.source
+				current_type = smartcast.typ
+			}
+		}
+		i += 2
+	}
+	return FastcRenderedExpression{
+		source: source
+		typ: current_type
+	}
+}
+
+// rewrite_embedded_as_casts replaces each `(expr as T)` / `(expr as T).field` group that is
+// embedded inside a larger expression (`a && (x.info as Struct).parent_type != 0`) with a
+// single synthetic token carrying the pre-rendered cast as its `source`. The stand-alone
+// `as`-cast paths only fire when the whole expression is the cast, so without this a cast used
+// as a boolean/comparison operand would reach the raw renderer with `as` left intact. Returns
+// none when the expression has no embedded `as` cast to lower.
+fn (g &Parser) rewrite_embedded_as_casts(tokens []FastcExpressionToken) ?[]FastcExpressionToken {
+	mut result := tokens.clone()
+	mut changed := false
+	for _ in 0 .. 64 {
+		mut rewrote := false
+		mut i := 0
+		for i < result.len {
+			if result[i].tok != .lpar {
+				i++
+				continue
+			}
+			// Only a grouping paren can introduce a cast; a `(` right after a name / `)` / `]`
+			// is a call or index whose argument may itself hold an `as` (`conv(x as T)`).
+			if i > 0 && result[i - 1].tok in [.name, .rpar, .rsbr] {
+				i++
+				continue
+			}
+			close := fastc_matching_rpar(result, i) or {
+				i++
+				continue
+			}
+			inner := result[i + 1..close]
+			if fastc_bare_as_cast_index(inner, 0, inner.len) == none {
+				i++
+				continue
+			}
+			mut end := close + 1
+			for end + 1 < result.len && result[end].tok == .dot && result[end + 1].tok == .name && !(end + 2 < result.len && result[end + 2].tok == .lpar) {
+				end += 2
+			}
+			// A trailing element index on the cast member access (`(x as T).val[0]`) is part of
+			// the group — render_as_cast_member_access lowers it to a string/array access — so
+			// consume it too, provided nothing indexes/dots the result further.
+			if end > close + 1 && end < result.len && result[end].tok == .lsbr {
+				if index_close := fastc_matching_delimiter(result, end, .lsbr, .rsbr) {
+					if index_close + 1 >= result.len || result[index_close + 1].tok !in [
+						.dot,
+						.lsbr,
+					] {
+						end = index_close + 1
+					}
+				}
+			}
+			if end - i == result.len {
+				// The whole expression is the cast; leave it to the stand-alone paths.
+				i = end
+				continue
+			}
+			rendered := if end > close + 1 {
+				g.render_as_cast_member_access(result[i..end]) or {
+					i = end
+					continue
+				}
+			} else {
+				g.render_as_cast_expression(inner) or {
+					i = end
+					continue
+				}
+			}
+			mut next := result[..i].clone()
+			next << FastcExpressionToken{
+				tok: .name
+				source: rendered.source
+				typ: rendered.typ
+			}
+			next << result[end..]
+			result = next.clone()
+			changed = true
+			rewrote = true
+			break
+		}
+		if !rewrote {
+			break
+		}
+	}
+	if !changed {
+		return none
+	}
+	return result
+}
+
 fn (g &Parser) render_as_cast_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
 	mut depth := 0
 	mut as_index := -1
@@ -1522,6 +2373,22 @@ fn (g &Parser) render_as_cast_expression(tokens []FastcExpressionToken) ?FastcRe
 		return none
 	}
 	left_tokens := tokens[..as_index]
+	// Assignment binds looser than `as`, so `x = y as T` parses as `x = (y as T)`, not
+	// `(x = y) as T`. A top-level assignment left of the `as` means this cast belongs to the
+	// assignment's RHS; bail so the assignment handler renders the target and lowers the cast
+	// on the RHS alone (otherwise the whole `x = y` is mistaken for the cast operand).
+	mut assign_depth := 0
+	for item in left_tokens {
+		match item.tok {
+			.lpar, .lsbr, .lcbr { assign_depth++ }
+			.rpar, .rsbr, .rcbr { assign_depth-- }
+			else {
+				if assign_depth == 0 && item.tok.is_assignment() {
+					return none
+				}
+			}
+		}
+	}
 	mut type_key := ''
 	if as_index == tokens.len - 2 && tokens[as_index + 1].tok == .name {
 		type_key = g.resolve_declared_type_key(tokens[as_index + 1].lit) or { return none }
@@ -1536,6 +2403,22 @@ fn (g &Parser) render_as_cast_expression(tokens []FastcExpressionToken) ?FastcRe
 	target_c := fastc_c_declared_type_name(type_key)
 	inferred_left := g.infer_expression_type(left_tokens) or { return none }
 	left_type := fastc_normalize_inferred_type(inferred_left)
+	if left_type.trim_right('*') == target_c {
+		// `x as T` where `x` is already `T` (e.g. through a smartcast): an identity
+		// cast, so just yield the value (dereferencing a smartcast pointer). A member/local
+		// chain must render through render_member_receiver so a live member smart-cast (a
+		// narrowed `right` reached as a variant pointer) is honored rather than the raw name.
+		left_source := if member := g.render_member_receiver(left_tokens) {
+			member
+		} else {
+			g.render_call_argument_expression(left_tokens, left_type) or { return none }
+		}
+		source := if left_type.ends_with('*') { '(*(${left_source}))' } else { left_source }
+		return FastcRenderedExpression{
+			source: source
+			typ: target_c
+		}
+	}
 	if !g.is_boxed_type(left_type) {
 		return none
 	}
@@ -1623,6 +2506,47 @@ fn (g &Parser) render_option_none_comparison(tokens []FastcExpressionToken) ?Fas
 				source: '((${value}).state ${operator} 2)'
 				typ: 'bool'
 			}
+		}
+	}
+	return none
+}
+
+// render_nil_comparison lowers `ptr == nil` / `ptr != nil` (`unsafe { nil }` renders to `NULL`).
+// The pointer operand must be compared as a pointer, not auto-dereferenced to its pointee value;
+// a `mut T` reference parameter is already the C pointer, so it is rendered without the deref.
+fn (g &Parser) render_nil_comparison(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	mut depth := 0
+	for i, item in tokens {
+		match item.tok {
+			.lpar, .lsbr, .lcbr { depth++ }
+			.rpar, .rsbr, .rcbr { depth-- }
+			.eq, .ne {
+				if depth != 0 || i == 0 || i + 1 >= tokens.len {
+					continue
+				}
+				left_tokens := tokens[..i]
+				right_tokens := tokens[i + 1..]
+				left_is_nil := left_tokens.len == 1 && left_tokens[0].tok == .key_nil
+				right_is_nil := right_tokens.len == 1 && right_tokens[0].tok == .key_nil
+				if left_is_nil == right_is_nil {
+					return none
+				}
+				value_tokens := if left_is_nil { right_tokens } else { left_tokens }
+				// Only a bare `mut T` reference parameter needs special handling: it is a C `T*`,
+				// but the raw renderer auto-dereferences it, so `node == nil` becomes an invalid
+				// `*node == NULL`. Every other operand (a member chain, an already-pointer local)
+				// is rendered correctly by the existing comparison paths, so leave those alone.
+				if !(value_tokens.len == 1 && value_tokens[0].tok == .name && (g.locals[value_tokens[0].lit] or { FastcLocal{} }).is_reference) {
+					return none
+				}
+				pointer := g.resolved_root_expression_name(value_tokens[0].lit)
+				operator := if item.tok == .eq { '==' } else { '!=' }
+				return FastcRenderedExpression{
+					source: '((${pointer}) ${operator} NULL)'
+					typ: 'bool'
+				}
+			}
+			else {}
 		}
 	}
 	return none
@@ -1735,6 +2659,29 @@ fn (g &Parser) render_mixed_integer_comparison_expression(tokens []FastcExpressi
 	return result
 }
 
+// fastc_tokens_have_top_level_boolean_or_membership reports whether tokens contain, at paren
+// depth 0, a boolean connective (`&&`/`||`) or a set-membership operator (`in`/`!in`). Such an
+// operand is a full boolean sub-expression rather than a plain comparison operand, so it must be
+// rendered through render_call_argument_expression to lower its nested membership/logical parts.
+fn fastc_tokens_have_top_level_boolean_or_membership(tokens []FastcExpressionToken) bool {
+	// Strip a fully-wrapping paren pair first: `(a && b)` is still a boolean sub-expression,
+	// so its connective must be seen even though the raw tokens nest it one level deep.
+	inner := fastc_strip_paren_tokens(tokens)
+	mut depth := 0
+	for item in inner {
+		match item.tok {
+			.lpar, .lsbr, .lcbr { depth++ }
+			.rpar, .rsbr, .rcbr { depth-- }
+			else {
+				if depth == 0 && item.tok in [.and, .logical_or, .key_in, .not_in] {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
 fn (g &Parser) render_mixed_integer_comparison_expression_impl(tokens []FastcExpressionToken) ?FastcRenderedExpression {
 	if tokens.len >= 3 && tokens[0].tok == .lpar && tokens.last().tok == .rpar {
 		close := fastc_matching_rpar(tokens, 0) or { -1 }
@@ -1783,11 +2730,19 @@ fn (g &Parser) render_mixed_integer_comparison_expression_impl(tokens []FastcExp
 		}
 		left_source := if left_special.source != '' {
 			left_special.source
+		} else if fastc_tokens_have_top_level_boolean_or_membership(left_tokens) {
+			// This side is itself a boolean sub-expression (a nested `&&`/`||` chain or a
+			// set-membership test), not a plain comparison operand. render_comparison_operand
+			// would emit it verbatim, leaving a raw `x !in [...]` in the C output; route it
+			// through the full expression renderer so its membership/logical parts lower.
+			g.render_call_argument_expression(left_tokens, 'bool') or { return none }
 		} else {
 			g.render_comparison_operand(left_tokens, 'bool') or { return none }
 		}
 		right_source := if right_special.source != '' {
 			right_special.source
+		} else if fastc_tokens_have_top_level_boolean_or_membership(right_tokens) {
+			g.render_call_argument_expression(right_tokens, 'bool') or { return none }
 		} else {
 			g.render_comparison_operand(right_tokens, 'bool') or { return none }
 		}
@@ -1854,15 +2809,211 @@ fn (g &Parser) render_mixed_integer_comparison_expression_impl(tokens []FastcExp
 	return none
 }
 
+// render_guard_comparison renders a top-level comparison guard (`expr.kind == .constant`)
+// by rendering each operand through render_comparison_operand, which reads any active
+// smart-cast on the left and resolves an enum-shorthand right operand against the left
+// operand's type. Returns none when there is no top-level comparison operator.
+fn (g &Parser) render_guard_comparison(tokens []FastcExpressionToken) ?string {
+	mut depth := 0
+	mut op_index := -1
+	mut op := token.Token.unknown
+	for i, item in tokens {
+		match item.tok {
+			.lpar, .lsbr, .lcbr { depth++ }
+			.rpar, .rsbr, .rcbr { depth-- }
+			.eq, .ne, .lt, .gt, .le, .ge {
+				if depth == 0 && op_index < 0 {
+					op_index = i
+					op = item.tok
+				}
+			}
+			else {}
+		}
+	}
+	if op_index <= 0 || op_index + 1 >= tokens.len {
+		return none
+	}
+	left_tokens := tokens[..op_index]
+	left := if fastc_tokens_have_top_level_boolean_or_membership(left_tokens) {
+		g.render_call_argument_expression(left_tokens, 'bool') or { return none }
+	} else {
+		g.render_comparison_operand(left_tokens, '') or { return none }
+	}
+	mut left_type := g.infer_expression_type(left_tokens) or { '' }
+	// Flow-sensitive member smartcasts can render the operand correctly while the
+	// generic inference still sees the boxed receiver. Recover the concrete field
+	// type so a shorthand RHS such as `.mul` resolves against its enum.
+	if member_type := g.infer_member_access_type(left_tokens, 0, left_tokens.len) {
+		left_type = member_type
+	}
+	right_tokens := tokens[op_index + 1..]
+	right := if fastc_tokens_have_top_level_boolean_or_membership(right_tokens) {
+		g.render_call_argument_expression(right_tokens, 'bool') or { return none }
+	} else {
+		g.render_comparison_operand(right_tokens, left_type) or { return none }
+	}
+	if fastc_normalize_inferred_type(left_type) == 'string' {
+		if op == .eq {
+			return 'builtin__string_eq(${left}, ${right})'
+		}
+		if op == .ne {
+			return '(!builtin__string_eq(${left}, ${right}))'
+		}
+	}
+	c_op := match op {
+		.eq { '==' }
+		.ne { '!=' }
+		.lt { '<' }
+		.gt { '>' }
+		.le { '<=' }
+		.ge { '>=' }
+		else {
+			return none
+		}
+	}
+	return '((${left}) ${c_op} (${right}))'
+}
+
+// fastc_tokens_contain_chained_index reports whether tokens contain an index applied directly
+// to another index's result (`fields[0][0]`, a string element). The raw renderer leaves the
+// second `[i]` as an invalid C index on the non-array value, so such an expression must be
+// lowered through render_array_access (via render_guard_comparison / render_comparison_operand).
+// fastc_tokens_have_top_level_assignment reports whether tokens contain an assignment operator
+// at paren/bracket/brace depth 0 (`x = …`, `x += …`), i.e. the expression is really a statement
+// assigning to `x`, not a bare value.
+fn fastc_tokens_have_top_level_assignment(tokens []FastcExpressionToken) bool {
+	mut depth := 0
+	for item in tokens {
+		match item.tok {
+			.lpar, .lsbr, .lcbr { depth++ }
+			.rpar, .rsbr, .rcbr { depth-- }
+			else {
+				if depth == 0 && item.tok.is_assignment() {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+fn fastc_tokens_contain_chained_index(tokens []FastcExpressionToken) bool {
+	for i in 1 .. tokens.len {
+		if tokens[i].tok == .lsbr && tokens[i - 1].tok == .rsbr {
+			return true
+		}
+	}
+	return false
+}
+
+// fastc_tokens_contain_nested_propagation reports whether a `!` result/option propagation
+// appears inside a parenthesized call argument (a `.not` at paren depth > 0 immediately
+// following a `)`), as in `f(g()!)`. The raw renderer leaves such a `!` as a stray C
+// operator; the expression must be lowered so the argument's Option is unwrapped.
+fn fastc_tokens_contain_nested_propagation(tokens []FastcExpressionToken) bool {
+	mut depth := 0
+	for i, item in tokens {
+		match item.tok {
+			.lpar, .lsbr, .lcbr { depth++ }
+			.rpar, .rsbr, .rcbr { depth-- }
+			.not {
+				if depth > 0 && i > 0 && tokens[i - 1].tok == .rpar {
+					return true
+				}
+			}
+			else {}
+		}
+	}
+	return false
+}
+
+// fastc_tokens_are_plain_call reports whether tokens form a single function or method call
+// (`f(a)`, `recv.m(a)`) with no trailing member access or index on its result. Such an
+// operand must be lowered through render_missing_call_arguments so its arguments receive the
+// value/pointer coercions (auto-deref of a `&T` argument to a `T` parameter, `!`/`?`
+// propagation) that the raw renderer, which streams the tokens verbatim, cannot apply.
+fn fastc_tokens_are_plain_call(tokens []FastcExpressionToken) bool {
+	if tokens.len < 3 || tokens.last().tok != .rpar {
+		return false
+	}
+	for i in 1 .. tokens.len {
+		if tokens[i].tok != .lpar || tokens[i - 1].tok != .name {
+			continue
+		}
+		close := fastc_matching_rpar(tokens, i) or { continue }
+		if close != tokens.len - 1 {
+			continue
+		}
+		name_index := i - 1
+		if name_index == 0 {
+			return true
+		}
+		if name_index >= 2 && tokens[name_index - 1].tok == .dot {
+			return fastc_method_receiver_start(tokens, name_index - 1) == 0
+		}
+		return false
+	}
+	return false
+}
+
+// fastc_comparison_operand_is_plain_call reports whether the left or right operand of the
+// first top-level comparison in `tokens` is a plain function/method call (see
+// fastc_tokens_are_plain_call), so the comparison should be lowered through
+// render_guard_comparison to coerce that call's arguments.
+fn fastc_comparison_operand_is_plain_call(tokens []FastcExpressionToken) bool {
+	mut depth := 0
+	for i, item in tokens {
+		match item.tok {
+			.lpar, .lsbr, .lcbr { depth++ }
+			.rpar, .rsbr, .rcbr { depth-- }
+			.eq, .ne, .lt, .gt, .le, .ge {
+				if depth == 0 {
+					return fastc_tokens_are_plain_call(tokens[..i]) || fastc_tokens_are_plain_call(tokens[i + 1..])
+				}
+			}
+			else {}
+		}
+	}
+	return false
+}
+
 fn (g &Parser) render_comparison_operand(tokens []FastcExpressionToken, expected_type string) ?string {
+	if g.selfhost && fastc_tokens_contain_chained_index(tokens) {
+		// The operand is itself a comparison with a chained index (`a[i][j] == c`, e.g. the right
+		// side of an `&&`); render it through render_guard_comparison so the nested string/array
+		// index lowers rather than leaving a raw C `(...)[j]`.
+		if guard := g.render_guard_comparison(tokens) {
+			return guard
+		}
+	}
+	if g.selfhost && g.expression_uses_member_smartcast(tokens) {
+		// A member-smartcast chain (`x.f.g` where `x.f is T`) must read through the
+		// concrete-variant pointer, not the boxed member's source spelling.
+		if member_source := g.render_member_receiver(tokens) {
+			return member_source
+		}
+	}
 	if g.selfhost && tokens.len > 1 && tokens.last().tok == .not && !fastc_trailing_not_marks_fixed_array_literal(tokens) {
 		if propagation := g.render_option_propagation(tokens[..tokens.len - 1]) {
 			return propagation.source
 		}
 	}
+	if g.selfhost {
+		if common_field := g.render_sumtype_common_field_access(tokens) {
+			return common_field.source
+		}
+	}
 	raw := g.render_raw_expression_tokens(tokens) or { return none }
 	if integer_comparison := g.render_mixed_integer_comparison_expression(tokens) {
 		return integer_comparison.source
+	}
+	// The operand may itself be an enum comparison (`sym(x).kind == .multi_return`, e.g. one
+	// side of an `&&`); resolve its `.member` shorthand against the enum type rather than
+	// leaving a raw C `.member`.
+	if g.selfhost {
+		if enum_comparison := g.render_enum_comparison_expression(tokens) {
+			return enum_comparison.source
+		}
 	}
 	if concatenation := g.render_composed_string_concatenation(tokens) {
 		return concatenation.source
@@ -1870,23 +3021,114 @@ fn (g &Parser) render_comparison_operand(tokens []FastcExpressionToken, expected
 	if struct_literal := g.render_struct_literal_expression(tokens) {
 		return struct_literal.source
 	}
+	if map_expression := g.render_map_expression(tokens) {
+		return map_expression.source
+	}
 	if array_access := g.render_array_access_expression(tokens) {
 		return array_access.source
 	}
 	if method_call := g.render_method_call_expression(tokens, raw) {
+		// A method can return an array that is indexed before a trailing member read
+		// (`node.generic_params()[0].len`). Lower that index after substituting the
+		// method's C call spelling, otherwise raw C indexes the array wrapper struct.
+		if nested_array := g.render_nested_array_access_expression(tokens, method_call.source) {
+			return nested_array.source
+		}
+		// A trailing field on a pointer-returning method call (`table.sym(x).cname`) is left as a
+		// raw `.field` by the method renderer; promote it to `->field` so C does not access a
+		// field on a pointer rvalue.
+		if pointer_members := g.render_pointer_member_access_expression(tokens, method_call.source) {
+			return pointer_members.source
+		}
 		return method_call.source
 	}
 	if call := g.render_missing_call_arguments(tokens) {
 		return call.source
 	}
 	if pointer_members := g.render_pointer_member_access_expression(tokens, raw) {
+		// Pointer-member rendering may rewrite the receiver before a dynamic-array
+		// field indexed by a nested method call. Finish lowering that index instead
+		// of returning a raw C subscript on the array wrapper.
+		if nested_array := g.render_nested_array_access_expression(tokens, pointer_members.source) {
+			return nested_array.source
+		}
 		return pointer_members.source
 	}
 	return g.render_membership_candidate(tokens, expected_type)
 }
 
+// render_enum_flag_shorthand_combination resolves a flag-enum combination written with
+// leading-dot shorthands against a known enum type, e.g. `.integer | .unsigned` with
+// expected type `Properties` -> `(Properties__integer | Properties__unsigned)`. Every
+// operand must be a `.member` shorthand and every separator a bitwise flag operator; any
+// other shape returns none so the caller falls back to the ordinary renderer.
+fn (g &Parser) render_enum_flag_shorthand_combination(tokens []FastcExpressionToken, enum_type string) ?string {
+	if tokens.len < 5 {
+		return none
+	}
+	enum_c := enum_type.trim_right('*')
+	mut out := ''
+	mut i := 0
+	for i < tokens.len {
+		if tokens[i].tok != .dot || i + 1 >= tokens.len || !(tokens[i + 1].tok == .name || tokens[i + 1].tok.is_keyword()) {
+			return none
+		}
+		out += '${enum_c}__${tokens[i + 1].lit}'
+		i += 2
+		if i == tokens.len {
+			break
+		}
+		operator := match tokens[i].tok {
+			.pipe { '|' }
+			.amp { '&' }
+			.xor { '^' }
+			else {
+				return none
+			}
+		}
+		out += ' ${operator} '
+		i++
+	}
+	return '(${out})'
+}
+
 fn (g &Parser) render_call_argument_expression(tokens []FastcExpressionToken, expected_type string) ?string {
+	if g.selfhost && tokens.len > 1 && tokens.last().tok == .question {
+		// A trailing `?` propagates an option exactly like `!` propagates a result, and FastC
+		// represents both with one `Option` type. read_expression normalizes only the top-level
+		// `?`; do the same here so propagation is lowered inside call arguments and struct-literal
+		// field values (`f(g()?, h()?)?`), not left as a raw C `?` (a stray ternary operator).
+		last := tokens.last()
+		mut normalized := tokens.clone()
+		normalized[normalized.len - 1] = FastcExpressionToken{
+			tok: .not
+			source: last.source
+			unsafe_depth: last.unsafe_depth
+			is_mut_argument: last.is_mut_argument
+			is_statement: last.is_statement
+			lit: last.lit
+			typ: last.typ
+		}
+		return g.render_call_argument_expression(normalized, expected_type)
+	}
 	if tokens.len == 1 && tokens[0].source != '' {
+		// A pre-rendered value (e.g. an interpolation) passed where a `voidptr` is expected (a
+		// map `.delete(key)` / generic argument) must still be boxed to a pointer, exactly as the
+		// non-synthetic path below does; otherwise a struct value is passed where `void*` is wanted.
+		if g.selfhost && expected_type == 'voidptr' && tokens[0].typ !in ['', 'voidptr', 'nil'] && !fastc_is_pointer_type(tokens[0].typ) {
+			actual := fastc_normalize_inferred_type(g.underlying_alias_type(tokens[0].typ))
+			return '({ ${actual} __v_fastc_generic_argument = (${tokens[0].source}); v_fastc_interface_box(&__v_fastc_generic_argument, sizeof(${actual})); })'
+		}
+		// An if/match-expression argument was pre-rendered to a ternary during streaming with the
+		// call-argument expected type cleared, so its branches may still hold raw `.member` enum
+		// shorthands (`f(if c { .arrow } else { .dot })`). The parameter enum type is only known
+		// here, so resolve them now.
+		if g.selfhost && tokens[0].source.contains('.') {
+			enum_key := g.semantic_type_key(expected_type)
+			if g.declared_kinds[enum_key] == .enum_ {
+				return fastc_resolve_enum_shorthands_in_source(tokens[0].source, fastc_c_declared_type_name(enum_key), g.enum_field_names[enum_key])
+			}
+		}
 		// A single token carrying a pre-rendered `({ ... })` (e.g. an `or`-unwrap synthesized
 		// as an array element or call argument): use it directly.
 		return tokens[0].source
@@ -1947,6 +3189,33 @@ fn (g &Parser) render_call_argument_expression(tokens []FastcExpressionToken, ex
 	if tokens.len == 2 && tokens[0].tok == .dot && tokens[1].tok == .name && g.declared_kinds[g.semantic_type_key(expected_type)] == .enum_ {
 		return '${expected_type.trim_right('*')}__${tokens[1].lit}'
 	}
+	if g.declared_kinds[g.semantic_type_key(expected_type)] == .enum_ {
+		if flag_combo := g.render_enum_flag_shorthand_combination(tokens, expected_type) {
+			return flag_combo
+		}
+		// A flag expression mixing a value with a `.member` shorthand (`~Show.zero() ^ .name`):
+		// render it normally, then rewrite the value-position shorthands against the enum type —
+		// render_enum_flag_shorthand_combination handles only a pure `.a | .b` chain.
+		mut has_flag_op := false
+		for flag_tok in tokens {
+			if flag_tok.tok in [.xor, .pipe, .amp] {
+				has_flag_op = true
+				break
+			}
+		}
+		if has_flag_op && fastc_expression_tokens_contain(tokens, .dot) {
+			// enum_field_names is keyed by the C type name (`flag__Show`), not the semantic key.
+			enum_c := fastc_c_declared_type_name(g.semantic_type_key(expected_type))
+			raw_flag := g.render_raw_expression_tokens(tokens) or { return none }
+			rendered_flag := if special := g.render_special_expression(tokens, raw_flag) {
+				special.source
+			} else {
+				raw_flag
+			}
+			resolved_flag := fastc_resolve_enum_shorthands_in_source(rendered_flag, enum_c, g.enum_field_names[enum_c])
+			return g.fastc_resolve_flag_enum_statics(resolved_flag, enum_c)
+		}
+	}
 	if function_value := g.render_function_value_expression(tokens) {
 		return function_value
 	}
@@ -1956,6 +3225,18 @@ fn (g &Parser) render_call_argument_expression(tokens []FastcExpressionToken, ex
 	raw := g.render_raw_expression_tokens(tokens) or { return none }
 	if tokens.len == 1 && tokens[0].tok == .name {
 		if local := g.locals[tokens[0].lit] {
+			if local.smartcast_origin_type != '' && local.smartcast_origin_source != '' && expected_type != '' {
+				origin_type := fastc_normalize_inferred_type(local.smartcast_origin_type)
+				if expected_type == origin_type {
+					return local.smartcast_origin_source
+				}
+				if expected_type.ends_with('*') && origin_type == expected_type.trim_right('*') {
+					return '&(${local.smartcast_origin_source})'
+				}
+				if origin_type.ends_with('*') && expected_type == origin_type.trim_right('*') {
+					return '*(${local.smartcast_origin_source})'
+				}
+			}
 			if local.is_reference {
 				if g.should_box_variant(expected_type, local.typ) {
 					// A `mut value T` parameter is a C `T*`. Interface conversion must
@@ -1975,11 +3256,22 @@ fn (g &Parser) render_call_argument_expression(tokens []FastcExpressionToken, ex
 	}
 	mut rendered := ''
 	mut rendered_type := ''
-	if special := g.render_special_expression(tokens, raw) {
-		rendered = special.source
-		rendered_type = special.typ
-	} else {
-		rendered = g.render_membership_candidate(tokens, expected_type) or { return none }
+	// A member/local smart-cast chain (`left` narrowed by `left is CS`) must read through the
+	// concrete-variant pointer, not the boxed subject's raw spelling — otherwise a later box
+	// (`Expr(left)`) stores the wrong object. Mirror render_comparison_operand.
+	if g.selfhost && g.expression_uses_member_smartcast(tokens) {
+		if member_source := g.render_member_receiver(tokens) {
+			rendered = member_source
+			rendered_type = fastc_normalize_inferred_type(g.infer_expression_type(tokens) or { '' })
+		}
+	}
+	if rendered == '' {
+		if special := g.render_special_expression(tokens, raw) {
+			rendered = special.source
+			rendered_type = special.typ
+		} else {
+			rendered = g.render_membership_candidate(tokens, expected_type) or { return none }
+		}
 	}
 	rendered = g.render_constant_references(tokens, rendered)
 	actual_type := if rendered_type != '' {
@@ -1997,6 +3289,12 @@ fn (g &Parser) render_call_argument_expression(tokens []FastcExpressionToken, ex
 	if expected_type == 'string' && fastc_trim_pointer_suffix(actual_type) == 'IError' {
 		return 'builtin__IError_msg(${rendered})'
 	}
+	if g.selfhost && actual_type.ends_with('*') && expected_type == actual_type.trim_right('*') && g.expression_uses_member_smartcast(tokens) {
+		// A member smart-cast (`node.args[0].expr is CallExpr`) supplies a variant POINTER; a
+		// by-value parameter (`resolve_return_type(node.args[0].expr)`) needs the pointee value.
+		// The `.lsbr` guard below would wrongly skip this because the chain indexes an array.
+		return '*(${rendered})'
+	}
 	if actual_type.ends_with('*') && expected_type == actual_type.trim_right('*') && !fastc_expression_tokens_contain(tokens, .lsbr) {
 		// V automatically dereferences an explicit reference when a by-value
 		// parameter is expected (`s &string` passed to `log_line(s string)`). A
@@ -2012,6 +3310,15 @@ fn (g &Parser) render_call_argument_expression(tokens []FastcExpressionToken, ex
 	}
 	if expected_type.ends_with('*') && actual_type == expected_type.trim_right('*') {
 		return '&(${rendered})'
+	}
+	if expected_type.ends_with('*') && g.should_box_variant(expected_type.trim_right('*'), actual_type) {
+		// A concrete value passed where a `&Interface` parameter is expected (`f(resolver
+		// &IResolver)` called with a `Gen`): box it into an interface value with heap lifetime.
+		// The pointer can escape through an assignment (`p := &Interface(value)`), so the
+		// address of a statement-expression local would immediately dangle.
+		iface_type := expected_type.trim_right('*')
+		boxed := g.interface_value_expression(iface_type, actual_type, rendered)
+		return '({ ${iface_type} __v_fastc_iface_ref = ${boxed}; (${iface_type} *)v_fastc_interface_box(&__v_fastc_iface_ref, sizeof(${iface_type})); })'
 	}
 	if g.should_box_variant(expected_type, actual_type) {
 		return g.interface_value_expression(expected_type, actual_type, rendered)
@@ -2035,8 +3342,17 @@ fn (g &Parser) render_array_literal_argument(tokens []FastcExpressionToken, expe
 	element_type := g.array_element_type(array_type) or { return none }
 	items := fastc_expression_list_items(tokens, 1, close) or { return none }
 	if items.len == 0 {
+		if is_fixed {
+			return FastcRenderedExpression{
+				source: '(${array_type}){0}'
+				typ: array_type
+			}
+		}
+		// A dynamic empty array needs a real header carrying `element_size`, otherwise a later
+		// `<<` push copies `len * 0` bytes into a NULL buffer and silently drops the elements.
+		normalized_empty_element := fastc_normalize_inferred_type(element_type)
 		return FastcRenderedExpression{
-			source: '(${array_type}){0}'
+			source: '((${array_type})builtin____new_array(0, 0, sizeof(${normalized_empty_element})))'
 			typ: array_type
 		}
 	}
@@ -2132,6 +3448,12 @@ fn (g &Parser) render_function_value_expression(tokens []FastcExpressionToken) ?
 
 fn (g &Parser) render_method_value_expression(tokens []FastcExpressionToken) ?string {
 	if tokens.len < 3 || tokens.last().tok != .name || tokens[tokens.len - 2].tok != .dot {
+		return none
+	}
+	// Only the complete expression may be a method value. Without this boundary check,
+	// `a.len == b.len && a.str == b.str` is mistaken for a method value on the boolean
+	// expression ending at `b`, and `.str` resolves to `bool.str`.
+	if fastc_method_receiver_start(tokens, tokens.len - 2) != 0 {
 		return none
 	}
 	receiver_tokens := tokens[..tokens.len - 2]
@@ -2300,20 +3622,93 @@ fn (g &Parser) should_box_variant(expected_type string, actual_type string) bool
 		return true
 	}
 	if fastc_trim_pointer_suffix(expected_type) in g.sum_types {
-		// Primitive or composite (`Array_`/`Map_`) value into a sum type. Interfaces
-		// have no primitive/composite implementers, so this is sum-type only.
+		// A primitive or composite (`Array_`/`Map_`) value, or a nested sum-type variant that
+		// is itself a sum type (`Stmt` passed where `Node` is expected), boxed into a sum type.
+		// Interfaces have no primitive/composite implementers, so this is sum-type only.
 		normalized := fastc_trim_pointer_suffix(fastc_normalize_inferred_type(actual_type))
-		return fastc_primitive_c_type(normalized) != none || normalized.starts_with('Array_') || normalized.starts_with('Map_')
+		return fastc_primitive_c_type(normalized) != none || normalized.starts_with('Array_') || normalized.starts_with('Map_') || g.sumtype_has_variant(expected_type, normalized)
 	}
 	return false
 }
 
+// render_map_index_inc_dec_expression lowers `m[k]++` / `m[k]--`. A map value is not a C
+// lvalue, so the entry is fetched (inserting a zero default when absent, matching V) and the
+// increment applied through the returned pointer.
+fn (g &Parser) render_map_index_inc_dec_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	if tokens.len < 5 || tokens.last().tok !in [.inc, .dec] {
+		return none
+	}
+	op := if tokens.last().tok == .inc { '++' } else { '--' }
+	index_tokens := tokens[..tokens.len - 1]
+	if index_tokens.last().tok != .rsbr {
+		return none
+	}
+	close := index_tokens.len - 1
+	mut open := -1
+	mut depth := 0
+	for i := close; i >= 0; i-- {
+		if index_tokens[i].tok == .rsbr {
+			depth++
+		} else if index_tokens[i].tok == .lsbr {
+			depth--
+			if depth == 0 {
+				open = i
+				break
+			}
+		}
+	}
+	if open <= 0 {
+		return none
+	}
+	base_tokens := index_tokens[..open]
+	map_type := g.infer_expression_type(base_tokens) or { return none }
+	key_type, value_type := g.map_key_value_types(map_type) or { return none }
+	key_source := g.render_call_argument_expression(index_tokens[open + 1..close], key_type) or {
+		return none
+	}
+	mut map_source := if base_tokens.len == 1 && base_tokens[0].tok == .name {
+		g.resolved_root_expression_name(base_tokens[0].lit)
+	} else {
+		g.render_member_receiver(base_tokens) or { return none }
+	}
+	if map_type.ends_with('*') {
+		map_source = '*(${map_source})'
+	}
+	return FastcRenderedExpression{
+		source: '({ ${key_type} __v_fastc_inc_key = (${key_source}); ${value_type} *__v_fastc_inc_value = (${value_type} *)builtin__map_get_check((map *)&(${map_source}), &__v_fastc_inc_key); if (__v_fastc_inc_value == NULL) { ${value_type} __v_fastc_inc_zero = (${value_type}){0}; builtin__map_set((map *)&(${map_source}), &__v_fastc_inc_key, &__v_fastc_inc_zero); __v_fastc_inc_value = (${value_type} *)builtin__map_get_check((map *)&(${map_source}), &__v_fastc_inc_key); } (*__v_fastc_inc_value)${op}; })'
+		typ: value_type
+	}
+}
+
 fn (g &Parser) render_map_lookup_option_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	// Strip leading `(` that have no matching `)` within these tokens: a grouped `or`-operand
+	// (`(m[k]` — the closing `)` sits after the `or { … }`) carries such an unmatched paren,
+	// while a deref base (`(*g.m)[k]`) keeps its balanced `(...)` for the base logic below.
 	mut start := 0
 	for start < tokens.len && tokens[start].tok == .lpar {
+		mut paren_depth := 0
+		mut matched := false
+		for i := start; i < tokens.len; i++ {
+			if tokens[i].tok == .lpar {
+				paren_depth++
+			} else if tokens[i].tok == .rpar {
+				paren_depth--
+				if paren_depth == 0 {
+					matched = true
+					break
+				}
+			}
+		}
+		if matched {
+			break
+		}
 		start++
 	}
-	lookup_tokens := tokens[start..]
+	mut lookup_tokens := tokens[start..].clone()
+	address_of_value := lookup_tokens.len > 1 && lookup_tokens[0].tok in [.amp, .and] && fastc_token_is_prefix_operator(lookup_tokens, 0)
+	if address_of_value {
+		lookup_tokens = lookup_tokens[1..].clone()
+	}
 	if lookup_tokens.len < 4 || lookup_tokens.last().tok != .rsbr {
 		return none
 	}
@@ -2333,20 +3728,144 @@ fn (g &Parser) render_map_lookup_option_expression(tokens []FastcExpressionToken
 	if open <= 0 {
 		return none
 	}
-	base_tokens := lookup_tokens[..open]
+	base_tokens := fastc_strip_paren_tokens(lookup_tokens[..open])
 	map_type := g.infer_expression_type(base_tokens) or { return none }
 	key_type, value_type := g.map_key_value_types(map_type) or { return none }
-	mut map_source := if base_tokens.len == 1 && base_tokens[0].tok == .name {
-		g.resolved_root_expression_name(base_tokens[0].lit)
+	// A nested-composite value type (`map[string]map[int][][]T` yields `Map_int_Array_Array_T`)
+	// is spelled in the lookup but is otherwise unreferenced, so register it here to emit its
+	// typedef.
+	mut wc := unsafe { &Parser(g) }
+	fastc_register_composite_type(value_type, mut wc.composite_types)
+	fastc_register_composite_type(key_type, mut wc.composite_types)
+	mut map_source := ''
+	mut needs_receiver_temp := false
+	if base_tokens.len == 1 && base_tokens[0].tok == .name {
+		map_source = g.resolved_root_expression_name(base_tokens[0].lit)
+	} else if base_tokens.len >= 2 && base_tokens[0].tok == .mul {
+		// `(*g.m)[k]` reads through a pointer-to-map; render the pointee map value so the
+		// `&(map)` the lookup takes below resolves back to the original pointer.
+		inner := g.render_member_receiver(base_tokens[1..]) or {
+			g.render_raw_expression_tokens(base_tokens[1..]) or { return none }
+		}
+		map_source = '*(${inner})'
+	} else if base_tokens.len > 0 && base_tokens.last().tok == .rsbr && g.render_map_expression(base_tokens) != none {
+		// A nested map read (`m[k1][k2]`): the base is itself a map lookup, an rvalue, so `&`
+		// it through a temp rather than treating it as a member chain / raw C index.
+		map_base := g.render_map_expression(base_tokens) or { return none }
+		map_source = map_base.source
+		needs_receiver_temp = true
+	} else if member := g.render_member_receiver(base_tokens) {
+		map_source = member
+	} else if call := g.render_missing_call_arguments(base_tokens) {
+		// A map produced by a call (`os.environ()[k]`) is an rvalue, so `&` needs a temp.
+		map_source = call.source
+		needs_receiver_temp = true
+	} else if method_base := g.render_method_call_expression(base_tokens, g.render_raw_expression_tokens(base_tokens) or {
+		''
+	}) {
+		// A map produced by a method call (`t.get_map()[k]`) is an rvalue too, so `&` needs a temp.
+		map_source = method_base.source
+		needs_receiver_temp = true
 	} else {
-		g.render_member_receiver(base_tokens) or { return none }
+		return none
 	}
 	if map_type.ends_with('*') {
 		map_source = '*(${map_source})'
 	}
 	key_source := g.render_membership_candidate(lookup_tokens[open + 1..lookup_tokens.len - 1], key_type) or { return none }
+	option_value_type := if address_of_value { '${value_type}*' } else { value_type }
+	option_result := if address_of_value {
+		'__v_fastc_map_value == NULL ? (Option){.state=2} : ${fastc_option_success_expression(option_value_type, '__v_fastc_map_value')}'
+	} else {
+		'(Option){.data=__v_fastc_map_value, .state=__v_fastc_map_value == NULL ? 2 : 0}'
+	}
+	if needs_receiver_temp {
+		return FastcRenderedExpression{
+			source: '({ ${map_type.trim_right('*')} __v_fastc_map_receiver = (${map_source}); ${key_type} __v_fastc_map_key = (${key_source}); ${value_type} *__v_fastc_map_value = (${value_type} *)builtin__map_get_check((map *)&(__v_fastc_map_receiver), &__v_fastc_map_key); ${option_result}; })'
+			typ: option_value_type
+		}
+	}
 	return FastcRenderedExpression{
-		source: '({ ${key_type} __v_fastc_map_key = (${key_source}); ${value_type} *__v_fastc_map_value = (${value_type} *)builtin__map_get_check((map *)&(${map_source}), &__v_fastc_map_key); (Option){.data=__v_fastc_map_value, .state=__v_fastc_map_value == NULL ? 2 : 0}; })'
+		source: '({ ${key_type} __v_fastc_map_key = (${key_source}); ${value_type} *__v_fastc_map_value = (${value_type} *)builtin__map_get_check((map *)&(${map_source}), &__v_fastc_map_key); ${option_result}; })'
+		typ: option_value_type
+	}
+}
+
+// render_slice_option_expression lowers a bounds-checked slice used with `or` (`s[a..b] or
+// {…}`) into the Option form: the substring/subarray on success, none when a or b is out of
+// range. Handles string and dynamic-array receivers.
+fn (g &Parser) render_slice_option_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	mut lead := 0
+	for lead < tokens.len && tokens[lead].tok == .lpar {
+		lead++
+	}
+	slice_tokens := tokens[lead..]
+	if slice_tokens.len < 5 || slice_tokens.last().tok != .rsbr {
+		return none
+	}
+	close := slice_tokens.len - 1
+	mut open := -1
+	mut depth := 0
+	for i := close; i >= 0; i-- {
+		if slice_tokens[i].tok == .rsbr {
+			depth++
+		} else if slice_tokens[i].tok == .lsbr {
+			depth--
+			if depth == 0 {
+				open = i
+				break
+			}
+		}
+	}
+	if open <= 0 {
+		return none
+	}
+	mut range_index := -1
+	mut range_depth := 0
+	for i := open + 1; i < close; i++ {
+		match slice_tokens[i].tok {
+			.lpar, .lsbr, .lcbr { range_depth++ }
+			.rpar, .rsbr, .rcbr { range_depth-- }
+			.dotdot {
+				if range_depth == 0 {
+					range_index = i
+					break
+				}
+			}
+			else {}
+		}
+	}
+	if range_index < 0 {
+		return none
+	}
+	base_tokens := slice_tokens[..open]
+	base_type := g.infer_expression_type(base_tokens) or { return none }
+	base_layout := g.underlying_alias_type(base_type)
+	is_string := base_layout == 'string'
+	is_array := fastc_trim_pointer_suffix(base_type).starts_with('Array_')
+	if !is_string && !is_array {
+		return none
+	}
+	base_source := g.render_call_argument_expression(base_tokens, base_type) or { return none }
+	receiver_source := if base_type.ends_with('*') { '*(${base_source})' } else { base_source }
+	value_type := if is_string { 'string' } else { fastc_trim_pointer_suffix(base_type) }
+	low := if range_index == open + 1 {
+		'0'
+	} else {
+		g.render_membership_candidate(slice_tokens[open + 1..range_index], 'int') or { return none }
+	}
+	high := if range_index + 1 == close {
+		'__v_fastc_slice_receiver.len'
+	} else {
+		g.render_membership_candidate(slice_tokens[range_index + 1..close], 'int') or { return none }
+	}
+	slice_value := if is_string {
+		'builtin__string_substr(__v_fastc_slice_receiver, __v_fastc_slice_low, __v_fastc_slice_high)'
+	} else {
+		'builtin__array_slice(__v_fastc_slice_receiver, __v_fastc_slice_low, __v_fastc_slice_high)'
+	}
+	return FastcRenderedExpression{
+		source: '({ ${value_type} __v_fastc_slice_receiver = (${receiver_source}); int __v_fastc_slice_low = (${low}); int __v_fastc_slice_high = (${high}); bool __v_fastc_slice_ok = __v_fastc_slice_low >= 0 && __v_fastc_slice_low <= __v_fastc_slice_high && __v_fastc_slice_high <= __v_fastc_slice_receiver.len; ${value_type} __v_fastc_slice_value = __v_fastc_slice_ok ? (${slice_value}) : (${value_type}){0}; (Option){.data=__v_fastc_slice_ok ? v_fastc_interface_box(&__v_fastc_slice_value, sizeof(${value_type})) : NULL, .state=__v_fastc_slice_ok ? 0 : 2}; })'
 		typ: value_type
 	}
 }
@@ -2378,13 +3897,23 @@ fn (g &Parser) render_array_lookup_option_expression(tokens []FastcExpressionTok
 	}
 	base_tokens := lookup_tokens[..open]
 	base_type := g.infer_expression_type(base_tokens) or { return none }
-	if !fastc_trim_pointer_suffix(base_type).starts_with('Array_') {
+	base_layout := fastc_trim_pointer_suffix(g.underlying_alias_type(base_type))
+	base_source := g.render_call_argument_expression(base_tokens, base_type) or { return none }
+	index_source := g.render_membership_candidate(lookup_tokens[open + 1..lookup_tokens.len - 1], 'int') or { return none }
+	if base_layout == 'string' {
+		// `s[i] or { … }`: a byte index that is bounds-checked to a `?u8` (V's
+		// `at_with_check`), read from the `string`'s `.str`/`.len` payload.
+		string_source := if base_type.ends_with('*') { '*(${base_source})' } else { base_source }
+		return FastcRenderedExpression{
+			source: '({ int __v_fastc_str_index = (${index_source}); string __v_fastc_str = (${string_source}); bool __v_fastc_str_missing = __v_fastc_str_index < 0 || __v_fastc_str_index >= __v_fastc_str.len; u8 *__v_fastc_str_value = __v_fastc_str_missing ? NULL : (u8 *)(__v_fastc_str.str + __v_fastc_str_index); (Option){.data=__v_fastc_str_value, .state=__v_fastc_str_missing ? 2 : 0}; })'
+			typ: 'u8'
+		}
+	}
+	if !base_layout.starts_with('Array_') {
 		return none
 	}
 	element_type := g.array_element_type(base_type) or { return none }
-	base_source := g.render_call_argument_expression(base_tokens, base_type) or { return none }
 	array_source := if base_type.ends_with('*') { '*(${base_source})' } else { base_source }
-	index_source := g.render_membership_candidate(lookup_tokens[open + 1..lookup_tokens.len - 1], 'int') or { return none }
 	return FastcRenderedExpression{
 		source: '({ int __v_fastc_array_index = (${index_source}); ${base_type.trim_right('*')} __v_fastc_array = (${array_source}); bool __v_fastc_array_missing = __v_fastc_array_index < 0 || __v_fastc_array_index >= __v_fastc_array.len; ${element_type} *__v_fastc_array_value = __v_fastc_array_missing ? NULL : (${element_type} *)((byteptr)__v_fastc_array.data + (usize)__v_fastc_array_index * (usize)__v_fastc_array.element_size); (Option){.data=__v_fastc_array_value, .state=__v_fastc_array_missing ? 2 : 0}; })'
 		typ: element_type
@@ -2461,16 +3990,17 @@ fn (g &Parser) render_append_expression(tokens []FastcExpressionToken, rendered_
 		return none
 	}
 	left_type := g.infer_expression_type(tokens[..operator_index]) or { return none }
+	left_array_type := fastc_trim_pointer_suffix(g.underlying_alias_type(left_type))
 	element_type := g.array_element_type(left_type) or { return none }
 	right_tokens := tokens[operator_index + 1..]
 	right_type := g.infer_expression_type(right_tokens) or { return none }
-	normalized_right := fastc_normalize_inferred_type(right_type)
+	normalized_right := fastc_trim_pointer_suffix(g.underlying_alias_type(fastc_normalize_inferred_type(right_type)))
 	// `[]T << []T` is push-many (append each element), but when the element type is a
 	// sum type that lists `[]T` as a variant (a recursive sum type such as
 	// `type Value = []Value | int`), the array must be boxed as a single element
 	// instead. This mirrors the `sumtype_has_variant` guard the main C backend applies
 	// before selecting push-many (see vlib/v/gen/c/infix.v).
-	is_array_append := normalized_right == fastc_normalize_inferred_type(left_type) && !g.sumtype_has_variant(element_type, normalized_right)
+	is_array_append := normalized_right == left_array_type && !g.sumtype_has_variant(element_type, normalized_right)
 	separator := rendered_expression.index('<<') or { return none }
 	left_tokens := tokens[..operator_index]
 	mut left_source := rendered_expression[..separator]
@@ -2480,7 +4010,7 @@ fn (g &Parser) render_append_expression(tokens []FastcExpressionToken, rendered_
 	// `arr << [a, b]`), and any call (`arr << s.clone()`, `arr << f(x)`) need the argument
 	// renderer, which boxes variants, lowers indexing, and routes method/function calls.
 	// Render through it whenever it succeeds, keeping the raw form only as a fallback.
-	expected_right_type := if is_array_append { left_type } else { element_type }
+	expected_right_type := if is_array_append { left_array_type } else { element_type }
 	if rerendered := g.render_call_argument_expression(right_tokens, expected_right_type) {
 		right_source = rerendered
 	}
@@ -2505,19 +4035,45 @@ fn (g &Parser) render_append_expression(tokens []FastcExpressionToken, rendered_
 			if key_type, value_type := g.map_key_value_types(map_type) {
 				if value_type == left_type {
 					key_source := g.render_call_argument_expression(left_tokens[open + 1..left_tokens.len - 1], key_type) or { return none }
-					mut map_source := if base_tokens.len == 1 && base_tokens[0].tok == .name {
-						g.globals[fastc_global_key(g.module_name, base_tokens[0].lit)] or {
-							g.resolved_expression_name(base_tokens[0].lit, .unknown)
+					// The map to insert into is addressed as a `map *`. A nested base (`m[k1][k2]
+					// << x`) is itself a map value, so get a mutable pointer to it (which inserts
+					// an empty map when absent); a plain base is `&`-taken.
+					mut map_address := ''
+					if base_tokens.len > 1 && base_tokens.last().tok == .rsbr {
+						if nested := g.render_mutable_map_value_pointer(base_tokens) {
+							map_address = '(map *)(${nested.source})'
 						}
+					}
+					if map_address == '' {
+						mut map_source := if base_tokens.len == 1 && base_tokens[0].tok == .name {
+							g.globals[fastc_global_key(g.module_name, base_tokens[0].lit)] or {
+								g.resolved_expression_name(base_tokens[0].lit, .unknown)
+							}
+						} else {
+							g.render_member_receiver(base_tokens) or { return none }
+						}
+						if map_type.ends_with('*') {
+							map_source = '*(${map_source})'
+						}
+						map_address = '(map *)&(${map_source})'
+					}
+					// A missing entry whose value is itself an array must be created with a real
+					// header carrying `element_size`; a `(Array_x){0}` has element_size 0, so the
+					// following `<<` copies `len * 0` bytes and silently drops the value.
+					map_empty := if fastc_trim_pointer_suffix(value_type).starts_with('Array_') {
+						elem := g.array_element_type(value_type) or { return none }
+						'((${value_type})builtin____new_array(0, 0, sizeof(${fastc_normalize_inferred_type(elem)})))'
 					} else {
-						g.render_member_receiver(base_tokens) or { return none }
+						'(${value_type}){0}'
 					}
-					if map_type.ends_with('*') {
-						map_source = '*(${map_source})'
+					left_source = '({ map *__v_fastc_append_map_addr = ${map_address}; ${key_type} __v_fastc_append_map_key = (${key_source}); ${value_type} *__v_fastc_append_map_value = (${value_type} *)builtin__map_get_check(__v_fastc_append_map_addr, &__v_fastc_append_map_key); if (__v_fastc_append_map_value == NULL) { ${value_type} __v_fastc_append_map_empty = ${map_empty}; builtin__map_set(__v_fastc_append_map_addr, &__v_fastc_append_map_key, &__v_fastc_append_map_empty); __v_fastc_append_map_value = (${value_type} *)builtin__map_get_check(__v_fastc_append_map_addr, &__v_fastc_append_map_key); } __v_fastc_append_map_value; })'
+					map_push := if is_array_append {
+						'${value_type} ${temporary} = (${right_source}); ${value_type} *__v_fastc_append_map_target = ${left_source}; builtin__array_push_many((array *)__v_fastc_append_map_target, ${temporary}.data, ${temporary}.len);'
+					} else {
+						'${element_type} ${temporary} = (${right_source}); ${value_type} *__v_fastc_append_map_target = ${left_source}; builtin__array_push((array *)__v_fastc_append_map_target, &${temporary});'
 					}
-					left_source = '({ ${key_type} __v_fastc_append_map_key = (${key_source}); ${value_type} *__v_fastc_append_map_value = (${value_type} *)builtin__map_get_check((map *)&(${map_source}), &__v_fastc_append_map_key); if (__v_fastc_append_map_value == NULL) { ${value_type} __v_fastc_append_map_empty = (${value_type}){0}; builtin__map_set((map *)&(${map_source}), &__v_fastc_append_map_key, &__v_fastc_append_map_empty); __v_fastc_append_map_value = (${value_type} *)builtin__map_get_check((map *)&(${map_source}), &__v_fastc_append_map_key); } __v_fastc_append_map_value; })'
 					return FastcRenderedExpression{
-						source: '({ ${element_type} ${temporary} = (${right_source}); ${value_type} *__v_fastc_append_map_target = ${left_source}; builtin__array_push((array *)__v_fastc_append_map_target, &${temporary}); 0; })'
+						source: '({ ${map_push} 0; })'
 						typ: 'void'
 					}
 				}
@@ -2557,6 +4113,81 @@ fn (g &Parser) render_append_expression(tokens []FastcExpressionToken, rendered_
 			}
 		}
 	}
+	// `arr.last() << x` / `arr.last().field << x`: append to the last/first element of `arr` (or
+	// a field of it) in place. `.last()`/`.first()` are not C lvalues, so target the element
+	// through array_get and apply any trailing field chain to the element pointer.
+	mut last_first_index := -1
+	for k := 1; k + 2 < left_tokens.len; k++ {
+		if left_tokens[k].tok == .name && left_tokens[k].lit in ['last', 'first'] && left_tokens[k - 1].tok == .dot && left_tokens[k + 1].tok == .lpar && left_tokens[k + 2].tok == .rpar {
+			last_first_index = k
+			break
+		}
+	}
+	if last_first_index > 0 {
+		method := left_tokens[last_first_index].lit
+		base_tokens := left_tokens[..last_first_index - 1]
+		suffix_tokens := left_tokens[last_first_index + 3..]
+		base_type := g.infer_expression_type(base_tokens) or { '' }
+		mut suffix := ''
+		mut si := 0
+		mut suffix_ok := true
+		for si + 1 < suffix_tokens.len {
+			if suffix_tokens[si].tok == .dot && suffix_tokens[si + 1].tok == .name {
+				sep := if si == 0 { '->' } else { '.' }
+				suffix += '${sep}${suffix_tokens[si + 1].lit}'
+				si += 2
+			} else {
+				suffix_ok = false
+				break
+			}
+		}
+		if suffix_ok && fastc_trim_pointer_suffix(g.underlying_alias_type(base_type)).starts_with('Array_') {
+			if elem_type := g.array_element_type(base_type) {
+				base_source := if base_tokens.len == 1 {
+					g.resolved_root_expression_name(base_tokens[0].lit)
+				} else if nested_base := g.render_array_access_expression(base_tokens) {
+					nested_base.source
+				} else if raw_base := g.render_raw_expression_tokens(base_tokens) {
+					g.render_member_receiver(base_tokens) or { raw_base }
+				} else {
+					return none
+				}
+				array_value := if base_type.ends_with('*') {
+					'*(${base_source})'
+				} else {
+					base_source
+				}
+				arr_tmp := '__v_fastc_append_last_array'
+				elem_tmp := '__v_fastc_append_last_elem'
+				norm_elem := fastc_normalize_inferred_type(elem_type)
+				index := if method == 'last' { '${arr_tmp}.len - 1' } else { '0' }
+				// No trailing field: the element itself is the array; otherwise the target is the
+				// field reached through the element pointer.
+				target := if suffix == '' {
+					'(array *)${elem_tmp}'
+				} else {
+					'(array *)&(${elem_tmp}${suffix})'
+				}
+				push := if is_array_append {
+					'builtin__array_push_many(${target}, ${temporary}.data, ${temporary}.len);'
+				} else {
+					'builtin__array_push(${target}, &${temporary});'
+				}
+				value_decl := if is_array_append { left_type.trim_right('*') } else { element_type }
+				return FastcRenderedExpression{
+					source: '({ array ${arr_tmp} = (${array_value}); ${norm_elem} *${elem_tmp} = (${norm_elem} *)builtin__array_get(${arr_tmp}, ${index}); ${value_decl} ${temporary} = (${right_source}); ${push} 0; })'
+					typ: 'void'
+				}
+			}
+		}
+	}
+	// A member-chain target that indexes a dynamic array mid-chain (`b.files[i].errors`)
+	// cannot be spelled with raw C indexing; the member receiver renderer lowers it.
+	if left_tokens.len > 1 {
+		if member_left := g.render_member_receiver(left_tokens) {
+			left_source = member_left
+		}
+	}
 	if is_array_append {
 		array_target := if left_type.ends_with('*') {
 			'(array *)(${left_source})'
@@ -2589,7 +4220,7 @@ fn (g &Parser) render_composed_string_concatenation(tokens []FastcExpressionToke
 			}
 			.plus {
 				if depth == 0 {
-					operand_type := g.infer_expression_type(tokens[operand_start..i]) or { '' }
+					operand_type := g.concatenation_operand_type(tokens[operand_start..i])
 					string_operands << fastc_trim_pointer_suffix(g.underlying_alias_type(operand_type)) == 'string'
 					operand_start = i + 1
 					plus_count++
@@ -2601,7 +4232,7 @@ fn (g &Parser) render_composed_string_concatenation(tokens []FastcExpressionToke
 	if plus_count == 0 {
 		return none
 	}
-	last_operand_type := g.infer_expression_type(tokens[operand_start..]) or { '' }
+	last_operand_type := g.concatenation_operand_type(tokens[operand_start..])
 	string_operands << fastc_trim_pointer_suffix(g.underlying_alias_type(last_operand_type)) == 'string'
 	mut has_string_operand := false
 	for is_string in string_operands {
@@ -2622,14 +4253,14 @@ fn (g &Parser) render_composed_string_concatenation(tokens []FastcExpressionToke
 		} else if item.tok in [.rpar, .rsbr, .rcbr] {
 			depth--
 		} else if item.tok == .plus && depth == 0 {
-			part := g.render_comparison_operand(tokens[operand_start..i], 'string') or {
+			part := g.render_concatenation_operand(tokens[operand_start..i]) or {
 				return none
 			}
 			parts << part
 			operand_start = i + 1
 		}
 	}
-	last_part := g.render_comparison_operand(tokens[operand_start..], 'string') or { return none }
+	last_part := g.render_concatenation_operand(tokens[operand_start..]) or { return none }
 	parts << last_part
 	mut combined := ''
 	if g.selfhost {
@@ -2646,6 +4277,31 @@ fn (g &Parser) render_composed_string_concatenation(tokens []FastcExpressionToke
 	}
 }
 
+// concatenation_operand_type returns the value type of one `+` operand in a string
+// concatenation, resolving a trailing `?`/`!` option/result propagation to the propagated
+// value type (`part(a)? + part(b)?` concatenates two strings, not two `Option`s).
+fn (g &Parser) concatenation_operand_type(tokens []FastcExpressionToken) string {
+	if tokens.len > 1 && tokens.last().tok in [.question, .not] {
+		inner := tokens[..tokens.len - 1]
+		value_type := g.option_value_type_for_expression(inner)
+		if value_type != '' {
+			return value_type
+		}
+		return g.infer_expression_type(inner) or { '' }
+	}
+	return g.infer_expression_type(tokens) or { '' }
+}
+
+// render_concatenation_operand renders one `+` operand of a string concatenation. An operand
+// ending in a `?`/`!` propagation is lowered through the argument path (which turns the
+// propagation into its unwrap stmt-expr); a plain operand keeps the comparison-operand path.
+fn (g &Parser) render_concatenation_operand(tokens []FastcExpressionToken) ?string {
+	if tokens.len > 1 && tokens.last().tok in [.question, .not] {
+		return g.render_call_argument_expression(tokens, 'string')
+	}
+	return g.render_comparison_operand(tokens, 'string')
+}
+
 // render_option_propagation lowers a `!`/`?`-propagated expression (`inner_tokens` is
 // the operand WITHOUT the trailing `!`): evaluate the option, propagate its error state
 // (return in a result fn, panic in `main`), else yield the unwrapped value. Used both
@@ -2656,7 +4312,13 @@ fn (g &Parser) render_option_propagation(inner_tokens []FastcExpressionToken) ?F
 	}
 	inner_raw := g.render_raw_expression_tokens(inner_tokens) or { return none }
 	mut inner_source := inner_raw
-	if explicit_generic := g.render_explicit_generic_call_expression(inner_tokens) {
+	if defaulted_call := g.render_missing_call_arguments(inner_tokens) {
+		// A plain `f(a, b)` call renders each argument through render_call_argument_expression,
+		// which lowers nested propagation (`f(x.m()?, y.m()?)?`) and fills defaults. The raw
+		// method-call rewrite below only rewrites method-call arguments in place, leaving a
+		// stray `?` (a C ternary) in them, so prefer the argument-aware path for whole calls.
+		inner_source = defaulted_call.source
+	} else if explicit_generic := g.render_explicit_generic_call_expression(inner_tokens) {
 		inner_source = explicit_generic.source
 	} else if static_expression := g.render_static_call_expression(inner_tokens, inner_raw) {
 		inner_source = static_expression.source
@@ -2693,6 +4355,45 @@ fn (g &Parser) render_option_propagation(inner_tokens []FastcExpressionToken) ?F
 		source: '({ Option ${temporary} = (${inner_source}); if (${temporary}.state) { ${failure} } ${value}; })'
 		typ: value_type
 	}
+}
+
+// render_propagation_before_member lowers `x()?.field` / `x()?.method(a)`: the `?`/`!`
+// propagates the option from `x()`, unwrapping it to the value, and the trailing member chain
+// then applies to that value. Returns none when there is no such mid-expression propagation.
+fn (g &Parser) render_propagation_before_member(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	mut depth := 0
+	for i, item in tokens {
+		match item.tok {
+			.lpar, .lsbr, .lcbr {
+				depth++
+			}
+			.rpar, .rsbr, .rcbr {
+				depth--
+			}
+			.question, .not {
+				if depth == 0 && i > 0 && i + 1 < tokens.len && tokens[i + 1].tok == .dot && !fastc_trailing_not_marks_fixed_array_literal(tokens[..i + 1]) {
+					unwrapped := g.render_option_propagation(tokens[..i]) or { return none }
+					if unwrapped.typ in ['', 'void'] {
+						return none
+					}
+					synth := FastcExpressionToken{
+						tok: .name
+						source: '(${unwrapped.source})'
+						typ: unwrapped.typ
+					}
+					mut chained := [synth]
+					chained << tokens[i + 1..]
+					source := g.render_call_argument_expression(chained, '') or { return none }
+					return FastcRenderedExpression{
+						source: source
+						typ: g.infer_expression_type(chained) or { '' }
+					}
+				}
+			}
+			else {}
+		}
+	}
+	return none
 }
 
 fn (g &Parser) render_nested_option_propagation(tokens []FastcExpressionToken, rendered_expression string) ?FastcRenderedExpression {
@@ -2768,6 +4469,13 @@ fn (g &Parser) render_method_receiver_expression(tokens []FastcExpressionToken) 
 	if cast_expression := g.render_cast_expression(tokens) {
 		return cast_expression
 	}
+	// A method receiver may be a member `as`-cast (`(sym.info as GenericInst).types.any(…)`);
+	// lower it here so the `as` does not reach the raw renderer intact.
+	if g.selfhost && tokens.len > 0 && tokens[0].tok == .lpar {
+		if as_member := g.render_as_cast_member_access(tokens) {
+			return as_member
+		}
+	}
 	if struct_literal := g.render_struct_literal_expression(tokens) {
 		return struct_literal
 	}
@@ -2778,6 +4486,14 @@ fn (g &Parser) render_method_receiver_expression(tokens []FastcExpressionToken) 
 		return FastcRenderedExpression{
 			source: source
 			typ: receiver_type
+		}
+	}
+	if g.selfhost {
+		// A call receiver may omit trailing defaulted / `@[params]` arguments
+		// (`new_suggestion(a, b).say(...)`); fill them here so the raw renderer below does
+		// not emit the call with too few arguments.
+		if defaulted := g.render_missing_call_arguments(tokens) {
+			return defaulted
 		}
 	}
 	if raw := g.render_raw_expression_tokens(tokens) {
@@ -2794,17 +4510,371 @@ fn (g &Parser) render_method_receiver_expression(tokens []FastcExpressionToken) 
 	return none
 }
 
+// render_sumtype_common_field_access lowers `x.f` where `x` is a boxed sum type and `f`
+// is a field common to every variant (V's "common sum-type field"). FastC boxes only a
+// `void*` payload, so the field is read through a runtime switch on the type tag that
+// casts the payload to the matched variant. Returns none unless `tokens` is exactly such
+// a member chain.
+// fastc_sumtype_field_switch_source renders the `({ … switch(_typ) … })` statement-expression
+// that reads the common field `field_name` (type `field_type`) from the boxed sum type
+// `receiver_type` (already rendered as `receiver_source`).
+fn (g &Parser) fastc_sumtype_field_switch_source(receiver_type string, receiver_source string, field_name string, field_type string) ?string {
+	access := if receiver_type.ends_with('*') { '->' } else { '.' }
+	subject := '__v_fastc_sumfield'
+	result_var := '__v_fastc_sumfield_result'
+	mut cases := []string{}
+	for variant in g.sum_type_leaf_variants(receiver_type) {
+		field := g.struct_field_metadata(variant, field_name) or { return none }
+		member := '((${variant} *)${subject}${access}_object)->${fastc_c_identifier(field.name)}'
+		cases << 'case __v_typeid_${variant}: ${result_var} = ${member}; break;'
+	}
+	return '({ ${receiver_type} ${subject} = (${receiver_source}); ${field_type} ${result_var}; switch (${subject}${access}_typ) { ${cases.join(' ')} default: memset(&${result_var}, 0, sizeof(${result_var})); break; } ${result_var}; })'
+}
+
+// fastc_interface_field_switch_source reads an interface FIELD (`iface.file`) through the boxed
+// object: a runtime `switch` on the interface's `_typ` casts `_object` to each implementer and
+// reads the field. FastC keeps no implementers list, so enumerate every declared struct/union whose
+// field of the same name has the interface field's type — only the real implementers' tags ever
+// occur at runtime, so any coincidental extra case is dead. Mirrors the sum-type field switch.
+fn (g &Parser) fastc_interface_field_switch_source(receiver_type string, receiver_source string, field_name string, field_type string) ?string {
+	access := if receiver_type.ends_with('*') { '->' } else { '.' }
+	subject := '__v_fastc_ifacefield'
+	result_var := '__v_fastc_ifacefield_result'
+	normalized_field_type := fastc_normalize_inferred_type(field_type)
+	mut cases := []string{}
+	for type_key, kind in g.declared_kinds {
+		if kind !in [.struct_, .union_] {
+			continue
+		}
+		c_type := fastc_c_declared_type_name(type_key)
+		field := g.struct_field_metadata(c_type, field_name) or { continue }
+		if field.storage_path.len > 0 || fastc_normalize_inferred_type(field.typ) != normalized_field_type {
+			continue
+		}
+		member := '((${c_type} *)${subject}${access}_object)->${fastc_c_identifier(field.name)}'
+		cases << 'case __v_typeid_${c_type}: ${result_var} = ${member}; break;'
+	}
+	if cases.len == 0 {
+		return none
+	}
+	return '({ ${receiver_type} ${subject} = (${receiver_source}); ${normalized_field_type} ${result_var}; switch (${subject}${access}_typ) { ${cases.join(' ')} default: memset(&${result_var}, 0, sizeof(${result_var})); break; } ${result_var}; })'
+}
+
+fn (g &Parser) render_sumtype_common_field_access(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	if tokens.len < 3 || tokens.last().tok != .name || tokens[tokens.len - 2].tok != .dot {
+		return none
+	}
+	// Phase 1: the LAST field is the common field. Its receiver may be ANY paren-balanced
+	// expression, including a method call / index (`node.stmts.first().pos`).
+	receiver_tokens := tokens[..tokens.len - 2]
+	mut receiver_depth := 0
+	for item in receiver_tokens {
+		match item.tok {
+			.lpar, .lsbr, .lcbr { receiver_depth++ }
+			.rpar, .rsbr, .rcbr { receiver_depth-- }
+			else {}
+		}
+	}
+	if receiver_depth == 0 {
+		if receiver_type := g.infer_expression_type(receiver_tokens) {
+			if field_type := g.sumtype_common_field_type(receiver_type, tokens.last().lit) {
+				// A plain member chain renders through render_member_receiver; a call/index
+				// receiver is rendered as a general expression.
+				receiver_source := if member := g.render_member_receiver(receiver_tokens) {
+					member
+				} else {
+					g.render_call_argument_expression(receiver_tokens, receiver_type) or {
+						return none
+					}
+				}
+				if switch_source := g.fastc_sumtype_field_switch_source(receiver_type, receiver_source, tokens.last().lit, field_type) {
+					return FastcRenderedExpression{
+						source: switch_source
+						typ: field_type
+					}
+				}
+			}
+		}
+	}
+	// Phase 2: the common field sits MID-CHAIN in a plain member chain (`expr.or_expr.kind`),
+	// with plain field accesses following it. Only a fully name/dot chain qualifies.
+	if tokens[0].tok != .name {
+		return none
+	}
+	mut current_type := g.infer_expression_type(tokens[..1]) or { return none }
+	mut split := -1
+	mut common_field := ''
+	mut field_type := ''
+	mut i := 1
+	for i + 1 < tokens.len {
+		if tokens[i].tok != .dot || tokens[i + 1].tok != .name {
+			return none
+		}
+		field := tokens[i + 1].lit
+		if ft := g.sumtype_common_field_type(current_type, field) {
+			split = i
+			common_field = field
+			field_type = ft
+			break
+		}
+		next_type := g.struct_member_type(current_type, field)
+		if next_type == '' {
+			return none
+		}
+		current_type = next_type
+		i += 2
+	}
+	// A common field at the very end was already handled by phase 1; require a real suffix.
+	if split < 0 || split + 2 >= tokens.len {
+		return none
+	}
+	mid_receiver_tokens := tokens[..split]
+	mid_receiver_type := g.infer_expression_type(mid_receiver_tokens) or { return none }
+	receiver_source := g.render_member_receiver(mid_receiver_tokens) or { return none }
+	switch_source := g.fastc_sumtype_field_switch_source(mid_receiver_type, receiver_source, common_field, field_type) or { return none }
+	mut suffix := ''
+	mut suffix_type := field_type
+	mut j := split + 2
+	for j + 1 < tokens.len {
+		if tokens[j].tok != .dot || tokens[j + 1].tok != .name {
+			return none
+		}
+		f := g.struct_field_metadata(suffix_type, tokens[j + 1].lit) or { return none }
+		separator := if suffix_type.ends_with('*') { '->' } else { '.' }
+		suffix += separator + fastc_c_identifier(f.name)
+		suffix_type = f.typ
+		j += 2
+	}
+	return FastcRenderedExpression{
+		source: '(${switch_source})${suffix}'
+		typ: suffix_type
+	}
+}
+
+// render_sumtype_common_field_assignment lowers `x.field = value` where `x` is a boxed sum type
+// and `field` is common to every variant. The boxed value stores the field in the concrete
+// variant behind `_object`, so the assignment dispatches on the runtime tag and writes through
+// the matched variant pointer (which the copied box shares), mirroring the read helper.
+fn (g &Parser) render_sumtype_common_field_assignment(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	mut depth := 0
+	mut assign_idx := -1
+	for i, item in tokens {
+		match item.tok {
+			.lpar, .lsbr, .lcbr { depth++ }
+			.rpar, .rsbr, .rcbr { depth-- }
+			.assign {
+				if depth == 0 {
+					assign_idx = i
+					break
+				}
+			}
+			else {}
+		}
+	}
+	if assign_idx <= 0 || assign_idx + 1 >= tokens.len {
+		return none
+	}
+	lhs := tokens[..assign_idx]
+	if lhs.len < 3 || lhs.last().tok != .name || lhs[lhs.len - 2].tok != .dot {
+		return none
+	}
+	field_name := lhs.last().lit
+	receiver_tokens := lhs[..lhs.len - 2]
+	mut rdepth := 0
+	for item in receiver_tokens {
+		match item.tok {
+			.lpar, .lsbr, .lcbr { rdepth++ }
+			.rpar, .rsbr, .rcbr { rdepth-- }
+			else {}
+		}
+	}
+	if rdepth != 0 {
+		return none
+	}
+	receiver_type := g.infer_expression_type(receiver_tokens) or { return none }
+	field_type := g.sumtype_common_field_type(receiver_type, field_name) or { return none }
+	receiver_source := if member := g.render_member_receiver(receiver_tokens) {
+		member
+	} else {
+		g.render_call_argument_expression(receiver_tokens, receiver_type) or { return none }
+	}
+	value_source := g.render_call_argument_expression(tokens[assign_idx + 1..], field_type) or {
+		return none
+	}
+	access := if receiver_type.ends_with('*') { '->' } else { '.' }
+	subject := '__v_fastc_sumfield_assign'
+	value_var := '__v_fastc_sumfield_assign_value'
+	mut cases := []string{}
+	for variant in g.sum_type_leaf_variants(receiver_type) {
+		field := g.struct_field_metadata(variant, field_name) or { return none }
+		member := '((${variant} *)${subject}${access}_object)->${fastc_c_identifier(field.name)}'
+		cases << 'case __v_typeid_${variant}: ${member} = ${value_var}; break;'
+	}
+	source := '({ ${receiver_type} ${subject} = (${receiver_source}); ${field_type} ${value_var} = (${value_source}); switch (${subject}${access}_typ) { ${cases.join(' ')} default: break; } (void)0; })'
+	return FastcRenderedExpression{
+		source: source
+		typ: 'void'
+	}
+}
+
+// render_common_field_comparison_expression renders a top-level comparison in which an
+// operand reads a common sum-type field (`node.typ == ast.invalid_type`). Such operands
+// lower to a switch statement-expression, which the ordinary raw comparison path cannot
+// splice in, so both operands are rendered through render_comparison_operand here.
+fn (g &Parser) render_common_field_comparison_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
+	mut depth := 0
+	mut op_index := -1
+	mut op := token.Token.unknown
+	for i, item in tokens {
+		match item.tok {
+			.lpar, .lsbr, .lcbr { depth++ }
+			.rpar, .rsbr, .rcbr { depth-- }
+			.eq, .ne, .lt, .gt, .le, .ge {
+				if depth == 0 && op_index < 0 {
+					op_index = i
+					op = item.tok
+				}
+			}
+			else {}
+		}
+	}
+	if op_index <= 0 || op_index + 1 >= tokens.len {
+		return none
+	}
+	left_tokens := tokens[..op_index]
+	right_tokens := tokens[op_index + 1..]
+	if g.render_sumtype_common_field_access(left_tokens) == none && g.render_sumtype_common_field_access(right_tokens) == none {
+		return none
+	}
+	left_type := g.infer_expression_type(left_tokens) or { '' }
+	right_type := g.infer_expression_type(right_tokens) or { '' }
+	left_source := g.render_comparison_operand(left_tokens, right_type) or { return none }
+	right_source := g.render_comparison_operand(right_tokens, left_type) or { return none }
+	if fastc_normalize_inferred_type(left_type) == 'string' || fastc_normalize_inferred_type(right_type) == 'string' {
+		if op == .eq {
+			return FastcRenderedExpression{
+				source: 'builtin__string_eq(${left_source}, ${right_source})'
+				typ: 'bool'
+			}
+		}
+		if op == .ne {
+			return FastcRenderedExpression{
+				source: '(!builtin__string_eq(${left_source}, ${right_source}))'
+				typ: 'bool'
+			}
+		}
+	}
+	c_op := match op {
+		.eq { '==' }
+		.ne { '!=' }
+		.lt { '<' }
+		.gt { '>' }
+		.le { '<=' }
+		.ge { '>=' }
+		else {
+			return none
+		}
+	}
+	return FastcRenderedExpression{
+		source: '((${left_source}) ${c_op} (${right_source}))'
+		typ: 'bool'
+	}
+}
+
 fn (g &Parser) render_member_receiver(tokens []FastcExpressionToken) ?string {
 	if tokens.len == 0 || tokens[0].tok != .name {
 		return none
 	}
-	mut source := g.resolved_expression_name(tokens[0].lit, .unknown)
-	mut current_type := g.infer_expression_type(tokens[..1]) or { return none }
+	mut source := ''
+	mut current_type := ''
+	if tokens[0].source != '' {
+		// A synthetic base token (an `x()?`-unwrap folded upstream: `get()!.field`) carries its C
+		// spelling and type in `.source`/`.typ`, not `.lit`; use them so the member chain reads from
+		// the real unwrapped value instead of an empty base.
+		source = tokens[0].source
+		current_type = tokens[0].typ
+	} else {
+		source = g.resolved_expression_name(tokens[0].lit, .unknown)
+		current_type = g.infer_expression_type(tokens[..1]) or { return none }
+	}
 	mut member_path := tokens[0].lit
+	mut multi_variants := []string{}
+	mut multi_tag_source := ''
+	mut multi_object_source := ''
+	// A smart-cast on the bare subject itself (`x is T`, narrowing the whole local) also
+	// applies before the first field access.
+	if smartcast := g.member_smartcasts[member_path] {
+		source = smartcast.source
+		current_type = smartcast.typ
+		multi_variants = smartcast.variants.clone()
+		multi_tag_source = smartcast.tag_source
+		multi_object_source = smartcast.object_source
+	}
 	mut i := 1
 	for i < tokens.len {
+		if tokens[i].tok == .lsbr {
+			// A dynamic-array element inside the chain (`b.files[i].errors`) is reached
+			// through the erased `.data` storage, so C indexing on the `array` struct itself
+			// is invalid — cast to the element pointer first.
+			close := fastc_matching_delimiter(tokens, i, .lsbr, .rsbr) or { return none }
+			layout := fastc_trim_pointer_suffix(g.underlying_alias_type(current_type))
+			if !layout.starts_with('Array_') {
+				return none
+			}
+			element_type := g.array_element_type(current_type) or { return none }
+			index_source := g.render_membership_candidate(tokens[i + 1..close], 'int') or {
+				return none
+			}
+			data_separator := if current_type.ends_with('*') { '->' } else { '.' }
+			source = '((${element_type} *)(${source})${data_separator}data)[${index_source}]'
+			current_type = element_type
+			member_path += '[]'
+			// A smart-cast on the indexed element itself (`node.left[0] is Ident`, keyed
+			// `node.left[]`) applies before a FOLLOWING field access (`node.left[0].name`), just
+			// as one on a `.field` subject does below. When the index is the last segment (the
+			// chain IS the smart-cast subject, e.g. a `node.left[i].method()` receiver), leave the
+			// boxed value in place so the caller's own variant unwrap is not applied twice.
+			if close + 1 < tokens.len {
+				if smartcast := g.member_smartcasts[member_path] {
+					source = smartcast.source
+					current_type = smartcast.typ
+					multi_variants = smartcast.variants.clone()
+					multi_tag_source = smartcast.tag_source
+					multi_object_source = smartcast.object_source
+				}
+			}
+			i = close + 1
+			continue
+		}
 		if i + 1 >= tokens.len || tokens[i].tok != .dot || tokens[i + 1].tok != .name {
 			return none
+		}
+		if multi_variants.len > 1 {
+			projected := g.render_multi_variant_field_projection(multi_variants, multi_tag_source, multi_object_source, tokens[i + 1].lit) or { return none }
+			source = projected.source
+			current_type = projected.typ
+			multi_variants = []
+			member_path += '.' + tokens[i + 1].lit
+			if smartcast := g.member_smartcasts[member_path] {
+				source = smartcast.source
+				current_type = smartcast.typ
+				multi_variants = smartcast.variants.clone()
+				multi_tag_source = smartcast.tag_source
+				multi_object_source = smartcast.object_source
+			}
+			i += 2
+			continue
+		}
+		if g.declared_kinds[g.semantic_type_key(current_type)] == .interface_ {
+			// An interface FIELD (`iface.file`) is not a member of the boxed `{_object,_typ,…}`
+			// struct; read it through a runtime `_typ` switch over the interface's implementers.
+			if iface_field := g.interface_fields['${g.semantic_type_key(current_type)}.${tokens[i + 1].lit}'] {
+				source = g.fastc_interface_field_switch_source(current_type, source, iface_field.name, iface_field.typ) or { return none }
+				current_type = fastc_normalize_inferred_type(iface_field.typ)
+				member_path += '.' + tokens[i + 1].lit
+				i += 2
+				continue
+			}
 		}
 		field := g.struct_field_metadata(current_type, tokens[i + 1].lit) or { return none }
 		for storage_name in field.storage_path {
@@ -2816,16 +4886,50 @@ fn (g &Parser) render_member_receiver(tokens []FastcExpressionToken) ?string {
 			}
 		}
 		separator := if current_type.ends_with('*') { '->' } else { '.' }
-		source += separator + fastc_c_identifier(field.name)
+		field_source := source + separator + fastc_c_identifier(field.name)
+		source = if field.is_shared_pointer { '*(${field_source})' } else { field_source }
 		current_type = field.typ
 		member_path += '.' + tokens[i + 1].lit
 		if smartcast := g.member_smartcasts[member_path] {
 			source = smartcast.source
 			current_type = smartcast.typ
+			multi_variants = smartcast.variants.clone()
+			multi_tag_source = smartcast.tag_source
+			multi_object_source = smartcast.object_source
 		}
 		i += 2
 	}
 	return source
+}
+
+// render_multi_variant_field_projection reads a field shared by every type in a grouped
+// sum-type match arm. The structs can place that field at different offsets, so select its
+// address using the runtime tag instead of casting every variant to the first arm type.
+fn (g &Parser) render_multi_variant_field_projection(variants []string, tag_source string, object_source string, field_name string) ?FastcRenderedExpression {
+	if variants.len < 2 || tag_source == '' || object_source == '' {
+		return none
+	}
+	mut field_type := ''
+	mut pointer_source := ''
+	for i := variants.len - 1; i >= 0; i-- {
+		variant := variants[i]
+		field := g.struct_field_metadata(variant, field_name) or { return none }
+		if field.storage_path.len > 0 {
+			return none
+		}
+		if field_type == '' {
+			field_type = field.typ
+			pointer_source = '((${field_type} *)0)'
+		} else if field.typ != field_type {
+			return none
+		}
+		field_pointer := '&((${variant} *)(${object_source}))->${fastc_c_identifier(field.name)}'
+		pointer_source = '((${tag_source}) == __v_typeid_${variant} ? ${field_pointer} : ${pointer_source})'
+	}
+	return FastcRenderedExpression{
+		source: '(*(${pointer_source}))'
+		typ: field_type
+	}
 }
 
 fn fastc_split_top_level_c_plus(source string) []string {

--- a/vlib/v3/gen/fastc/render_calls.v
+++ b/vlib/v3/gen/fastc/render_calls.v
@@ -147,7 +147,14 @@ fn (g &Parser) render_cast_expression(tokens []FastcExpressionToken) ?FastcRende
 	type_start := if is_option_cast { 1 } else { 0 }
 	mut open := -1
 	mut c_type := ''
-	type_qualifier_start := if tokens.len > 0 && tokens[0].tok in [.amp, .and] { 1 } else { 0 }
+	// The qualified-type check below reads the token where the type name begins; skip a leading
+	// `&`/`&&` pointer prefix or a `?` option-cast prefix (`?flat.NodeId(none)`) so a module
+	// qualifier (`flat.`) is recognized rather than mistaken for a `receiver.method(` call.
+	type_qualifier_start := if tokens.len > 0 && tokens[0].tok in [.amp, .and, .question] {
+		1
+	} else {
+		0
+	}
 	for i, item in tokens {
 		if item.tok != .lpar || i <= type_start {
 			continue
@@ -205,7 +212,43 @@ fn (g &Parser) render_cast_expression(tokens []FastcExpressionToken) ?FastcRende
 			typ: 'Option'
 		}
 	}
-	inner := g.render_call_argument_expression(inner_tokens, c_type) or { return none }
+	// A conversion into a boxed sum type (`Expr(EmptyExpr(0))`) is a box, not a C cast: the
+	// concrete variant value is stored behind `_object` with its own type id. Casting the
+	// variant straight to the `{_object,_typ,_methods}` struct is invalid C, and matters for
+	// primitive-alias variants (`type EmptyExpr = u8`) that cannot be reinterpret-cast at all.
+	if g.selfhost && !fastc_is_pointer_type(c_type) && fastc_trim_pointer_suffix(c_type) in g.sum_types {
+		inner_type := g.infer_expression_type(inner_tokens) or { '' }
+		variant := fastc_trim_pointer_suffix(fastc_normalize_inferred_type(inner_type))
+		if variant != '' && variant != fastc_trim_pointer_suffix(c_type) && g.sumtype_has_variant(c_type, variant) {
+			// A member/local chain must render through render_member_receiver so a live member
+			// smart-cast (`if left is CS { Expr(left) }`) supplies the concrete variant pointer
+			// (`((CS *)left->_object)`) rather than the boxed subject itself.
+			boxed_inner := if member := g.render_member_receiver(inner_tokens) {
+				member
+			} else {
+				g.render_call_argument_expression(inner_tokens, inner_type) or { return none }
+			}
+			object := if fastc_is_pointer_type(inner_type) {
+				'(void*)(${boxed_inner})'
+			} else {
+				fastc_box_expression(variant, boxed_inner)
+			}
+			return FastcRenderedExpression{
+				source: '(${c_type}){._object=${object}, ._typ=__v_typeid_${variant}, ._methods=NULL}'
+				typ: c_type
+			}
+		}
+	}
+	inner_type := g.infer_expression_type(inner_tokens) or { '' }
+	// `voidptr(callback)` is a pointer reinterpretation, not a generic-value box.
+	// Rendering its function-alias operand against `voidptr` would allocate storage
+	// for the callback pointer and return that storage address, which is not callable.
+	inner_expected_type := if c_type == 'voidptr' && inner_type in g.fn_alias_return_types {
+		inner_type
+	} else {
+		c_type
+	}
+	inner := g.render_call_argument_expression(inner_tokens, inner_expected_type) or { return none }
 	return FastcRenderedExpression{
 		source: '((${fastc_output_c_type(c_type)})(${inner}))'
 		typ: c_type
@@ -281,7 +324,10 @@ fn (g &Parser) render_flag_method_expression(tokens []FastcExpressionToken, rend
 		mut argument_index := i + 2
 		for argument_index < call_end {
 			if tokens[argument_index].tok == .dot && argument_index + 1 < call_end && tokens[argument_index + 1].tok == .name {
-				raw_argument.write_string('.${tokens[argument_index + 1].lit}')
+				// The raw renderer mangles a `.member` shorthand whose name is a C keyword
+				// (`.unsigned` -> `.__v_fastc_keyword_unsigned`); match that spelling so the
+				// needle still finds the call. The enum constant itself keeps the raw name.
+				raw_argument.write_string('.${fastc_c_identifier(tokens[argument_index + 1].lit)}')
 				c_argument.write_string('${fastc_c_declared_type_name(receiver_key)}__${tokens[argument_index + 1].lit}')
 				argument_index += 2
 				continue
@@ -310,6 +356,16 @@ fn (g &Parser) render_flag_method_expression(tokens []FastcExpressionToken, rend
 			'has' { '((${receiver_source} & ${c_argument_source}) != 0)' }
 			'set' { '((${receiver_source}) |= (${c_argument_source}))' }
 			else { '((${receiver_source}) &= ~(${c_argument_source}))' }
+		}
+		if receiver_start == 0 && call_end == tokens.len - 1 {
+			// A standalone flag-method call (`t.a.nodes.flags.set(.nogrow)` as a whole expression):
+			// return the reconstructed operation directly. render_raw's buffer can spell a pointer
+			// FIELD receiver inconsistently (`t->a.nodes` not `t->a->nodes`) so no needle matches;
+			// render_member_receiver spells it correctly.
+			return FastcRenderedExpression{
+				source: replacement
+				typ: if method == 'has' { 'bool' } else { 'void' }
+			}
 		}
 		if !rendered.contains(needle) {
 			continue
@@ -608,11 +664,45 @@ fn (g &Parser) render_interface_cast_expression(tokens []FastcExpressionToken, r
 		struct_literal.source
 	} else if actual_base.starts_with('Array_') || actual_base.starts_with('Map_') {
 		g.render_call_argument_expression(inner_tokens, actual_type) or { return none }
+	} else if g.selfhost && g.expression_uses_member_smartcast(inner_tokens) {
+		// A narrowed subject (`Expr(left)` where `left is CS`) must box the concrete-variant
+		// pointer the smart-cast supplies, not the boxed subject's raw streamed text.
+		g.render_member_receiver(inner_tokens) or {
+			rendered_expression[prefix.len..rendered_expression.len - 2]
+		}
+	} else if g.selfhost && fastc_bare_as_cast_index(inner_tokens, 0, inner_tokens.len) != none {
+		// An `as`-cast operand (`AsmArg(x as AsmRegister)`): the raw streamed text keeps the V
+		// `as` keyword, which is not valid C, so lower it through the as-cast renderer.
+		if as_expr := g.render_as_cast_expression(inner_tokens) {
+			as_expr.source
+		} else {
+			g.render_call_argument_expression(inner_tokens, actual_type) or {
+				rendered_expression[prefix.len..rendered_expression.len - 2]
+			}
+		}
+	} else if g.selfhost && fastc_expression_tokens_contain(inner_tokens, .lpar) {
+		// A call operand (`Stmt(f(node.arr[0]))`): the raw streamed text leaves the call's
+		// arguments un-lowered (e.g. an array index on a match-cast member stays an invalid C
+		// `[0]` on the array header), so render it through the argument path.
+		g.render_call_argument_expression(inner_tokens, actual_type) or {
+			rendered_expression[prefix.len..rendered_expression.len - 2]
+		}
 	} else {
 		rendered_expression[prefix.len..rendered_expression.len - 2]
 	}
+	mut box_type := actual_type
+	if fastc_is_pointer_type(actual_type) && inner_tokens.len == 1 && inner_tokens[0].tok == .name {
+		if local := g.locals[inner_tokens[0].lit] {
+			// `Expr(node)` where `node` is a `mut T` parameter (a C `T*`): the streamed operand
+			// is auto-dereferenced to the pointee value (`*(node)`), so box that value rather than
+			// letting interface_value_expression's pointer branch cast a struct value to `void*`.
+			if local.is_reference && local.typ == actual_type {
+				box_type = fastc_trim_pointer_suffix(actual_type)
+			}
+		}
+	}
 	return FastcRenderedExpression{
-		source: g.interface_value_expression(interface_type, actual_type, inner_source)
+		source: g.interface_value_expression(interface_type, box_type, inner_source)
 		typ: interface_type
 	}
 }

--- a/vlib/v3/gen/fastc/render_method_calls.v
+++ b/vlib/v3/gen/fastc/render_method_calls.v
@@ -77,6 +77,21 @@ fn (g &Parser) render_missing_call_arguments(tokens []FastcExpressionToken) ?Fas
 				typ: signature.return_type
 			}
 		}
+		// `f(x, ...arr)` spreads an existing array into the variadic parameter: the array itself
+		// is the variadic argument, so pass it directly rather than packing its `...` token into a
+		// C array literal.
+		if call_args.len == fixed_arguments + 1 && call_args[fixed_arguments].len >= 2 && call_args[fixed_arguments][0].tok == .ellipsis {
+			mut c_arguments := []string{cap: fixed_arguments + 1}
+			for argument_index in 0 .. fixed_arguments {
+				c_arguments << g.render_call_argument_expression(call_args[argument_index], signature.parameter_types[argument_index]) or { return none }
+			}
+			spread := g.render_call_argument_expression(call_args[fixed_arguments][1..], variadic_type) or { return none }
+			c_arguments << spread
+			return FastcRenderedExpression{
+				source: '${fastc_c_function_name_for_key(function_key)}(${c_arguments.join(',')})'
+				typ: signature.return_type
+			}
+		}
 		mut rendered_arguments := []string{}
 		for argument_index, argument in call_args {
 			expected_type := if argument_index < fixed_arguments {
@@ -151,14 +166,68 @@ fn (g &Parser) render_method_call_expression(tokens []FastcExpressionToken, rend
 		}
 		// `mod.func()` is a module-qualified call; skip method rendering. But a FIELD named
 		// like an imported module (`recv.mod.method()`, e.g. `h.time.elapsed()`) is a real
-		// method call — only skip when `mod` is a bare module ref, not preceded by a `.`.
-		if tokens[i - 2].tok == .name && (tokens[i - 2].lit in g.imports || tokens[i - 2].lit == 'C') && (i < 3 || tokens[i - 3].tok != .dot) {
+		// method call — only skip when `mod` is a bare module ref, not preceded by a `.`. A LOCAL
+		// of the module's name (`for token in … { token.starts_with(…) }`) shadows the module.
+		if tokens[i - 2].tok == .name && (tokens[i - 2].lit in g.imports || tokens[i - 2].lit == 'C') && tokens[i - 2].lit !in g.locals && (i < 3 || tokens[i - 3].tok != .dot) {
 			continue
 		}
 		receiver_start := fastc_method_receiver_start(tokens, i - 1)
 		receiver_tokens := tokens[receiver_start..i - 1]
-		receiver_type := g.infer_expression_type(receiver_tokens) or { continue }
-		if tokens[i].lit == 'contains' && fastc_trim_pointer_suffix(fastc_normalize_inferred_type(receiver_type)).starts_with('Array_') {
+		mut receiver_type := g.infer_expression_type(receiver_tokens) or { '' }
+		if receiver_type == '' {
+			// An imported struct reached through an active sum-type smartcast can
+			// lose its member type in generic expression inference. The dedicated
+			// member walk still has the narrowed receiver and field metadata.
+			receiver_type = g.infer_member_access_type(receiver_tokens, 0, receiver_tokens.len) or {
+				continue
+			}
+		}
+		// A method defined on the whole sum type (`fn (e Expr) is_blank_ident()`) stays
+		// callable after the value is narrowed to a variant. When the narrowed type lacks the
+		// method but the receiver is a bare local whose declared (un-narrowed) type has it,
+		// dispatch on the un-narrowed value instead of the smart-cast variant pointer.
+		mut unnarrowed_receiver := ''
+		if receiver_tokens.len == 1 && receiver_tokens[0].tok == .name && receiver_tokens[0].lit in g.member_smartcasts {
+			narrowed_key, _ := g.resolve_method(receiver_type, tokens[i].lit)
+			if narrowed_key !in g.functions && narrowed_key !in g.mono_functions {
+				if local := g.locals[receiver_tokens[0].lit] {
+					original_key, _ := g.resolve_method(local.typ, tokens[i].lit)
+					if original_key in g.functions || original_key in g.mono_functions {
+						receiver_type = local.typ
+						unnarrowed_receiver = g.resolved_expression_name(receiver_tokens[0].lit, .unknown)
+					}
+				}
+			}
+		}
+		// A bare-local `is` smart-cast shadows the local with the narrowed variant value, whose
+		// declared C name still holds the boxed original. A method named like a variant field but
+		// defined on the whole sum type (`ast.Ident` has a `pos` field; `ast.Expr` has a `pos()`
+		// method) is not on the variant, so dispatch it on the boxed original C variable.
+		if unnarrowed_receiver == '' && receiver_tokens.len == 1 && receiver_tokens[0].tok == .name {
+			if local := g.locals[receiver_tokens[0].lit] {
+				if local.smartcast_origin_type != '' && local.smartcast_origin_type != receiver_type {
+					narrowed_key, _ := g.resolve_method(receiver_type, tokens[i].lit)
+					if narrowed_key !in g.functions && narrowed_key !in g.mono_functions {
+						origin_key, _ := g.resolve_method(local.smartcast_origin_type, tokens[i].lit)
+						if origin_key in g.functions || origin_key in g.mono_functions {
+							receiver_type = local.smartcast_origin_type
+							unnarrowed_receiver = fastc_c_identifier(receiver_tokens[0].lit)
+						}
+					}
+				}
+			}
+		}
+		contains_method_key, _ := g.resolve_method(receiver_type, 'contains')
+		// The generic `array.contains` is a compiler-magic builtin with no emitted body, so it must
+		// still be lowered inline; only a genuine USER-defined `contains` (a non-builtin module)
+		// suppresses the inline. Without this the call links against an undefined builtin__array_contains.
+		mut array_has_user_contains := contains_method_key in g.functions || contains_method_key in g.mono_functions
+		if sig := g.functions[contains_method_key] {
+			if sig.module_name == 'builtin' {
+				array_has_user_contains = false
+			}
+		}
+		if tokens[i].lit == 'contains' && !array_has_user_contains && fastc_trim_pointer_suffix(fastc_normalize_inferred_type(receiver_type)).starts_with('Array_') {
 			call_end := fastc_matching_rpar(tokens, i + 1) or { continue }
 			call_args := fastc_call_arguments(tokens, i + 1, call_end) or { continue }
 			if call_args.len != 1 {
@@ -190,6 +259,89 @@ fn (g &Parser) render_method_call_expression(tokens []FastcExpressionToken, rend
 				changed = true
 			}
 			continue
+		}
+		if tokens[i].lit in ['index', 'last_index'] && fastc_trim_pointer_suffix(fastc_normalize_inferred_type(receiver_type)).starts_with('Array_') {
+			element_type := g.array_element_type(receiver_type) or { '' }
+			if fastc_trim_pointer_suffix(g.underlying_alias_type(element_type)) == 'string' {
+				call_end := fastc_matching_rpar(tokens, i + 1) or { continue }
+				call_args := fastc_call_arguments(tokens, i + 1, call_end) or { continue }
+				if call_args.len != 1 {
+					continue
+				}
+				receiver := g.render_method_receiver_expression(receiver_tokens) or { continue }
+				argument := g.render_call_argument_expression(call_args[0], element_type) or {
+					continue
+				}
+				access := if receiver_type.ends_with('*') { '->' } else { '.' }
+				loop_init := if tokens[i].lit == 'last_index' {
+					'__v_fastc_index_collection${access}len - 1'
+				} else {
+					'0'
+				}
+				loop_condition := if tokens[i].lit == 'last_index' {
+					'__v_fastc_index_cursor >= 0'
+				} else {
+					'__v_fastc_index_cursor < __v_fastc_index_collection${access}len'
+				}
+				loop_step := if tokens[i].lit == 'last_index' {
+					'__v_fastc_index_cursor--'
+				} else {
+					'__v_fastc_index_cursor++'
+				}
+				call_source := '({ ${element_type} __v_fastc_index_item = (${argument}); __typeof__((${receiver.source})) __v_fastc_index_collection = (${receiver.source}); int __v_fastc_index_result = -1; for (int __v_fastc_index_cursor = ${loop_init}; ${loop_condition}; ${loop_step}) { if (builtin__string_eq(__v_fastc_index_item, ((${element_type} *)__v_fastc_index_collection${access}data)[__v_fastc_index_cursor])) { __v_fastc_index_result = __v_fastc_index_cursor; break; } } __v_fastc_index_result; })'
+				if receiver_start == 0 && call_end == tokens.len - 1 {
+					return FastcRenderedExpression{
+						source: call_source
+						typ: 'int'
+					}
+				}
+				raw_call := g.render_raw_expression_tokens(tokens[receiver_start..call_end + 1]) or {
+					continue
+				}
+				if rendered.contains(raw_call) {
+					rendered = rendered.replace(raw_call, call_source)
+					changed = true
+				}
+				continue
+			}
+		}
+		if tokens[i].lit == 'wait' && receiver_type.trim_right('*').starts_with('Array_') {
+			element := g.array_element_type(receiver_type) or { '' }
+			if element.starts_with(fastc_thread_type_prefix) {
+				// `[]thread T`.wait() joins every handle and gathers their `[]T` results.
+				wait_end := fastc_matching_rpar(tokens, i + 1) or { continue }
+				receiver := g.render_method_receiver_expression(receiver_tokens) or { continue }
+				value_type := g.thread_value_types[element] or { continue }
+				result_type := fastc_array_c_type(value_type)
+				mut w := unsafe { &Parser(g) }
+				fastc_register_composite_type(result_type, mut w.composite_types)
+				wait_helper := g.fastc_unclaimed_generated_name(fastc_thread_wait_name(element))
+				recv_src := if receiver_type.ends_with('*') {
+					'*(${receiver.source})'
+				} else {
+					receiver.source
+				}
+				wait_all := '({ __typeof__((${recv_src})) __v_fastc_threads = (${recv_src}); ${result_type} __v_fastc_results = (${result_type})builtin____new_array(0, __v_fastc_threads.len, sizeof(${value_type})); for (int __v_fastc_ti = 0; __v_fastc_ti < __v_fastc_threads.len; __v_fastc_ti++) { ${value_type} __v_fastc_tv = ${wait_helper}(((${element} *)__v_fastc_threads.data)[__v_fastc_ti]); builtin__array_push((array *)&__v_fastc_results, &__v_fastc_tv); } __v_fastc_results; })'
+				if receiver_start == 0 && wait_end == tokens.len - 1 {
+					return FastcRenderedExpression{
+						source: wait_all
+						typ: result_type
+					}
+				}
+				mut wait_needle := '${receiver.source}.wait()'
+				if !rendered.contains(wait_needle) {
+					raw_receiver := g.render_raw_expression_tokens(receiver_tokens) or { '' }
+					raw_needle := '${raw_receiver}.wait()'
+					if raw_receiver != '' && rendered.contains(raw_needle) {
+						wait_needle = raw_needle
+					}
+				}
+				if rendered.contains(wait_needle) {
+					rendered = rendered.replace(wait_needle, wait_all)
+					changed = true
+				}
+				continue
+			}
 		}
 		if tokens[i].lit == 'wait' && receiver_type.starts_with(fastc_thread_type_prefix) {
 			// `.wait()` joins a spawned thread (see spawn.v); it has no entry in
@@ -232,6 +384,123 @@ fn (g &Parser) render_method_call_expression(tokens []FastcExpressionToken, rend
 				helper := w.fastc_default_struct_str_name(receiver_type.trim_right('*')) or {
 					continue
 				}
+				// A member smart-cast reads the narrowed struct through a variant pointer, so its
+				// rendered source is a `T*` even though the inferred receiver type is the value
+				// `T`; the by-value default `str(T)` helper then needs an explicit deref.
+				receiver_is_pointer := receiver_type.ends_with('*') || (g.selfhost && g.expression_uses_member_smartcast(receiver_tokens))
+				receiver_argument := if receiver_is_pointer {
+					'*(${receiver.source})'
+				} else {
+					receiver.source
+				}
+				call_source := '${helper}(${receiver_argument})'
+				if receiver_start == 0 && call_end == tokens.len - 1 {
+					return FastcRenderedExpression{
+						source: call_source
+						typ: 'string'
+					}
+				}
+				raw_call := g.render_raw_expression_tokens(tokens[receiver_start..call_end + 1]) or {
+					continue
+				}
+				if rendered.contains(raw_call) {
+					rendered = rendered.replace(raw_call, call_source)
+					changed = true
+				}
+				continue
+			}
+			if tokens[i].lit == 'str' && g.declared_kinds[g.semantic_type_key(receiver_type)] == .enum_ {
+				// `enum_val.str()`: reuse the generated `v_fastc_enum_str_<T>` helper.
+				call_end := fastc_matching_rpar(tokens, i + 1) or { continue }
+				if call_end != i + 2 {
+					continue
+				}
+				receiver := g.render_method_receiver_expression(receiver_tokens) or { continue }
+				enum_c := fastc_normalize_inferred_type(receiver_type).trim_right('*')
+				receiver_argument := if receiver_type.ends_with('*') {
+					'*(${receiver.source})'
+				} else {
+					receiver.source
+				}
+				call_source := 'v_fastc_enum_str_${enum_c}(${receiver_argument})'
+				if receiver_start == 0 && call_end == tokens.len - 1 {
+					return FastcRenderedExpression{
+						source: call_source
+						typ: 'string'
+					}
+				}
+				raw_call := g.render_raw_expression_tokens(tokens[receiver_start..call_end + 1]) or {
+					continue
+				}
+				if rendered.contains(raw_call) {
+					rendered = rendered.replace(raw_call, call_source)
+					changed = true
+				}
+				continue
+			}
+			if tokens[i].lit == 'str' && receiver_type.trim_right('*').starts_with('Array_') {
+				// `arr.str()`: reuse the same generated array formatter as `${arr}`.
+				call_end := fastc_matching_rpar(tokens, i + 1) or { continue }
+				if call_end != i + 2 {
+					continue
+				}
+				receiver := g.render_method_receiver_expression(receiver_tokens) or { continue }
+				mut w := unsafe { &Parser(g) }
+				helper := w.fastc_array_str_name(receiver_type) or { continue }
+				receiver_argument := if receiver_type.ends_with('*') {
+					'*(${receiver.source})'
+				} else {
+					receiver.source
+				}
+				call_source := '${helper}(${receiver_argument})'
+				if receiver_start == 0 && call_end == tokens.len - 1 {
+					return FastcRenderedExpression{
+						source: call_source
+						typ: 'string'
+					}
+				}
+				raw_call := g.render_raw_expression_tokens(tokens[receiver_start..call_end + 1]) or {
+					continue
+				}
+				if rendered.contains(raw_call) {
+					rendered = rendered.replace(raw_call, call_source)
+					changed = true
+				}
+				continue
+			}
+			if tokens[i].lit == 'free' {
+				// A struct's auto-generated `free()` has no FastC method; under `-gc none`
+				// it is a no-op. (Real `free()` methods — arrays, strings, user types —
+				// resolve above and never reach here.)
+				call_end := fastc_matching_rpar(tokens, i + 1) or { continue }
+				if call_end != i + 2 {
+					continue
+				}
+				call_source := '((void)0)'
+				if receiver_start == 0 && call_end == tokens.len - 1 {
+					return FastcRenderedExpression{
+						source: call_source
+						typ: 'void'
+					}
+				}
+				raw_call := g.render_raw_expression_tokens(tokens[receiver_start..call_end + 1]) or {
+					continue
+				}
+				if rendered.contains(raw_call) {
+					rendered = rendered.replace(raw_call, call_source)
+					changed = true
+				}
+				continue
+			}
+			if tokens[i].lit == 'type_name' && g.is_boxed_type(fastc_normalize_inferred_type(receiver_type)) {
+				// `x.type_name()` on a sum type / interface: switch on the runtime tag.
+				call_end := fastc_matching_rpar(tokens, i + 1) or { continue }
+				if call_end != i + 2 {
+					continue
+				}
+				receiver := g.render_method_receiver_expression(receiver_tokens) or { continue }
+				mut w := unsafe { &Parser(g) }
+				helper := w.fastc_sumtype_type_name_helper(receiver_type) or { continue }
 				receiver_argument := if receiver_type.ends_with('*') {
 					'*(${receiver.source})'
 				} else {
@@ -330,7 +599,14 @@ fn (g &Parser) render_method_call_expression(tokens []FastcExpressionToken, rend
 			}
 			continue
 		}
-		receiver := g.render_method_receiver_expression(receiver_tokens) or { continue }
+		receiver := if unnarrowed_receiver != '' {
+			FastcRenderedExpression{
+				source: unnarrowed_receiver
+				typ: receiver_type
+			}
+		} else {
+			g.render_method_receiver_expression(receiver_tokens) or { continue }
+		}
 		mut receiver_source := receiver.source
 		mut separator := if receiver_tokens.len == 1 && receiver_type.ends_with('*') {
 			'->'
@@ -340,9 +616,13 @@ fn (g &Parser) render_method_call_expression(tokens []FastcExpressionToken, rend
 		mut method_marker := '${separator}${tokens[i].lit}('
 		if receiver_start == 0 {
 			raw_receiver := g.render_raw_expression_tokens(receiver_tokens) or { receiver_source }
+			// Only align `receiver_source` to the text already in `rendered` when the receiver
+			// renders the same way there (no member smart-cast). A smart-cast receiver renders
+			// differently (a variant pointer) and must be kept for the call argument; the raw
+			// receiver text is matched separately by the raw-needle fallback below.
 			if receiver_source == raw_receiver && fastc_contains(rendered, method_marker) {
 				receiver_source = rendered.all_before_last(method_marker)
-			} else {
+			} else if receiver_source == raw_receiver {
 				alternate_separator := if separator == '.' { '->' } else { '.' }
 				alternate_marker := '${alternate_separator}${tokens[i].lit}('
 				if fastc_contains(rendered, alternate_marker) {
@@ -355,10 +635,24 @@ fn (g &Parser) render_method_call_expression(tokens []FastcExpressionToken, rend
 		mut needle := '${receiver_source}${separator}${tokens[i].lit}('
 		if !fastc_contains(rendered, needle) {
 			raw_receiver := g.render_raw_expression_tokens(receiver_tokens) or { '' }
-			raw_needle := '${raw_receiver}${separator}${tokens[i].lit}('
-			if raw_receiver != '' && fastc_contains(rendered, raw_needle) {
-				needle = raw_needle
+			if raw_receiver != '' {
+				// The smart-cast receiver may render with a pointer `->` while the raw receiver
+				// text uses a value `.` (a narrowed local read as a variant pointer); try both.
+				for candidate_separator in ['.', '->'] {
+					raw_needle := '${raw_receiver}${candidate_separator}${tokens[i].lit}('
+					if fastc_contains(rendered, raw_needle) {
+						needle = raw_needle
+						break
+					}
+				}
 			}
+		}
+		if !rendered.contains(needle) && receiver_start == 0 && rendered.contains(method_marker) {
+			// A receiver that renders differently in the boxed method form than in the raw
+			// expression (a sum-type conversion `Node(x).m()`, whose grouping parens differ):
+			// splice at the raw receiver text preceding the call, while the boxed receiver is
+			// still used for the actual call argument built below.
+			needle = rendered.all_before_last(method_marker) + method_marker
 		}
 		expected_receiver := signature.parameter_types[0]
 		mut effective_receiver_source := receiver_source
@@ -504,8 +798,14 @@ fn (g &Parser) render_method_call_expression(tokens []FastcExpressionToken, rend
 			call_replacement = '(*(((${element_type} *)${replacement}))))'
 		}
 		if fastc_contains(rendered, call_needle) {
-			rendered = fastc_replace(rendered, call_needle, call_replacement)
-			changed = true
+			// Boundary-aware replace: a receiver needle like `return_type.clear(` must NOT match
+			// the suffix of a longer chain `g.fn_decl.return_type.clear(` (whose receiver is the
+			// whole `g.fn_decl.return_type`), or the method would splice onto the wrong receiver.
+			replaced := fastc_replace_call_needle(rendered, call_needle, call_replacement)
+			if replaced != rendered {
+				rendered = replaced
+				changed = true
+			}
 		}
 	}
 	if !changed {

--- a/vlib/v3/gen/fastc/render_struct_literal.v
+++ b/vlib/v3/gen/fastc/render_struct_literal.v
@@ -8,7 +8,16 @@ struct FastcStructLiteralFieldValue {
 	is_fixed_array        bool
 }
 
-fn (g &Parser) render_struct_literal_field_value(value_tokens []FastcExpressionToken, expected_type string, c_field_name string, temporary_start int) ?FastcStructLiteralFieldValue {
+fn (g &Parser) render_struct_literal_field_value(value_tokens []FastcExpressionToken, expected_type string, c_field_name string, temporary_start int, is_shared_pointer bool) ?FastcStructLiteralFieldValue {
+	if value_tokens.len >= 2 && value_tokens[0].tok == .name && value_tokens[0].lit == 'chan' {
+		// `jobs: chan Task{cap: N}`: channels are erased to a stub `void*`, so drop the capacity
+		// initializer to a zero channel. The struct-literal path would otherwise mistake `chan` for
+		// a struct type and emit an invalid `(chan){.cap=…}` designated initializer on a `void*`.
+		return FastcStructLiteralFieldValue{
+			rendered_field: '.${c_field_name}=((chan){0})'
+			field_value: '(chan){0}'
+		}
+	}
 	if fixed_element_type := fastc_fixed_array_element_type(expected_type) {
 		array_end := if value_tokens.len > 0 && value_tokens.last().tok == .not {
 			value_tokens.len - 1
@@ -60,10 +69,23 @@ fn (g &Parser) render_struct_literal_field_value(value_tokens []FastcExpressionT
 		g.render_call_argument_expression(value_tokens, expected_type) or { return none }
 	}
 	temporary := '__v_fastc_struct_field_${temporary_start}'
+	// TinyCC cannot `__typeof__` a statement-expression that declares locals or ends in a
+	// designated compound literal (`chan T{cap: …}`, an `or`-block); the field type is known, so
+	// name it directly in that case rather than inferring it back from the value.
+	field_decl_type := if expected_type != '' && value.starts_with('({') {
+		fastc_normalize_inferred_type(expected_type)
+	} else {
+		'__typeof__((${value}))'
+	}
+	stored_value := if is_shared_pointer {
+		'(${expected_type}*)v_fastc_interface_box(&${temporary}, sizeof(${expected_type}))'
+	} else {
+		temporary
+	}
 	return FastcStructLiteralFieldValue{
-		explicit_initializers: ['__typeof__((${value})) ${temporary} = (${value});']
-		rendered_field: '.${c_field_name}=(${temporary})'
-		field_value: temporary
+		explicit_initializers: ['${field_decl_type} ${temporary} = (${value});']
+		rendered_field: '.${c_field_name}=(${stored_value})'
+		field_value: stored_value
 	}
 }
 
@@ -104,6 +126,14 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 	if layout_type.starts_with('Array_') {
 		layout_type = 'array'
 	}
+	// `Alias{}` where `Alias = u8` (a primitive alias, e.g. ast.EmptyExpr) has no fields, so
+	// the "struct literal" is really the primitive's zero value; C rejects the empty `{}`.
+	if c_type != '' && open + 1 == close && fastc_primitive_c_type(fastc_normalize_inferred_type(g.underlying_alias_type(c_type))) != none {
+		return FastcRenderedExpression{
+			source: '((${c_type})0)'
+			typ: c_type
+		}
+	}
 	if c_type == '' || (!is_c_struct_literal && layout_type !in g.struct_fields && g.declared_kinds[g.semantic_type_key(c_type)] !in [
 		.struct_,
 		.union_,
@@ -127,12 +157,17 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 		if is_positional {
 			mut values := []string{cap: items.len}
 			for item_index, item in items {
-				expected_type := if !is_c_struct_literal && item_index < g.struct_field_info[layout_type].len {
-					g.struct_field_info[layout_type][item_index].typ
+				field := if !is_c_struct_literal && item_index < g.struct_field_info[layout_type].len {
+					g.struct_field_info[layout_type][item_index]
 				} else {
-					''
+					FastcStructField{}
 				}
-				values << g.render_call_argument_expression(item, expected_type) or { return none }
+				rendered_item := g.render_call_argument_expression(item, field.typ) or { return none }
+				values << if field.is_shared_pointer {
+					'({ ${field.typ} __v_fastc_shared_field_value = (${rendered_item}); (${field.typ}*)v_fastc_interface_box(&__v_fastc_shared_field_value, sizeof(${field.typ})); })'
+				} else {
+					rendered_item
+				}
 			}
 			source := if c_type.ends_with('*') {
 				'&(${c_type.trim_right('*')}){${values.join(',')}}'
@@ -152,6 +187,8 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 	mut fixed_array_copies := []string{}
 	mut has_applied_defaults := false
 	mut update_source := ''
+	mut array_init_tokens := []FastcExpressionToken{}
+	mut has_array_init := false
 	mut index := open + 1
 	for index < close {
 		for index < close && tokens[index].tok in [.semicolon, .comma] {
@@ -188,6 +225,12 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 			mut brackets := 0
 			mut braces := 0
 			for index < close {
+				// Fields written one-per-line (or trailing named call args) carry no comma
+				// between them, so a following `name:` at the top level begins the next
+				// field and ends this value.
+				if parens == 0 && brackets == 0 && braces == 0 && index > value_start && tokens[index].tok == .name && index + 1 < close && tokens[index + 1].tok == .colon {
+					break
+				}
 				match tokens[index].tok {
 					.lpar {
 						parens++
@@ -226,13 +269,26 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 		} else {
 			fastc_c_identifier(field_name)
 		}
+		// An array `init:` value is a per-element closure (it may read the special `index`
+		// element counter), so it must be rendered inside the fill loop, not hoisted into a
+		// temp before it. Capture its raw tokens and skip the ordinary field rendering.
+		if layout_type == 'array' && field_name == 'init' && value_start >= 0 {
+			array_init_tokens = tokens[value_start..value_end].clone()
+			has_array_init = true
+			continue
+		}
+		mut field_metadata := FastcStructField{}
 		mut expected_type := if layout_type == 'array' && field_name == 'init' {
 			g.array_element_type(c_type) or { '' }
 		} else {
 			g.struct_direct_member_type(c_type, field_name)
 		}
+		if expected_type != '' {
+			field_metadata = g.struct_field_metadata(c_type, field_name) or { FastcStructField{} }
+		}
 		if expected_type == '' && !is_c_struct_literal {
 			if field := g.struct_field_metadata(c_type, field_name) {
+				field_metadata = field
 				expected_type = field.typ
 				mut storage_path := field.storage_path.clone()
 				storage_path << field.name
@@ -254,14 +310,14 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 			}
 		}
 		field_value := if value_start >= 0 {
-			g.render_struct_literal_field_value(tokens[value_start..value_end], expected_type, c_field_name, explicit_initializers.len) or { return none }
+			g.render_struct_literal_field_value(tokens[value_start..value_end], expected_type, c_field_name, explicit_initializers.len, field_metadata.is_shared_pointer) or { return none }
 		} else {
 			g.render_struct_literal_field_value([
 				FastcExpressionToken{
 					tok: .name
 					lit: field_name
 				},
-			], expected_type, c_field_name, explicit_initializers.len) or { return none }
+			], expected_type, c_field_name, explicit_initializers.len, field_metadata.is_shared_pointer) or { return none }
 		}
 		explicit_initializers << field_value.explicit_initializers
 		if field_value.rendered_field != '' {
@@ -281,14 +337,18 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 		// re-parses a file that did so after they are ready.
 		fastc_note_field_defaults_use(g)
 		for field in g.struct_field_info[layout_type] {
-			if field.default_value == '' || field.name in field_values {
+			if field.name in field_values {
+				continue
+			}
+			field_default := g.struct_field_initializer_default(field)
+			if field_default == '' {
 				continue
 			}
 			c_field_name := fastc_c_identifier(field.name)
-			rendered_field := '.${c_field_name}=(${field.default_value})'
+			rendered_field := '.${c_field_name}=(${field_default})'
 			rendered_fields << rendered_field
 			rendered_fields_by_name[field.name] = rendered_field
-			field_values[field.name] = field.default_value
+			field_values[field.name] = field_default
 			has_applied_defaults = true
 		}
 	}
@@ -320,8 +380,13 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 		}
 		base := '((${array_type})builtin____new_array(${length},${capacity},sizeof(${element_type})))'
 		mut value_source := base
-		if initial := field_values['init'] {
-			value_source = '({ ${explicit_initializers.join(' ')} ${array_type} __v_fastc_array_init = ${base}; ${element_type} __v_fastc_array_default = (${initial}); for (int __v_fastc_array_index = 0; __v_fastc_array_index < __v_fastc_array_init.len; __v_fastc_array_index++) { ((${element_type} *)__v_fastc_array_init.data)[__v_fastc_array_index] = __v_fastc_array_default; } __v_fastc_array_init; })'
+		if has_array_init {
+			inner := g.render_call_argument_expression(array_init_tokens, element_type) or {
+				return none
+			}
+			// `index` names the current element position inside an `init:` closure; bind it
+			// to the loop counter so an expression like `init: index` fills 0, 1, 2, ….
+			value_source = '({ ${explicit_initializers.join(' ')} ${array_type} __v_fastc_array_init = ${base}; for (int __v_fastc_array_index = 0; __v_fastc_array_index < __v_fastc_array_init.len; __v_fastc_array_index++) { int index = __v_fastc_array_index; (void)index; ((${element_type} *)__v_fastc_array_init.data)[__v_fastc_array_index] = (${inner}); } __v_fastc_array_init; })'
 		} else if inner_array_element_type != '' {
 			// A zeroed inner dynamic array has element_size == 0, so appending to an
 			// element of `[][]T{len: n}` copies no data. Construct a valid empty inner

--- a/vlib/v3/gen/fastc/signatures.v
+++ b/vlib/v3/gen/fastc/signatures.v
@@ -127,6 +127,7 @@ fn collect_function_signatures(source string, path string, header FastcSourceHea
 	scan.init(file, source)
 	mut brace_depth := 0
 	mut next_declaration_is_enabled := true
+	mut next_declaration_is_c_extern := false
 	mut previous_tok := token.Token.unknown
 	mut skip_index := 0
 	mut tok := scan.scan()
@@ -135,6 +136,7 @@ fn collect_function_signatures(source string, path string, header FastcSourceHea
 			attribute := fastc_scan_declaration_attribute(mut scan, path, prefs)!
 			tok = attribute.tok
 			next_declaration_is_enabled = next_declaration_is_enabled && attribute.is_enabled
+			next_declaration_is_c_extern = next_declaration_is_c_extern || attribute.is_c_extern
 			continue
 		}
 		if tok == .key_type && brace_depth == 0 {
@@ -377,6 +379,7 @@ fn collect_function_signatures(source string, path string, header FastcSourceHea
 				last_parameter_is_params: fixed_parameter_count > 0 && fastc_parameter_is_params_struct(parameter_types.last(), params_structs)
 				is_public: is_public || is_c_function
 				is_disabled: !next_declaration_is_enabled
+				is_c_extern: is_c_function && next_declaration_is_c_extern
 				module_name: header.module_name
 				path: path
 			}
@@ -388,17 +391,20 @@ fn collect_function_signatures(source string, path string, header FastcSourceHea
 					}
 					if previous.path.ends_with('.c.v') {
 						next_declaration_is_enabled = true
+						next_declaration_is_c_extern = false
 						continue
 					}
 				}
 			}
 			functions[function_key] = signature
 			next_declaration_is_enabled = true
+			next_declaration_is_c_extern = false
 			continue
 		}
 		if brace_depth == 0 && tok in [.key_struct, .key_enum, .key_interface, .key_type, .key_union,
 			.key_const, .key_global] {
 			next_declaration_is_enabled = true
+			next_declaration_is_c_extern = false
 		}
 		if tok == .lcbr && brace_depth == 0 {
 			skipped, next_skip := fastc_skip_recorded_body(mut scan, skips, skip_index)
@@ -554,6 +560,9 @@ fn fastc_collect_referenced_function_names(sources []FastcSourceFile, prefs &pre
 		'new_array_from_c_array': true
 		'string_plus_many':       true
 		'v_fixed_index':          true
+		// `m1 == m2` lowers to a `builtin__map_map_eq` call in generated C, so no source
+		// `.map_map_eq(` reference surfaces; seed it so it survives reachability pruning.
+		'map_map_eq':             true
 	}
 	for name in top_level_references.keys() {
 		used[name] = true
@@ -1403,6 +1412,33 @@ fn fastc_map_key_value_types(typ string) ?(string, string) {
 	return none
 }
 
+fn fastc_declared_map_key_value_types(typ string, declared_kinds map[string]FastcDeclaredTypeKind) ?(string, string) {
+	base := typ.trim_right('*')
+	if !base.starts_with('Map_') {
+		return none
+	}
+	payload := base['Map_'.len..]
+	mut matched_key := ''
+	mut matched_prefix := ''
+	for type_key, kind in declared_kinds {
+		// Map keys may be enums or aliases of scalar key types. Choose the longest
+		// matching C spelling because qualified type names can share prefixes.
+		if kind !in [.enum_, .alias_] {
+			continue
+		}
+		c_type := fastc_c_declared_type_name(type_key)
+		prefix := '${fastc_composite_type_part(c_type)}_'
+		if payload.starts_with(prefix) && prefix.len > matched_prefix.len {
+			matched_key = c_type
+			matched_prefix = prefix
+		}
+	}
+	if matched_key == '' {
+		return none
+	}
+	return matched_key, fastc_decode_map_value_type(payload[matched_prefix.len..])
+}
+
 fn fastc_decode_map_value_type(encoded string) string {
 	// A trailing `_ptr` on a composite value can belong to its nested element
 	// type (`map[string][]&T` -> `Map_string_Array_T_ptr`), not to the map
@@ -1417,28 +1453,7 @@ fn (g &Parser) map_key_value_types(typ string) ?(string, string) {
 	if key_type, value_type := fastc_map_key_value_types(typ) {
 		return key_type, value_type
 	}
-	base := typ.trim_right('*')
-	if !base.starts_with('Map_') {
-		return none
-	}
-	payload := base['Map_'.len..]
-	mut matched_key := ''
-	mut matched_prefix := ''
-	for type_key, kind in g.declared_kinds {
-		if kind != .enum_ {
-			continue
-		}
-		c_type := g.declared_type_c_names[type_key] or { fastc_c_declared_type_name(type_key) }
-		prefix := '${fastc_composite_type_part(c_type)}_'
-		if payload.starts_with(prefix) && prefix.len > matched_prefix.len {
-			matched_key = c_type
-			matched_prefix = prefix
-		}
-	}
-	if matched_key == '' {
-		return none
-	}
-	return matched_key, fastc_decode_map_value_type(payload[matched_prefix.len..])
+	return fastc_declared_map_key_value_types(typ, g.declared_kinds)
 }
 
 fn fastc_register_composite_type(typ string, mut composite_types map[string]bool) {

--- a/vlib/v3/gen/fastc/source.v
+++ b/vlib/v3/gen/fastc/source.v
@@ -334,6 +334,18 @@ fn fastc_resolve_source_files_deferring_memo(paths []string, prefs &pref.Prefere
 			}
 		}
 	}
+	// A module reached through two import spellings is scanned once. Rewrite
+	// import values to the canonical module name used by the loaded source.
+	if module_aliases.len > 0 {
+		for index in 0 .. sources.len {
+			sources[index] = FastcSourceFile{
+				path: sources[index].path
+				source: sources[index].source
+				source_offset: sources[index].source_offset
+				header: fastc_canonicalize_header_imports(sources[index].header, module_aliases)
+			}
+		}
+	}
 	timer.mark('resolve.imports')
 	if memo_path != '' {
 		memo_entry_paths := if prefs.building_v { paths } else { []string{} }
@@ -1155,6 +1167,31 @@ fn fastc_preloaded_source_headers(paths []string, prefs &pref.Preferences, prelo
 		}
 	}
 	return result
+}
+
+// fastc_canonicalize_header_imports rewrites a header's import values to the
+// module name each import was actually loaded and keyed under, so a file that
+// imports a module by an alternate path spelling still resolves its symbols.
+fn fastc_canonicalize_header_imports(header FastcSourceHeader, module_aliases map[string]string) FastcSourceHeader {
+	mut resolved := map[string]string{}
+	for alias, import_path in header.imports {
+		resolved[alias] = module_aliases[import_path] or { import_path }
+	}
+	return FastcSourceHeader{
+		module_name: header.module_name
+		imports: resolved
+		import_order: header.import_order
+		blank_imports: header.blank_imports
+		has_globals: header.has_globals
+		has_constants: header.has_constants
+		has_global_declarations: header.has_global_declarations
+		has_interfaces: header.has_interfaces
+		has_comptime_if: header.has_comptime_if
+		has_type_keywords: header.has_type_keywords
+		has_generic_fn_syntax: header.has_generic_fn_syntax
+		has_select: header.has_select
+		body_spans: header.body_spans
+	}
 }
 
 // fastc_entry_module_files returns the other source files of the entry file's

--- a/vlib/v3/gen/fastc/stmt.v
+++ b/vlib/v3/gen/fastc/stmt.v
@@ -17,6 +17,15 @@ fn (mut g Parser) parse_block_body() !bool {
 			return g.unsupported('unfinished block')
 		}
 		g.statement_reachable = outer_statement_reachable && !terminates
+		if g.selfhost && g.or_value_capture && ((g.tok == .key_if && g.if_starts_final_block_expression()) || (g.tok == .key_match && g.match_starts_final_block_expression())) {
+			// The block's final value is an `if`/`match` EXPRESSION (`or { if c { a } else { b } }`);
+			// read it as a value (a ternary/stmt-expr) so a guard variable inside it stays in the
+			// branch scope, instead of parsing it as statements whose value leaks out of scope.
+			value := g.read_expression([token.Token.semicolon, token.Token.rcbr])!
+			g.capture_or_value(value)
+			g.skip_semicolons()
+			continue
+		}
 		statement_terminates := g.parse_statement()!
 		if statement_terminates {
 			terminates = true
@@ -34,7 +43,12 @@ fn (mut g Parser) parse_block_body() !bool {
 	}
 	g.next()
 	g.skip_semicolons()
-	g.write_deferred_blocks_from(deferred_block_start)
+	// A block that already terminated (via `return`, which flushed every deferred scope)
+	// must not re-emit this block's defers at its natural end — that would duplicate them
+	// as unreachable code and redeclare their temporaries.
+	if !terminates {
+		g.write_deferred_blocks_from(deferred_block_start)
+	}
 	g.deferred_lines.trim(deferred_line_start)
 	g.deferred_block_starts.trim(deferred_block_start)
 	g.restore_local_scope(local_scope_start)
@@ -167,9 +181,7 @@ fn (mut g Parser) parse_statement() !bool {
 			if g.tok != .decl_assign {
 				return g.unsupported('static local without `:=`')
 			}
-			// FastC only needs compile-time static locals for generic helper caches.
-			// Lowering them as mutable function locals preserves compile/link behavior.
-			g.parse_declaration_after_name(name, true)!
+			g.parse_declaration_after_name(name, true, true)!
 			false
 		}
 		.key_unsafe {
@@ -178,6 +190,19 @@ fn (mut g Parser) parse_statement() !bool {
 			g.unsafe_depth += 1
 			terminates := g.parse_block_body()!
 			g.unsafe_depth -= 1
+			terminates
+		}
+		.key_lock, .key_rlock {
+			g.parse_lock_statement()!
+		}
+		.lcbr {
+			// A bare `{ … }` block introduces a nested scope (`{ mut core_fns := [...] }`).
+			g.next()
+			g.write_line('{')
+			g.indent++
+			terminates := g.parse_block_body()!
+			g.indent--
+			g.write_line('}')
 			terminates
 		}
 		else {
@@ -323,6 +348,11 @@ fn (g &Parser) method_uses_undefined_receiver() bool {
 		if fastc_global_key(g.module_name, r) in g.globals {
 			continue
 		}
+		// A `__global` declared in ANOTHER module (`global_table` in v.ast, referenced from the
+		// transformer) is still a valid receiver — globals are truly global.
+		if _ := g.resolve_cross_module_global_type(r) {
+			continue
+		}
 		if g.is_enum_type_name(r) {
 			continue
 		}
@@ -336,9 +366,49 @@ fn (g &Parser) method_uses_undefined_receiver() bool {
 
 fn (mut g Parser) parse_defer() ! {
 	g.next()
+	mut is_function_defer := false
+	if g.tok == .lpar {
+		// `defer(fn)` stays active beyond the declaring lexical scope and runs only
+		// when the function exits.
+		g.next()
+		if g.tok != .key_fn {
+			return g.unsupported('unknown defer mode `${g.token_source()}`')
+		}
+		is_function_defer = true
+		g.next()
+		g.expect(.rpar)!
+	}
 	g.expect(.lcbr)!
+	mut referenced_locals := []string{}
+	if is_function_defer {
+		referenced_locals = g.function_defer_referenced_locals()
+	}
 	previous_capture := g.capturing_defer
 	previous_lines := g.captured_defer_lines.clone()
+	mut saved_locals := map[string]FastcLocal{}
+	mut capture_assignments := []string{}
+	if is_function_defer {
+		for name in referenced_locals {
+			local := g.locals[name] or { continue }
+			saved_locals[name] = local
+			capture_name := g.temporary_name('defer_capture')
+			capture_type := local.typ
+			if capture_type == '' || capture_type.contains('(*)') {
+				continue
+			}
+			g.function_defer_declarations << '${capture_type} ${capture_name};'
+			source_name := if local.c_name != '' {
+				local.c_name
+			} else {
+				fastc_c_identifier(name)
+			}
+			capture_assignments << '${capture_name} = ${source_name};'
+			g.locals[name] = FastcLocal{
+				...local
+				c_name: capture_name
+			}
+		}
+	}
 	g.capturing_defer = true
 	g.defer_depth++
 	g.captured_defer_lines = []string{}
@@ -347,10 +417,51 @@ fn (mut g Parser) parse_defer() ! {
 	g.defer_depth--
 	g.capturing_defer = previous_capture
 	g.captured_defer_lines = previous_lines.clone()
+	for name, local in saved_locals {
+		g.locals[name] = local
+	}
+	if is_function_defer {
+		flag := g.temporary_name('defer_active')
+		g.function_defer_declarations << 'bool ${flag} = false;'
+		for assignment in capture_assignments {
+			g.write_line(assignment)
+		}
+		g.write_line('${flag} = true;')
+		g.function_defer_blocks << FastcFunctionDeferBlock{
+			flag: flag
+			lines: block
+		}
+		return
+	}
 	g.deferred_block_starts << g.deferred_lines.len
 	for line in block {
 		g.deferred_lines << line
 	}
+}
+
+fn (g &Parser) function_defer_referenced_locals() []string {
+	mut names := []string{}
+	mut seen := map[string]bool{}
+	mut tok := g.tok
+	mut lit := g.lit
+	mut scan := g.s
+	mut depth := 1
+	for depth > 0 && tok != .eof {
+		if tok == .lcbr {
+			depth++
+		} else if tok == .rcbr {
+			depth--
+			if depth == 0 {
+				break
+			}
+		} else if tok == .name && lit in g.locals && !seen[lit] {
+			seen[lit] = true
+			names << lit
+		}
+		tok = scan.scan()
+		lit = scan.lit
+	}
+	return names
 }
 
 fn (mut g Parser) write_deferred_blocks_from(first int) {
@@ -362,7 +473,16 @@ fn (mut g Parser) write_deferred_blocks_from(first int) {
 			g.deferred_lines.len
 		}
 		for line_index in line_start .. line_end {
-			g.out.writeln(g.deferred_lines[line_index])
+			line := g.deferred_lines[line_index]
+			if g.capturing_defer {
+				// `or { return ... }` and other expression blocks are rendered into a
+				// temporary line buffer. Keep the return-path cleanup in that buffer;
+				// writing it straight to `out` would execute the defer before the
+				// fallible expression, even when the error branch is not taken.
+				g.captured_defer_lines << line
+			} else {
+				g.out.writeln(line)
+			}
 		}
 	}
 }
@@ -370,6 +490,22 @@ fn (mut g Parser) write_deferred_blocks_from(first int) {
 fn (mut g Parser) write_all_deferred_scopes() {
 	if g.deferred_block_starts.len > 0 {
 		g.write_deferred_blocks_from(0)
+	}
+	g.write_function_deferred_blocks()
+}
+
+fn (mut g Parser) write_function_deferred_blocks() {
+	for block_index := g.function_defer_blocks.len - 1; block_index >= 0; block_index-- {
+		block := g.function_defer_blocks[block_index]
+		g.write_line('if (${block.flag}) {')
+		for line in block.lines {
+			if g.capturing_defer {
+				g.captured_defer_lines << '\t' + line
+			} else {
+				g.out.writeln('\t' + line)
+			}
+		}
+		g.write_line('}')
 	}
 }
 
@@ -385,6 +521,12 @@ fn (g &Parser) deferred_scopes_source() string {
 		for line_index in line_start .. line_end {
 			lines << g.deferred_lines[line_index]
 		}
+	}
+	for block_index := g.function_defer_blocks.len - 1; block_index >= 0; block_index-- {
+		block := g.function_defer_blocks[block_index]
+		lines << 'if (${block.flag}) {'
+		lines << block.lines
+		lines << '}'
 	}
 	return lines.join(' ')
 }
@@ -404,12 +546,16 @@ fn (mut g Parser) parse_loop_block_body() !FastcLoopBlockResult {
 
 fn (mut g Parser) parse_match_statement() !bool {
 	g.expect(.key_match)!
+	// `read_expression` consumes `mut`, so retain it to keep branch smart-casts
+	// bound to the boxed variant object instead of a detached value copy.
+	subject_is_mut := g.tok == .key_mut
 	subject := g.read_expression([token.Token.lcbr])!
 	subject_type := fastc_normalize_inferred_type(g.last_expression_type)
 	if subject == '' || subject_type == '' {
 		return g.unsupported('unverifiable match subject')
 	}
 	subject_tokens := g.last_expression.clone()
+	smartcast_is_reference := subject_is_mut || subject_type.ends_with('*')
 	g.expect(.lcbr)!
 	subject_name := g.temporary_name('match')
 	g.write_line('__typeof__((${subject})) ${subject_name} = (${subject});')
@@ -429,10 +575,16 @@ fn (mut g Parser) parse_match_statement() !bool {
 		subject_local = subject_tokens[1].lit
 	}
 	mut subject_member_path := ''
-	if is_boxed && subject_tokens.len >= 3 && subject_tokens.len % 2 == 1 && subject_tokens[0].tok == .name && subject_tokens[0].lit in g.locals {
+	mut member_start := 0
+	if subject_tokens.len > 0 && subject_tokens[0].tok in [.key_mut, .amp] {
+		// `match mut sym.info { … }`: the leading `mut` renders as `&`/`mut`, so start
+		// the member-chain scan after it.
+		member_start = 1
+	}
+	if is_boxed && subject_tokens.len - member_start >= 3 && (subject_tokens.len - member_start) % 2 == 1 && subject_tokens[member_start].tok == .name && subject_tokens[member_start].lit in g.locals {
 		mut is_member_chain := true
-		mut path := subject_tokens[0].lit
-		for i := 1; i + 1 < subject_tokens.len; i += 2 {
+		mut path := subject_tokens[member_start].lit
+		for i := member_start + 1; i + 1 < subject_tokens.len; i += 2 {
 			if subject_tokens[i].tok != .dot || subject_tokens[i + 1].tok != .name {
 				is_member_chain = false
 				break
@@ -545,6 +697,11 @@ fn (mut g Parser) parse_match_statement() !bool {
 		mut had_member_smartcast := false
 		mut member_smartcast_active := false
 		common_numeric_type := fastc_match_common_numeric_variant(variant_types)
+		// Several struct variants in one arm (`FnTypeDecl, AliasTypeDecl { node.type_pos }`)
+		// may only read fields common to all of them, which V lays out compatibly, so a
+		// plain-local subject narrows through the first variant — mirroring the member-chain
+		// smart-cast below.
+		struct_multi_variant := variant_types.len > 1 && common_numeric_type == '' && !variant_types.any(it.starts_with('Array_'))
 		smartcast_active := is_boxed && !is_else && (variant_types.len == 1 || common_numeric_type != '') && subject_local != ''
 		if smartcast_active {
 			variant_cname := if common_numeric_type != '' {
@@ -552,29 +709,71 @@ fn (mut g Parser) parse_match_statement() !bool {
 			} else {
 				variant_types[0]
 			}
-			smartcast_value := if common_numeric_type != '' {
+			smartcast_value := if smartcast_is_reference {
+				'(${variant_cname} *)${subject_name}${boxed_access}_object'
+			} else if common_numeric_type != '' {
 				fastc_match_multi_variant_value(subject_name, boxed_access, variant_types, common_numeric_type)
 			} else {
 				'*(${variant_cname} *)${subject_name}${boxed_access}_object'
 			}
-			g.write_line('${variant_cname} ${fastc_c_identifier(subject_local)} = ${smartcast_value};')
+			// The narrowed value is stored in a UNIQUELY named C temporary (not a shadow of the
+			// subject's own C name), so a `defer` body — rendered at function scope and emitted
+			// at each return, including inside this arm — still binds the original subject.
+			shadow_name := g.temporary_name('match_cast')
+			shadow_type := if smartcast_is_reference {
+				variant_cname + '*'
+			} else {
+				variant_cname
+			}
+			g.write_line('${shadow_type} ${shadow_name} = ${smartcast_value};')
 			smartcast_saved = g.locals[subject_local] or { FastcLocal{} }
+			origin_source := g.local_c_name(subject_local)
 			g.locals[subject_local] = FastcLocal{
 				is_mut: smartcast_saved.is_mut
-				typ: variant_cname
+				is_reference: smartcast_is_reference
+				typ: shadow_type
+				c_name: shadow_name
+				smartcast_origin_type: smartcast_saved.typ
+				smartcast_origin_source: origin_source
 			}
 		}
-		if is_boxed && !is_else && variant_types.len == 1 && subject_member_path != '' {
-			variant_cname := variant_types[0]
+		// A single-variant branch narrows the member to that variant; a branch listing
+		// several struct variants may only read fields common to all of them, which V lays
+		// out compatibly, so reading through the first variant (or the shared `array`
+		// layout for array variants) is correct.
+		member_smartcast_type := if variant_types.len == 1 {
+			variant_types[0]
+		} else if variant_types.len > 1 && variant_types.all(it.starts_with('Array_')) {
+			'array'
+		} else if variant_types.len > 1 && common_numeric_type == '' {
+			variant_types[0]
+		} else {
+			''
+		}
+		projection_path := if subject_member_path != '' {
+			subject_member_path
+		} else if struct_multi_variant {
+			subject_local
+		} else {
+			''
+		}
+		if is_boxed && !is_else && member_smartcast_type != '' && projection_path != '' {
 			member_smartcast_name := g.temporary_name('smartcast_member')
-			g.write_line('${variant_cname} *${member_smartcast_name} = (${variant_cname} *)${subject_name}${boxed_access}_object;')
-			member_smartcast_saved = g.member_smartcasts[subject_member_path] or {
+			g.write_line('${member_smartcast_type} *${member_smartcast_name} = (${member_smartcast_type} *)${subject_name}${boxed_access}_object;')
+			member_smartcast_saved = g.member_smartcasts[projection_path] or {
 				FastcMemberSmartcast{}
 			}
-			had_member_smartcast = subject_member_path in g.member_smartcasts
-			g.member_smartcasts[subject_member_path] = FastcMemberSmartcast{
-				typ: variant_cname + '*'
-				source: member_smartcast_name
+			had_member_smartcast = projection_path in g.member_smartcasts
+			g.member_smartcasts[projection_path] = FastcMemberSmartcast{
+				typ: member_smartcast_type + '*'
+				source: if smartcast_is_reference {
+					'((${member_smartcast_type} *)${subject_name}${boxed_access}_object)'
+				} else {
+					member_smartcast_name
+				}
+				variants: if struct_multi_variant { variant_types.clone() } else { [] }
+				tag_source: '${subject_name}${boxed_access}_typ'
+				object_source: '${subject_name}${boxed_access}_object'
 			}
 			member_smartcast_active = true
 		}
@@ -584,9 +783,9 @@ fn (mut g Parser) parse_match_statement() !bool {
 		}
 		if member_smartcast_active {
 			if had_member_smartcast {
-				g.member_smartcasts[subject_member_path] = member_smartcast_saved
+				g.member_smartcasts[projection_path] = member_smartcast_saved
 			} else {
-				g.member_smartcasts.delete(subject_member_path)
+				g.member_smartcasts.delete(projection_path)
 			}
 		}
 		if !terminates {
@@ -702,7 +901,7 @@ fn (mut g Parser) parse_return() !bool {
 		g.consume_statement_end()
 		mut evaluated_values := []string{cap: values.len}
 		for value in values {
-			if g.deferred_block_starts.len == 0 {
+			if !g.has_deferred_blocks() {
 				evaluated_values << value
 				continue
 			}
@@ -761,6 +960,39 @@ fn (mut g Parser) parse_return() !bool {
 		expression = '${contextual_return_type.trim_right('*')}__${g.last_expression[1].lit}'
 		actual_type = contextual_return_type
 	}
+	if g.selfhost && g.return_type.contains('_FASTC_ARRAY_OF_') && g.fixed_array_uses_raw_storage(g.last_expression) {
+		// A struct-field/global/`__global` fixed array is stored as a raw C array, but the
+		// by-value return type is the `struct { T data[N]; }` wrapper; copy the raw array into
+		// its `.data` so the value can be returned.
+		expression = '({ ${g.return_type} __v_fastc_fixed_ret; memcpy(__v_fastc_fixed_ret.data, ${expression}, sizeof(__v_fastc_fixed_ret.data)); __v_fastc_fixed_ret; })'
+		actual_type = g.return_type
+	}
+	if g.selfhost && actual_type.ends_with('*') && !g.return_type.ends_with('*') && g.return_type == actual_type.trim_right('*') {
+		// A member smart-cast (`match x { Variant { return x } }`) yields a pointer to the
+		// concrete variant; a by-value return must dereference it.
+		expression = '*(${expression})'
+		actual_type = g.return_type
+	}
+	if g.selfhost && g.return_type.ends_with('*') && actual_type == g.return_type && g.last_expression.len == 2 && g.last_expression[0].tok == .amp && g.last_expression[1].tok == .name {
+		// A pointer returned from a V local escapes the function. Taking its C address
+		// directly leaves a dangling stack pointer (for example `return &pool` in
+		// sync.pool.new_pool_processor), so copy the local into heap-backed storage.
+		local_name := g.last_expression[1].lit
+		if local := g.locals[local_name] {
+			if !local.is_reference {
+				local_type := fastc_normalize_inferred_type(local.typ)
+				temporary := g.temporary_name('return_reference')
+				expression = '({ ${local_type} ${temporary} = (${fastc_c_identifier(local_name)}); (${g.return_type})v_fastc_interface_box(&${temporary}, sizeof(${local_type})); })'
+			}
+		}
+	}
+	if g.selfhost && g.return_type !in ['Option', 'MultiReturn'] && g.should_box_variant(g.return_type, actual_type) {
+		// A concrete variant returned where the function's boxed sum type is expected
+		// (`fn () Expr { return ArrayInit{...} }`) must be boxed, exactly as the interface
+		// and assignment paths do; otherwise the variant struct is returned raw.
+		expression = g.interface_value_expression(g.return_type, actual_type, expression)
+		actual_type = g.return_type
+	}
 	if g.selfhost && g.return_type !in ['Option', 'MultiReturn'] && g.declared_kinds[g.semantic_type_key(g.return_type)] != .interface_ && !fastc_types_share_lowering_representation(actual_type, g.return_type) && !g.selfhost_types_share_lowering_representation(actual_type, g.return_type) {
 		actual_type = g.return_type
 	}
@@ -772,8 +1004,12 @@ fn (mut g Parser) parse_return() !bool {
 		expression = '(Option){.err=${expression}, .state=1}'
 		actual_type = 'Option'
 	} else if g.selfhost && g.return_type == 'Option' && actual_type != 'Option' {
-		actual_base := fastc_normalize_inferred_type(actual_type)
-		expression = '(Option){.data=${fastc_box_expression(actual_base, expression)}, .state=0}'
+		mut payload_type := fastc_normalize_inferred_type(actual_type)
+		if g.option_return_type != '' && (g.should_box_variant(g.option_return_type, payload_type) || (g.declared_kinds[g.semantic_type_key(g.option_return_type)] == .interface_ && g.declared_kinds[g.semantic_type_key(payload_type)] != .interface_)) {
+			expression = g.interface_value_expression(g.option_return_type, payload_type, expression)
+			payload_type = g.option_return_type
+		}
+		expression = '(Option){.data=${fastc_box_expression(payload_type, expression)}, .state=0}'
 		actual_type = 'Option'
 	}
 	g.consume_statement_end()
@@ -782,7 +1018,7 @@ fn (mut g Parser) parse_return() !bool {
 }
 
 fn (mut g Parser) write_return_expression(expression string) {
-	if g.deferred_block_starts.len == 0 {
+	if !g.has_deferred_blocks() {
 		g.write_line('return ${expression};')
 		return
 	}
@@ -792,23 +1028,66 @@ fn (mut g Parser) write_return_expression(expression string) {
 	g.write_line('return ${temporary};')
 }
 
+fn (g &Parser) has_deferred_blocks() bool {
+	return g.deferred_block_starts.len > 0 || g.function_defer_blocks.len > 0
+}
+
 fn (g &Parser) interface_value_expression(interface_type string, actual_type string, expression string) string {
 	// Normalize so a boxed primitive literal (`Any(42)`) gets a concrete C type and
 	// a matching `__v_typeid_int` rather than the pseudo type `integer literal`.
-	// This is a no-op for declared types.
-	normalized := g.underlying_alias_type(fastc_normalize_inferred_type(actual_type))
+	// Preserve a declared alias when it is itself a direct sum-type variant. For
+	// example, `Expr(EmptyExpr(0))` must carry `__v_typeid_EmptyExpr`, not the tag
+	// of EmptyExpr's underlying `u8`, or `expr is EmptyExpr` will never match.
+	normalized_actual := fastc_normalize_inferred_type(actual_type)
+	actual_variant := fastc_trim_pointer_suffix(normalized_actual)
+	normalized := if fastc_trim_pointer_suffix(interface_type) in g.sum_types && g.sumtype_has_variant(interface_type, actual_variant) {
+		normalized_actual
+	} else {
+		g.underlying_alias_type(normalized_actual)
+	}
 	actual_base := normalized.trim_right('*')
 	actual_key := g.semantic_type_key(normalized)
 	object := if fastc_is_pointer_type(normalized) {
-		'(void*)(${expression})'
+		if expression.trim_space().starts_with('&') {
+			'v_fastc_interface_box((const void*)(${expression}), sizeof(${actual_base}))'
+		} else {
+			'(void*)(${expression})'
+		}
 	} else {
 		fastc_box_expression(actual_base, expression)
 	}
 	return '(${interface_type}){._object=${object}, ._typ=__v_typeid_${fastc_c_declared_type_name(actual_key)}, ._methods=NULL}'
 }
 
+// parse_lock_statement lowers a `lock`/`rlock` statement to a plain scoped block.
+// FastC performs no real locking (its `shared` fields are ordinary members), so
+// the lock targets are skipped and the body runs directly.
+fn (mut g Parser) parse_lock_statement() !bool {
+	g.next() // consume `lock`/`rlock`
+	for g.tok != .lcbr && g.tok != .eof {
+		g.next()
+	}
+	if g.tok != .lcbr {
+		return g.unsupported('`lock` without a block')
+	}
+	g.next() // consume `{`
+	g.write_line('{')
+	g.indent++
+	outer_locals := g.locals.clone()
+	terminates := g.parse_block_body()!
+	g.locals = outer_locals.clone()
+	g.indent--
+	g.write_line('}')
+	return terminates
+}
+
 fn (mut g Parser) parse_mutable_declaration() ! {
 	g.next()
+	mut is_static := false
+	if g.tok == .key_static {
+		is_static = true
+		g.next()
+	}
 	if g.tok != .name && !g.tok.is_keyword() {
 		return g.unsupported('mutable declaration')
 	}
@@ -821,7 +1100,7 @@ fn (mut g Parser) parse_mutable_declaration() ! {
 	if g.tok != .decl_assign {
 		return g.unsupported('`mut` statement without `:=`')
 	}
-	g.parse_declaration_after_name(name, true)!
+	g.parse_declaration_after_name(name, true, is_static)!
 }
 
 fn (mut g Parser) parse_simple_statement() ! {
@@ -879,29 +1158,45 @@ fn (mut g Parser) parse_simple_statement() ! {
 			return
 		}
 		if g.tok == .decl_assign {
-			g.parse_declaration_after_name(name, false)!
+			g.parse_declaration_after_name(name, false, false)!
 			return
 		}
 		if g.selfhost && g.tok == .left_shift {
-			local := g.locals[name] or { return g.unsupported('append to unknown name `${name}`') }
-			if !local.is_mut {
+			mut target_type := ''
+			mut target_is_mut := false
+			mut c_name := ''
+			if local := g.locals[name] {
+				target_type = local.typ
+				target_is_mut = local.is_mut
+				c_name = fastc_c_identifier(name)
+			} else if global_c_name := g.globals[fastc_global_key(g.module_name, name)] {
+				// A `__global` array (`codegen_files << …`) appends the same way; globals
+				// are always mutable and referenced by their resolved C name.
+				target_type = g.global_types[fastc_global_key(g.module_name, name)] or { '' }
+				target_is_mut = true
+				c_name = global_c_name
+			} else {
+				return g.unsupported('append to unknown name `${name}`')
+			}
+			if !target_is_mut {
 				return g.unsupported('append to immutable name `${name}`')
 			}
-			element_type := g.array_element_type(local.typ) or {
-				return g.unsupported('append to non-array `${name}` of type `${local.typ}`')
+			element_type := g.array_element_type(target_type) or {
+				return g.unsupported('append to non-array `${name}` of type `${target_type}`')
 			}
 			g.next()
 			value := g.read_expression([token.Token.semicolon, token.Token.rcbr])!
 			value_type := fastc_normalize_inferred_type(g.last_expression_type)
+			target_array_type := fastc_trim_pointer_suffix(g.underlying_alias_type(target_type))
+			value_array_type := fastc_trim_pointer_suffix(g.underlying_alias_type(value_type))
 			// `[]T << []T` is push-many, unless the element type is a sum type that lists
 			// `[]T` as a variant (a recursive sum type such as `type Value = []Value | int`),
 			// in which case the array is boxed as one element. Mirrors the main C backend's
 			// `sumtype_has_variant` guard (see vlib/v/gen/c/infix.v).
-			boxes_array_variant := value_type == local.typ && g.sumtype_has_variant(element_type, value_type)
-			is_array_append := value_type == local.typ && !boxes_array_variant
+			boxes_array_variant := value_array_type == target_array_type && g.sumtype_has_variant(element_type, value_array_type)
+			is_array_append := value_array_type == target_array_type && !boxes_array_variant
 			g.consume_statement_end()
-			c_name := fastc_c_identifier(name)
-			array_target := if local.typ.ends_with('*') {
+			array_target := if target_type.ends_with('*') {
 				'(array *)${c_name}'
 			} else {
 				'(array *)&${c_name}'
@@ -913,13 +1208,34 @@ fn (mut g Parser) parse_simple_statement() ! {
 				}
 				g.write_line('${element_type} ${value_name} = (${boxed});')
 				g.write_line('builtin__array_push(${array_target}, &${value_name});')
-			} else {
+			} else if is_array_append {
 				g.write_line('__typeof__((${value})) ${value_name} = (${value});')
-				if is_array_append {
-					g.write_line('builtin__array_push_many(${array_target}, ${value_name}.data, ${value_name}.len);')
+				g.write_line('builtin__array_push_many(${array_target}, ${value_name}.data, ${value_name}.len);')
+			} else {
+				// A `.member` enum-shorthand element needs its target enum type to lower; re-render it
+				// through the argument path. Other values keep their raw streamed form so contextual
+				// re-rendering never disturbs a spawn/thread or already-correct value.
+				is_complex_or := value.contains('({') && (value.contains('return ') || value.contains('for (') || value.contains('switch ('))
+				boxes_variant := g.should_box_variant(element_type, value_type)
+				push_value := if boxes_variant || (g.last_expression.len == 2 && g.last_expression[0].tok == .dot && g.last_expression[1].tok == .name) || is_complex_or {
+					// A `.member` enum-shorthand element, or a complex `or { return … }`-unwrap: the
+					// streamed form can carry a paren imbalance and/or unresolved shorthand. A
+					// smart-cast variant appended to a sum-type array also needs to be boxed back into
+					// the array's element type, so re-render cleanly from the tokens.
+					g.render_call_argument_expression(g.last_expression, element_type) or { value }
 				} else {
-					g.write_line('builtin__array_push(${array_target}, &${value_name});')
+					value
 				}
+				// TinyCC cannot `__typeof__` a statement expression that runs a `return`/`for`/
+				// `switch` (an `or { return … }`-unwrap element); name the element type directly, as
+				// the declaration path does. Gated on `({` so a compound-literal value is unaffected.
+				push_decl_type := if boxes_variant || (element_type != '' && push_value.contains('({') && (push_value.contains('return ') || push_value.contains('for (') || push_value.contains('switch ('))) {
+					element_type
+				} else {
+					'__typeof__((${push_value}))'
+				}
+				g.write_line('${push_decl_type} ${value_name} = (${push_value});')
+				g.write_line('builtin__array_push(${array_target}, &${value_name});')
 			}
 			return
 		}
@@ -939,7 +1255,15 @@ fn (mut g Parser) parse_simple_statement() ! {
 			expected_type := if is_global {
 				g.global_types[global_key]
 			} else if local := g.locals[name] {
-				if local.is_reference { local.typ.trim_right('*') } else { local.typ }
+				// Assigning to a smart-cast local widens it back to the boxed sum type (`c_target`
+				// is the raw C variable, not the narrowed shadow), so expect the origin type — else
+				// a variant value would be stored into the sum-type slot without the required box.
+				base := if local.smartcast_origin_type != '' {
+					local.smartcast_origin_type
+				} else {
+					local.typ
+				}
+				if local.is_reference { base.trim_right('*') } else { base }
 			} else {
 				''
 			}
@@ -1032,6 +1356,10 @@ fn (mut g Parser) parse_simple_statement() ! {
 				// A concrete struct assigned to an interface variable is boxed with its
 				// type id so the dispatch functions can recover the receiver.
 				assigned_value = g.interface_value_expression(resolved_expected_type, actual_type, value)
+			} else if g.selfhost && operator == .assign && actual_type.ends_with('*') && !resolved_expected_type.ends_with('*') && resolved_expected_type == actual_type.trim_right('*') {
+				// A member smart-cast (`if x.f is T { x = x.f }`) yields a pointer to the
+				// concrete variant; assigning it to a by-value target dereferences it.
+				assigned_value = '*(${value})'
 			} else if g.selfhost && operator == .assign && resolved_expected_type == 'voidptr' && actual_type !in ['',
 				'voidptr', 'nil'] && !fastc_expression_is_zero(g.last_expression) && !fastc_is_pointer_type(actual_type) {
 				// An unmonomorphized imported generic stores `T` as `voidptr`. Preserve a
@@ -1145,6 +1473,7 @@ fn (mut g Parser) capture_or_value(expression string) {
 fn (mut g Parser) parse_parallel_assignment(initial_names []string, initial_mut bool, force_declaration bool) ! {
 	mut names := initial_names.clone()
 	mut mutability := []bool{len: initial_names.len, init: initial_mut}
+	mut member_targets := map[int]FastcRenderedExpression{}
 	for g.tok == .comma {
 		g.next()
 		mut is_mut := false
@@ -1155,9 +1484,25 @@ fn (mut g Parser) parse_parallel_assignment(initial_names []string, initial_mut 
 		if g.tok != .name && !(g.tok == .key_shared && g.shared_token_is_identifier(.unknown)) {
 			return g.unsupported('parallel assignment target')
 		}
-		names << g.lit
-		mutability << is_mut
+		target_name := g.lit
 		g.next()
+		if g.tok == .dot || g.tok == .lsbr {
+			// A member/index lvalue target (`_, node.value = f()`): read the rest of the
+			// target expression and remember its rendered form for the assignment below.
+			source := g.read_statement_expression_with_prefix(target_name, [
+				token.Token.comma,
+				token.Token.assign,
+			])!
+			member_targets[names.len] = g.validate_parallel_expression_assignment_target(source, g.last_expression.clone(), g.last_expression_type)!
+			names << ''
+			mutability << is_mut
+			continue
+		}
+		names << target_name
+		mutability << is_mut
+	}
+	if member_targets.len > 0 {
+		return g.finish_parallel_member_assignment(names, member_targets)
 	}
 	is_declaration := force_declaration || g.tok == .decl_assign
 	if g.tok !in [.decl_assign, .assign] {
@@ -1262,6 +1607,66 @@ fn (mut g Parser) parse_parallel_assignment(initial_names []string, initial_mut 
 	}
 }
 
+// finish_parallel_member_assignment lowers a parallel assignment that has at least
+// one member/index lvalue target (`_, node.value = f()`). Such targets can only be
+// assigned, never declared, so this reads the `=` RHS and assigns each rendered
+// target, blanking `_` positions. `member_targets` holds the rendered lvalues by
+// target index; the remaining `names` entries are plain names (or `_`).
+fn (mut g Parser) finish_parallel_member_assignment(names []string, member_targets map[int]FastcRenderedExpression) ! {
+	if g.tok != .assign {
+		return g.unsupported('parallel assignment operator `${g.token_source()}`')
+	}
+	g.next()
+	mut targets := []FastcRenderedExpression{cap: names.len}
+	for i, name in names {
+		if member_target := member_targets[i] {
+			targets << member_target
+		} else {
+			rendered := g.validate_parallel_assignment_targets([name])!
+			targets << rendered[0]
+		}
+	}
+	g.last_multi_return_types = []string{}
+	mut values := []string{}
+	for {
+		value := g.read_expression([token.Token.comma, token.Token.semicolon, token.Token.rcbr])!
+		if value == '' {
+			return g.unsupported('empty parallel assignment')
+		}
+		values << value
+		if g.tok != .comma {
+			break
+		}
+		g.next()
+	}
+	g.consume_statement_end()
+	if values.len > 1 {
+		if values.len != targets.len {
+			return g.unsupported('parallel assignment with ${targets.len} targets and ${values.len} values')
+		}
+		mut temporaries := []string{cap: values.len}
+		for value in values {
+			temporary := g.temporary_name('parallel')
+			g.write_line('__typeof__((${value})) ${temporary} = (${value});')
+			temporaries << temporary
+		}
+		for i, target in targets {
+			if target.source != '' {
+				g.write_line('${target.source} = ${temporaries[i]};')
+			}
+		}
+		return
+	}
+	temporary := g.temporary_name('multi_return')
+	g.write_line('MultiReturn ${temporary} = (${values[0]});')
+	for i, target in targets {
+		if target.source == '' {
+			continue
+		}
+		g.write_line('memcpy(&${target.source}, ${temporary}.values[${i}].data, sizeof(${target.source}));')
+	}
+}
+
 // parallel_rhs_is_option_tuple_or reports whether the RHS of a parallel `:=` (the
 // scanner is positioned at its first token) has the shape `<expr> or { … , … }` — an
 // option unwrapped with a comma-separated TUPLE fallback. Bounded to the current
@@ -1347,6 +1752,26 @@ fn (mut g Parser) parse_parallel_option_tuple(names []string, mutability []bool,
 	g.locals['err'] = FastcLocal{
 		typ: 'IError'
 	}
+	// The `or` block may run leading statements (`has_field = false`, an `if`, …) before
+	// its final comma-separated fallback values. Capture those statements so they run in
+	// the error branch ahead of the fallback assignments.
+	previous_capture := g.capturing_defer
+	previous_lines := g.captured_defer_lines.clone()
+	g.capturing_defer = true
+	g.captured_defer_lines = []string{}
+	for g.or_block_has_statements() {
+		if g.tok == .key_if && g.if_starts_final_block_expression() {
+			break
+		}
+		if g.tok == .key_match && g.match_starts_final_block_expression() {
+			break
+		}
+		_ = g.parse_statement()!
+		g.skip_semicolons()
+	}
+	or_statements := g.captured_defer_lines.clone()
+	g.capturing_defer = previous_capture
+	g.captured_defer_lines = previous_lines
 	mut fallbacks := []string{}
 	for g.tok != .rcbr && g.tok != .eof {
 		g.skip_semicolons()
@@ -1392,6 +1817,9 @@ fn (mut g Parser) parse_parallel_option_tuple(names []string, mutability []bool,
 	g.write_line('if (${guard}.state) {')
 	g.indent++
 	g.write_line('IError err = ${guard}.err;')
+	for line in or_statements {
+		g.write_line(line)
+	}
 	for i, name in names {
 		if name == '_' {
 			continue
@@ -1596,6 +2024,15 @@ fn (g &Parser) multi_return_types_for_expression(tokens []FastcExpressionToken) 
 }
 
 fn (g &Parser) option_value_type_for_expression(tokens []FastcExpressionToken) string {
+	// `Enum.from_string(s)` is a compiler-provided static method returning `?Enum`; its
+	// wrapped value type is the enum itself, so an `or {}` recovers the parsed value.
+	if tokens.len >= 4 && tokens[0].tok == .name && tokens[1].tok == .dot && tokens[2].tok == .name && tokens[2].lit == 'from_string' && tokens[3].tok == .lpar {
+		if enum_key := g.resolve_declared_type_key(tokens[0].lit) {
+			if g.declared_kinds[enum_key] == .enum_ {
+				return fastc_c_declared_type_name(enum_key)
+			}
+		}
+	}
 	if map_lookup := g.render_map_lookup_option_expression(tokens) {
 		return map_lookup.typ
 	}
@@ -1811,13 +2248,19 @@ fn (g &Parser) expression_tokens_are_statement(expression_tokens []FastcExpressi
 			}
 			receiver_start := fastc_method_receiver_start(tokens, i - 1)
 			receiver_type := g.infer_expression_type(tokens[receiver_start..i - 1]) or { continue }
-			if tokens[i].lit == 'wait' && receiver_type.starts_with(fastc_thread_type_prefix) {
-				// Generated thread waiters are absent from g.functions, but joining
-				// a void-returning spawn is still a valid standalone statement.
+			if tokens[i].lit == 'wait' && (receiver_type.starts_with(fastc_thread_type_prefix) || (receiver_type.trim_right('*').starts_with('Array_') && (g.array_element_type(receiver_type) or { '' }).starts_with(fastc_thread_type_prefix))) {
+				// Generated thread waiters are absent from g.functions, but joining a spawn
+				// (or every spawn in a `[]thread` via `.wait()`) is a valid standalone
+				// statement even when the joined value is discarded.
 				return true
 			}
 			resolved_method_key, _ := g.resolve_method(receiver_type, tokens[i].lit)
 			if resolved_method_key in g.functions || resolved_method_key in g.mono_functions || g.struct_member_type(receiver_type, tokens[i].lit) != '' {
+				return true
+			}
+			if tokens[i].lit == 'free' {
+				// A struct's auto-generated `free()` (no explicit method) is a valid
+				// statement; FastC compiles it to a no-op under `-gc none`.
 				return true
 			}
 		}
@@ -1845,12 +2288,16 @@ fn (g &Parser) expression_tokens_are_statement(expression_tokens []FastcExpressi
 			if local.fn_return_type != '' {
 				return true
 			}
+			// Calling a value whose type is a `type X = fn (...)` alias is a statement.
+			if fastc_trim_pointer_suffix(local.typ) in g.fn_alias_return_types {
+				return true
+			}
 		}
 	}
 	return function_key in g.functions || (name_index == 0 && name in ['print', 'println'])
 }
 
-fn (mut g Parser) parse_declaration_after_name(name string, is_mut bool) ! {
+fn (mut g Parser) parse_declaration_after_name(name string, is_mut bool, is_static bool) ! {
 	if !g.selfhost && name in g.locals {
 		return g.unsupported('redeclaration of `${name}`')
 	}
@@ -1861,9 +2308,23 @@ fn (mut g Parser) parse_declaration_after_name(name string, is_mut bool) ! {
 			return g.parse_orm_sql_select_declaration(name, is_mut)
 		}
 	}
+	// A bare `name := expr` has no declared target type; clear any expected type left over from
+	// a previous statement so the RHS (e.g. an `or {}` block, which adopts the expected type as
+	// its value type) infers its own type rather than a stale one.
+	previous_declaration_expected := g.expected_expression_type
+	g.expected_expression_type = ''
 	expression := g.read_expression([token.Token.semicolon, token.Token.rcbr])!
+	g.expected_expression_type = previous_declaration_expected
 	if expression.len == 0 {
 		return g.unsupported('empty declaration')
+	}
+	// Record whether this bool is `x is A && y is B && …`, so a later `name && x.field` narrows
+	// `x`/`y` (V's smart-cast-through-a-bool-variable). Computed now while g.last_expression is the
+	// just-read RHS; attached to the scoped local below.
+	bool_implications := if g.selfhost {
+		g.compute_bool_is_implications(g.last_expression)
+	} else {
+		[]FastcBoolImplication{}
 	}
 	option_value_type := if g.selfhost {
 		if g.last_expression.len == 0 {
@@ -1879,23 +2340,36 @@ fn (mut g Parser) parse_declaration_after_name(name string, is_mut bool) ! {
 	// direct path preserve V's `:=` without running any inference or type checker.
 	c_name := fastc_c_identifier(name)
 	normalized_type := fastc_normalize_inferred_type(g.last_expression_type)
-	if expression.starts_with('"') {
-		// C's typeof preserves a literal's array type instead of applying the usual
-		// pointer decay. The spelling alone is enough to lower this case.
-		g.write_line('string ${c_name} = (${expression});')
-	} else if normalized_type == 'int' {
-		// V's platform `int` is i64 (on 64-bit targets); `__typeof__` of an integer
-		// literal or C-`int` expression would give C `int` (32-bit), silently
-		// truncating `int` arithmetic. Spell the platform int type explicitly so the
-		// local matches the width used for `int` params, fields, and the C backend.
-		g.write_line('${fastc_platform_int_c_type} ${c_name} = (${expression});')
-	} else {
-		g.write_line('__typeof__((${expression})) ${c_name} = (${expression});')
-	}
 	local_type := if g.selfhost && g.last_expression_type == '' {
 		'int'
 	} else {
 		normalized_type
+	}
+	mut declaration_type := '__typeof__((${expression}))'
+	if expression.starts_with('"') {
+		// C's typeof preserves a literal's array type instead of applying the usual
+		// pointer decay. The spelling alone is enough to lower this case.
+		declaration_type = 'string'
+	} else if normalized_type == 'int' {
+		// V's platform `int` is i64 on 64-bit targets. C `__typeof__` would keep
+		// integer literals and C-int expressions at 32 bits and silently truncate.
+		declaration_type = fastc_platform_int_c_type
+	} else if expression.starts_with('({') && (expression.contains('for (') || expression.contains('switch (') || expression.contains('return ')) && g.last_expression_type != '' && local_type != '' {
+		// TinyCC cannot take `__typeof__` of a statement expression that runs a `for` loop (as an
+		// array `{len:, init:}` initializer lowers to), a `switch` (as a sum-type common-field
+		// read lowers to), or a `return` (an `x or { return … }` propagation), so name the known
+		// result type directly instead of inferring it back from the expression.
+		declaration_type = local_type
+	}
+	if is_static {
+		// V function statics may have runtime initializers. Keep C static storage and guard
+		// the assignment so later calls (including at-exit callbacks) see the retained value.
+		init_guard := g.temporary_name('static_init')
+		g.write_line('static ${declaration_type} ${c_name};')
+		g.write_line('static bool ${init_guard};')
+		g.write_line('if (!${init_guard}) { ${init_guard} = true; ${c_name} = (${expression}); }')
+	} else {
+		g.write_line('${declaration_type} ${c_name} = (${expression});')
 	}
 	function_alias := g.functions[local_type] or { FastcFunctionSignature{} }
 	g.set_scoped_local(name, FastcLocal{
@@ -1904,6 +2378,7 @@ fn (mut g Parser) parse_declaration_after_name(name string, is_mut bool) ! {
 		option_value_type: option_value_type
 		fn_return_type: function_alias.return_type
 		fn_option_value_type: function_alias.option_type
+		bool_implications: bool_implications
 	})
 }
 

--- a/vlib/v3/gen/fastc/stmt.v
+++ b/vlib/v3/gen/fastc/stmt.v
@@ -1663,7 +1663,7 @@ fn (mut g Parser) finish_parallel_member_assignment(names []string, member_targe
 		if target.source == '' {
 			continue
 		}
-		g.write_line('memcpy(&${target.source}, ${temporary}.values[${i}].data, sizeof(${target.source}));')
+		g.write_line('memcpy(&${target.source}, V_FASTC_MULTI_SOURCE(${temporary}.values[${i}], sizeof(${target.source})), sizeof(${target.source}));')
 	}
 }
 

--- a/vlib/v3/gen/fastc/str_intp.v
+++ b/vlib/v3/gen/fastc/str_intp.v
@@ -82,6 +82,70 @@ fn (mut g Parser) fastc_fixed_array_str_name(c_type string) ?string {
 
 // fastc_array_str_name returns a helper that renders a dynamic array using the
 // element type retained in FastC's `Array_T` spelling.
+// fastc_sumtype_str_helper generates a `str()` helper for a boxed sum type: it
+// switches on the runtime `_typ` tag and formats the concrete variant with the
+// same per-type logic as struct-field formatting. Returns none for a non-sum type
+// or when any variant cannot be formatted.
+fn (mut g Parser) fastc_sumtype_str_helper(c_type string) ?string {
+	base := fastc_normalize_inferred_type(c_type).trim_right('*')
+	if base !in g.sum_types {
+		return none
+	}
+	fn_name := 'v_fastc_sumtype_str_${base}'
+	if fn_name in g.spawn_helpers {
+		return fn_name
+	}
+	g.spawn_helpers[fn_name] = ''
+	g.protos.writeln('string ${fn_name}(${base} it);')
+	mut body := 'string ${fn_name}(${base} it) {\n\tswitch (it._typ) {\n'
+	mut variant_keys := g.sum_type_variants.keys()
+	variant_keys.sort()
+	for key in variant_keys {
+		if !key.starts_with('${base}|') {
+			continue
+		}
+		variant := key.all_after('|')
+		formatted := g.fastc_struct_field_str_expression('(*(${variant} *)it._object)', variant) or {
+			g.spawn_helpers.delete(fn_name)
+			return none
+		}
+		body += '\t\tcase __v_typeid_${variant}: return ${formatted};\n'
+	}
+	body += '\t}\n\treturn _S("unknown");\n}'
+	g.spawn_helpers[fn_name] = body
+	return fn_name
+}
+
+// fastc_sumtype_type_name_helper generates a `type_name()` helper for a boxed
+// sum type or interface: it switches on the runtime `_typ` tag and returns the
+// variant's dotted name (`v.ast.CallExpr`). Returns none for non-boxed types.
+fn (mut g Parser) fastc_sumtype_type_name_helper(c_type string) ?string {
+	base := fastc_normalize_inferred_type(c_type).trim_right('*')
+	if base !in g.sum_types && g.declared_kinds[g.semantic_type_key(base)] != .interface_ {
+		return none
+	}
+	fn_name := 'v_fastc_typename_${base}'
+	if fn_name in g.spawn_helpers {
+		return fn_name
+	}
+	g.spawn_helpers[fn_name] = ''
+	g.protos.writeln('string ${fn_name}(${base} it);')
+	mut body := 'string ${fn_name}(${base} it) {\n\tswitch (it._typ) {\n'
+	mut variant_keys := g.sum_type_variants.keys()
+	variant_keys.sort()
+	for key in variant_keys {
+		if !key.starts_with('${base}|') {
+			continue
+		}
+		variant := key.all_after('|')
+		display := variant.replace('__', '.')
+		body += '\t\tcase __v_typeid_${variant}: return _S("${display}");\n'
+	}
+	body += '\t}\n\treturn _S("unknown");\n}'
+	g.spawn_helpers[fn_name] = body
+	return fn_name
+}
+
 fn (mut g Parser) fastc_array_str_name(c_type string) ?string {
 	array_type := fastc_normalize_inferred_type(c_type).trim_right('*')
 	if !array_type.starts_with('Array_') {
@@ -144,8 +208,7 @@ fn (mut g Parser) fastc_struct_field_str_expression(value_c string, field_c_type
 		} else {
 			value_c
 		}
-		return '${fastc_method_c_name(method_signature.module_name,
-			fastc_c_declared_type_name(key), 'str')}(${receiver})'
+		return '${fastc_method_c_name(method_signature.module_name, fastc_c_declared_type_name(key), 'str')}(${receiver})'
 	}
 	if g.declared_kinds[key] == .enum_ {
 		return 'v_fastc_enum_str_${fastc_c_declared_type_name(key)}(${value_c})'
@@ -179,8 +242,7 @@ fn (mut g Parser) read_interpolated_string() !string {
 		value_tokens := g.last_expression.clone()
 		value_type := fastc_normalize_inferred_type(g.last_expression_type)
 		value_key := g.semantic_type_key(value_type)
-		alias_has_str_method := g.declared_kinds[value_key] == .alias_
-			&& '${value_key}.str' in g.functions
+		alias_has_str_method := g.declared_kinds[value_key] == .alias_ && '${value_key}.str' in g.functions
 		interpolation_type := if alias_has_str_method {
 			value_type
 		} else {
@@ -201,8 +263,7 @@ fn (mut g Parser) read_interpolated_string() !string {
 			}
 		}
 		g.expect(.rcbr)!
-		if format_specifier.ends_with('c') && fastc_is_integer_expression_type(interpolation_type)
-			&& !fastc_integer_interpolation_format_is_supported(format_specifier, fastc_is_unsigned_integer_type(interpolation_type)) {
+		if format_specifier.ends_with('c') && fastc_is_integer_expression_type(interpolation_type) && !fastc_integer_interpolation_format_is_supported(format_specifier, fastc_is_unsigned_integer_type(interpolation_type)) {
 			return g.unsupported('interpolation format `${format_specifier}` for `${value_type}`')
 		}
 		if !g.selfhost && format_specifier.ends_with('c') {
@@ -227,10 +288,8 @@ fn (mut g Parser) read_interpolated_string() !string {
 			helper := g.fastc_fixed_array_str_name(interpolation_type) or {
 				return g.unsupported('interpolation of fixed array type `${value_type}`')
 			}
-			is_member_array := value_tokens.len >= 3 && value_tokens.last().tok == .name
-				&& value_tokens[value_tokens.len - 2].tok == .dot
-			is_global_array := value_tokens.len == 1 && value_tokens[0].tok == .name
-				&& fastc_global_key(g.module_name, value_tokens[0].lit) in g.globals
+			is_member_array := value_tokens.len >= 3 && value_tokens.last().tok == .name && value_tokens[value_tokens.len - 2].tok == .dot
+			is_global_array := value_tokens.len == 1 && value_tokens[0].tok == .name && fastc_global_key(g.module_name, value_tokens[0].lit) in g.globals
 			data_source := if is_member_array || is_global_array {
 				value
 			} else {
@@ -251,9 +310,7 @@ fn (mut g Parser) read_interpolated_string() !string {
 			} else {
 				u8(0)
 			}
-			if format_character == `d` || format_character == `u` || format_character == `x`
-				|| format_character == `X` || format_character == `o` || format_character == `c`
-				|| format_character == `b` {
+			if format_character == `d` || format_character == `u` || format_character == `x` || format_character == `X` || format_character == `o` || format_character == `c` || format_character == `b` {
 				if !fastc_integer_interpolation_format_is_supported(format_specifier, is_unsigned) {
 					return g.unsupported('interpolation format `${format_specifier}` for enum `${value_type}`')
 				}
@@ -267,7 +324,19 @@ fn (mut g Parser) read_interpolated_string() !string {
 					return g.unsupported('interpolation format `${format_specifier}` for enum `${value_type}`')
 				}
 				enum_type := fastc_c_declared_type_name(enum_key)
-				enum_name := 'v_fastc_enum_str_${enum_type}(${value})'
+				enum_name := if method_signature := g.functions['${enum_key}.str'] {
+					expected_receiver := method_signature.parameter_types[0]
+					receiver := if expected_receiver.ends_with('*') && !interpolation_type.ends_with('*') {
+						'&(${value})'
+					} else if !expected_receiver.ends_with('*') && interpolation_type.ends_with('*') {
+						'*(${value})'
+					} else {
+						value
+					}
+					'${fastc_method_c_name(method_signature.module_name, enum_type, 'str')}(${receiver})'
+				} else {
+					'v_fastc_enum_str_${enum_type}(${value})'
+				}
 				parts << if width.width > 0 {
 					'v_fastc_string_pad(${enum_name}, ${width.width}, ${width.left_align})'
 				} else {
@@ -277,9 +346,7 @@ fn (mut g Parser) read_interpolated_string() !string {
 		} else {
 			mut converted_primitive := false
 			if !g.selfhost {
-				if primitive_conversion := fastc_primitive_interpolation_expression(interpolation_type,
-					value, format_specifier)
-				{
+				if primitive_conversion := fastc_primitive_interpolation_expression(interpolation_type, value, format_specifier) {
 					parts << primitive_conversion
 					converted_primitive = true
 				} else if fastc_is_primitive_interpolation_type(interpolation_type) {
@@ -291,19 +358,32 @@ fn (mut g Parser) read_interpolated_string() !string {
 				method_key := '${receiver_key}.str'
 				if method_signature := g.functions[method_key] {
 					expected_receiver := method_signature.parameter_types[0]
-					receiver := if expected_receiver.ends_with('*')
-						&& !interpolation_type.ends_with('*') {
+					receiver := if expected_receiver.ends_with('*') && !interpolation_type.ends_with('*') {
 						'&(${value})'
 					} else if !expected_receiver.ends_with('*') && interpolation_type.ends_with('*') {
 						'*(${value})'
 					} else {
 						value
 					}
-					parts << '${fastc_method_c_name(method_signature.module_name,
-						fastc_c_declared_type_name(receiver_key), 'str')}(${receiver})'
+					parts << '${fastc_method_c_name(method_signature.module_name, fastc_c_declared_type_name(receiver_key), 'str')}(${receiver})'
+				} else if sumtype_helper := g.fastc_sumtype_str_helper(interpolation_type) {
+					// A boxed sum type dispatches `str()` on its runtime variant tag.
+					receiver := if interpolation_type.ends_with('*') {
+						'*(${value})'
+					} else {
+						value
+					}
+					parts << '${sumtype_helper}(${receiver})'
 				} else if default_name := g.fastc_default_struct_str_name(interpolation_type) {
-					// No user `str()`: emit V's default `Type{...}` representation.
-					parts << '${default_name}(${value})'
+					// No user `str()`: emit V's default `Type{...}` representation. A pointer
+					// value — a member smart-cast narrows a boxed variant to a `T*`, or the
+					// receiver itself is `&T` — must be deref'd for the by-value helper argument.
+					receiver := if interpolation_type.ends_with('*') || (g.selfhost && g.expression_uses_member_smartcast(value_tokens)) {
+						'*(${value})'
+					} else {
+						value
+					}
+					parts << '${default_name}(${receiver})'
 				} else {
 					local_type := if g.last_expression.len > 0 && g.last_expression[0].tok == .name {
 						local := g.locals[g.last_expression[0].lit] or { FastcLocal{} }
@@ -366,7 +446,7 @@ fn fastc_string_interpolation_width(format string) ?FastcInterpolationWidth {
 		width = width * 10 + int(format[i] - `0`)
 	}
 	return FastcInterpolationWidth{
-		width:      width
+		width: width
 		left_align: left_align
 	}
 }
@@ -376,9 +456,7 @@ fn fastc_integer_interpolation_format_is_supported(format string, is_unsigned bo
 		return true
 	}
 	specifier := format[format.len - 1]
-	supported := specifier == `d` || specifier == `x` || specifier == `X`
-		|| specifier == `o` || specifier == `c` || specifier == `b`
-		|| (is_unsigned && specifier == `u`)
+	supported := specifier == `d` || specifier == `x` || specifier == `X` || specifier == `o` || specifier == `c` || specifier == `b` || (is_unsigned && specifier == `u`)
 	if !supported {
 		return false
 	}
@@ -437,10 +515,27 @@ fn fastc_primitive_interpolation_expression(value_type string, value string, for
 
 fn fastc_string_literal_is_incomplete(literal string) bool {
 	mut raw := literal
+	mut is_raw := false
 	if raw.len > 0 && raw[0] == `r` {
+		is_raw = true
 		raw = raw[1..]
 	}
-	return raw.len < 2 || raw[raw.len - 1] != raw[0]
+	if raw.len < 2 || raw[raw.len - 1] != raw[0] {
+		return true
+	}
+	if is_raw {
+		return false
+	}
+	// The last character matches the opening quote, but when it is an *escaped* quote
+	// (`… \'` before an interpolation) it is not a closing quote — the literal continues
+	// into a `${…}` fragment, so it is incomplete.
+	mut backslashes := 0
+	mut i := raw.len - 2
+	for i >= 0 && raw[i] == `\\` {
+		backslashes++
+		i--
+	}
+	return backslashes % 2 == 1
 }
 
 fn fastc_c_interpolation_segment(literal string, is_first bool, quote u8) !string {
@@ -453,7 +548,11 @@ fn fastc_c_interpolation_segment(literal string, is_first bool, quote u8) !strin
 			content = content[1..]
 		}
 	}
-	if !is_first && content.len > 0 && content[content.len - 1] == quote {
+	// Only the final segment ends with the closing quote of the whole string; a
+	// middle segment that ends with `quote` carries an escaped quote (`\'`)
+	// that belongs to the body, so stripping it would drop the quote and leave a
+	// dangling backslash that corrupts the emitted C string literal.
+	if !is_first && content.len > 0 && content[content.len - 1] == quote && !fastc_trailing_quote_is_escaped(content) {
 		content = content[..content.len - 1]
 	}
 	if content == '' {
@@ -462,6 +561,19 @@ fn fastc_c_interpolation_segment(literal string, is_first bool, quote u8) !strin
 	wrapper := if quote == `'` { "'" } else { '"' }
 	c_literal := fastc_c_string(wrapper + content + wrapper)!
 	return '_S(${c_literal})'
+}
+
+// fastc_trailing_quote_is_escaped reports whether the last character of `content` is
+// preceded by an odd number of backslashes, meaning it is an escaped quote (`\'`) that
+// is part of the string body rather than an unescaped closing delimiter.
+fn fastc_trailing_quote_is_escaped(content string) bool {
+	mut backslashes := 0
+	mut i := content.len - 2
+	for i >= 0 && content[i] == `\\` {
+		backslashes++
+		i--
+	}
+	return backslashes % 2 == 1
 }
 
 fn fastc_method_c_name_for_key(receiver_key string, name string) string {
@@ -572,9 +684,14 @@ fn fastc_c_string(literal string) !string {
 				i += 4
 				continue
 			}
-			if raw[i + 1] >= `0` && raw[i + 1] <= `7` && (i + 3 >= raw.len - 1
-				|| raw[i + 2] < `0` || raw[i + 2] > `7` || raw[i + 3] < `0`
-				|| raw[i + 3] > `7`) {
+			if raw[i + 1] >= `0` && raw[i + 1] <= `7` && (i + 3 >= raw.len - 1 || raw[i + 2] < `0` || raw[i + 2] > `7` || raw[i + 3] < `0` || raw[i + 3] > `7`) {
+				// V's `\0` is a NUL byte; emit a full three-digit octal so a following
+				// digit cannot extend the escape (`_S`'s `sizeof`-based length keeps it).
+				if raw[i + 1] == `0` {
+					result.write_string('\\000')
+					i += 2
+					continue
+				}
 				// V only decodes three-digit octal escapes. Preserve a shorter
 				// spelling as a literal backslash and digits instead of letting C
 				// consume it as a one- or two-digit octal escape.
@@ -632,7 +749,9 @@ fn fastc_c_rune(literal string) !string {
 				96 { 96 }
 				`'` { 39 }
 				`"` { 34 }
-				else { return error('unsupported fastc rune escape') }
+				else {
+					return error('unsupported fastc rune escape')
+				}
 			}
 			return '((rune)${value})'
 		}
@@ -707,8 +826,7 @@ fn fastc_string_has_unrenderable_nul(content string, is_raw bool) bool {
 			i += 2
 			continue
 		}
-		if escape >= `0` && escape <= `7` && i + 3 < content.len && content[i + 2] >= `0`
-			&& content[i + 2] <= `7` && content[i + 3] >= `0` && content[i + 3] <= `7` {
+		if escape >= `0` && escape <= `7` && i + 3 < content.len && content[i + 2] >= `0` && content[i + 2] <= `7` && content[i + 3] >= `0` && content[i + 3] <= `7` {
 			high := int(escape - `0`)
 			middle := int(content[i + 2] - `0`)
 			low := int(content[i + 3] - `0`)
@@ -721,9 +839,9 @@ fn fastc_string_has_unrenderable_nul(content string, is_raw bool) bool {
 			i += 4
 			continue
 		}
-		if escape == `0`
-			|| (escape == `u` && i + 5 < content.len && content[i + 2..i + 6] == '0000')
-			|| (escape == `U` && i + 9 < content.len && content[i + 2..i + 10] == '00000000') {
+		// `\0` renders to the octal escape `\000`; only an all-zero unicode escape
+		// (` `/` `) has no faithful C spelling.
+		if (escape == `u` && i + 5 < content.len && content[i + 2..i + 6] == '0000') || (escape == `U` && i + 9 < content.len && content[i + 2..i + 10] == '00000000') {
 			return true
 		}
 		i += 2
@@ -751,8 +869,7 @@ fn fastc_string_contains_nul(content string, is_raw bool) bool {
 			i += 2
 			continue
 		}
-		if escape >= `0` && escape <= `7` && i + 3 < content.len && content[i + 2] >= `0`
-			&& content[i + 2] <= `7` && content[i + 3] >= `0` && content[i + 3] <= `7` {
+		if escape >= `0` && escape <= `7` && i + 3 < content.len && content[i + 2] >= `0` && content[i + 2] <= `7` && content[i + 3] >= `0` && content[i + 3] <= `7` {
 			high := int(escape - `0`)
 			middle := int(content[i + 2] - `0`)
 			low := int(content[i + 3] - `0`)
@@ -765,10 +882,7 @@ fn fastc_string_contains_nul(content string, is_raw bool) bool {
 			i += 4
 			continue
 		}
-		if escape == `0`
-			|| (escape == `x` && i + 3 < content.len && content[i + 2..i + 4] == '00')
-			|| (escape == `u` && i + 5 < content.len && content[i + 2..i + 6] == '0000')
-			|| (escape == `U` && i + 9 < content.len && content[i + 2..i + 10] == '00000000') {
+		if escape == `0` || (escape == `x` && i + 3 < content.len && content[i + 2..i + 4] == '00') || (escape == `u` && i + 5 < content.len && content[i + 2..i + 6] == '0000') || (escape == `U` && i + 9 < content.len && content[i + 2..i + 10] == '00000000') {
 			return true
 		}
 		i += 2

--- a/vlib/v3/gen/fastc/types.v
+++ b/vlib/v3/gen/fastc/types.v
@@ -6,6 +6,41 @@ fn fastc_matching_rpar(tokens []FastcExpressionToken, open int) ?int {
 	return fastc_matching_rpar_before(tokens, open, tokens.len)
 }
 
+// fastc_bare_as_cast_index returns the index of a top-level `as` in tokens[start..end]
+// when the tokens are a bare `X as T` cast (no surrounding binary operator, so
+// `a == b as T` — a comparison — is excluded). Returns none otherwise.
+fn fastc_bare_as_cast_index(tokens []FastcExpressionToken, start int, end int) ?int {
+	mut depth := 0
+	mut as_index := -1
+	for i := start; i < end; i++ {
+		match tokens[i].tok {
+			.lpar, .lsbr, .lcbr {
+				depth++
+			}
+			.rpar, .rsbr, .rcbr {
+				depth--
+			}
+			.key_as {
+				if depth == 0 {
+					as_index = i
+				}
+			}
+			.eq, .ne, .lt, .gt, .le, .ge, .and, .logical_or, .plus, .minus, .mul, .div, .mod, .pipe, .amp, .xor, .left_shift, .right_shift, .right_shift_unsigned {
+				if depth == 0 && as_index < 0 {
+					// A binary operator before any `as` means the whole expression is not a
+					// cast (e.g. `a == b as T`).
+					return none
+				}
+			}
+			else {}
+		}
+	}
+	if as_index < 0 {
+		return none
+	}
+	return as_index
+}
+
 fn fastc_matching_rpar_before(tokens []FastcExpressionToken, open int, end int) ?int {
 	mut depth := 0
 	for i in open .. end {
@@ -231,9 +266,10 @@ fn (g &Parser) infer_boolean_binary_expression_type(tokens []FastcExpressionToke
 		right_type := g.type_from_expression_tokens(tokens[operator_index + 1..end]) or {
 			return g.unsupported('type test `${operator.str()}` with an undeclared target type')
 		}
-		if g.semantic_type_key(right_type) !in g.declared_types && !right_type.starts_with('Array_') && !right_type.starts_with('Map_') {
-			// Composite variants (`x is []string` / `x is map[…]`) are not declared
-			// types but do get generated `__v_typeid_` tags, so allow them.
+		if g.semantic_type_key(right_type) !in g.declared_types && !right_type.starts_with('Array_') && !right_type.starts_with('Map_') && fastc_primitive_c_type(right_type) == none {
+			// Composite variants (`x is []string` / `x is map[…]`) and primitive variants
+			// (`x is u64`) are not declared types but do get generated `__v_typeid_` tags,
+			// so allow them.
 			return g.unsupported('type test `${operator.str()}` with undeclared type `${right_type}`')
 		}
 		return 'bool'
@@ -341,6 +377,8 @@ fn (g &Parser) nonlocal_name_type(name string) string {
 		global_type
 	} else if global_type := g.global_types[fastc_global_key('builtin', name)] {
 		global_type
+	} else if global_type := g.resolve_cross_module_global_type(name) {
+		global_type
 	} else if g.selfhost {
 		'int'
 	} else {
@@ -362,6 +400,12 @@ fn (g &Parser) infer_expression_type(tokens []FastcExpressionToken) !string {
 // lowerings ask about the same operands and receivers repeatedly.
 fn (g &Parser) infer_expression_type_range(tokens []FastcExpressionToken, expression_start int, expression_end int) !string {
 	if expression_end - expression_start < 2 {
+		return g.infer_expression_type_range_impl(tokens, expression_start, expression_end)!
+	}
+	// Flow-sensitive member smartcasts are installed while an `&&` expression is rendered.
+	// A type cached before the left operand narrows its subject is stale for the operands to
+	// its right, so infer those ranges directly while an active smartcast affects them.
+	if g.expression_uses_member_smartcast(tokens[expression_start..expression_end]) {
 		return g.infer_expression_type_range_impl(tokens, expression_start, expression_end)!
 	}
 	memo_key := fastc_comparison_memo_key(tokens[expression_start..expression_end], 2)
@@ -395,6 +439,14 @@ fn (g &Parser) infer_expression_type_range_impl(tokens []FastcExpressionToken, e
 	if start >= end {
 		return ''
 	}
+	// `X as T` yields the target type `T` (so `(x as T).field` resolves).
+	if as_index := fastc_bare_as_cast_index(tokens, start, end) {
+		if as_index + 1 < end {
+			if target := g.type_from_expression_tokens(tokens[as_index + 1..end]) {
+				return fastc_normalize_inferred_type(target)
+			}
+		}
+	}
 	if end - start == 1 {
 		item := tokens[start]
 		if item.typ != '' {
@@ -402,7 +454,10 @@ fn (g &Parser) infer_expression_type_range_impl(tokens []FastcExpressionToken, e
 		}
 		return match item.tok {
 			.name {
-				if local := g.locals[item.lit] {
+				if smartcast := g.member_smartcasts[item.lit] {
+					// A bare local narrowed by `x is T` reads as the concrete variant.
+					smartcast.typ
+				} else if local := g.locals[item.lit] {
 					local.typ
 				} else {
 					g.nonlocal_name_type(item.lit)
@@ -569,6 +624,10 @@ fn (g &Parser) infer_expression_type_range_impl(tokens []FastcExpressionToken, e
 							// Calling a function-pointer parameter (`f(x)`).
 							return local.fn_return_type
 						}
+						// Calling a value whose type is a `type X = fn (...) Ret` alias.
+						if ret := g.fn_alias_return_types[fastc_trim_pointer_suffix(local.typ)] {
+							return ret
+						}
 					}
 					if primitive := fastc_primitive_c_type(name) {
 						return primitive
@@ -605,9 +664,56 @@ fn (g &Parser) infer_expression_type_range_impl(tokens []FastcExpressionToken, e
 			continue
 		}
 		receiver_start := fastc_method_receiver_start_after(tokens, i - 1, start)
+		if receiver_start != start {
+			// A prefix before the receiver (`*a.node(id)`, `-x.len()`) modifies the
+			// method result, so its type is not the method return type; let the
+			// prefix-operator handling below (e.g. `*` deref) infer it instead.
+			continue
+		}
 		receiver_type := g.infer_expression_type_range(tokens, receiver_start, i - 1)!
 		if receiver_type == '' {
 			continue
+		}
+		if tokens[i].lit in ['map', 'filter', 'any', 'all', 'count'] && fastc_trim_pointer_suffix(fastc_normalize_inferred_type(g.underlying_alias_type(receiver_type))).starts_with('Array_') {
+			// The magic closure methods change the result type: `filter` keeps the array,
+			// `count` is an int, `any`/`all` are bools, and `map` yields an array of the
+			// closure's element type (inferred with `it` bound to the element).
+			method := tokens[i].lit
+			if method == 'filter' {
+				return fastc_trim_pointer_suffix(fastc_normalize_inferred_type(g.underlying_alias_type(receiver_type)))
+			}
+			if method == 'count' {
+				return 'int'
+			}
+			if method in ['any', 'all'] {
+				return 'bool'
+			}
+			array_type := fastc_normalize_inferred_type(g.underlying_alias_type(receiver_type))
+			if element_type := g.array_element_type(array_type) {
+				mut closure_start := i + 2
+				mut it_name := 'it'
+				if tokens[closure_start].tok == .pipe && closure_start + 2 < close {
+					it_name = tokens[closure_start + 1].lit
+					closure_start += 3
+				}
+				mut w := unsafe { &Parser(g) }
+				had_it := it_name in g.locals
+				saved_it := g.locals[it_name] or { FastcLocal{} }
+				w.locals[it_name] = FastcLocal{
+					typ: element_type
+				}
+				closure_type := g.infer_expression_type_range(tokens, closure_start, close) or {
+					''
+				}
+				if had_it {
+					w.locals[it_name] = saved_it
+				} else {
+					w.locals.delete(it_name)
+				}
+				if closure_type != '' {
+					return fastc_array_c_type(fastc_normalize_inferred_type(closure_type))
+				}
+			}
 		}
 		if tokens[i].lit == 'wait' && receiver_type.starts_with(fastc_thread_type_prefix) {
 			value_type := g.thread_value_types[receiver_type] or { '' }
@@ -616,14 +722,45 @@ fn (g &Parser) infer_expression_type_range_impl(tokens []FastcExpressionToken, e
 			}
 			return value_type
 		}
-		function_key, _ := g.resolve_method(receiver_type, tokens[i].lit)
+		if tokens[i].lit == 'wait' && receiver_type.trim_right('*').starts_with('Array_') {
+			// `[]thread T`.wait() joins every thread and returns their `[]T` results.
+			element := g.array_element_type(receiver_type) or { '' }
+			if element.starts_with(fastc_thread_type_prefix) {
+				value_type := g.thread_value_types[element] or { '' }
+				if value_type != '' {
+					return fastc_array_c_type(value_type)
+				}
+			}
+		}
+		mut function_key, _ := g.resolve_method(receiver_type, tokens[i].lit)
+		mut method_receiver_type := receiver_type
+		if function_key !in g.functions && i - receiver_start == 2 && tokens[receiver_start].tok == .name && tokens[i - 1].tok == .dot {
+			// A method of the whole sum type (`fn (t Type) tname()`) invoked on a NARROWED variant
+			// receiver (`base is Prim && base.tname()`) is not found on the variant; resolve it on
+			// the local's boxed origin, as the method renderer does — so a `base.tname() == 'u8'`
+			// string comparison is typed as string and not left a raw pointer `==`.
+			if local := g.locals[tokens[receiver_start].lit] {
+				origin := if local.smartcast_origin_type != '' {
+					local.smartcast_origin_type
+				} else {
+					local.typ
+				}
+				if origin != '' && origin != receiver_type {
+					origin_key, _ := g.resolve_method(origin, tokens[i].lit)
+					if origin_key in g.functions {
+						function_key = origin_key
+						method_receiver_type = origin
+					}
+				}
+			}
+		}
 		if static_key := g.static_function_key_for_call(tokens, i) {
 			if signature := g.functions[static_key] {
 				return signature.return_type
 			}
 		}
 		if signature := g.functions[function_key] {
-			return g.specialized_method_return_type(receiver_type, function_key, signature)
+			return g.specialized_method_return_type(method_receiver_type, function_key, signature)
 		}
 		if field := g.struct_field_metadata(receiver_type, tokens[i].lit) {
 			if function_alias := g.functions[field.typ] {
@@ -633,13 +770,35 @@ fn (g &Parser) infer_expression_type_range_impl(tokens []FastcExpressionToken, e
 		if tokens[i].lit == 'str' && g.can_generate_default_struct_str(receiver_type) {
 			return 'string'
 		}
+		if tokens[i].lit == 'str' && g.declared_kinds[g.semantic_type_key(receiver_type)] == .enum_ {
+			return 'string'
+		}
+		if tokens[i].lit == 'str' && receiver_type.trim_right('*').starts_with('Array_') {
+			return 'string'
+		}
+		if tokens[i].lit == 'type_name' && g.is_boxed_type(fastc_normalize_inferred_type(receiver_type)) {
+			return 'string'
+		}
 	}
 	if end - start >= 3 && tokens[end - 2].tok == .dot && tokens[end - 1].tok == .name {
 		receiver_start := fastc_method_receiver_start_after(tokens, end - 2, start)
 		if receiver_start == start {
+			// A member smartcast on the full path overrides the declared field type
+			// (`if x.f is T { … x.f.g … }`, incl. an indexed chain `x.args[0].expr` keyed
+			// as `x.args[].expr`, reads the member as the concrete variant).
+			if member_path := fastc_indexed_member_chain_path(tokens[start..end]) {
+				if smartcast := g.member_smartcasts[member_path] {
+					return smartcast.typ
+				}
+			}
 			receiver_type := g.infer_expression_type_range(tokens, start, end - 2)!
 			if field := g.struct_field_metadata(receiver_type, tokens[end - 1].lit) {
 				return field.typ
+			}
+			// A field shared by every variant of a boxed sum type (`node.name` where
+			// `node` is `ast.TypeDecl`) resolves to that common field's type.
+			if common := g.sumtype_common_field_type(receiver_type, tokens[end - 1].lit) {
+				return common
 			}
 		}
 	}
@@ -652,6 +811,16 @@ fn (g &Parser) infer_expression_type_range_impl(tokens []FastcExpressionToken, e
 	}
 	if tokens[start].tok in [.amp, .and] {
 		operand_type := g.infer_expression_type_range(tokens, start + 1, end)!
+		// A mutable/reference local has pointer storage but value type `T` in V.
+		// Taking `&local` therefore yields its existing `T*` storage type, not
+		// `T**`. The rendered `&(*local)` expression follows the same rule.
+		if tokens[start].tok == .amp && end - start == 2 && tokens[start + 1].tok == .name {
+			if local := g.locals[tokens[start + 1].lit] {
+				if local.is_reference {
+					return local.typ
+				}
+			}
+		}
 		mut pointer_count := 1
 		if tokens[start].tok == .and {
 			pointer_count = 2
@@ -664,7 +833,14 @@ fn (g &Parser) infer_expression_type_range_impl(tokens []FastcExpressionToken, e
 	}
 	if tokens[start].tok == .mul {
 		operand_type := g.infer_expression_type_range(tokens, start + 1, end)!
-		return fastc_trim_pointer_suffix(operand_type)
+		// Dereferencing removes exactly one pointer level. trim_right('*') collapses
+		// `T**` all the way to `T`, which makes values such as
+		// `*(&&ast.File(ptr))` look by-value and adds a bogus address-of later.
+		return if operand_type.ends_with('*') {
+			operand_type[..operand_type.len - 1]
+		} else {
+			operand_type
+		}
 	}
 	if tokens[start].tok == .bit_not {
 		operand_type := g.infer_expression_type_range(tokens, start + 1, end)!
@@ -864,6 +1040,126 @@ fn fastc_expression_tokens_contain_range(tokens []FastcExpressionToken, start in
 	return false
 }
 
+// fastc_member_chain_path returns the dotted path (`a.b.c`) for a pure member
+// chain `name (. name)*` spanning tokens[start..end], or none for anything else.
+fn fastc_member_chain_path(tokens []FastcExpressionToken, start int, end int) ?string {
+	if start >= end || tokens[start].tok != .name {
+		return none
+	}
+	mut path := tokens[start].lit
+	mut i := start + 1
+	for i < end {
+		if i + 1 >= end || tokens[i].tok != .dot || tokens[i + 1].tok != .name {
+			return none
+		}
+		path += '.' + tokens[i + 1].lit
+		i += 2
+	}
+	return path
+}
+
+// fastc_indexed_member_chain_path is like fastc_member_chain_path but also accepts array
+// index segments (`right.args[0].expr`), keying each `[…]` as the `[]` marker that
+// render_member_receiver uses so a member smart-cast registered here is found when the
+// chain is rendered.
+fn fastc_indexed_member_chain_path(tokens []FastcExpressionToken) ?string {
+	if tokens.len == 0 || tokens[0].tok != .name {
+		return none
+	}
+	mut path := tokens[0].lit
+	mut i := 1
+	for i < tokens.len {
+		if tokens[i].tok == .lsbr {
+			close := fastc_matching_delimiter(tokens, i, .lsbr, .rsbr) or { return none }
+			path += '[]'
+			i = close + 1
+			continue
+		}
+		if i + 1 < tokens.len && tokens[i].tok == .dot && tokens[i + 1].tok == .name {
+			path += '.' + tokens[i + 1].lit
+			i += 2
+			continue
+		}
+		return none
+	}
+	return path
+}
+
+// sum_type_variant_list returns the C variant type names of a sum type (`base` is a
+// normalized C type name; any pointer suffix is trimmed).
+fn (g &Parser) sum_type_variant_list(sum_type string) []string {
+	base := fastc_trim_pointer_suffix(sum_type)
+	prefix := '${base}|'
+	mut variants := []string{}
+	for key, present in g.sum_type_variants {
+		if present && key.starts_with(prefix) {
+			variants << key[prefix.len..]
+		}
+	}
+	return variants
+}
+
+// sum_type_leaf_variants returns the concrete (non-sum-type) variants of `sum_type`,
+// recursively expanding any variant that is itself a sum type. A value whose static type is
+// a sum type always carries the runtime tag of one of these leaf struct variants, so field
+// dispatch and common-field detection must reason over the flattened set.
+fn (g &Parser) sum_type_leaf_variants(sum_type string) []string {
+	mut leaves := []string{}
+	for variant in g.sum_type_variant_list(sum_type) {
+		if fastc_trim_pointer_suffix(variant) in g.sum_types {
+			leaves << g.sum_type_leaf_variants(variant)
+		} else {
+			leaves << variant
+		}
+	}
+	return leaves
+}
+
+// sumtype_common_field_type returns the shared C type of a field that every variant of
+// `sum_type` declares (a V "common sum-type field"), or none when the field is absent
+// from some variant, has different types across variants, or is reached through an
+// embedded field. Only direct fields are treated as common. Variants that are themselves
+// sum types are flattened to their leaf struct variants first.
+fn (g &Parser) sumtype_common_field_type(sum_type string, field_name string) ?string {
+	base := fastc_trim_pointer_suffix(sum_type)
+	if base !in g.sum_types {
+		return none
+	}
+	variants := g.sum_type_leaf_variants(base)
+	if variants.len == 0 {
+		return none
+	}
+	mut common_type := ''
+	for variant in variants {
+		field := g.struct_field_metadata(variant, field_name) or { return none }
+		if field.storage_path.len > 0 {
+			return none
+		}
+		if common_type == '' {
+			common_type = field.typ
+		} else if field.typ != common_type {
+			return none
+		}
+	}
+	if common_type == '' {
+		return none
+	}
+	return common_type
+}
+
+// resolve_cross_module_global_type returns the type of a `__global` declared in ANY module,
+// looked up by its bare name — `__global`s are truly global, so a reference from a different
+// module than the declaring one (`global_table` in v.ast, used from v.checker) still resolves.
+fn (g &Parser) resolve_cross_module_global_type(name string) ?string {
+	suffix := '.${name}'
+	for key, global_type in g.global_types {
+		if key == name || key.ends_with(suffix) {
+			return global_type
+		}
+	}
+	return none
+}
+
 fn (g &Parser) infer_member_access_type(tokens []FastcExpressionToken, start int, end int) ?string {
 	if end - start < 3 || tokens[start].tok != .name {
 		return none
@@ -877,10 +1173,18 @@ fn (g &Parser) infer_member_access_type(tokens []FastcExpressionToken, start int
 		current_type = constant_type
 	} else if constant_type := g.constant_types[fastc_constant_key('builtin', tokens[start].lit)] {
 		current_type = constant_type
+	} else if global_type := g.resolve_cross_module_global_type(tokens[start].lit) {
+		current_type = global_type
 	} else {
 		return none
 	}
 	mut member_path := tokens[start].lit
+	// A smart-cast on the bare subject itself (`x is T`, or an option local narrowed by
+	// `x != none`) reshapes it before any field access, exactly as render_member_receiver
+	// does when producing the matching source.
+	if smartcast := g.member_smartcasts[member_path] {
+		current_type = smartcast.typ
+	}
 	mut index := start + 1
 	for index < end {
 		if tokens[index].tok == .lsbr {
@@ -909,6 +1213,12 @@ fn (g &Parser) infer_member_access_type(tokens []FastcExpressionToken, start int
 				current_type = current_type[..current_type.len - 1]
 			} else {
 				return none
+			}
+			// Key the index segment as the `[]` marker so a member smart-cast registered on an
+			// indexed chain (`right.args[0].expr is T` → `right.args[].expr`) is found below.
+			member_path += '[]'
+			if smartcast := g.member_smartcasts[member_path] {
+				current_type = smartcast.typ
 			}
 			index = close + 1
 			continue
@@ -969,12 +1279,16 @@ fn (g &Parser) semantic_type_key(c_type string) string {
 }
 
 fn (g &Parser) underlying_alias_type(c_type string) string {
+	return fastc_underlying_alias_type(c_type, g.alias_base_types)
+}
+
+fn fastc_underlying_alias_type(c_type string, alias_base_types map[string]string) string {
 	// Fast path: most types are not aliases, so resolve the first hop before
 	// allocating the cycle-guard map. underlying_alias_type is called for
 	// nearly every inferred expression type; the unconditional map allocation
 	// showed up as a hot allocation site under -prealloc.
 	base0 := fastc_trim_pointer_suffix(c_type)
-	first := g.alias_base_types[base0] or { return c_type }
+	first := alias_base_types[base0] or { return c_type }
 	mut resolved := first + c_type[base0.len..]
 	mut seen := map[string]bool{}
 	seen[base0] = true
@@ -983,7 +1297,7 @@ fn (g &Parser) underlying_alias_type(c_type string) string {
 		if base in seen {
 			return resolved
 		}
-		alias_base := g.alias_base_types[base] or { return resolved }
+		alias_base := alias_base_types[base] or { return resolved }
 		seen[base] = true
 		resolved = alias_base + resolved[base.len..]
 	}
@@ -1128,6 +1442,15 @@ fn fastc_is_pointer_type(typ string) bool {
 }
 
 fn fastc_array_element_type(typ string) ?string {
+	// A `FixedArray_<len>_FASTC_ARRAY_OF_<elem>` name carries the raw element type after the
+	// marker, and that element may itself be a pointer (`[N]&T` -> `..._FASTC_ARRAY_OF_T*`).
+	// Extract it before any trailing-`*` trim mistakes the element's pointer for a suffix on
+	// the whole array type.
+	if typ.starts_with('FixedArray_') && typ.contains('_FASTC_ARRAY_OF_') {
+		if element_type := fastc_fixed_array_element_type(typ) {
+			return element_type
+		}
+	}
 	base := fastc_trim_pointer_suffix(typ)
 	if base.starts_with('Array_') && base.len > 'Array_'.len {
 		return fastc_decode_ptr_element_type(base['Array_'.len..])

--- a/vlib/v3/gen/fastc/validate.v
+++ b/vlib/v3/gen/fastc/validate.v
@@ -65,6 +65,11 @@ fn (g &Parser) expression_token(previous token.Token, previous_lit string, quali
 		.dot {
 			g.dot_piece(previous, previous_lit, module_separator)
 		}
+		.right_shift_unsigned {
+			// V's logical right shift `>>>` has no C spelling; it is used on unsigned operands
+			// (V code casts first, e.g. `u64(x) >>> n`), where a plain C `>>` is logical.
+			'>>'
+		}
 		else {
 			g.tok.str()
 		}
@@ -106,9 +111,27 @@ fn (g &Parser) validate_imported_global_visibility(imported_module string, name 
 	}
 }
 
+// local_c_name is the C spelling of a local: its smart-cast override name when one is active
+// (see FastcLocal.c_name), otherwise the sanitized identifier.
+fn (g &Parser) local_c_name(name string) string {
+	if local := g.locals[name] {
+		if local.c_name != '' {
+			return local.c_name
+		}
+	}
+	return fastc_c_identifier(name)
+}
+
 fn (g &Parser) resolved_expression_name(name string, previous token.Token) string {
 	if previous != .dot && name == 'C' {
 		return ''
+	}
+	if previous != .dot {
+		if local := g.locals[name] {
+			if local.c_name != '' {
+				return local.c_name
+			}
+		}
 	}
 	if previous != .dot && name !in g.locals {
 		return g.resolved_nonlocal_expression_name_cached(name)
@@ -157,6 +180,13 @@ fn (g &Parser) resolved_nonlocal_expression_name(name string) string {
 	}
 	if c_name := g.globals[fastc_global_key('builtin', name)] {
 		return c_name
+	}
+	// A `__global` is truly global, including from a different module than its declaration.
+	suffix := '.${name}'
+	for key, c_name in g.globals {
+		if key == name || key.ends_with(suffix) {
+			return c_name
+		}
 	}
 	return fastc_c_identifier(name)
 }


### PR DESCRIPTION
## Summary

- make the V3 FastC backend compile `cmd/v/v.v` into a working V compiler
- make that FastC-built compiler compile `cmd/v/v.v` again (gen-2 self-host)
- add the missing self-host lowering, typing, runtime, module-resolution, and linking support exercised by `cmd/v`
- keep compile-only and link-only TinyCC arguments separate for parallel FastC builds

## Validation

- rebuilt `vnew` with `./v -g -keepc -o ./vnew cmd/v`
- gen 1: `./vnew -no-memory-limit -silent -b fastc -d fastc_real_builtin -o ./v_fastc_pr_gen1 cmd/v/v.v`
- gen 2: `./v_fastc_pr_gen1 -no-memory-limit -silent -b fastc -d fastc_real_builtin -o ./v_fastc_pr_gen2 cmd/v/v.v`
- both generated compilers report `V 0.5.2`
- focused FastC regressions, driver C-flag tests, and Mach-O signing tests pass
- compiler diagnostics: 1,696 passed, 1 skipped
- C output fixtures: 98 output and 133 pattern fixtures passed; platform-only fixtures skipped
- broad stable-compiler run: 2,338 passed, 26 skipped; environmental VLS failures pass with the checkout on `PATH`, and the transient project test passes in isolation. The remaining shared-struct/usecache failures reproduce on master.

## Performance

Production build (`./v -prod -d fastc_selfhost`) on Apple M5 Max, arm64, 18 logical CPUs:

`fastc-bench: files=181 lines=78248 best_gen=31.68ms loc/s=2469949 (repeat=11)`
