### PR TITLE
ci: fix remaining non-FastC master failures

### DIFF
--- a/.github/workflows/benchmark_footprint_json_decode.yml
+++ b/.github/workflows/benchmark_footprint_json_decode.yml
@@ -20,7 +20,7 @@ jobs:
         run: make -j4 && ./v symlink
 
       - name: Run V benchmark and save output
-        run: (echo '```txt'; v -prod crun vlib/json2/tests/bench.v; echo '```') > vlib/json2/tests/bench_out.md
+        run: (echo '```txt'; v -prod -w crun vlib/json2/tests/bench.v; echo '```') > vlib/json2/tests/bench_out.md
 
       - name: Upload result file
         uses: actions/upload-artifact@v7

--- a/.github/workflows/gh_restart_failed.v
+++ b/.github/workflows/gh_restart_failed.v
@@ -1,5 +1,5 @@
 import os
-import json
+import json2
 import term
 import time
 
@@ -125,7 +125,7 @@ fn get_checks_for_pr(pr_number int) []Check {
 		println('Error: ${res.output}')
 		exit(1)
 	}
-	return json.decode([]Check, res.output) or { exit(1) }
+	return json2.decode[[]Check](res.output) or { exit(1) }
 }
 
 fn get_checks_for_commit(commit string) []Check {
@@ -135,12 +135,12 @@ fn get_checks_for_commit(commit string) []Check {
 		println('Error: ${res.output}')
 		exit(1)
 	}
-	resp := json.decode(GhCheckRunsResponse, res.output) or { exit(1) }
+	resp := json2.decode[GhCheckRunsResponse](res.output) or { exit(1) }
 	mut checks := []Check{}
 	for cr in resp.check_runs {
 		checks << Check{
-			name:     cr.name
-			bucket:   if cr.conclusion == 'failure' {
+			name: cr.name
+			bucket: if cr.conclusion == 'failure' {
 				'fail'
 			} else if cr.conclusion == 'cancelled' {
 				'cancel'
@@ -149,12 +149,12 @@ fn get_checks_for_commit(commit string) []Check {
 			} else {
 				'pending'
 			}
-			state:    if cr.conclusion != '' {
+			state: if cr.conclusion != '' {
 				cr.conclusion.to_upper()
 			} else {
 				cr.status.to_upper()
 			}
-			link:     cr.html_url
+			link: cr.html_url
 			workflow: 'Actions'
 		}
 	}

--- a/.github/workflows/make_sure_ci_run_with_64bit_compiler_test.v
+++ b/.github/workflows/make_sure_ci_run_with_64bit_compiler_test.v
@@ -1,5 +1,5 @@
 fn test_ci_run_with_64bit_compiler() {
-    $if x32 {
-        assert false
-    }	
+	$if x32 {
+		assert false
+	}
 }

--- a/cmd/tools/vfmt_test.v
+++ b/cmd/tools/vfmt_test.v
@@ -94,7 +94,7 @@ fn test_fmt_checks_accept_legacy_formatted_source() {
 
 	format_res := os.execute('${os.quoted_path(vexe)} fmt ${os.quoted_path(source_path)}')
 	assert format_res.exit_code == 0, format_res.output
-	assert format_res.output == '// Header\nmodule main\n', format_res.output
+	assert format_res.output == source, format_res.output
 
 	for check_args in ['-verify -inprocess', '-verify', '-c'] {
 		res :=

--- a/cmd/v/macos_v3_dispatch.c.v
+++ b/cmd/v/macos_v3_dispatch.c.v
@@ -78,8 +78,7 @@ fn retry_macos_v3_at_exit() {
 	if state == unsafe { nil } {
 		return
 	}
-	retry_macos_v3_with_old_compiler(state.caller_environment, state.fallback_file,
-		state.c_error_dir, state.retry_args, state.is_verbose, state.input_snapshot)
+	retry_macos_v3_with_old_compiler(state.caller_environment, state.fallback_file, state.c_error_dir, state.retry_args, state.is_verbose, state.input_snapshot)
 }
 
 fn macos_v3_compiler_error_message(stage string) string {
@@ -279,11 +278,11 @@ fn launch_macos_v3_compiler(prefs &pref.Preferences, raw_args []string) ?MacosV3
 	retry_args := os.args[1..].clone()
 	retry_state := &MacosV3RetryState{
 		caller_environment: caller_environment
-		fallback_file:      fallback_file
-		c_error_dir:        c_error_dir
-		retry_args:         retry_args
-		is_verbose:         is_verbose
-		input_snapshot:     input_snapshot
+		fallback_file: fallback_file
+		c_error_dir: c_error_dir
+		retry_args: retry_args
+		is_verbose: is_verbose
+		input_snapshot: input_snapshot
 	}
 	unsafe { macos_v3_retry_state(retry_state) }
 	at_exit(retry_macos_v3_at_exit) or {
@@ -303,14 +302,10 @@ fn launch_macos_v3_fastc_compiler(prefs &pref.Preferences, raw_args []string) {
 	if prefs.is_verbose {
 		println('Running macOS V3 compiler in process: ${util.args_quote_paths(forwarded_args)}')
 	}
-	preserve_macos_v3_caller_process_value('VEXE', macos_v3_caller_vexe_env,
-		macos_v3_caller_vexe_present_env)
-	preserve_macos_v3_caller_process_value('VCHILD', macos_v3_caller_vchild_env,
-		macos_v3_caller_vchild_present_env)
-	preserve_macos_v3_caller_process_value(macos_v3_no_fallback_env,
-		macos_v3_caller_no_fallback_env, macos_v3_caller_no_fallback_present_env)
-	for private_name in [macos_v3_fallback_file_env, macos_v3_c_error_dir_env,
-		macos_v3_retry_env] {
+	preserve_macos_v3_caller_process_value('VEXE', macos_v3_caller_vexe_env, macos_v3_caller_vexe_present_env)
+	preserve_macos_v3_caller_process_value('VCHILD', macos_v3_caller_vchild_env, macos_v3_caller_vchild_present_env)
+	preserve_macos_v3_caller_process_value(macos_v3_no_fallback_env, macos_v3_caller_no_fallback_env, macos_v3_caller_no_fallback_present_env)
+	for private_name in [macos_v3_fallback_file_env, macos_v3_c_error_dir_env, macos_v3_retry_env] {
 		os.unsetenv(private_name)
 	}
 	os.setenv('VCHILD', 'true', true)
@@ -383,8 +378,7 @@ fn retry_macos_v3_with_old_compiler(caller_environment map[string]string, fallba
 			eprintln('V3 requested a C-error fallback, but its diagnostics could not be read')
 			return
 		}
-		export_macos_v3_report_content(report.kind, report.ccompiler, report.c_output,
-			report.c_file, report.v_sources, true)
+		export_macos_v3_report_content(report.kind, report.ccompiler, report.c_output, report.c_file, report.v_sources, true)
 		os.rmdir_all(c_error_dir) or {}
 		if should_report {
 			eprintln('V3 C compilation failed; retrying with `-old-compiler`.')
@@ -404,9 +398,7 @@ fn retry_macos_v3_with_old_compiler(caller_environment map[string]string, fallba
 		input_digests := read_macos_v3_source_digests(c_error_dir) or {
 			map[string]string{}
 		}
-		export_macos_v3_bounded_report_content(macos_v3_compiler_error_fallback, 'v3',
-			macos_v3_compiler_error_message(fallback_stage), v_file, v_source, v_source_focus,
-			v_source_truncated, input_digests, input_digests.len > 0)
+		export_macos_v3_bounded_report_content(macos_v3_compiler_error_fallback, 'v3', macos_v3_compiler_error_message(fallback_stage), v_file, v_source, v_source_focus, v_source_truncated, input_digests, input_digests.len > 0)
 		os.rmdir_all(c_error_dir) or {}
 		if should_report {
 			eprintln('V3 compilation failed; retrying with `-old-compiler`.')
@@ -416,8 +408,7 @@ fn retry_macos_v3_with_old_compiler(caller_environment map[string]string, fallba
 		// filing a report. Still forward a notice-only marker so that once the stable
 		// build succeeds the user sees the documented fallback notice (doc/docs.md) rather
 		// than a silent switch that is indistinguishable from a direct V3 success.
-		export_macos_v3_report_content(macos_v3_inline_asm_fallback, 'v3', '', '',
-			map[string]string{}, false)
+		export_macos_v3_report_content(macos_v3_inline_asm_fallback, 'v3', '', '', map[string]string{}, false)
 		os.rmdir_all(c_error_dir) or {}
 		if should_report {
 			eprintln('V3 requested the compatibility compiler for inline assembly')
@@ -442,14 +433,14 @@ fn retry_macos_v3_with_old_compiler(caller_environment map[string]string, fallba
 fn take_macos_v3_report_content() ?MacosV3CErrorReport {
 	report := builder.take_external_v3_report_from_env()?
 	return MacosV3CErrorReport{
-		kind:                   report.kind
-		ccompiler:              report.ccompiler
-		c_output:               report.c_output
-		v_file:                 report.v_file
-		v_source:               report.v_source
-		v_source_truncated:     report.v_source_truncated
-		v_source_focus:         report.v_source_focus
-		input_digests:          report.input_digests
+		kind: report.kind
+		ccompiler: report.ccompiler
+		c_output: report.c_output
+		v_file: report.v_file
+		v_source: report.v_source
+		v_source_truncated: report.v_source_truncated
+		v_source_focus: report.v_source_focus
+		input_digests: report.input_digests
 		input_digests_complete: report.input_digests_complete
 	}
 }
@@ -458,25 +449,23 @@ fn take_macos_v3_report_content() ?MacosV3CErrorReport {
 // the report and therefore trusts `c_file` — and forwards only that content to the V1
 // retry through the environment.
 fn export_macos_v3_report_content(kind string, ccompiler string, c_output string, c_file string, v_sources map[string]string, input_digests_complete bool) {
-	v_file, v_source, v_source_focus := builder.bounded_v3_fallback_source(kind, c_output, c_file,
-		v_sources)
-	export_macos_v3_bounded_report_content(kind, ccompiler, c_output, v_file, v_source,
-		v_source_focus, false, v_sources, input_digests_complete)
+	v_file, v_source, v_source_focus := builder.bounded_v3_fallback_source(kind, c_output, c_file, v_sources)
+	export_macos_v3_bounded_report_content(kind, ccompiler, c_output, v_file, v_source, v_source_focus, false, v_sources, input_digests_complete)
 }
 
 fn export_macos_v3_bounded_report_content(kind string, ccompiler string, c_output string, v_file string, v_source string, v_source_focus int, v_source_truncated bool, input_digests map[string]string, input_digests_complete bool) {
 	builder.export_external_v3_report_to_env(builder.ExternalCErrorBugReport{
-		kind:                   kind
-		ccompiler:              ccompiler
-		c_output:               c_output
-		v_file:                 v_file
-		v_source:               v_source
-		v_source_focus:         v_source_focus
-		v_source_truncated:     v_source_truncated
-		source_inline:          true
-		input_digests:          input_digests
+		kind: kind
+		ccompiler: ccompiler
+		c_output: c_output
+		v_file: v_file
+		v_source: v_source
+		v_source_focus: v_source_focus
+		v_source_truncated: v_source_truncated
+		source_inline: true
+		input_digests: input_digests
 		input_digests_complete: input_digests_complete
-		tag:                    'V3'
+		tag: 'V3'
 	})
 }
 
@@ -491,12 +480,12 @@ fn macos_v3_compiler_error_input_snapshot(input_path string) MacosV3InputSnapsho
 	source := os.read_file(v_path) or { return MacosV3InputSnapshot{} }
 	v_file, v_source, v_source_focus := builder.bounded_v3_internal_fallback_source(v_path, source)
 	return MacosV3InputSnapshot{
-		path:               v_path
-		digest:             sha256.hexhash(source)
-		v_file:             v_file
-		v_source:           v_source
+		path: v_path
+		digest: sha256.hexhash(source)
+		v_file: v_file
+		v_source: v_source
 		v_source_truncated: v_source.len < source.len
-		focus:              v_source_focus
+		focus: v_source_focus
 	}
 }
 
@@ -517,7 +506,7 @@ fn (snapshot MacosV3InputSnapshot) current_report_source() (string, string, int,
 fn macos_v3_compiler_error_input_source(input_path string) string {
 	if input_path != '' && os.is_file(input_path)
 		&& (input_path.ends_with('.v') || input_path.ends_with('.vsh')
-		|| input_path.ends_with('.vv')) {
+			|| input_path.ends_with('.vv')) {
 		return input_path
 	}
 	return ''
@@ -577,11 +566,11 @@ fn read_macos_v3_c_error_report(report_dir string) ?MacosV3StagedReport {
 	}
 	v_sources := read_macos_v3_source_digests(report_dir)?
 	return MacosV3StagedReport{
-		kind:       kind
-		ccompiler:  ccompiler.trim_space()
-		c_output:   c_output
-		c_file:     c_file
-		v_sources:  v_sources
+		kind: kind
+		ccompiler: ccompiler.trim_space()
+		c_output: c_output
+		c_file: c_file
+		v_sources: v_sources
 		report_dir: report_dir
 	}
 }
@@ -590,8 +579,7 @@ fn read_macos_v3_source_digests(report_dir string) ?map[string]string {
 	v_sources_text := os.read_file(os.join_path(report_dir, macos_v3_c_error_v_sources_file)) or {
 		return none
 	}
-	v_source_digests_text := os.read_file(os.join_path(report_dir,
-		macos_v3_c_error_v_source_digests_file)) or { return none }
+	v_source_digests_text := os.read_file(os.join_path(report_dir, macos_v3_c_error_v_source_digests_file)) or { return none }
 	v_source_paths := v_sources_text.split('\x00').filter(it != '')
 	v_source_digests := v_source_digests_text.split('\x00').filter(it != '')
 	if v_source_paths.len != v_source_digests.len {
@@ -610,13 +598,9 @@ fn read_macos_v3_source_digests(report_dir string) ?map[string]string {
 
 fn macos_v3_child_environment(vexe string, fallback_file string, caller_environment map[string]string) map[string]string {
 	mut environment := caller_environment.clone()
-	preserve_macos_v3_caller_environment_value(mut environment, caller_environment, 'VEXE',
-		macos_v3_caller_vexe_env, macos_v3_caller_vexe_present_env)
-	preserve_macos_v3_caller_environment_value(mut environment, caller_environment, 'VCHILD',
-		macos_v3_caller_vchild_env, macos_v3_caller_vchild_present_env)
-	preserve_macos_v3_caller_environment_value(mut environment, caller_environment,
-		macos_v3_no_fallback_env, macos_v3_caller_no_fallback_env,
-		macos_v3_caller_no_fallback_present_env)
+	preserve_macos_v3_caller_environment_value(mut environment, caller_environment, 'VEXE', macos_v3_caller_vexe_env, macos_v3_caller_vexe_present_env)
+	preserve_macos_v3_caller_environment_value(mut environment, caller_environment, 'VCHILD', macos_v3_caller_vchild_env, macos_v3_caller_vchild_present_env)
+	preserve_macos_v3_caller_environment_value(mut environment, caller_environment, macos_v3_no_fallback_env, macos_v3_caller_no_fallback_env, macos_v3_caller_no_fallback_present_env)
 	for private_name in ['V_MACOS_V3_FALLBACK_FILE', 'V_MACOS_V3_C_ERROR_DIR', 'V_MACOS_V3_RETRY'] {
 		environment.delete(private_name)
 	}
@@ -655,16 +639,12 @@ fn macos_v3_original_caller_environment(dispatch_environment map[string]string) 
 	vexe_present := dispatch_environment[macos_v3_caller_vexe_present_env] or { '' }
 	vchild_present := dispatch_environment[macos_v3_caller_vchild_present_env] or { '' }
 	if vexe_present in ['0', '1'] && vchild_present in ['0', '1'] {
-		restore_macos_v3_caller_environment_value(mut caller_environment, dispatch_environment,
-			'VEXE', macos_v3_caller_vexe_env, macos_v3_caller_vexe_present_env)
-		restore_macos_v3_caller_environment_value(mut caller_environment, dispatch_environment,
-			'VCHILD', macos_v3_caller_vchild_env, macos_v3_caller_vchild_present_env)
+		restore_macos_v3_caller_environment_value(mut caller_environment, dispatch_environment, 'VEXE', macos_v3_caller_vexe_env, macos_v3_caller_vexe_present_env)
+		restore_macos_v3_caller_environment_value(mut caller_environment, dispatch_environment, 'VCHILD', macos_v3_caller_vchild_env, macos_v3_caller_vchild_present_env)
 	}
 	no_fallback_present := dispatch_environment[macos_v3_caller_no_fallback_present_env] or { '' }
 	if no_fallback_present in ['0', '1'] {
-		restore_macos_v3_caller_environment_value(mut caller_environment, dispatch_environment,
-			macos_v3_no_fallback_env, macos_v3_caller_no_fallback_env,
-			macos_v3_caller_no_fallback_present_env)
+		restore_macos_v3_caller_environment_value(mut caller_environment, dispatch_environment, macos_v3_no_fallback_env, macos_v3_caller_no_fallback_env, macos_v3_caller_no_fallback_present_env)
 	}
 	for private_name in [macos_v3_fallback_file_env, macos_v3_c_error_dir_env, macos_v3_vhash_env,
 		macos_v3_vcurrent_hash_env, macos_v3_embedded_env, macos_v3_retry_env,

--- a/vlib/builtin/linux_bare/old/.checks/checks.v
+++ b/vlib/builtin/linux_bare/old/.checks/checks.v
@@ -2,31 +2,29 @@ module main
 
 import os
 
-fn failed (msg string) {
-	println ("!!! failed: ${msg}")
+fn failed(msg string) {
+	println('!!! failed: ${msg}')
 }
 
-fn passed (msg string) {
-	println (">>> passed: ${msg}")
+fn passed(msg string) {
+	println('>>> passed: ${msg}')
 }
-
 
 fn vcheck(vfile string) {
-	run_check := "v -user_mod_path . -freestanding run "
-	if 0 == os.system("${run_check} ${vfile}/${vfile}.v") {
+	run_check := 'v -user_mod_path . -freestanding run '
+	if 0 == os.system('${run_check} ${vfile}/${vfile}.v') {
 		passed(run_check)
 	} else {
 		failed(run_check)
 	}
-	os.system("ls -lh ${vfile}/${vfile}")
-	os.system("rm -f ${vfile}/${vfile}")
+	os.system('ls -lh ${vfile}/${vfile}')
+	os.system('rm -f ${vfile}/${vfile}')
 }
 
 fn main() {
-	vcheck("linuxsys")
-	vcheck("string")
-	vcheck("consts")
-	vcheck("structs")
+	vcheck('linuxsys')
+	vcheck('string')
+	vcheck('consts')
+	vcheck('structs')
 	exit(0)
 }
-

--- a/vlib/builtin/linux_bare/old/.checks/consts/consts.v
+++ b/vlib/builtin/linux_bare/old/.checks/consts/consts.v
@@ -1,22 +1,21 @@
 module main
+
 import forkedtest
 
-const (
-	integer1 = 111
-	integer2 = 222
-	integer3 = integer1+integer2
-	integer9 = integer3 * 3
-	abc = "123"
-)
+const integer1 = 111
+const integer2 = 222
+const integer3 = integer1 + integer2
+const integer9 = integer3 * 3
+const abc = '123'
 
 fn check_const_initialization() {
-	assert abc == "123"
+	assert abc == '123'
 	assert integer9 == 999
 }
 
-fn main(){
+fn main() {
 	mut fails := 0
-	fails += forkedtest.normal_run(check_const_initialization, "check_const_initialization")
+	fails += forkedtest.normal_run(check_const_initialization, 'check_const_initialization')
 	assert fails == 0
 	sys_exit(0)
 }

--- a/vlib/builtin/linux_bare/old/.checks/forkedtest/forkedtest.v
+++ b/vlib/builtin/linux_bare/old/.checks/forkedtest/forkedtest.v
@@ -1,13 +1,13 @@
 module forkedtest
 
-pub fn run (op fn(), label string, code Wi_si_code, status int) int {
+pub fn run(op fn (), label string, code Wi_si_code, status int) int {
 	child := sys_fork()
 	if child == 0 {
 		op()
 		sys_exit(0)
 	}
 
-	siginfo := []int{len:int(Sig_index.si_size)}
+	siginfo := []int{len: int(Sig_index.si_size)}
 
 	e := sys_waitid(.p_pid, child, intptr(&siginfo[0]), .wexited, 0)
 
@@ -19,31 +19,31 @@ pub fn run (op fn(), label string, code Wi_si_code, status int) int {
 	r_code := siginfo[Sig_index.si_code]
 	r_status := siginfo[Sig_index.si_status]
 
-	print("+++ ")
+	print('+++ ')
 	print(label)
 	if (int(code) == r_code) && (status == r_status) {
-		println(" PASSED")
+		println(' PASSED')
 		return 0
 	}
-	println(" FAILED")
+	println(' FAILED')
 
 	if int(code) != r_code {
-		print(">> Expecting si_code 0x")
-		println(i64_str(int(code),16))
-		print(">> Got 0x")
-		println(i64_str(r_code,16))
+		print('>> Expecting si_code 0x')
+		println(i64_str(int(code), 16))
+		print('>> Got 0x')
+		println(i64_str(r_code, 16))
 	}
 
 	if status != r_status {
-		print(">> Expecting status 0x")
-		println(i64_str(status,16))
-		print(">> Got 0x")
-		println(i64_str(r_status,16))
+		print('>> Expecting status 0x')
+		println(i64_str(status, 16))
+		print('>> Got 0x')
+		println(i64_str(r_status, 16))
 	}
 
 	return 1
 }
 
-pub fn normal_run (op fn(), label string) int {
-	return run (op, label, .cld_exited, 0)
+pub fn normal_run(op fn (), label string) int {
+	return run(op, label, .cld_exited, 0)
 }

--- a/vlib/builtin/linux_bare/old/.checks/linuxsys/linuxsys.v
+++ b/vlib/builtin/linux_bare/old/.checks/linuxsys/linuxsys.v
@@ -2,9 +2,7 @@ module main
 
 import builtin.linux_bare.old.checks.forkedtest
 
-const (
-	sample_text_file1 = ''
-)
+const sample_text_file1 = ''
 
 fn check_fork_minimal() {
 	child := sys_fork()
@@ -164,7 +162,7 @@ fn check_read_file() {
 }
 
 fn check_open_file_fail() {
-	fd1, ec1 := sys_open('./nofilehere'.str, .o_rdonly, 0)
+	fd1, ec1 := sys_open(c'./nofilehere', .o_rdonly, 0)
 	assert fd1 == -1
 	assert ec1 == .enoent
 }
@@ -191,8 +189,7 @@ fn check_munmap_fail() {
 fn check_mmap_one_page() {
 	mp := int(Mm_prot.prot_read) | int(Mm_prot.prot_write)
 	mf := int(Map_flags.map_private) | int(Map_flags.map_anonymous)
-	mut a, e := sys_mmap(0, u64(Linux_mem.page_size), Mm_prot(mp), Map_flags(mf), -1,
-		0)
+	mut a, e := sys_mmap(0, u64(Linux_mem.page_size), Mm_prot(mp), Map_flags(mf), -1, 0)
 
 	assert e == .enoerror
 	assert a != byteptr(-1)

--- a/vlib/builtin/linux_bare/old/.checks/structs/structs.v
+++ b/vlib/builtin/linux_bare/old/.checks/structs/structs.v
@@ -1,42 +1,42 @@
 module main
+
 import forkedtest
 
-struct SimpleEmptyStruct{
+struct SimpleEmptyStruct {}
+
+struct NonEmptyStruct {
+	x int
+	y int
+	z int
 }
 
-struct NonEmptyStruct{
-  x int
-  y int
-  z int
+fn check_simple_empty_struct() {
+	s := SimpleEmptyStruct{}
+	addr_s := &s
+	str_addr_s := ptr_str(addr_s)
+	assert !isnil(addr_s)
+	assert str_addr_s.len > 3
+	println(str_addr_s)
 }
 
-fn check_simple_empty_struct(){  
-  s := SimpleEmptyStruct{}
-  addr_s := &s
-  str_addr_s := ptr_str( addr_s )
-  assert !isnil(addr_s)
-  assert str_addr_s.len > 3
-  println(str_addr_s)
+fn check_non_empty_struct() {
+	a := NonEmptyStruct{1, 2, 3}
+	b := NonEmptyStruct{4, 5, 6}
+	assert sizeof(NonEmptyStruct) > 0
+	assert sizeof(SimpleEmptyStruct) < sizeof(NonEmptyStruct)
+	assert a.x == 1
+	assert a.y == 2
+	assert a.z == 3
+	assert b.x + b.y + b.z == 15
+	assert ptr_str(&a) != ptr_str(&b)
+	println('sizeof SimpleEmptyStruct:' + i64_str(sizeof(SimpleEmptyStruct), 10))
+	println('sizeof NonEmptyStruct:' + i64_str(sizeof(NonEmptyStruct), 10))
 }
 
-fn check_non_empty_struct(){  
-  a := NonEmptyStruct{1,2,3}
-  b := NonEmptyStruct{4,5,6}
-  assert sizeof(NonEmptyStruct) > 0
-  assert sizeof(SimpleEmptyStruct) < sizeof(NonEmptyStruct)
-  assert a.x == 1
-  assert a.y == 2
-  assert a.z == 3
-  assert b.x + b.y + b.z == 15
-  assert ptr_str(&a) != ptr_str(&b)
-  println('sizeof SimpleEmptyStruct:' + i64_str( sizeof(SimpleEmptyStruct) , 10 ))
-  println('sizeof NonEmptyStruct:' + i64_str( sizeof(NonEmptyStruct) , 10 ))
-}
-
-fn main(){
+fn main() {
 	mut fails := 0
-	fails += forkedtest.normal_run(check_simple_empty_struct, "check_simple_empty_struct")
-	fails += forkedtest.normal_run(check_non_empty_struct,    "check_non_empty_struct")
+	fails += forkedtest.normal_run(check_simple_empty_struct, 'check_simple_empty_struct')
+	fails += forkedtest.normal_run(check_non_empty_struct, 'check_non_empty_struct')
 	assert fails == 0
 	sys_exit(0)
 }

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -89,14 +89,14 @@ fn c_output_suggests_missing_header_for_typedef_c_struct(c_output string, known_
 			}
 			if name in known_typedef_c_struct_aliases
 				&& (lower_line.contains('expected (got') || lower_line.contains('unknown type name')
-				|| lower_line.contains('undeclared identifier')
-				|| lower_line.contains('does not name a type')) {
+					|| lower_line.contains('undeclared identifier')
+					|| lower_line.contains('does not name a type')) {
 				return known_typedef_c_struct_aliases[name]
 			}
 			if name.contains('__')
 				&& (lower_line.contains('expected (got') || lower_line.contains('unknown type name')
-				|| lower_line.contains('undeclared identifier')
-				|| lower_line.contains('does not name a type')) {
+					|| lower_line.contains('undeclared identifier')
+					|| lower_line.contains('does not name a type')) {
 				suffix := name.all_after_last('__')
 				if suffix in known_typedef_c_structs {
 					return suffix
@@ -378,8 +378,7 @@ fn normalized_missing_library_name(raw_name string, allow_plain_name bool) strin
 fn c_error_missing_library_name(c_output string) string {
 	for line in c_output.split_into_lines() {
 		if line.contains("library '") && line.contains("' not found") {
-			return normalized_missing_library_name(line.all_after("library '").all_before("' not found"),
-				true)
+			return normalized_missing_library_name(line.all_after("library '").all_before("' not found"), true)
 		}
 		lower_line := line.to_lower()
 		for marker in [
@@ -398,8 +397,7 @@ fn c_error_missing_library_name(c_output string) string {
 			}
 		}
 		if line.contains(': error: ') && lower_line.contains(': no such file or directory') {
-			lib_name := normalized_missing_library_name(line.all_after(': error: ').all_before(': No such file or directory'),
-				false)
+			lib_name := normalized_missing_library_name(line.all_after(': error: ').all_before(': No such file or directory'), false)
 			if lib_name != '' {
 				return lib_name
 			}
@@ -477,8 +475,7 @@ fn (mut v Builder) post_process_c_compiler_output_with_report(ccompiler string, 
 				error_keyword = libatomic_marker
 				error_context_before = 0
 			}
-			elines := error_context_lines(trimmed_output, error_keyword, error_context_before,
-				cut_off_limit)
+			elines := error_context_lines(trimmed_output, error_keyword, error_context_before, cut_off_limit)
 			header := '================== ${c_compilation_error_title} (from ${ccompiler}): =============='
 			println(header)
 			for eline in elines {
@@ -516,13 +513,11 @@ fn (mut v Builder) post_process_c_compiler_output_with_report(ccompiler string, 
 		|| res.output.contains('.o: file not recognized') {
 		more_suggestions += '\n${highlight_word('Suggestion')}: try `v wipe-cache`, then repeat your compilation.'
 	}
-	missing_typedef_header_name := c_output_suggests_missing_header_for_typedef_c_struct(res.output,
-		v.known_typedef_c_structs(), v.known_typedef_c_struct_aliases())
+	missing_typedef_header_name := c_output_suggests_missing_header_for_typedef_c_struct(res.output, v.known_typedef_c_structs(), v.known_typedef_c_struct_aliases())
 	if missing_typedef_header_name != '' {
 		more_suggestions += '\n${highlight_word('Suggestion')}: the C typedef `${missing_typedef_header_name}` backing `@[typedef] struct C.${missing_typedef_header_name} {}` was not found by the C compiler. Make sure the header that defines it is included on this platform and that its `#flag -I` path is correct. If the C API actually declares `struct ${missing_typedef_header_name}` without a typedef, remove `@[typedef]` from the V redeclaration.'
 	}
-	missing_typedef_name := c_output_suggests_missing_typedef_for_c_struct(res.output,
-		v.known_non_typedef_c_structs())
+	missing_typedef_name := c_output_suggests_missing_typedef_for_c_struct(res.output, v.known_non_typedef_c_structs())
 	if missing_typedef_name != '' {
 		more_suggestions += '\n${highlight_word('Suggestion')}: if `${missing_typedef_name}` is declared in the C header with `typedef struct ... ${missing_typedef_name};`, add `@[typedef]` to the V redeclaration: `@[typedef] struct C.${missing_typedef_name} { ... }`.'
 	}
@@ -748,14 +743,14 @@ fn quote_spaced_ordered_pkgconfig_operand(flag cflag.CFlag, preserve_msvc_slash_
 		operand := value[colon_index + 1..]
 		is_operand_quoted := operand.len >= 2
 			&& ((operand[0] == `"` && operand[operand.len - 1] == `"`)
-			|| (operand[0] == `'` && operand[operand.len - 1] == `'`))
+				|| (operand[0] == `'` && operand[operand.len - 1] == `'`))
 		if option_name != '' && option_name.bytes().all(it.is_alnum())
 			&& operand.contains_any(' \t\r\n') && !is_operand_quoted {
 			return cflag.CFlag{
-				mod:    flag.mod
-				os:     flag.os
-				name:   flag.name
-				value:  '${value[..colon_index + 1]}"${operand}"'
+				mod: flag.mod
+				os: flag.os
+				name: flag.name
+				value: '${value[..colon_index + 1]}"${operand}"'
 				cached: flag.cached
 			}
 		}
@@ -766,10 +761,10 @@ fn quote_spaced_ordered_pkgconfig_operand(flag cflag.CFlag, preserve_msvc_slash_
 		return flag
 	}
 	return cflag.CFlag{
-		mod:    flag.mod
-		os:     flag.os
-		name:   flag.name
-		value:  '"${value}"'
+		mod: flag.mod
+		os: flag.os
+		name: flag.name
+		value: '"${value}"'
 		cached: flag.cached
 	}
 }
@@ -780,10 +775,10 @@ fn generic_ordered_pkgconfig_flag(flag cflag.CFlag) cflag.CFlag {
 		return flag
 	}
 	return cflag.CFlag{
-		mod:    flag.mod
-		os:     flag.os
-		name:   flag.name
-		value:  value[1..value.len - 1]
+		mod: flag.mod
+		os: flag.os
+		name: flag.name
+		value: value[1..value.len - 1]
 		cached: flag.cached
 	}
 }
@@ -812,7 +807,8 @@ fn ordinary_flag_takes_linker_operand(flag cflag.CFlag) bool {
 	raw := flag.value.trim_space()
 	return (flag.name == '' && raw in ['-Xlinker', '-force_load', '-weak_framework'])
 		|| (flag.name == '-Wl'
-		&& raw in [',-rpath', ',--rpath', ',-R', ',-rpath-link', ',--rpath-link', ',--version-script'])
+			&& raw in [',-rpath', ',--rpath', ',-R', ',-rpath-link', ',--rpath-link',
+				',--version-script'])
 }
 
 fn ordered_ordinary_link_args(flag cflag.CFlag, force_linker bool) []string {
@@ -848,7 +844,10 @@ fn (v &Builder) split_ordered_pkgconfig_link_flags(cflags []cflag.CFlag) ([]cfla
 	mut ordered_link_flags := []string{}
 	mut pkgconfig_pthread := false
 	mut pending_linker_option := ''
-	convert_windows_import_libs := v.pref.os == .windows && v.pref.ccompiler_type in [.gcc, .mingw]
+	convert_windows_import_libs := v.pref.os == .windows && v.pref.ccompiler_type in [
+		.gcc,
+		.mingw,
+	]
 	for segment in v.table.link_flag_segments {
 		if segment.is_pkgconfig {
 			if pending_linker_option != '' {
@@ -1407,25 +1406,25 @@ fn (v &Builder) thirdparty_cross_compile_config() ThirdpartyCrossCompileConfig {
 	if v.pref.os == .linux && current_os != 'linux' {
 		sysroot := os.join_path(os.vmodules_dir(), 'linuxroot')
 		return ThirdpartyCrossCompileConfig{
-			target_args:           ['-target x86_64-linux-gnu']
+			target_args: ['-target x86_64-linux-gnu']
 			trailing_include_args: [
 				'-I',
 				os.quoted_path('${sysroot}/include'),
 			]
-			sysroot:               sysroot
+			sysroot: sysroot
 		}
 	}
 	if v.pref.os == .freebsd && current_os != 'freebsd' {
 		sysroot := os.join_path(os.vmodules_dir(), 'freebsdroot')
 		return ThirdpartyCrossCompileConfig{
-			target_args:           ['-target x86_64-unknown-freebsd14.0']
+			target_args: ['-target x86_64-unknown-freebsd14.0']
 			trailing_include_args: [
 				'-I',
 				os.quoted_path('${sysroot}/include'),
 				'-I',
 				os.quoted_path('${sysroot}/usr/include'),
 			]
-			sysroot:               sysroot
+			sysroot: sysroot
 		}
 	}
 	return ThirdpartyCrossCompileConfig{}
@@ -1491,13 +1490,11 @@ fn (mut v Builder) setup_output_name() {
 		}
 	}
 	if v.pref.build_mode == .build_module {
-		v.pref.out_name = v.pref.cache_manager.mod_postfix_with_key2cpath(v.pref.path, '.o',
-			v.pref.path) // v.out_name
+		v.pref.out_name = v.pref.cache_manager.mod_postfix_with_key2cpath(v.pref.path, '.o', v.pref.path) // v.out_name
 		if v.pref.is_verbose {
 			println('Building ${v.pref.path} to ${v.pref.out_name} ...')
 		}
-		v.pref.cache_manager.mod_save(v.pref.path, '.output.description.txt', v.pref.path,
-			get_dsc_content('PREF.PATH: ${v.pref.path}\nVOPTS: ${v.pref.cache_manager.vopts}\n')) or {
+		v.pref.cache_manager.mod_save(v.pref.path, '.output.description.txt', v.pref.path, get_dsc_content('PREF.PATH: ${v.pref.path}\nVOPTS: ${v.pref.cache_manager.vopts}\n')) or {
 			panic(err)
 		}
 	}
@@ -1954,8 +1951,7 @@ pub fn (mut v Builder) cc() {
 		}
 		v.handle_usecache(vexe)
 		reproducible_debug_object_lock.release()
-		reproducible_debug_object = v.prepare_reproducible_macos_debug_compiler_object(ccompiler,
-			vdir, mut reproducible_debug_object_lock)
+		reproducible_debug_object = v.prepare_reproducible_macos_debug_compiler_object(ccompiler, vdir, mut reproducible_debug_object_lock)
 		if reproducible_debug_object != '' {
 			// Link the persistent object instead of letting clang use a random temporary
 			// object, whose path would otherwise be recorded in the Mach-O debug map.
@@ -2021,8 +2017,7 @@ pub fn (mut v Builder) cc() {
 			v.show_c_compiler_output(ccompiler, res)
 		}
 		os.chdir(original_pwd) or {}
-		vcache.dlog('| Builder.' + @FN,
-			'>       v.pref.use_cache: ${v.pref.use_cache} | v.pref.retry_compilation: ${v.pref.retry_compilation}')
+		vcache.dlog('| Builder.' + @FN, '>       v.pref.use_cache: ${v.pref.use_cache} | v.pref.retry_compilation: ${v.pref.retry_compilation}')
 		vcache.dlog('| Builder.' + @FN, '>      cmd res.exit_code: ${res.exit_code} | cmd: ${cmd}')
 		vcache.dlog('| Builder.' + @FN, '>  response_file_content:\n${response_file_content}')
 		if res.exit_code != 0 {
@@ -2031,7 +2026,7 @@ pub fn (mut v Builder) cc() {
 			if v.pref.building_v && v.pref.is_prod && !v.pref.no_prod_options && !v.disable_flto
 				&& v.ccoptions.cc == .gcc && response_file_content.contains('-flto')
 				&& (res.output.contains('undefined symbol: main')
-				|| res.output.contains('undefined reference to `main')) {
+					|| res.output.contains('undefined reference to `main')) {
 				v.disable_flto = true
 				if !v.pref.is_quiet {
 					eprintln('Retrying compiler build without `-flto` after a linker failure with missing `main`.')
@@ -2073,12 +2068,7 @@ pub fn (mut v Builder) cc() {
 				}
 			}
 			if res.exit_code == 127 {
-				verror('C compiler error, while attempting to run: \n' +
-					'-----------------------------------------------------------\n' + '${cmd}\n' +
-					'-----------------------------------------------------------\n' +
-					'Probably your C compiler is missing. \n' +
-					'Please reinstall it, or make it available in your PATH.\n\n' +
-					missing_compiler_info())
+				verror('C compiler error, while attempting to run: \n' + '-----------------------------------------------------------\n' + '${cmd}\n' + '-----------------------------------------------------------\n' + 'Probably your C compiler is missing. \n' + 'Please reinstall it, or make it available in your PATH.\n\n' + missing_compiler_info())
 			}
 		}
 		v.post_process_c_compiler_output(ccompiler, res)
@@ -2226,8 +2216,7 @@ fn (mut v Builder) prepare_reproducible_macos_debug_compiler_object(ccompiler st
 		}
 		now := time.now().unix()
 		os.utime(object_dir, now, now) or {}
-		prune_reproducible_macos_debug_compiler_cache(cache_dir, object_path,
-			max_reproducible_macos_debug_cache_bytes)
+		prune_reproducible_macos_debug_compiler_cache(cache_dir, object_path, max_reproducible_macos_debug_cache_bytes)
 		return object_path
 	}
 	return ''
@@ -2264,10 +2253,10 @@ fn prune_reproducible_macos_debug_compiler_cache(cache_dir string, retained_obje
 			total_size += object_stat.size
 			if object_path != retained_object {
 				candidates << ReproducibleMacosDebugCacheEntry{
-					object_dir:  object_dir
+					object_dir: object_dir
 					object_path: object_path
-					size:        object_stat.size
-					last_used:   dir_stat.mtime
+					size: object_stat.size
+					last_used: dir_stat.mtime
 				}
 			}
 		}
@@ -2353,25 +2342,21 @@ fn (v &Builder) should_finalize_reproducible_macos_debug_compiler() bool {
 }
 
 fn macho_little_endian_u32(data []u8, offset int) u32 {
-	return u32(data[offset]) | (u32(data[offset + 1]) << 8) | (u32(data[offset + 2]) << 16) |
-		(u32(data[offset + 3]) << 24)
+	return u32(data[offset]) | (u32(data[offset + 1]) << 8) | (u32(data[offset + 2]) << 16) | (u32(data[offset + 3]) << 24)
 }
 
 fn macho_u32(data []u8, offset int, little_endian bool) u32 {
 	if little_endian {
 		return macho_little_endian_u32(data, offset)
 	}
-	return (u32(data[offset]) << 24) | (u32(data[offset + 1]) << 16) |
-		(u32(data[offset + 2]) << 8) | u32(data[offset + 3])
+	return (u32(data[offset]) << 24) | (u32(data[offset + 1]) << 16) | (u32(data[offset + 2]) << 8) | u32(data[offset + 3])
 }
 
 fn macho_u64(data []u8, offset int, little_endian bool) u64 {
 	if little_endian {
-		return u64(macho_u32(data, offset, true)) |
-			(u64(macho_u32(data, offset + 4, true)) << 32)
+		return u64(macho_u32(data, offset, true)) | (u64(macho_u32(data, offset + 4, true)) << 32)
 	}
-	return (u64(macho_u32(data, offset, false)) << 32) |
-		u64(macho_u32(data, offset + 4, false))
+	return (u64(macho_u32(data, offset, false)) << 32) | u64(macho_u32(data, offset + 4, false))
 }
 
 fn normalize_thin_macho_uuid(mut data []u8) !bool {
@@ -2384,7 +2369,9 @@ fn normalize_thin_macho_uuid(mut data []u8) !bool {
 		u32(0xfeedfacf) { 32, true }
 		u32(0xcefaedfe) { 28, false }
 		u32(0xcffaedfe) { 32, false }
-		else { return false }
+		else {
+			return false
+		}
 	}
 	if data.len < header_size {
 		return error('Mach-O header is truncated')
@@ -2510,8 +2497,7 @@ fn (v &Builder) generate_reproducible_macos_debug_compiler_dsym(debug_object str
 			verror('could not find `dsymutil` to finalize the reproducible macOS compiler debug information')
 			return
 		}
-		dsymutil_result := os.execute('${os.quoted_path(dsymutil_path)} -o ${os.quoted_path(
-			v.pref.out_name + '.dSYM')} ${os.quoted_path(v.pref.out_name)}')
+		dsymutil_result := os.execute('${os.quoted_path(dsymutil_path)} -o ${os.quoted_path(v.pref.out_name + '.dSYM')} ${os.quoted_path(v.pref.out_name)}')
 		if dsymutil_result.exit_code != 0 {
 			verror('failed to generate the reproducible macOS compiler debug information:\n${dsymutil_result.output}')
 		}
@@ -2729,9 +2715,9 @@ fn linux_cross_target_for_arch(arch pref.Arch) !LinuxCrossTarget {
 		return error('Linux cross compilation currently supports only `-arch amd64`; the bundled linuxroot sysroot does not provide `${arch}` runtime files.')
 	}
 	return LinuxCrossTarget{
-		triple:           'x86_64-linux-gnu'
-		lib_dir:          'x86_64-linux-gnu'
-		dynamic_linker:   '/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2'
+		triple: 'x86_64-linux-gnu'
+		lib_dir: 'x86_64-linux-gnu'
+		dynamic_linker: '/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2'
 		linker_emulation: 'elf_x86_64'
 	}
 }
@@ -2783,14 +2769,13 @@ fn (mut b Builder) cc_linux_cross() {
 	}
 	mut extra_objs := []string{cap: extra_sources.len}
 	for src in extra_sources {
-		src_obj := os.join_path(os.vtmp_dir(), os.file_name(src) + '.' +
-			linux_cross_target.lib_dir + '.o')
+		src_obj := os.join_path(os.vtmp_dir(), os.file_name(src) + '.' + linux_cross_target.lib_dir + '.o')
 		mut src_args := []string{cap: 16}
 		src_args << '-w'
 		src_args << '-fPIC'
 		src_args << '-target ${linux_cross_target.triple}'
 		src_args << defines
-		src_args << '-I ${os.quoted_path('${sysroot}/include')}'
+		src_args << '-I ${os.quoted_path('\${sysroot}/include')}'
 		src_args << other_flags
 		src_args << '-o ${os.quoted_path(src_obj)}'
 		src_args << '-c ${os.quoted_path(src)}'
@@ -2811,7 +2796,7 @@ fn (mut b Builder) cc_linux_cross() {
 	cc_args << '-fPIC'
 	cc_args << '-target ${linux_cross_target.triple}'
 	cc_args << defines
-	cc_args << '-I ${os.quoted_path('${sysroot}/include')} '
+	cc_args << '-I ${os.quoted_path('\${sysroot}/include')} '
 	cc_args << other_flags
 	cc_args << '-o ${os.quoted_path(obj_file)}'
 	cc_args << '-c ${os.quoted_path(b.out_name_c)}'
@@ -3040,8 +3025,7 @@ fn (mut b Builder) build_thirdparty_obj_files() {
 			rest_of_module_flags := b.get_rest_of_module_cflags(flag)
 			$if windows {
 				if b.pref.ccompiler == 'msvc' {
-					b.build_thirdparty_obj_file_with_msvc(flag.mod, flag.value,
-						rest_of_module_flags)
+					b.build_thirdparty_obj_file_with_msvc(flag.mod, flag.value, rest_of_module_flags)
 					continue
 				}
 			}
@@ -3104,8 +3088,7 @@ fn (v &Builder) fixup_tcc_macos_comma_path_flags(mut ccoptions CcompilerOptions)
 	if !plan.required {
 		return
 	}
-	linker_flags, pre_args := materialize_and_rewrite_tcc_macos_libgc_flags(plan,
-		ccoptions.linker_flags, ccoptions.pre_args) or { verror(err.msg()) }
+	linker_flags, pre_args := materialize_and_rewrite_tcc_macos_libgc_flags(plan, ccoptions.linker_flags, ccoptions.pre_args) or { verror(err.msg()) }
 	ccoptions.linker_flags = linker_flags
 	ccoptions.pre_args = pre_args
 }
@@ -3170,8 +3153,7 @@ fn (mut v Builder) build_thirdparty_obj_file(mod string, path string, moduleflag
 	trace_thirdparty_obj_files := 'trace_thirdparty_obj_files' in v.pref.compile_defines
 	obj_path := os.real_path(path)
 	opath := v.pref.cache_manager.mod_postfix_with_key2cpath(mod, '.o', obj_path)
-	thirdparty_desc_path := v.pref.cache_manager.mod_postfix_with_key2cpath(mod,
-		'.thirdparty.description.txt', obj_path)
+	thirdparty_desc_path := v.pref.cache_manager.mod_postfix_with_key2cpath(mod, '.thirdparty.description.txt', obj_path)
 	mut source_file := c_project_source_from_object_path(obj_path) or { '' }
 	source_kind := if source_file.ends_with('.c') {
 		SourceKind.c
@@ -3182,13 +3164,11 @@ fn (mut v Builder) build_thirdparty_obj_file(mod string, path string, moduleflag
 	} else {
 		SourceKind.unknown
 	}
-	sqlite_validation_message := sqlite_thirdparty_validation_error(mod, obj_path, source_file,
-		source_kind)
+	sqlite_validation_message := sqlite_thirdparty_validation_error(mod, obj_path, source_file, source_kind)
 	if sqlite_validation_message != '' {
 		verror(sqlite_validation_message)
 	}
-	compile_bundled_source := v.should_compile_bundled_thirdparty_object_from_source(obj_path,
-		source_file, source_kind)
+	compile_bundled_source := v.should_compile_bundled_thirdparty_object_from_source(obj_path, source_file, source_kind)
 	if os.exists(obj_path) && !compile_bundled_source {
 		// Some .o files are distributed with no source
 		// for example thirdparty\tcc\lib\openlibm.o
@@ -3272,8 +3252,7 @@ fn (mut v Builder) build_thirdparty_obj_file(mod string, path string, moduleflag
 		verror(res.output)
 		return
 	}
-	v.pref.cache_manager.mod_save(mod, '.thirdparty.description.txt', obj_path,
-		get_dsc_content('OBJ_PATH: ${obj_path}\nCMD: ${cmd}\n')) or { panic(err) }
+	v.pref.cache_manager.mod_save(mod, '.thirdparty.description.txt', obj_path, get_dsc_content('OBJ_PATH: ${obj_path}\nCMD: ${cmd}\n')) or { panic(err) }
 	if v.pref.show_cc {
 		println('>> OBJECT FILE compilation cmd: ${cmd}')
 	}
@@ -3393,8 +3372,7 @@ pub fn (mut v Builder) quote_compiler_name(name string) string {
 
 fn write_response_file(response_file string, response_file_content string) {
 	$if windows {
-		os.write_file_array(response_file,
-			string_to_ansi_not_null_terminated(response_file_content)) or {
+		os.write_file_array(response_file, string_to_ansi_not_null_terminated(response_file_content)) or {
 			write_response_file_error(response_file_content, err)
 		}
 	} $else {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -4752,8 +4752,7 @@ fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, sourc
 			g.add_native_source_context_directive(module_name, c_native_source_context_header_include(include_arg, g.compiler_vroot, source_file, include_dirs), before_import)
 		}
 		if trimmed_space(include_arg) == '<objc/message.h>' {
-			g.record_header_owned_include(module_name, include_arg, source_file, before_import,
-				true)
+			g.record_header_owned_include(module_name, include_arg, source_file, before_import, true)
 			g.collect_preserved_c_fns(c_preserved_system_include_declared_fns(include_arg))
 			g.collect_preserved_c_structs(c_preserved_system_include_struct_names(include_arg))
 			g.collect_preserved_c_typedef_names(c_preserved_system_include_typedef_names(include_arg))
@@ -4769,9 +4768,7 @@ fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, sourc
 			g.add_c_directive(module_name, '#include ${include_arg}', before_import)
 			return true
 		}
-		if header := c_inline_header_text_scoped(include_arg, g.compiler_vroot, source_file,
-			include_dirs, g.use_system_stdint, g.scope_parallel_workers)
-		{
+		if header := c_inline_header_text_scoped(include_arg, g.compiler_vroot, source_file, include_dirs, g.use_system_stdint, g.scope_parallel_workers) {
 			g.record_header_owned_include(module_name, include_arg, source_file, before_import, false)
 			header_text := header.text
 			late_source := c_include_is_late_source(include_arg)
@@ -4841,9 +4838,9 @@ fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, sourc
 		'error', 'warning'] {
 		directive := c_preprocessor_directive_line(node.value, node.typ)
 		g.header_owned_directives << CHeaderOwnershipDirective{
-			module:        module_name
-			directive:     directive
-			source_file:   source_file
+			module: module_name
+			directive: directive
+			source_file: source_file
 			before_import: before_import
 		}
 		g.add_native_source_context_directive(module_name, directive, before_import)
@@ -4855,11 +4852,11 @@ fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, sourc
 
 fn (mut g FlatGen) record_header_owned_include(module_name string, include_arg string, source_file string, before_import bool, dedupe bool) {
 	g.header_owned_directives << CHeaderOwnershipDirective{
-		module:        module_name
-		include_arg:   include_arg
-		source_file:   source_file
+		module: module_name
+		include_arg: include_arg
+		source_file: source_file
 		before_import: before_import
-		dedupe:        dedupe
+		dedupe: dedupe
 	}
 }
 
@@ -4870,15 +4867,14 @@ fn (mut g FlatGen) rebuild_header_owned_c_typedefs() {
 	}
 	g.header_owned_pragma_once_seen.clear()
 	effective_flags := g.header_owned_effective_c_flags()
-	include_macros, dynamic_include_macros := c_flag_include_macro_definitions(effective_flags,
-		map[string]string{})
+	include_macros, dynamic_include_macros := c_flag_include_macro_definitions(effective_flags, map[string]string{})
 	g.header_owned_macro_context = CHeaderOwnedMacroContext{
-		initialized:            true
-		state:                  g.header_owned_initial_macro_state()
-		include_macros:         include_macros
+		initialized: true
+		state: g.header_owned_initial_macro_state()
+		include_macros: include_macros
 		dynamic_include_macros: dynamic_include_macros
 		literal_include_macros: map[string][]string{}
-		conditionals:           []CHeaderOwnedConditional{}
+		conditionals: []CHeaderOwnedConditional{}
 	}
 	include_dirs := c_flag_include_dirs(effective_flags)
 	quote_include_dirs := c_flag_quote_include_dirs(effective_flags)
@@ -4943,8 +4939,7 @@ fn (g &FlatGen) ordered_header_owned_directives() []CHeaderOwnershipDirective {
 	mut visiting := map[string]bool{}
 	mut visited := map[string]bool{}
 	for mod in module_order {
-		g.visit_header_owned_directive_module(mod, directives_by_module, mut visiting, mut visited,
-			mut result)
+		g.visit_header_owned_directive_module(mod, directives_by_module, mut visiting, mut visited, mut result)
 	}
 	return result
 }
@@ -4962,8 +4957,7 @@ fn (g &FlatGen) visit_header_owned_directive_module(mod string, directives_by_mo
 	}
 	for dep in g.module_imports[mod] or { []string{} } {
 		if dep in directives_by_module {
-			g.visit_header_owned_directive_module(dep, directives_by_module, mut visiting, mut visited,
-				mut result)
+			g.visit_header_owned_directive_module(dep, directives_by_module, mut visiting, mut visited, mut result)
 		}
 	}
 	visiting.delete(mod)
@@ -5038,18 +5032,13 @@ fn (mut g FlatGen) collect_header_owned_c_typedefs_with_include_dirs(include_arg
 		if !os.is_file(path) {
 			continue
 		}
-		g.header_owned_macro_context.state = g.collect_header_owned_c_typedef_file(path,
-			include_dirs, g.header_owned_macro_context.state, mut seen, mut
-			g.header_owned_macro_context.include_macros, mut
-			g.header_owned_macro_context.dynamic_include_macros, mut
-			g.header_owned_macro_context.literal_include_macros)
+		g.header_owned_macro_context.state = g.collect_header_owned_c_typedef_file(path, include_dirs, g.header_owned_macro_context.state, mut seen, mut g.header_owned_macro_context.include_macros, mut g.header_owned_macro_context.dynamic_include_macros, mut g.header_owned_macro_context.literal_include_macros)
 		found = true
 		break
 	}
 	if !found {
 		g.collect_known_header_owned_c_typedef_names(include_arg)
-		g.header_owned_macro_context.state = c_header_macro_state_after_unknown_include(
-			g.header_owned_macro_context.state)
+		g.header_owned_macro_context.state = c_header_macro_state_after_unknown_include(g.header_owned_macro_context.state)
 	}
 }
 
@@ -5058,17 +5047,15 @@ fn (mut g FlatGen) ensure_header_owned_macro_context() {
 		return
 	}
 	effective_flags := g.header_owned_effective_c_flags()
-	include_macros, dynamic_include_macros := c_flag_include_macro_definitions(effective_flags,
-		map[string]string{})
+	include_macros, dynamic_include_macros := c_flag_include_macro_definitions(effective_flags, map[string]string{})
 	g.header_owned_macro_context = CHeaderOwnedMacroContext{
-		initialized:            true
-		state:                  g.header_owned_initial_macro_state()
-		include_macros:         include_macros
+		initialized: true
+		state: g.header_owned_initial_macro_state()
+		include_macros: include_macros
 		dynamic_include_macros: dynamic_include_macros
 		literal_include_macros: map[string][]string{}
-		conditionals:           []CHeaderOwnedConditional{}
-		implicit_include_dirs:  c_header_compiler_implicit_include_dirs(g.ccompiler, effective_flags,
-			g.c99_mode, g.target)
+		conditionals: []CHeaderOwnedConditional{}
+		implicit_include_dirs: c_header_compiler_implicit_include_dirs(g.ccompiler, effective_flags, g.c99_mode, g.target)
 	}
 }
 
@@ -5397,8 +5384,7 @@ fn (mut g FlatGen) collect_header_owned_source_macro_directive_in_file(directive
 	if name in ['if', 'ifdef', 'ifndef'] {
 		parent_possible := g.header_owned_macro_context.conditionals.all(it.current_possible)
 		parent_definite := g.header_owned_macro_context.conditionals.all(it.current_definite)
-		condition := c_header_owned_source_condition(directive, g.header_owned_macro_context.state,
-			c_effective_strict_iso_mode(g.c_flags, g.c99_mode), g.target, include_context)
+		condition := c_header_owned_source_condition(directive, g.header_owned_macro_context.state, c_effective_strict_iso_mode(g.c_flags, g.c99_mode), g.target, include_context)
 		g.header_owned_macro_context.conditionals << CHeaderOwnedConditional{
 			entry_state: c_header_macro_state_clone(g.header_owned_macro_context.state)
 			branch_states: []CHeaderMacroState{}
@@ -5434,9 +5420,7 @@ fn (mut g FlatGen) collect_header_owned_source_macro_directive_in_file(directive
 			conditional.current_possible = false
 			conditional.current_definite = false
 		} else {
-			next_condition := c_header_owned_source_condition(directive,
-				g.header_owned_macro_context.state,
-				c_effective_strict_iso_mode(g.c_flags, g.c99_mode), g.target, include_context)
+			next_condition := c_header_owned_source_condition(directive, g.header_owned_macro_context.state, c_effective_strict_iso_mode(g.c_flags, g.c99_mode), g.target, include_context)
 			prior_known := conditional.taken_known
 			prior_taken := conditional.taken
 			conditional.current_possible = conditional.parent_possible && next_condition >= 0
@@ -5467,8 +5451,7 @@ fn (mut g FlatGen) collect_header_owned_source_macro_directive_in_file(directive
 				conditional.branch_states << c_header_macro_state_clone(conditional.entry_state)
 				conditional.branch_typedef_aliases << map[string]bool{}
 			}
-			g.header_owned_macro_context.state = c_header_macro_states_merge(conditional.branch_states,
-				conditional.entry_state)
+			g.header_owned_macro_context.state = c_header_macro_states_merge(conditional.branch_states, conditional.entry_state)
 			common_typedef_aliases := c_header_typedef_alias_state_intersection(conditional.branch_typedef_aliases)
 			g.header_owned_macro_context.conditionals.delete_last()
 			if g.header_owned_macro_context.conditionals.len > 0 {
@@ -5486,8 +5469,7 @@ fn (mut g FlatGen) collect_header_owned_source_macro_directive_in_file(directive
 		}
 		return
 	}
-	if name !in ['define', 'undef']
-		|| g.header_owned_macro_context.conditionals.any(!it.current_possible) {
+	if name !in ['define', 'undef'] || g.header_owned_macro_context.conditionals.any(!it.current_possible) {
 		return
 	}
 	macro_name, macro_value, has_macro_value, function_macro_value := c_header_define_name_and_value(directive)
@@ -5513,8 +5495,7 @@ fn (mut g FlatGen) collect_header_owned_source_macro_directive_in_file(directive
 			macro_values.delete(macro_name)
 			function_macro_values.delete(macro_name)
 		}
-		c_record_literal_include_macro_definition(directive, mut
-			g.header_owned_macro_context.literal_include_macros)
+		c_record_literal_include_macro_definition(directive, mut g.header_owned_macro_context.literal_include_macros)
 	} else {
 		defined.delete(macro_name)
 		undefined[macro_name] = true
@@ -5522,16 +5503,14 @@ fn (mut g FlatGen) collect_header_owned_source_macro_directive_in_file(directive
 		function_macro_values.delete(macro_name)
 	}
 	g.header_owned_macro_context.state = CHeaderMacroState{
-		defined:                  defined
-		undefined:                undefined
-		uncertain:                uncertain
-		macro_values:             macro_values
-		function_macro_values:    function_macro_values
+		defined: defined
+		undefined: undefined
+		uncertain: uncertain
+		macro_values: macro_values
+		function_macro_values: function_macro_values
 		external_macros_possible: g.header_owned_macro_context.state.external_macros_possible
 	}
-	c_record_include_macro_definition(directive, false, mut
-		g.header_owned_macro_context.include_macros, mut
-		g.header_owned_macro_context.dynamic_include_macros, false)
+	c_record_include_macro_definition(directive, false, mut g.header_owned_macro_context.include_macros, mut g.header_owned_macro_context.dynamic_include_macros, false)
 }
 
 fn c_header_define_name_and_value(directive string) (string, string, bool, string) {
@@ -5589,11 +5568,11 @@ fn c_header_macro_states_merge(states []CHeaderMacroState, fallback CHeaderMacro
 		}
 	}
 	mut result := CHeaderMacroState{
-		defined:                  map[string]bool{}
-		undefined:                map[string]bool{}
-		uncertain:                map[string]bool{}
-		macro_values:             map[string]string{}
-		function_macro_values:    map[string]string{}
+		defined: map[string]bool{}
+		undefined: map[string]bool{}
+		uncertain: map[string]bool{}
+		macro_values: map[string]string{}
+		function_macro_values: map[string]string{}
 		external_macros_possible: external_macros_possible
 	}
 	for name in names.keys() {
@@ -5637,15 +5616,12 @@ fn c_header_owned_source_condition(directive string, state CHeaderMacroState, st
 	name := c_directive_name(directive)
 	known, mut active := if name in ['ifdef', 'ifndef'] {
 		macro_name := c_directive_arg(directive).fields()[0] or { '' }
-		c_preprocessor_ifdef_macro_state(macro_name, state.defined, state.undefined, state.uncertain,
-			state.external_macros_possible, strict_iso_mode, target)
+		c_preprocessor_ifdef_macro_state(macro_name, state.defined, state.undefined, state.uncertain, state.external_macros_possible, strict_iso_mode, target)
 	} else {
 		expanded := c_header_expand_condition_function_macros(c_directive_arg(directive), state)
 		include_condition := c_header_condition_resolve_has_include(expanded, state, include_context)
-		condition := c_header_condition_resolve_feature_predicates(include_condition,
-			include_context.feature_predicates)
-		c_header_objective_c_condition_state(condition, state.defined, state.undefined,
-			state.uncertain, state.macro_values, strict_iso_mode, target)
+		condition := c_header_condition_resolve_feature_predicates(include_condition, include_context.feature_predicates)
+		c_header_objective_c_condition_state(condition, state.defined, state.undefined, state.uncertain, state.macro_values, strict_iso_mode, target)
 	}
 	if name == 'ifndef' {
 		active = !active
@@ -5666,8 +5642,7 @@ fn (mut g FlatGen) collect_header_owned_c_typedef_file(path string, include_dirs
 		seen.delete(real_path)
 	}
 	text := os.read_file(real_path) or { return c_header_macro_state_clone(state) }
-	feature_predicates := c_header_compiler_feature_predicate_values(g.ccompiler,
-		g.header_owned_effective_c_flags(), g.c99_mode, g.target, text)
+	feature_predicates := c_header_compiler_feature_predicate_values(g.ccompiler, g.header_owned_effective_c_flags(), g.c99_mode, g.target, text)
 	strict_iso_mode := c_effective_strict_iso_mode(g.c_flags, g.c99_mode)
 	quote_include_dirs := c_flag_quote_include_dirs(g.header_owned_effective_c_flags())
 	framework_include_dirs := c_flag_framework_include_dirs(g.header_owned_effective_c_flags())
@@ -5684,16 +5659,14 @@ fn (mut g FlatGen) collect_header_owned_c_typedef_file(path string, include_dirs
 			framework_include_dirs: framework_include_dirs
 			feature_predicates: feature_predicates
 		}
-		scan := c_header_definitely_active_scan_with_include_results(text, state, strict_iso_mode,
-			g.target, include_results, include_context)
+		scan := c_header_definitely_active_scan_with_include_results(text, state, strict_iso_mode, g.target, include_results, include_context)
 		if scan.has_pragma_once {
 			g.header_owned_pragma_once_seen[real_path] = true
 		}
 		mut unresolved_include := -1
 		for i, include_key in scan.include_keys {
 			include_state_signature := c_header_macro_state_signature(scan.include_states[i])
-			if include_key !in include_results
-				|| include_results[include_key].input_signature != include_state_signature {
+			if include_key !in include_results || include_results[include_key].input_signature != include_state_signature {
 				unresolved_include = i
 				break
 			}
@@ -5706,16 +5679,14 @@ fn (mut g FlatGen) collect_header_owned_c_typedef_file(path string, include_dirs
 		}
 		include_key := scan.include_keys[unresolved_include]
 		include_line_index := include_key.all_before(':').int()
-		c_record_active_include_macro_definitions(scan.text, macro_line_index, include_line_index,
-			mut include_macros, mut dynamic_include_macros, mut literal_include_macros)
+		c_record_active_include_macro_definitions(scan.text, macro_line_index, include_line_index, mut include_macros, mut dynamic_include_macros, mut literal_include_macros)
 		macro_line_index = include_line_index + 1
 		include_state := scan.include_states[unresolved_include]
 		include_is_definitely_active := scan.include_definitely_active[unresolved_include]
 		include_at_file_scope := scan.include_at_file_scope[unresolved_include]
 		include_is_next := scan.include_next[unresolved_include]
 		raw_include_arg := scan.include_args[unresolved_include]
-		include_args := c_header_owned_include_args(raw_include_arg, include_state,
-			g.compiler_vroot, real_path)
+		include_args := c_header_owned_include_args(raw_include_arg, include_state, g.compiler_vroot, real_path)
 		mut found := false
 		mut result_state := CHeaderMacroState{}
 		mut result_typedef_aliases := []string{}
@@ -5730,9 +5701,7 @@ fn (mut g FlatGen) collect_header_owned_c_typedef_file(path string, include_dirs
 					if !include_at_file_scope {
 						owned_before = g.header_owned_c_typedefs.clone()
 					}
-					result_state = g.collect_header_owned_c_typedef_file(nested_path, include_dirs,
-						include_state, mut seen, mut include_macros, mut dynamic_include_macros, mut
-						literal_include_macros)
+					result_state = g.collect_header_owned_c_typedef_file(nested_path, include_dirs, include_state, mut seen, mut include_macros, mut dynamic_include_macros, mut literal_include_macros)
 					if !include_at_file_scope {
 						g.header_owned_c_typedefs = owned_before.move()
 					}
@@ -5755,9 +5724,7 @@ fn (mut g FlatGen) collect_header_owned_c_typedef_file(path string, include_dirs
 					mut possible_include_macros := include_macros.clone()
 					mut possible_dynamic_include_macros := dynamic_include_macros.clone()
 					mut possible_literal_include_macros := literal_include_macros.clone()
-					_ = g.collect_header_owned_c_typedef_file(nested_path, include_dirs,
-						include_state, mut seen, mut possible_include_macros, mut
-						possible_dynamic_include_macros, mut possible_literal_include_macros)
+					_ = g.collect_header_owned_c_typedef_file(nested_path, include_dirs, include_state, mut seen, mut possible_include_macros, mut possible_dynamic_include_macros, mut possible_literal_include_macros)
 					for alias, _ in g.header_owned_c_typedefs {
 						if include_at_file_scope && alias !in owned_before {
 							result_typedef_aliases << alias
@@ -5784,19 +5751,18 @@ fn (mut g FlatGen) collect_header_owned_c_typedef_file(path string, include_dirs
 		}
 		include_results[include_key] = CHeaderIncludeResult{
 			input_signature: c_header_macro_state_signature(include_state)
-			output_state:    result_state
+			output_state: result_state
 			typedef_aliases: result_typedef_aliases
 		}
 	}
-	fallback_scan := c_header_definitely_active_scan_in_file(text, state, strict_iso_mode, g.target,
-		CHeaderIncludeContext{
-			vroot: g.compiler_vroot
-			source_file: real_path
-			include_dirs: include_dirs
-			quote_include_dirs: quote_include_dirs
-			framework_include_dirs: framework_include_dirs
-			feature_predicates: feature_predicates
-		})
+	fallback_scan := c_header_definitely_active_scan_in_file(text, state, strict_iso_mode, g.target, CHeaderIncludeContext{
+		vroot: g.compiler_vroot
+		source_file: real_path
+		include_dirs: include_dirs
+		quote_include_dirs: quote_include_dirs
+		framework_include_dirs: framework_include_dirs
+		feature_predicates: feature_predicates
+	})
 	if fallback_scan.has_pragma_once {
 		g.header_owned_pragma_once_seen[real_path] = true
 	}
@@ -5920,8 +5886,7 @@ fn c_record_active_include_macro_definitions(text string, start_line int, end_li
 		if c_directive_name(clean) == 'define' {
 			c_record_literal_include_macro_definition(clean, mut literal_include_macros)
 		}
-		c_record_include_macro_definition(clean, false, mut include_macros, mut
-			dynamic_include_macros, false)
+		c_record_include_macro_definition(clean, false, mut include_macros, mut dynamic_include_macros, false)
 	}
 }
 
@@ -6141,8 +6106,7 @@ fn (mut g FlatGen) collect_preserved_header_file_with_state_and_scope(path strin
 		g.preserved_header_scans_active.delete(visit_key)
 		return c_header_macro_state_clone(state)
 	}
-	feature_predicates := c_header_compiler_feature_predicate_values(g.ccompiler,
-		g.header_owned_effective_c_flags(), g.c99_mode, g.target, text)
+	feature_predicates := c_header_compiler_feature_predicate_values(g.ccompiler, g.header_owned_effective_c_flags(), g.c99_mode, g.target, text)
 	strict_iso_mode := c_effective_strict_iso_mode(g.c_flags, g.c99_mode)
 	mut include_results := map[string]CHeaderIncludeResult{}
 	// Resolve one include at a time, from left to right. Restarting the scan after
@@ -6158,8 +6122,7 @@ fn (mut g FlatGen) collect_preserved_header_file_with_state_and_scope(path strin
 			include_dirs: include_dirs
 			feature_predicates: feature_predicates
 		}
-		scan := c_header_definitely_active_scan_with_include_results(text, state, strict_iso_mode,
-			g.target, include_results, include_context)
+		scan := c_header_definitely_active_scan_with_include_results(text, state, strict_iso_mode, g.target, include_results, include_context)
 		cgen_worker_scope_leave(scan_scope)
 		mut unresolved_include := -1
 		for i, include_key in scan.include_keys {
@@ -6188,8 +6151,7 @@ fn (mut g FlatGen) collect_preserved_header_file_with_state_and_scope(path strin
 		include_arg := c_include_arg(raw_include_arg, g.compiler_vroot, real_path)
 		mut found := false
 		mut result_state := CHeaderMacroState{}
-		paths := c_header_include_file_paths(include_arg, g.compiler_vroot, real_path, include_dirs,
-			include_is_next)
+		paths := c_header_include_file_paths(include_arg, g.compiler_vroot, real_path, include_dirs, include_is_next)
 		for nested_path in paths {
 			if os.is_file(nested_path) {
 				if include_is_definitely_active {
@@ -6218,13 +6180,12 @@ fn (mut g FlatGen) collect_preserved_header_file_with_state_and_scope(path strin
 	// A pathological include cycle should never let uncertain metadata suppress a
 	// generated prototype. Fall back to the conservative, pre-propagation scan.
 	fallback_scope := cgen_worker_scope_begin(g.scope_parallel_workers)
-	fallback_scan := c_header_definitely_active_scan_in_file(text, state, strict_iso_mode, g.target,
-		CHeaderIncludeContext{
-			vroot: g.compiler_vroot
-			source_file: real_path
-			include_dirs: include_dirs
-			feature_predicates: feature_predicates
-		})
+	fallback_scan := c_header_definitely_active_scan_in_file(text, state, strict_iso_mode, g.target, CHeaderIncludeContext{
+		vroot: g.compiler_vroot
+		source_file: real_path
+		include_dirs: include_dirs
+		feature_predicates: feature_predicates
+	})
 	cgen_worker_scope_leave(fallback_scope)
 	result := g.finish_preserved_header_scan(fallback_scan, visit_key, collect_declarations)
 	cgen_worker_scope_free(fallback_scope)
@@ -6330,11 +6291,11 @@ struct CHeaderIncludeResult {
 
 fn c_header_macro_state_clone(state CHeaderMacroState) CHeaderMacroState {
 	return CHeaderMacroState{
-		defined:                  state.defined.clone()
-		undefined:                state.undefined.clone()
-		uncertain:                state.uncertain.clone()
-		macro_values:             state.macro_values.clone()
-		function_macro_values:    state.function_macro_values.clone()
+		defined: state.defined.clone()
+		undefined: state.undefined.clone()
+		uncertain: state.uncertain.clone()
+		macro_values: state.macro_values.clone()
+		function_macro_values: state.function_macro_values.clone()
 		external_macros_possible: state.external_macros_possible
 	}
 }
@@ -6345,18 +6306,17 @@ fn c_header_macro_state_after_unknown_include(state CHeaderMacroState) CHeaderMa
 	mut uncertain := state.uncertain.clone()
 	c_preprocessor_invalidate_macro_state(mut defined, mut undefined, mut uncertain)
 	return CHeaderMacroState{
-		defined:                  defined
-		undefined:                undefined
-		uncertain:                uncertain
-		macro_values:             map[string]string{}
-		function_macro_values:    map[string]string{}
+		defined: defined
+		undefined: undefined
+		uncertain: uncertain
+		macro_values: map[string]string{}
+		function_macro_values: map[string]string{}
 		external_macros_possible: true
 	}
 }
 
 fn c_header_macro_state_signature(state CHeaderMacroState) string {
-	mut parts := []string{cap: state.defined.len + state.undefined.len + state.uncertain.len +
-		state.macro_values.len + state.function_macro_values.len + 1}
+	mut parts := []string{cap: state.defined.len + state.undefined.len + state.uncertain.len + state.macro_values.len + state.function_macro_values.len + 1}
 	for name in state.defined.keys().sorted() {
 		parts << 'd:${name}'
 	}
@@ -6465,7 +6425,7 @@ fn c_header_macro_state_for_flags(flags []string) CHeaderMacroState {
 		defined: defined
 		undefined: undefined
 		uncertain: map[string]bool{}
-		macro_values:          macro_values
+		macro_values: macro_values
 		function_macro_values: map[string]string{}
 	}
 }
@@ -6479,13 +6439,11 @@ fn c_header_definitely_active_text(text string, flags []string, c99_mode bool, t
 }
 
 fn c_header_definitely_active_scan(text string, state CHeaderMacroState, strict_iso_mode bool, target pref.Target) CHeaderActiveScan {
-	return c_header_definitely_active_scan_in_file(text, state, strict_iso_mode, target,
-		CHeaderIncludeContext{})
+	return c_header_definitely_active_scan_in_file(text, state, strict_iso_mode, target, CHeaderIncludeContext{})
 }
 
 fn c_header_definitely_active_scan_in_file(text string, state CHeaderMacroState, strict_iso_mode bool, target pref.Target, include_context CHeaderIncludeContext) CHeaderActiveScan {
-	return c_header_definitely_active_scan_with_include_results(text, state, strict_iso_mode,
-		target, map[string]CHeaderIncludeResult{}, include_context)
+	return c_header_definitely_active_scan_with_include_results(text, state, strict_iso_mode, target, map[string]CHeaderIncludeResult{}, include_context)
 }
 
 // collect_possibly_active_header_macros conservatively follows an include from
@@ -6500,30 +6458,27 @@ fn (mut g FlatGen) collect_possibly_active_header_macros(path string, include_di
 	g.preserved_macro_files_seen[real_path] = true
 	g.preserved_header_files_seen[real_path] = true
 	text := os.read_file(real_path) or { return }
-	feature_predicates := c_header_compiler_feature_predicate_values(g.ccompiler,
-		g.header_owned_effective_c_flags(), g.c99_mode, g.target, text)
+	feature_predicates := c_header_compiler_feature_predicate_values(g.ccompiler, g.header_owned_effective_c_flags(), g.c99_mode, g.target, text)
 	flag_state := c_header_macro_state_for_flags(g.c_flags)
 	state := CHeaderMacroState{
-		defined:                  flag_state.defined
-		undefined:                flag_state.undefined
-		uncertain:                flag_state.uncertain
-		macro_values:             flag_state.macro_values
+		defined: flag_state.defined
+		undefined: flag_state.undefined
+		uncertain: flag_state.uncertain
+		macro_values: flag_state.macro_values
 		external_macros_possible: true
 	}
-	scan := c_header_definitely_active_scan_in_file(text, state,
-		c_effective_strict_iso_mode(g.c_flags, g.c99_mode), g.target, CHeaderIncludeContext{
-			vroot: g.compiler_vroot
-			source_file: real_path
-			include_dirs: include_dirs
-			feature_predicates: feature_predicates
-		})
+	scan := c_header_definitely_active_scan_in_file(text, state, c_effective_strict_iso_mode(g.c_flags, g.c99_mode), g.target, CHeaderIncludeContext{
+		vroot: g.compiler_vroot
+		source_file: real_path
+		include_dirs: include_dirs
+		feature_predicates: feature_predicates
+	})
 	for macro_name in scan.possibly_active_macro_names {
 		g.possibly_active_c_macros[macro_name] = true
 	}
 	for i, raw_include_arg in scan.include_args {
 		include_arg := c_include_arg(raw_include_arg, g.compiler_vroot, real_path)
-		paths := c_header_include_file_paths(include_arg, g.compiler_vroot, real_path, include_dirs,
-			scan.include_next[i])
+		paths := c_header_include_file_paths(include_arg, g.compiler_vroot, real_path, include_dirs, scan.include_next[i])
 		for nested_path in paths {
 			if os.is_file(nested_path) {
 				g.collect_possibly_active_header_macros(nested_path, include_dirs)
@@ -6568,15 +6523,14 @@ fn c_header_definitely_active_scan_with_include_results(text string, state CHead
 			parent_possible := conditionals.all(it.current_possible)
 			parent_definite := conditionals.all(it.current_definite)
 			current_state := CHeaderMacroState{
-				defined:                  defined
-				undefined:                undefined
-				uncertain:                uncertain
-				macro_values:             macro_values
-				function_macro_values:    function_macro_values
+				defined: defined
+				undefined: undefined
+				uncertain: uncertain
+				macro_values: macro_values
+				function_macro_values: function_macro_values
 				external_macros_possible: external_macros_possible
 			}
-			condition := c_header_owned_source_condition(clean, current_state, strict_iso_mode,
-				target, include_context)
+			condition := c_header_owned_source_condition(clean, current_state, strict_iso_mode, target, include_context)
 			conditionals << CHeaderOwnedConditional{
 				entry_state: c_header_macro_state_clone(current_state)
 				branch_states: []CHeaderMacroState{}
@@ -6599,11 +6553,11 @@ fn c_header_definitely_active_scan_with_include_results(text string, state CHead
 			mut conditional := conditionals[conditional_idx]
 			if conditional.current_possible {
 				conditional.branch_states << CHeaderMacroState{
-					defined:                  defined.clone()
-					undefined:                undefined.clone()
-					uncertain:                uncertain.clone()
-					macro_values:             macro_values.clone()
-					function_macro_values:    function_macro_values.clone()
+					defined: defined.clone()
+					undefined: undefined.clone()
+					uncertain: uncertain.clone()
+					macro_values: macro_values.clone()
+					function_macro_values: function_macro_values.clone()
 					external_macros_possible: external_macros_possible
 				}
 				conditional.branch_brace_depths << brace_depth
@@ -6631,15 +6585,14 @@ fn c_header_definitely_active_scan_with_include_results(text string, state CHead
 				conditional.current_definite = false
 			} else {
 				current_state := CHeaderMacroState{
-					defined:                  defined
-					undefined:                undefined
-					uncertain:                uncertain
-					macro_values:             macro_values
-					function_macro_values:    function_macro_values
+					defined: defined
+					undefined: undefined
+					uncertain: uncertain
+					macro_values: macro_values
+					function_macro_values: function_macro_values
 					external_macros_possible: external_macros_possible
 				}
-				next_condition := c_header_owned_source_condition(clean, current_state,
-					strict_iso_mode, target, include_context)
+				next_condition := c_header_owned_source_condition(clean, current_state, strict_iso_mode, target, include_context)
 				prior_known := conditional.taken_known
 				prior_taken := conditional.taken
 				conditional.current_possible = conditional.parent_possible
@@ -6665,11 +6618,11 @@ fn c_header_definitely_active_scan_with_include_results(text string, state CHead
 			mut conditional := conditionals.last()
 			if conditional.current_possible {
 				conditional.branch_states << CHeaderMacroState{
-					defined:                  defined.clone()
-					undefined:                undefined.clone()
-					uncertain:                uncertain.clone()
-					macro_values:             macro_values.clone()
-					function_macro_values:    function_macro_values.clone()
+					defined: defined.clone()
+					undefined: undefined.clone()
+					uncertain: uncertain.clone()
+					macro_values: macro_values.clone()
+					function_macro_values: function_macro_values.clone()
 					external_macros_possible: external_macros_possible
 				}
 				conditional.branch_brace_depths << brace_depth
@@ -6745,8 +6698,7 @@ fn c_header_definitely_active_scan_with_include_results(text string, state CHead
 					saved := stack.last()
 					stack.delete_last()
 					macro_stacks[pop_name] = stack
-					c_header_restore_macro_name(pop_name, saved, mut defined, mut undefined,
-						mut uncertain, mut macro_values, mut function_macro_values)
+					c_header_restore_macro_name(pop_name, saved, mut defined, mut undefined, mut uncertain, mut macro_values, mut function_macro_values)
 				} else {
 					macro_stacks.delete(pop_name)
 					defined.delete(pop_name)
@@ -6792,11 +6744,11 @@ fn c_header_definitely_active_scan_with_include_results(text string, state CHead
 		}
 		if name in ['include', 'include_next', 'import'] && possibly_active {
 			include_state := CHeaderMacroState{
-				defined:                  defined.clone()
-				undefined:                undefined.clone()
-				uncertain:                uncertain.clone()
-				macro_values:             macro_values.clone()
-				function_macro_values:    function_macro_values.clone()
+				defined: defined.clone()
+				undefined: undefined.clone()
+				uncertain: uncertain.clone()
+				macro_values: macro_values.clone()
+				function_macro_values: function_macro_values.clone()
 				external_macros_possible: external_macros_possible
 			}
 			include_key := '${line_index}:${clean}'
@@ -6895,12 +6847,12 @@ fn c_header_definitely_active_scan_with_include_results(text string, state CHead
 		include_at_file_scope: include_at_file_scope
 		macro_names: macro_names.keys()
 		possibly_active_macro_names: possibly_active_macro_names.keys()
-		final_state:                 CHeaderMacroState{
-			defined:                  defined
-			undefined:                undefined
-			uncertain:                uncertain
-			macro_values:             macro_values
-			function_macro_values:    function_macro_values
+		final_state: CHeaderMacroState{
+			defined: defined
+			undefined: undefined
+			uncertain: uncertain
+			macro_values: macro_values
+			function_macro_values: function_macro_values
 			external_macros_possible: external_macros_possible
 		}
 	}
@@ -7027,8 +6979,7 @@ fn c_header_invoked_typedef_macro_expansion(line string, defined map[string]bool
 			return none
 		}
 		bound_args := c_header_function_macro_bound_args(params, args, variadic) or { return none }
-		substituted := c_header_substitute_function_macro(body, params, bound_args, defined,
-			undefined, uncertain, macro_values)
+		substituted := c_header_substitute_function_macro(body, params, bound_args, defined, undefined, uncertain, macro_values)
 		replacement = c_header_apply_token_pasting(substituted) or { return none }
 		seen[macro_name] = true
 	}
@@ -7043,18 +6994,16 @@ fn c_header_invoked_typedef_macro_expansion(line string, defined map[string]bool
 			// must be expanded alongside object-like values. Otherwise the alias tag
 			// this scan records differs from the tag the real compiler declares.
 			state := CHeaderMacroState{
-				defined:               defined
-				undefined:             undefined
-				uncertain:             uncertain
-				macro_values:          macro_values
+				defined: defined
+				undefined: undefined
+				uncertain: uncertain
+				macro_values: macro_values
 				function_macro_values: function_macro_values
 			}
 			mut expanded := clean
 			for _ in 0 .. 64 {
-				function_expanded := c_header_expand_condition_function_macros(expanded,
-					state)
-				object_expanded := c_header_expand_macro_argument(function_expanded, defined,
-					undefined, uncertain, macro_values)
+				function_expanded := c_header_expand_condition_function_macros(expanded, state)
+				object_expanded := c_header_expand_macro_argument(function_expanded, defined, undefined, uncertain, macro_values)
 				if object_expanded == expanded {
 					break
 				}
@@ -7080,11 +7029,9 @@ fn c_header_invoked_typedef_macro_expansion(line string, defined map[string]bool
 		if !valid_nested_definition {
 			break
 		}
-		nested_bound_args := c_header_function_macro_bound_args(nested_params, nested_args,
-			nested_variadic) or { break }
+		nested_bound_args := c_header_function_macro_bound_args(nested_params, nested_args, nested_variadic) or { break }
 		seen[nested_name] = true
-		nested_substituted := c_header_substitute_function_macro(nested_body, nested_params,
-			nested_bound_args, defined, undefined, uncertain, macro_values)
+		nested_substituted := c_header_substitute_function_macro(nested_body, nested_params, nested_bound_args, defined, undefined, uncertain, macro_values)
 		replacement = c_header_apply_token_pasting(nested_substituted) or { break }
 	}
 	clean_replacement := replacement.trim_space()
@@ -8390,8 +8337,7 @@ fn c_header_objective_c_integer_expression_value(raw string, defined map[string]
 	if or_parts.len > 1 {
 		mut all_known := true
 		for part in or_parts {
-			value := c_header_objective_c_integer_expression_value(part, defined, undefined,
-				uncertain, macro_values, strict_iso_mode, target, mut seen, depth + 1) or {
+			value := c_header_objective_c_integer_expression_value(part, defined, undefined, uncertain, macro_values, strict_iso_mode, target, mut seen, depth + 1) or {
 				all_known = false
 				continue
 			}
@@ -8408,8 +8354,7 @@ fn c_header_objective_c_integer_expression_value(raw string, defined map[string]
 	if and_parts.len > 1 {
 		mut all_known := true
 		for part in and_parts {
-			value := c_header_objective_c_integer_expression_value(part, defined, undefined,
-				uncertain, macro_values, strict_iso_mode, target, mut seen, depth + 1) or {
+			value := c_header_objective_c_integer_expression_value(part, defined, undefined, uncertain, macro_values, strict_iso_mode, target, mut seen, depth + 1) or {
 				all_known = false
 				continue
 			}
@@ -10056,16 +10001,13 @@ fn (mut g FlatGen) collect_inlined_c_source_typedefs(text string, module_name st
 	} else {
 		text
 	}
-	scan := c_header_definitely_active_scan_in_file(source_with_context,
-		g.header_owned_initial_macro_state(),
-		c_effective_strict_iso_mode(effective_flags, g.c99_mode), g.target, CHeaderIncludeContext{
-			vroot: g.compiler_vroot
-			include_dirs: c_flag_include_dirs(effective_flags)
-			quote_include_dirs: c_flag_quote_include_dirs(effective_flags)
-			framework_include_dirs: c_flag_framework_include_dirs(effective_flags)
-			feature_predicates: c_header_compiler_feature_predicate_values(g.ccompiler,
-				effective_flags, g.c99_mode, g.target, source_with_context)
-		})
+	scan := c_header_definitely_active_scan_in_file(source_with_context, g.header_owned_initial_macro_state(), c_effective_strict_iso_mode(effective_flags, g.c99_mode), g.target, CHeaderIncludeContext{
+		vroot: g.compiler_vroot
+		include_dirs: c_flag_include_dirs(effective_flags)
+		quote_include_dirs: c_flag_quote_include_dirs(effective_flags)
+		framework_include_dirs: c_flag_framework_include_dirs(effective_flags)
+		feature_predicates: c_header_compiler_feature_predicate_values(g.ccompiler, effective_flags, g.c99_mode, g.target, source_with_context)
+	})
 	clean := c_header_owned_typedef_scan_text(scan.text + '\n' + scan.typedef_macro_expansions)
 	for alias in c_typedef_all_aggregate_aliases(clean) {
 		if 'C.${alias}' in g.tc.c_typedef_structs {
@@ -11809,8 +11751,7 @@ fn c_header_condition_resolve_has_include(raw string, state CHeaderMacroState, i
 			continue
 		}
 		paren_close := paren_open + close_offset
-		include_args := c_header_owned_include_args(raw[paren_open + 1..paren_close], state,
-			include_context.vroot, include_context.source_file)
+		include_args := c_header_owned_include_args(raw[paren_open + 1..paren_close], state, include_context.vroot, include_context.source_file)
 		if include_args.len == 0 {
 			result.write_string(raw[i..paren_close + 1])
 			i = paren_close + 1
@@ -11945,10 +11886,10 @@ fn c_header_condition_macro_state(text string) CHeaderMacroState {
 		}
 	}
 	return CHeaderMacroState{
-		defined:               defined
-		undefined:             map[string]bool{}
-		uncertain:             map[string]bool{}
-		macro_values:          macro_values
+		defined: defined
+		undefined: map[string]bool{}
+		uncertain: map[string]bool{}
+		macro_values: macro_values
 		function_macro_values: function_macro_values
 	}
 }
@@ -18301,6 +18242,12 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 		.prefix {
 			child_id := g.a.child(node, 0)
 			child := g.a.nodes[int(child_id)]
+			if node.op == .amp && cgen_unalias_type(g.usable_expr_type(child_id)) is types.FnType {
+				// Function values are already C pointers. Taking the address of a local
+				// function value would store a pointer to its stack slot instead.
+				g.gen_expr(child_id)
+				return
+			}
 			if node.op == .mul && node.value.len == 0 && g.source_mut_pointer_param_deref_type(child_id) != none {
 				g.gen_expr(child_id)
 				return

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -105,8 +105,7 @@ $if !windows {
 		master := unsafe { &FlatGen(a.g) }
 		mut view := master.new_collect_gen_info_view()
 		nodes := unsafe { &[]int(a.nodes_ptr) }
-		a.candidates = view.collect_fn_gen_candidates_range(*nodes, a.start, a.end, a.file,
-			a.module_name, a.direct_array_access_fns, a.ignore_overflow_fns, a.program_modules)
+		a.candidates = view.collect_fn_gen_candidates_range(*nodes, a.start, a.end, a.file, a.module_name, a.direct_array_access_fns, a.ignore_overflow_fns, a.program_modules)
 		cgen_worker_scope_leave(a.scope)
 		return unsafe { nil }
 	}
@@ -232,9 +231,7 @@ $if !windows {
 						cur_module = item_module
 						text_cache.generation++
 					}
-					cost, needs_prelude_scan := exact_flat_fn_gen_item_cost_and_prep(g,
-						items[idx].node_id, idx, mut a.refs, mut stack, mut a.cands, mut
-						text_cache, mut type_seen, mut resolved_call_cache)
+					cost, needs_prelude_scan := exact_flat_fn_gen_item_cost_and_prep(g, items[idx].node_id, idx, mut a.refs, mut stack, mut a.cands, mut text_cache, mut type_seen, mut resolved_call_cache)
 					items[idx].cost = cost
 					items[idx].skip_prelude_scan = !needs_prelude_scan
 				}
@@ -243,8 +240,7 @@ $if !windows {
 		}
 		for idx in a.start .. a.end {
 			unsafe {
-				cost, needs_prelude_scan := exact_flat_fn_gen_item_cost(a.a, items[idx].node_id, mut
-					a.refs, mut stack)
+				cost, needs_prelude_scan := exact_flat_fn_gen_item_cost(a.a, items[idx].node_id, mut a.refs, mut stack)
 				items[idx].cost = cost
 				items[idx].skip_prelude_scan = !needs_prelude_scan
 			}
@@ -445,13 +441,11 @@ $if !windows {
 fn (mut g FlatGen) collect_fn_gen_candidates_parallel(direct_array_access_fns DirectArrayAccessFns, ignore_overflow_fns DirectArrayAccessFns, program_modules map[string]bool) []FlatFnGenCandidate {
 	$if windows {
 		nodes := g.top_level_nodes()
-		return g.collect_fn_gen_candidates_range(nodes, 0, nodes.len, '', '',
-			direct_array_access_fns, ignore_overflow_fns, program_modules)
+		return g.collect_fn_gen_candidates_range(nodes, 0, nodes.len, '', '', direct_array_access_fns, ignore_overflow_fns, program_modules)
 	} $else {
 		nodes := g.top_level_nodes()
 		if isnil(g.a.worker_pool) || g.a.worker_pool.size() == 0 || nodes.len < 2048 {
-			return g.collect_fn_gen_candidates_range(nodes, 0, nodes.len, '', '',
-				direct_array_access_fns, ignore_overflow_fns, program_modules)
+			return g.collect_fn_gen_candidates_range(nodes, 0, nodes.len, '', '', direct_array_access_fns, ignore_overflow_fns, program_modules)
 		}
 		mut n_jobs := g.a.worker_pool.size() + 1
 		if n_jobs > max_flat_cgen_select_jobs {
@@ -482,24 +476,24 @@ fn (mut g FlatGen) collect_fn_gen_candidates_parallel(direct_array_access_fns Di
 		mut args := []FlatCgenSelectArgs{cap: n_jobs}
 		for job in 0 .. n_jobs {
 			args << FlatCgenSelectArgs{
-				g:                       voidptr(g)
-				nodes_ptr:               unsafe { voidptr(&nodes) }
-				start:                   nodes.len * job / n_jobs
-				end:                     nodes.len * (job + 1) / n_jobs
-				file:                    files[job]
-				module_name:             modules[job]
+				g: voidptr(g)
+				nodes_ptr: unsafe { voidptr(&nodes) }
+				start: nodes.len * job / n_jobs
+				end: nodes.len * (job + 1) / n_jobs
+				file: files[job]
+				module_name: modules[job]
 				direct_array_access_fns: direct_array_access_fns
-				ignore_overflow_fns:     ignore_overflow_fns
-				program_modules:         program_modules
-				candidates:              []FlatFnGenCandidate{}
-				scope:                   unsafe { nil }
+				ignore_overflow_fns: ignore_overflow_fns
+				program_modules: program_modules
+				candidates: []FlatFnGenCandidate{}
+				scope: unsafe { nil }
 			}
 		}
 		mut tasks := []workers.Task{cap: n_jobs}
 		for job in 0 .. n_jobs {
 			tasks << workers.Task{
-				run:        flat_cgen_select_thread
-				arg:        unsafe { voidptr(&args[job]) }
+				run: flat_cgen_select_thread
+				arg: unsafe { voidptr(&args[job]) }
 				force_sync: job == 0
 			}
 		}
@@ -534,15 +528,15 @@ fn (mut g FlatGen) scan_collect_gen_info(no_parallel bool) CollectGenInfoScanCou
 		mut tasks := []workers.Task{cap: n_jobs}
 		for job in 0 .. n_jobs {
 			args << CollectGenInfoScanArgs{
-				g:     voidptr(g)
+				g: voidptr(g)
 				start: g.a.nodes.len * job / n_jobs
-				end:   g.a.nodes.len * (job + 1) / n_jobs
+				end: g.a.nodes.len * (job + 1) / n_jobs
 			}
 		}
 		for job in 0 .. n_jobs {
 			tasks << workers.Task{
-				run:        collect_gen_info_scan_count_thread
-				arg:        unsafe { voidptr(&args[job]) }
+				run: collect_gen_info_scan_count_thread
+				arg: unsafe { voidptr(&args[job]) }
 				force_sync: job == 0
 			}
 		}
@@ -574,8 +568,8 @@ fn (mut g FlatGen) scan_collect_gen_info(no_parallel bool) CollectGenInfoScanCou
 		tasks.clear()
 		for job in 0 .. n_jobs {
 			tasks << workers.Task{
-				run:        collect_gen_info_scan_fill_thread
-				arg:        unsafe { voidptr(&args[job]) }
+				run: collect_gen_info_scan_fill_thread
+				arg: unsafe { voidptr(&args[job]) }
 				force_sync: job == 0
 			}
 		}
@@ -605,15 +599,15 @@ fn (mut g FlatGen) apply_fn_signature_registrations(registrations []FnSignatureR
 		mut tasks := []workers.Task{cap: 4}
 		for group in 0 .. 4 {
 			args << FnSignatureRegistrationArgs{
-				g:                 voidptr(g)
+				g: voidptr(g)
 				registrations_ptr: unsafe { voidptr(&registrations) }
-				group:             group
+				group: group
 			}
 		}
 		for group in 0 .. 4 {
 			tasks << workers.Task{
-				run:        fn_signature_registration_thread
-				arg:        unsafe { voidptr(&args[group]) }
+				run: fn_signature_registration_thread
+				arg: unsafe { voidptr(&args[group]) }
 				force_sync: group == 0
 			}
 		}
@@ -723,19 +717,19 @@ fn (mut g FlatGen) collect_gen_info_fn_preps(node_ids []int, no_parallel bool) [
 		mut tasks := []workers.Task{cap: n_jobs}
 		for job in 0 .. n_jobs {
 			args << CollectGenInfoFnPrepArgs{
-				g:            voidptr(g)
+				g: voidptr(g)
 				node_ids_ptr: unsafe { voidptr(&node_ids) }
-				preps_ptr:    unsafe { voidptr(&preps) }
-				start:        node_ids.len * job / n_jobs
-				end:          node_ids.len * (job + 1) / n_jobs
-				file:         context_files[job]
-				module_name:  context_modules[job]
+				preps_ptr: unsafe { voidptr(&preps) }
+				start: node_ids.len * job / n_jobs
+				end: node_ids.len * (job + 1) / n_jobs
+				file: context_files[job]
+				module_name: context_modules[job]
 			}
 		}
 		for job in 0 .. n_jobs {
 			tasks << workers.Task{
-				run:        collect_gen_info_fn_prep_thread
-				arg:        unsafe { voidptr(&args[job]) }
+				run: collect_gen_info_fn_prep_thread
+				arg: unsafe { voidptr(&args[job]) }
 				force_sync: job == 0
 			}
 		}
@@ -770,8 +764,7 @@ fn (mut g FlatGen) finish_pending_item_prep_serial() {
 			}
 			g.tc.cur_file = item.file
 			g.tc.cur_module = item.module
-			g.fn_gen_items[i].cost = g.fn_item_cost_and_prep(item.node_id, mut stack, mut
-				type_text_cache)
+			g.fn_gen_items[i].cost = g.fn_item_cost_and_prep(item.node_id, mut stack, mut type_text_cache)
 		}
 	}
 	if g.prep_externs_pending {
@@ -835,17 +828,17 @@ fn (mut g FlatGen) refine_fn_item_costs(no_parallel bool, reserve_worker bool) {
 		}
 		for job in 0 .. n_jobs {
 			args << FlatCgenCostArgs{
-				a:         unsafe { g.a }
+				a: unsafe { g.a }
 				items_ptr: unsafe { voidptr(&g.fn_gen_items) }
-				start:     boundaries[job]
-				end:       boundaries[job + 1]
-				g:         prep_g
+				start: boundaries[job]
+				end: boundaries[job + 1]
+				g: prep_g
 			}
 		}
 		for job in 0 .. n_jobs {
 			tasks << workers.Task{
-				run:        flat_cgen_cost_thread
-				arg:        unsafe { voidptr(&args[job]) }
+				run: flat_cgen_cost_thread
+				arg: unsafe { voidptr(&args[job]) }
 				force_sync: job == 0
 			}
 		}
@@ -970,15 +963,15 @@ fn (mut g FlatGen) prepare_pre_dispatch_master() {
 			mut owned_items := []FlatFnGenItem{cap: items.len}
 			for item in items {
 				owned_items << FlatFnGenItem{
-					node_id:                   item.node_id
-					file:                      item.file
-					module:                    item.module
-					c_name:                    item.c_name.clone()
-					cost:                      item.cost
+					node_id: item.node_id
+					file: item.file
+					module: item.module
+					c_name: item.c_name.clone()
+					cost: item.cost
 					is_program_specialization: item.is_program_specialization
-					is_program:                item.is_program
-					direct_array_access:       item.direct_array_access
-					ignore_overflow:           item.ignore_overflow
+					is_program: item.is_program
+					direct_array_access: item.direct_array_access
+					ignore_overflow: item.ignore_overflow
 				}
 			}
 			g.fn_gen_items = owned_items
@@ -1067,7 +1060,7 @@ fn clone_generic_app_cache(source &GenericAppCache) &GenericAppCache {
 			entries[key.clone()] = GenericAppInfo{
 				base: value.base.clone()
 				args: value.args.clone()
-				ok:   value.ok
+				ok: value.ok
 			}
 		}
 	}
@@ -1184,8 +1177,8 @@ fn (mut g FlatGen) absorb_scoped_cgen_batch(batch &FlatGen, output_streamed bool
 	for wrappers in batch.parallel_chunk_wrapper_defs {
 		g.parallel_chunk_wrapper_defs << ParallelChunkWrapperDefs{
 			chunk_idx: wrappers.chunk_idx
-			spawn:     clone_cgen_string_list(wrappers.spawn)
-			callback:  clone_cgen_string_list(wrappers.callback)
+			spawn: clone_cgen_string_list(wrappers.spawn)
+			callback: clone_cgen_string_list(wrappers.callback)
 		}
 	}
 }
@@ -1315,11 +1308,11 @@ fn clone_embedded_fields_by_type(values map[string][]types.StructField) map[stri
 		mut owned_fields := []types.StructField{cap: fields.len}
 		for field in fields {
 			owned_fields << types.StructField{
-				name:        field.name.clone()
-				typ:         types.clone_owned_type(field.typ)
+				name: field.name.clone()
+				typ: types.clone_owned_type(field.typ)
 				has_default: field.has_default
-				is_embed:    field.is_embed
-				is_mut:      field.is_mut
+				is_embed: field.is_embed
+				is_mut: field.is_mut
 			}
 		}
 		cloned[name.clone()] = owned_fields
@@ -1481,19 +1474,19 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 				mut tasks := []workers.Task{cap: chunk_count + 1}
 				for ci in 0 .. chunk_count {
 					args << FlatCgenChunkArgs{
-						worker:         cgen_workers[ci]
+						worker: cgen_workers[ci]
 						work_items_ptr: unsafe { voidptr(&chunk_items[ci]) }
 					}
 					tasks << workers.Task{
-						run:        flat_cgen_chunk_thread
-						arg:        unsafe { voidptr(&args[ci]) }
+						run: flat_cgen_chunk_thread
+						arg: unsafe { voidptr(&args[ci]) }
 						force_sync: fail == 'cgen:all' || fail == 'cgen:body:all'
 							|| fail == 'cgen:body:${ci}'
 					}
 				}
 				tasks << workers.Task{
-					run:        parallel_type_decls_thread
-					arg:        voidptr(g)
+					run: parallel_type_decls_thread
+					arg: voidptr(g)
 					force_sync: true
 				}
 				g.parallel_used = g.a.worker_pool.run(tasks)
@@ -1504,7 +1497,7 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 				mut dsw := time.new_stopwatch()
 				ordered_chunk_outputs = []string{len: chunk_count}
 				ordered_wrapper_defs = []ParallelChunkWrapperDefs{len: chunk_count}
-				chunk_queue := chan int{cap: chunk_count}
+				chunk_queue := chan int{ cap: chunk_count }
 				for ci in 0 .. chunk_count {
 					chunk_queue <- ci
 				}
@@ -1522,14 +1515,14 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 				}
 				for ci in 0 .. worker_count {
 					args << FlatCgenDynamicArgs{
-						worker:          cgen_workers[ci]
+						worker: cgen_workers[ci]
 						work_chunks_ptr: unsafe { voidptr(&chunk_items) }
-						chunk_queue:     chunk_queue
-						reserve_cost:    reserve_cost
+						chunk_queue: chunk_queue
+						reserve_cost: reserve_cost
 					}
 					tasks << workers.Task{
-						run:        flat_cgen_dynamic_thread
-						arg:        unsafe { voidptr(&args[ci]) }
+						run: flat_cgen_dynamic_thread
+						arg: unsafe { voidptr(&args[ci]) }
 						force_sync: ci == 0
 					}
 				}
@@ -1543,8 +1536,7 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 			for worker_ptr in cgen_workers {
 				mut w := unsafe { &FlatGen(worker_ptr) }
 				if ordered_chunk_outputs.len > 0 {
-					g.merge_parallel_worker_ordered(w, mut ordered_chunk_outputs, mut
-						ordered_wrapper_defs)
+					g.merge_parallel_worker_ordered(w, mut ordered_chunk_outputs, mut ordered_wrapper_defs)
 				} else {
 					g.merge_parallel_worker(w)
 				}
@@ -1578,9 +1570,9 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 		thread_count := chunk_count - 1
 		mut args := []FlatCgenChunkArgs{cap: chunk_count}
 		args << FlatCgenChunkArgs{
-			worker:         voidptr(g)
+			worker: voidptr(g)
 			work_items_ptr: unsafe { voidptr(&chunk_items[0]) }
-			is_master:      true
+			is_master: true
 		}
 		// Keep helper output in ordered result segments until the join so generated
 		// string IDs can be reconciled with literals emitted by the master chunk.
@@ -1592,7 +1584,7 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 		}
 		for ci := 0; ci < thread_count; ci++ {
 			args << FlatCgenChunkArgs{
-				worker:         cgen_workers[ci]
+				worker: cgen_workers[ci]
 				work_items_ptr: unsafe { voidptr(&chunk_items[ci + 1]) }
 			}
 		}
@@ -1602,8 +1594,8 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 		for ci in 0 .. chunk_count {
 			helper_idx := ci - 1
 			tasks << workers.Task{
-				run:        flat_cgen_chunk_thread
-				arg:        unsafe { voidptr(&args[ci]) }
+				run: flat_cgen_chunk_thread
+				arg: unsafe { voidptr(&args[ci]) }
 				force_sync: ci == 0 || fail == 'cgen:all' || fail == 'cgen:body:all'
 					|| fail == 'cgen:body:${helper_idx}'
 			}
@@ -1952,7 +1944,7 @@ fn (g &FlatGen) parallel_cached_expr_type(id flat.NodeId, node &flat.Node) ?type
 // registration order matches the former serial walk exactly.
 struct FlatCgenPrepCandidate {
 	is_expr  bool
-	text     string     // node.typ text (is_expr == false)
+	text     string // node.typ text (is_expr == false)
 	typ      types.Type // checker-cached expr type (is_expr == true)
 	item_idx int
 }
@@ -2014,7 +2006,7 @@ fn exact_flat_fn_gen_item_cost_and_prep(g &FlatGen, node_id flat.NodeId, item_id
 				text_cache.verdicts[slot] = parallel_type_text_may_preseed(g, node.typ)
 				if text_cache.verdicts[slot] {
 					cands << FlatCgenPrepCandidate{
-						text:     node.typ
+						text: node.typ
 						item_idx: item_idx
 					}
 				}
@@ -2027,8 +2019,8 @@ fn exact_flat_fn_gen_item_cost_and_prep(g &FlatGen, node_id flat.NodeId, item_id
 				type_seen.w1[slot] = w1
 				type_seen.seen[slot] = true
 				cands << FlatCgenPrepCandidate{
-					is_expr:  true
-					typ:      expr_type
+					is_expr: true
+					typ: expr_type
 					item_idx: item_idx
 				}
 			}
@@ -2375,229 +2367,229 @@ fn (g &FlatGen) new_parallel_result_worker(worker_id int) &FlatGen {
 
 fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &FlatGen {
 	mut w := &FlatGen{
-		sb:                             strings.new_builder(if result_only { 0 } else { 64_000 })
-		a:                              unsafe { g.a }
-		used_fns:                       g.used_fns
-		used_fn_names:                  g.used_fn_names
-		fn_gen_items:                   g.fn_gen_items
-		top_level_node_ids:             g.top_level_node_ids
-		test_files:                     if result_only { g.test_files } else { g.test_files.clone() }
-		show_test_stats:                g.show_test_stats
-		print_fn_names:                 g.print_fn_names
-		is_prod:                        g.is_prod
-		check_overflow:                 g.check_overflow
-		force_bounds_checking:          g.force_bounds_checking
-		object_file_mode:               g.object_file_mode
-		cache_program_files:            g.cache_program_files
-		incremental_fn_names:           g.incremental_fn_names
-		cached_support_identifiers:     g.cached_support_identifiers
-		str_lits:                       if result_only {
+		sb: strings.new_builder(if result_only { 0 } else { 64_000 })
+		a: unsafe { g.a }
+		used_fns: g.used_fns
+		used_fn_names: g.used_fn_names
+		fn_gen_items: g.fn_gen_items
+		top_level_node_ids: g.top_level_node_ids
+		test_files: if result_only { g.test_files } else { g.test_files.clone() }
+		show_test_stats: g.show_test_stats
+		print_fn_names: g.print_fn_names
+		is_prod: g.is_prod
+		check_overflow: g.check_overflow
+		force_bounds_checking: g.force_bounds_checking
+		object_file_mode: g.object_file_mode
+		cache_program_files: g.cache_program_files
+		incremental_fn_names: g.incremental_fn_names
+		cached_support_identifiers: g.cached_support_identifiers
+		str_lits: if result_only {
 			clone_cgen_string_list(g.str_lits)
 		} else if g.scope_parallel_workers {
 			g.str_lits
 		} else {
 			g.str_lits.clone()
 		}
-		str_lit_ids:                    if result_only {
+		str_lit_ids: if result_only {
 			clone_cgen_string_int_map(g.str_lit_ids)
 		} else if g.scope_parallel_workers {
 			g.str_lit_ids
 		} else {
 			g.str_lit_ids.clone()
 		}
-		str_lits_shared:                g.scope_parallel_workers && !result_only
-		global_types:                   g.global_types
-		global_raw_type_texts:          g.global_raw_type_texts
-		enum_vals:                      g.enum_vals
-		enum_value_exprs:               g.enum_value_exprs
-		interfaces:                     g.interfaces
-		const_vals:                     g.const_vals
-		const_modules:                  g.const_modules
-		const_init_order:               g.const_init_order
-		fixed_storage_consts:           g.fixed_storage_consts
-		global_modules:                 g.global_modules
-		global_inits:                   g.global_inits
-		global_init_order:              g.global_init_order
-		c_decl_abi_names:               g.c_decl_abi_names
-		c_extern_global_names:          g.c_extern_global_names
-		enum_backing_infos:             g.enum_backing_infos
-		iface_impls:                    g.iface_impls
-		interface_dispatch_required:    g.interface_dispatch_required
-		iface_type_ids:                 g.iface_type_ids
-		interface_boxed_types:          g.interface_boxed_types
-		interface_boxed_types_done:     g.interface_boxed_types_done
-		ierror_method_emit_names:       g.ierror_method_emit_names
-		recursive_drop_helpers:         g.recursive_drop_helpers
-		sum_name_lookup:                g.sum_name_lookup
-		sum_variant_lookup:             g.sum_variant_lookup
-		sum_variant_actual_cache:       &SumVariantActualCache{}
-		module_init_fns:                g.module_init_fns
-		module_init_fn_modules:         g.module_init_fn_modules
-		module_cleanup_fns:             g.module_cleanup_fns
-		module_cleanup_fn_modules:      g.module_cleanup_fn_modules
-		module_imports:                 g.module_imports
-		preserved_header_files_seen:    g.preserved_header_files_seen
-		libc_compat_fns:                g.libc_compat_fns.clone()
-		tc:                             if result_only {
+		str_lits_shared: g.scope_parallel_workers && !result_only
+		global_types: g.global_types
+		global_raw_type_texts: g.global_raw_type_texts
+		enum_vals: g.enum_vals
+		enum_value_exprs: g.enum_value_exprs
+		interfaces: g.interfaces
+		const_vals: g.const_vals
+		const_modules: g.const_modules
+		const_init_order: g.const_init_order
+		fixed_storage_consts: g.fixed_storage_consts
+		global_modules: g.global_modules
+		global_inits: g.global_inits
+		global_init_order: g.global_init_order
+		c_decl_abi_names: g.c_decl_abi_names
+		c_extern_global_names: g.c_extern_global_names
+		enum_backing_infos: g.enum_backing_infos
+		iface_impls: g.iface_impls
+		interface_dispatch_required: g.interface_dispatch_required
+		iface_type_ids: g.iface_type_ids
+		interface_boxed_types: g.interface_boxed_types
+		interface_boxed_types_done: g.interface_boxed_types_done
+		ierror_method_emit_names: g.ierror_method_emit_names
+		recursive_drop_helpers: g.recursive_drop_helpers
+		sum_name_lookup: g.sum_name_lookup
+		sum_variant_lookup: g.sum_variant_lookup
+		sum_variant_actual_cache: &SumVariantActualCache{}
+		module_init_fns: g.module_init_fns
+		module_init_fn_modules: g.module_init_fn_modules
+		module_cleanup_fns: g.module_cleanup_fns
+		module_cleanup_fn_modules: g.module_cleanup_fn_modules
+		module_imports: g.module_imports
+		preserved_header_files_seen: g.preserved_header_files_seen
+		libc_compat_fns: g.libc_compat_fns.clone()
+		tc: if result_only {
 			unsafe { g.tc }
 		} else {
 			g.clone_parallel_type_checker()
 		}
-		has_builtins:                   g.has_builtins
-		cache_split:                    g.cache_split
-		compile_values:                 g.compile_values
-		trace_calls:                    g.trace_calls
-		skip_generics:                  g.skip_generics
-		tmp_count:                      (worker_id + 1) * 100_000
-		line_start:                     true
-		modules:                        g.modules
-		fn_ptr_types:                   g.fn_ptr_types.clone()
-		used_fn_ptr_types:              if g.scope_parallel_workers {
+		has_builtins: g.has_builtins
+		cache_split: g.cache_split
+		compile_values: g.compile_values
+		trace_calls: g.trace_calls
+		skip_generics: g.skip_generics
+		tmp_count: (worker_id + 1) * 100_000
+		line_start: true
+		modules: g.modules
+		fn_ptr_types: g.fn_ptr_types.clone()
+		used_fn_ptr_types: if g.scope_parallel_workers {
 			map[string]bool{}
 		} else {
 			g.used_fn_ptr_types.clone()
 		}
-		fixed_array_ret_wrappers:       g.fixed_array_ret_wrappers
-		concrete_optional_abi_fns:      g.concrete_optional_abi_fns
-		fn_decl_param_types:            g.fn_decl_param_types
-		fn_decl_variadic:               g.fn_decl_variadic
-		fn_decl_variadic_short_counts:  g.fn_decl_variadic_short_counts
-		fn_decl_shared_params:          g.fn_decl_shared_params
-		fn_shared_params_resolved:      g.fn_shared_params_resolved
-		has_shared_params:              g.has_shared_params
-		fn_decl_mut_receivers:          g.fn_decl_mut_receivers
-		fn_decl_ret_types:              g.fn_decl_ret_types
+		fixed_array_ret_wrappers: g.fixed_array_ret_wrappers
+		concrete_optional_abi_fns: g.concrete_optional_abi_fns
+		fn_decl_param_types: g.fn_decl_param_types
+		fn_decl_variadic: g.fn_decl_variadic
+		fn_decl_variadic_short_counts: g.fn_decl_variadic_short_counts
+		fn_decl_shared_params: g.fn_decl_shared_params
+		fn_shared_params_resolved: g.fn_shared_params_resolved
+		has_shared_params: g.has_shared_params
+		fn_decl_mut_receivers: g.fn_decl_mut_receivers
+		fn_decl_ret_types: g.fn_decl_ret_types
 		non_generic_fn_names_by_module: g.non_generic_fn_names_by_module
-		generic_fn_keys_by_short:       g.generic_fn_keys_by_short
-		generic_fn_keys_by_cname:       g.generic_fn_keys_by_cname
-		generic_fn_key_ordinal:         g.generic_fn_key_ordinal
-		struct_decl_infos:              g.struct_decl_infos
-		struct_decl_short_infos:        g.struct_decl_short_infos
-		header_owned_c_typedefs:        g.header_owned_c_typedefs
-		decl_attrs:                     g.decl_attrs
-		decl_attrs_by_source_position:  g.decl_attrs_by_source_position
-		shared_type_names:              g.shared_type_names
-		shared_alias_pointer_shorts:    g.shared_alias_pointer_shorts
-		const_runtime_inits:            if result_only {
+		generic_fn_keys_by_short: g.generic_fn_keys_by_short
+		generic_fn_keys_by_cname: g.generic_fn_keys_by_cname
+		generic_fn_key_ordinal: g.generic_fn_key_ordinal
+		struct_decl_infos: g.struct_decl_infos
+		struct_decl_short_infos: g.struct_decl_short_infos
+		header_owned_c_typedefs: g.header_owned_c_typedefs
+		decl_attrs: g.decl_attrs
+		decl_attrs_by_source_position: g.decl_attrs_by_source_position
+		shared_type_names: g.shared_type_names
+		shared_alias_pointer_shorts: g.shared_alias_pointer_shorts
+		const_runtime_inits: if result_only {
 			g.const_runtime_inits
 		} else {
 			g.const_runtime_inits.clone()
 		}
-		runtime_inits:                  if result_only {
+		runtime_inits: if result_only {
 			g.runtime_inits
 		} else {
 			g.runtime_inits.clone()
 		}
-		compiler_vroot:                 g.compiler_vroot
-		compiler_vexe:                  g.compiler_vexe
-		compiler_vexe_env_setup:        g.compiler_vexe_env_setup
-		ccompiler:                      g.ccompiler
-		macro_probe_c_flags:             g.macro_probe_c_flags
-		target:                         g.target
-		suppress_main:                  g.suppress_main
-		cur_param_names:                if result_only {
+		compiler_vroot: g.compiler_vroot
+		compiler_vexe: g.compiler_vexe
+		compiler_vexe_env_setup: g.compiler_vexe_env_setup
+		ccompiler: g.ccompiler
+		macro_probe_c_flags: g.macro_probe_c_flags
+		target: g.target
+		suppress_main: g.suppress_main
+		cur_param_names: if result_only {
 			g.cur_param_names
 		} else {
 			g.cur_param_names.clone()
 		}
-		cur_param_type_values:          if result_only {
+		cur_param_type_values: if result_only {
 			g.cur_param_type_values
 		} else {
 			g.cur_param_type_values.clone()
 		}
-		cur_param_types:                if result_only {
+		cur_param_types: if result_only {
 			g.cur_param_types
 		} else {
 			g.cur_param_types.clone()
 		}
-		cur_param_name_bits:            g.cur_param_name_bits
-		cur_concrete_optional_params:   if result_only {
+		cur_param_name_bits: g.cur_param_name_bits
+		cur_concrete_optional_params: if result_only {
 			g.cur_concrete_optional_params
 		} else {
 			g.cur_concrete_optional_params.clone()
 		}
-		cur_mut_params:                 if result_only {
+		cur_mut_params: if result_only {
 			g.cur_mut_params
 		} else {
 			g.cur_mut_params.clone()
 		}
-		cur_mut_pointer_params:         if result_only {
+		cur_mut_pointer_params: if result_only {
 			g.cur_mut_pointer_params
 		} else {
 			g.cur_mut_pointer_params.clone()
 		}
-		cur_mut_param_owners:           if result_only {
+		cur_mut_param_owners: if result_only {
 			g.cur_mut_param_owners
 		} else {
 			g.cur_mut_param_owners.clone()
 		}
-		cur_fn_ret:                     g.cur_fn_ret
-		cur_fn_ret_is_optional:         g.cur_fn_ret_is_optional
-		cur_fn_ret_base:                g.cur_fn_ret_base
-		memo_usable_expr_types:         g.memo_usable_expr_types
-		cache_struct_fields:            g.cache_struct_fields
-		dedup_fn_decl_aliases:          g.dedup_fn_decl_aliases
-		prefix_param_scan:              g.prefix_param_scan
-		lean_parallel_worker_init:      g.lean_parallel_worker_init
-		lazy_param_abi_merge:           g.lazy_param_abi_merge
-		expected_expr_type:             g.expected_expr_type
-		expected_enum:                  g.expected_enum
-		needed_optional_types:          g.needed_optional_types.clone()
-		optional_types_ready:           g.optional_types_ready
-		emitted_optional_types:         if result_only {
+		cur_fn_ret: g.cur_fn_ret
+		cur_fn_ret_is_optional: g.cur_fn_ret_is_optional
+		cur_fn_ret_base: g.cur_fn_ret_base
+		memo_usable_expr_types: g.memo_usable_expr_types
+		cache_struct_fields: g.cache_struct_fields
+		dedup_fn_decl_aliases: g.dedup_fn_decl_aliases
+		prefix_param_scan: g.prefix_param_scan
+		lean_parallel_worker_init: g.lean_parallel_worker_init
+		lazy_param_abi_merge: g.lazy_param_abi_merge
+		expected_expr_type: g.expected_expr_type
+		expected_enum: g.expected_enum
+		needed_optional_types: g.needed_optional_types.clone()
+		optional_types_ready: g.optional_types_ready
+		emitted_optional_types: if result_only {
 			g.emitted_optional_types
 		} else {
 			g.emitted_optional_types.clone()
 		}
 		// Function selection is complete before workers are created; body
 		// generation only reads this set.
-		emitted_fns:                     g.emitted_fns
-		array_method_cache:              if result_only {
+		emitted_fns: g.emitted_fns
+		array_method_cache: if result_only {
 			g.array_method_cache
 		} else {
 			g.array_method_cache.clone()
 		}
-		param_types_cache:               if result_only {
+		param_types_cache: if result_only {
 			g.param_types_cache
 		} else {
 			g.param_types_cache.clone()
 		}
-		interface_receiver_cache:        &StringLookupCache{}
-		normalize_call_cache:            &StringLookupCache{}
-		flattened_generic_name_cache:    &StringLookupCache{}
+		interface_receiver_cache: &StringLookupCache{}
+		normalize_call_cache: &StringLookupCache{}
+		flattened_generic_name_cache: &StringLookupCache{}
 		generic_struct_context_ct_cache: &StringLookupCache{}
-		struct_cname_cache:              &StringLookupCache{}
-		unique_struct_ct_cache:          &StringLookupCache{}
-		alias_method_cache:              &StringLookupCache{}
-		import_alias_cache:              &ContextStringLookupCache{}
-		enum_selector_cache:             &ContextStringLookupCache{}
-		enum_method_cache:               &ContextStringLookupCache{}
-		qualified_enum_method_cache:     &ContextStringLookupCache{}
-		struct_decl_pref_cache:          &StructDeclPrefCache{}
-		embedded_fields_by_type:         g.embedded_fields_by_type
-		param_types_by_short:            g.param_types_by_short
-		generic_method_candidates:       g.generic_method_candidates
-		spawn_wrapper_names:             g.spawn_wrapper_names.clone()
-		spawn_wrapper_defs:              g.spawn_wrapper_defs.clone()
-		spawn_wrapper_defs_seen:         g.spawn_wrapper_defs_seen.clone()
-		callback_wrapper_names:          g.callback_wrapper_names.clone()
-		callback_wrapper_defs:           g.callback_wrapper_defs.clone()
-		callback_wrapper_defs_seen:      g.callback_wrapper_defs_seen.clone()
-		c_extern_refs:                   g.c_extern_refs.clone()
-		c_extern_refs_ready:             g.c_extern_refs_ready
-		scope_parallel_workers:          g.scope_parallel_workers
-		c_name_cache:                    &CNameCache{
+		struct_cname_cache: &StringLookupCache{}
+		unique_struct_ct_cache: &StringLookupCache{}
+		alias_method_cache: &StringLookupCache{}
+		import_alias_cache: &ContextStringLookupCache{}
+		enum_selector_cache: &ContextStringLookupCache{}
+		enum_method_cache: &ContextStringLookupCache{}
+		qualified_enum_method_cache: &ContextStringLookupCache{}
+		struct_decl_pref_cache: &StructDeclPrefCache{}
+		embedded_fields_by_type: g.embedded_fields_by_type
+		param_types_by_short: g.param_types_by_short
+		generic_method_candidates: g.generic_method_candidates
+		spawn_wrapper_names: g.spawn_wrapper_names.clone()
+		spawn_wrapper_defs: g.spawn_wrapper_defs.clone()
+		spawn_wrapper_defs_seen: g.spawn_wrapper_defs_seen.clone()
+		callback_wrapper_names: g.callback_wrapper_names.clone()
+		callback_wrapper_defs: g.callback_wrapper_defs.clone()
+		callback_wrapper_defs_seen: g.callback_wrapper_defs_seen.clone()
+		c_extern_refs: g.c_extern_refs.clone()
+		c_extern_refs_ready: g.c_extern_refs_ready
+		scope_parallel_workers: g.scope_parallel_workers
+		c_name_cache: &CNameCache{
 			base: if !isnil(g.c_name_cache.base) { g.c_name_cache.base } else { g.c_name_cache }
 		}
 		// The master freezes the const short-name index before forking workers;
 		// sharing the read-only index avoids a rebuild per worker.
-		const_short_index:               g.const_short_index
-		mut_recv_facts:                  &FnNameFactCache{}
-		local_typedef_shadow_facts:      &FnNameFactCache{}
-		local_global_shadow_facts:       &ContextNameFactCache{}
-		local_global_suffix_names:       g.local_global_suffix_names
+		const_short_index: g.const_short_index
+		mut_recv_facts: &FnNameFactCache{}
+		local_typedef_shadow_facts: &FnNameFactCache{}
+		local_global_shadow_facts: &ContextNameFactCache{}
+		local_global_suffix_names: g.local_global_suffix_names
 		local_global_suffix_names_ready: g.local_global_suffix_names_ready
-		generic_app_cache:               &GenericAppCache{
+		generic_app_cache: &GenericAppCache{
 			base: if !isnil(g.generic_app_cache.base) {
 				g.generic_app_cache.base
 			} else {
@@ -2627,95 +2619,95 @@ fn (g &FlatGen) clone_parallel_type_checker_legacy() &types.TypeChecker {
 	// over the immutable checked scope instead of cloning the full symbol table.
 	fs := types.new_scope(g.tc.file_scope)
 	mut wtc := &types.TypeChecker{
-		a:                                     unsafe { g.tc.a }
-		fast_parse_recent:                     g.tc.fast_parse_recent
-		fast_type_text_refs:                   g.tc.fast_type_text_refs
-		fast_c_type_recent:                    g.tc.fast_c_type_recent
-		memo_call_info:                        g.tc.memo_call_info
-		fn_ret_types:                          g.tc.fn_ret_types
-		fn_param_types:                        g.tc.fn_param_types
-		c_fn_module_ret_types:                 g.tc.c_fn_module_ret_types
-		c_fn_module_param_types:               g.tc.c_fn_module_param_types
-		c_fn_module_variadic:                  g.tc.c_fn_module_variadic
-		fn_ret_type_texts:                     g.tc.fn_ret_type_texts
-		fn_param_type_texts:                   g.tc.fn_param_type_texts
-		fn_type_files:                         g.tc.fn_type_files
-		fn_type_modules:                       g.tc.fn_type_modules
-		fn_generic_params:                     g.tc.fn_generic_params
-		specialized_generic_fns:               g.tc.specialized_generic_fns
-		fn_variadic:                           g.tc.fn_variadic
-		fn_implicit_veb_ctx:                   g.tc.fn_implicit_veb_ctx
-		c_variadic_fns:                        g.tc.c_variadic_fns
-		structs:                               g.tc.structs
-		struct_modules:                        g.tc.struct_modules
-		struct_files:                          g.tc.struct_files
-		soa_structs:                           g.tc.soa_structs
-		struct_error_embeds_shadow_builtin:    g.tc.struct_error_embeds_shadow_builtin
-		struct_generic_params:                 g.tc.struct_generic_params
-		struct_field_c_abi_fns:                g.tc.struct_field_c_abi_fns
-		unions:                                g.tc.unions
-		type_aliases:                          g.tc.type_aliases
-		type_alias_modules:                    g.tc.type_alias_modules
-		type_alias_generic_params:             g.tc.type_alias_generic_params
-		type_alias_c_abi_fns:                  g.tc.type_alias_c_abi_fns
-		sum_types:                             g.tc.sum_types
-		sum_generic_params:                    g.tc.sum_generic_params
-		enum_names:                            g.tc.enum_names
-		enum_fields:                           g.tc.enum_fields
-		flag_enums:                            g.tc.flag_enums
-		interface_names:                       g.tc.interface_names
-		interface_generic_params:              g.tc.interface_generic_params
-		interface_fields:                      g.tc.interface_fields
-		interface_embeds:                      g.tc.interface_embeds
-		interface_abstract_methods:            g.tc.interface_abstract_methods
-		interface_impl_name_snapshots:         g.tc.interface_impl_name_snapshots
+		a: unsafe { g.tc.a }
+		fast_parse_recent: g.tc.fast_parse_recent
+		fast_type_text_refs: g.tc.fast_type_text_refs
+		fast_c_type_recent: g.tc.fast_c_type_recent
+		memo_call_info: g.tc.memo_call_info
+		fn_ret_types: g.tc.fn_ret_types
+		fn_param_types: g.tc.fn_param_types
+		c_fn_module_ret_types: g.tc.c_fn_module_ret_types
+		c_fn_module_param_types: g.tc.c_fn_module_param_types
+		c_fn_module_variadic: g.tc.c_fn_module_variadic
+		fn_ret_type_texts: g.tc.fn_ret_type_texts
+		fn_param_type_texts: g.tc.fn_param_type_texts
+		fn_type_files: g.tc.fn_type_files
+		fn_type_modules: g.tc.fn_type_modules
+		fn_generic_params: g.tc.fn_generic_params
+		specialized_generic_fns: g.tc.specialized_generic_fns
+		fn_variadic: g.tc.fn_variadic
+		fn_implicit_veb_ctx: g.tc.fn_implicit_veb_ctx
+		c_variadic_fns: g.tc.c_variadic_fns
+		structs: g.tc.structs
+		struct_modules: g.tc.struct_modules
+		struct_files: g.tc.struct_files
+		soa_structs: g.tc.soa_structs
+		struct_error_embeds_shadow_builtin: g.tc.struct_error_embeds_shadow_builtin
+		struct_generic_params: g.tc.struct_generic_params
+		struct_field_c_abi_fns: g.tc.struct_field_c_abi_fns
+		unions: g.tc.unions
+		type_aliases: g.tc.type_aliases
+		type_alias_modules: g.tc.type_alias_modules
+		type_alias_generic_params: g.tc.type_alias_generic_params
+		type_alias_c_abi_fns: g.tc.type_alias_c_abi_fns
+		sum_types: g.tc.sum_types
+		sum_generic_params: g.tc.sum_generic_params
+		enum_names: g.tc.enum_names
+		enum_fields: g.tc.enum_fields
+		flag_enums: g.tc.flag_enums
+		interface_names: g.tc.interface_names
+		interface_generic_params: g.tc.interface_generic_params
+		interface_fields: g.tc.interface_fields
+		interface_embeds: g.tc.interface_embeds
+		interface_abstract_methods: g.tc.interface_abstract_methods
+		interface_impl_name_snapshots: g.tc.interface_impl_name_snapshots
 		interface_impl_candidates_at_snapshot: g.tc.interface_impl_candidates_at_snapshot
-		c_globals:                             g.tc.c_globals
-		const_types:                           g.tc.const_types
-		const_exprs:                           g.tc.const_exprs
-		const_modules:                         g.tc.const_modules
-		const_files:                           g.tc.const_files
-		const_suffixes:                        g.tc.const_suffixes
-		imports:                               g.tc.imports
-		file_imports:                          g.tc.file_imports
-		file_selective_imports:                g.tc.file_selective_imports
-		file_modules:                          g.tc.file_modules
-		file_scope:                            g.tc.file_scope
-		cur_scope:                             fs
-		scope_pool:                            []&types.Scope{}
-		has_builtins:                          g.tc.has_builtins
-		resolution_type_mode:                  g.tc.resolution_type_mode
-		trust_checked_expr_types:              g.tc.trust_checked_expr_types
-		cur_module:                            g.tc.cur_module
-		cur_file:                              g.tc.cur_file
-		errors:                                g.tc.errors.clone()
-		resolved_call_names:                   g.tc.resolved_call_names
-		resolved_call_set:                     g.tc.resolved_call_set
-		resolved_fn_value_names:               g.tc.resolved_fn_value_names
-		resolved_fn_value_set:                 g.tc.resolved_fn_value_set
-		statement_nodes:                       g.tc.statement_nodes
-		expr_type_values:                      g.tc.expr_type_values
-		expr_type_set:                         g.tc.expr_type_set
-		checking_nodes:                        g.tc.checking_nodes
-		parallel_check_sparse:                 g.tc.parallel_check_sparse
-		check_range_lo:                        g.tc.check_range_lo
-		check_range_hi:                        g.tc.check_range_hi
-		sparse_resolved_call_names:            g.tc.sparse_resolved_call_names
-		sparse_resolved_fn_values:             g.tc.sparse_resolved_fn_values
-		sparse_statement_nodes:                g.tc.sparse_statement_nodes
-		sparse_expr_type_values:               g.tc.sparse_expr_type_values
-		sparse_checking_nodes:                 g.tc.sparse_checking_nodes
-		diagnose_unknown_calls:                g.tc.diagnose_unknown_calls
-		reject_unlowered_map_mutation:         g.tc.reject_unlowered_map_mutation
-		diagnostic_files:                      g.tc.diagnostic_files
-		selected_file_called_fns:              g.tc.selected_file_called_fns
-		smartcasts:                            g.tc.smartcasts
+		c_globals: g.tc.c_globals
+		const_types: g.tc.const_types
+		const_exprs: g.tc.const_exprs
+		const_modules: g.tc.const_modules
+		const_files: g.tc.const_files
+		const_suffixes: g.tc.const_suffixes
+		imports: g.tc.imports
+		file_imports: g.tc.file_imports
+		file_selective_imports: g.tc.file_selective_imports
+		file_modules: g.tc.file_modules
+		file_scope: g.tc.file_scope
+		cur_scope: fs
+		scope_pool: []&types.Scope{}
+		has_builtins: g.tc.has_builtins
+		resolution_type_mode: g.tc.resolution_type_mode
+		trust_checked_expr_types: g.tc.trust_checked_expr_types
+		cur_module: g.tc.cur_module
+		cur_file: g.tc.cur_file
+		errors: g.tc.errors.clone()
+		resolved_call_names: g.tc.resolved_call_names
+		resolved_call_set: g.tc.resolved_call_set
+		resolved_fn_value_names: g.tc.resolved_fn_value_names
+		resolved_fn_value_set: g.tc.resolved_fn_value_set
+		statement_nodes: g.tc.statement_nodes
+		expr_type_values: g.tc.expr_type_values
+		expr_type_set: g.tc.expr_type_set
+		checking_nodes: g.tc.checking_nodes
+		parallel_check_sparse: g.tc.parallel_check_sparse
+		check_range_lo: g.tc.check_range_lo
+		check_range_hi: g.tc.check_range_hi
+		sparse_resolved_call_names: g.tc.sparse_resolved_call_names
+		sparse_resolved_fn_values: g.tc.sparse_resolved_fn_values
+		sparse_statement_nodes: g.tc.sparse_statement_nodes
+		sparse_expr_type_values: g.tc.sparse_expr_type_values
+		sparse_checking_nodes: g.tc.sparse_checking_nodes
+		diagnose_unknown_calls: g.tc.diagnose_unknown_calls
+		reject_unlowered_map_mutation: g.tc.reject_unlowered_map_mutation
+		diagnostic_files: g.tc.diagnostic_files
+		selected_file_called_fns: g.tc.selected_file_called_fns
+		smartcasts: g.tc.smartcasts
 		// Read-only map cgen uses to recover substituted signatures for generic-receiver
 		// method values (`Box[int].method` as a callback); without it a parallel worker
 		// sees an empty map and gen_method_value_closure falls through.
 		generic_method_value_info: g.tc.generic_method_value_info
-		params_structs:            g.tc.params_structs
-		c_typedef_structs:         g.tc.c_typedef_structs
+		params_structs: g.tc.params_structs
+		c_typedef_structs: g.tc.c_typedef_structs
 	}
 	wtc.inherit_ownership_codegen_metadata_from(g.tc)
 	// A private empty TypeCache lets the worker use the lazily-built lookup
@@ -2852,8 +2844,7 @@ fn (mut g FlatGen) merge_parallel_worker_into(w &FlatGen, mut ordered []string, 
 			g.fn_segs << stable_output
 			unsafe { worker_output.free() }
 		} else if string_id_remap.len > 0 {
-			g.fn_segs << remap_scoped_worker_string_symbols(worker_output, string_id_remap,
-				user_c_symbols)
+			g.fn_segs << remap_scoped_worker_string_symbols(worker_output, string_id_remap, user_c_symbols)
 			unsafe { worker_output.free() }
 		} else {
 			g.fn_segs << worker_output
@@ -2942,8 +2933,7 @@ fn (mut g FlatGen) merge_parallel_worker_into(w &FlatGen, mut ordered []string, 
 			if g.cache_split {
 				g.add_spawn_wrapper_def(ww.rewrite_cache_string_symbols(def))
 			} else if string_id_remap.len > 0 {
-				g.add_spawn_wrapper_def(remap_scoped_worker_string_symbols(def, string_id_remap,
-					user_c_symbols))
+				g.add_spawn_wrapper_def(remap_scoped_worker_string_symbols(def, string_id_remap, user_c_symbols))
 			} else {
 				g.add_spawn_wrapper_def(def.clone())
 			}
@@ -2975,8 +2965,7 @@ fn (mut g FlatGen) merge_parallel_worker_into(w &FlatGen, mut ordered []string, 
 			if g.cache_split {
 				g.add_callback_wrapper_def(ww.rewrite_cache_string_symbols(def))
 			} else if string_id_remap.len > 0 {
-				g.add_callback_wrapper_def(remap_scoped_worker_string_symbols(def, string_id_remap,
-					user_c_symbols))
+				g.add_callback_wrapper_def(remap_scoped_worker_string_symbols(def, string_id_remap, user_c_symbols))
 			} else {
 				g.add_callback_wrapper_def(def.clone())
 			}
@@ -3039,18 +3028,18 @@ fn (mut g FlatGen) run_pre_dispatch_parallel(no_parallel bool) bool {
 			// support tasks' completions and return while its payloads are still live.
 			g.a.worker_pool.run([
 				workers.Task{
-					run:        fixed_storage_scan_thread
-					arg:        voidptr(fs_worker)
+					run: fixed_storage_scan_thread
+					arg: voidptr(fs_worker)
 					force_sync: fail == 'cgen:all' || fail == 'cgen:pre:all' || fail == 'cgen:pre:0'
 				},
 				workers.Task{
-					run:        fixed_array_support_thread
-					arg:        voidptr(fixed_array_worker)
+					run: fixed_array_support_thread
+					arg: voidptr(fixed_array_worker)
 					force_sync: fail == 'cgen:all' || fail == 'cgen:pre:all'
 				},
 				workers.Task{
-					run:        optional_support_thread
-					arg:        voidptr(optional_worker)
+					run: optional_support_thread
+					arg: voidptr(optional_worker)
 					force_sync: fail == 'cgen:all' || fail == 'cgen:pre:all'
 				},
 			])

--- a/vlib/v3/gen/c/names_test.v
+++ b/vlib/v3/gen/c/names_test.v
@@ -201,7 +201,7 @@ fn test_voidptr_method_value_arg_does_not_panic_for_alias_to_voidptr() {
 	g.a = &a
 	g.tc = &tc
 	alias_to_voidptr := types.Type(types.Alias{
-		name:      'Data'
+		name: 'Data'
 		base_type: types.Type(types.Pointer{
 			base_type: types.Type(types.void_)
 		})
@@ -218,8 +218,8 @@ fn test_same_named_user_context_does_not_route_to_embedded_framework_context() {
 	tc.cur_module = 'veb'
 	tc.structs['main.Context'] = [
 		types.StructField{
-			name:     'veb.Context'
-			typ:      types.Type(types.Struct{
+			name: 'veb.Context'
+			typ: types.Type(types.Struct{
 				name: 'veb.Context'
 			})
 			is_embed: true
@@ -234,8 +234,7 @@ fn test_same_named_user_context_does_not_route_to_embedded_framework_context() {
 	})
 	assert g.embedded_receiver_path_for_expected(base, expected) == none
 	assert g.emitted_method_belongs_to_receiver(base, 'before_request', 'Context__before_request')
-	assert !g.emitted_method_belongs_to_receiver(base, 'before_request',
-		'veb__Context__before_request')
+	assert !g.emitted_method_belongs_to_receiver(base, 'before_request', 'veb__Context__before_request')
 }
 
 fn test_array_receiver_method_is_not_reselected_as_generic() {
@@ -247,12 +246,11 @@ fn test_array_receiver_method_is_not_reselected_as_generic() {
 	g.generic_method_candidates[generic_method_candidate_key('jsonrpc', 'encode_batch')] = [
 		GenericMethodCandidate{
 			name: 'jsonrpc.[]Request.encode_batch'
-			ret:  types.Type(types.string_)
+			ret: types.Type(types.string_)
 		},
 	]
 
-	assert g.specialized_generic_method_name_for_call_with_arg_count(flat.empty_node,
-		'jsonrpc.[]Response.encode_batch', -1) == none
+	assert g.specialized_generic_method_name_for_call_with_arg_count(flat.empty_node, 'jsonrpc.[]Response.encode_batch', -1) == none
 }
 
 fn test_context_lookup_cache_tracks_source_file_imports() {
@@ -292,10 +290,10 @@ fn test_cgen_typeof_display_canonicalizes_fixed_array_generic_args() {
 	assert typeof_display_type_name('Box[int][3]') == '[3]Box[int]'
 	fixed_maps := types.Type(types.ArrayFixed{
 		elem_type: types.Type(types.Map{
-			key_type:   types.Type(types.String{})
+			key_type: types.Type(types.String{})
 			value_type: types.Type(types.int_)
 		})
-		len:       3
+		len: 3
 	})
 	assert typeof_display_resolved_type_name(fixed_maps) == '[3]map[string]int'
 }
@@ -335,11 +333,11 @@ fn test_sum_type_index_emission_override_is_limited_to_flatgen() {
 	g.tc = &tc
 	g.used_fns = &used
 	assert g.should_emit_fn_node_in_module_known(flat.Node{
-		kind:  .fn_decl
+		kind: .fn_decl
 		value: 'FlatGen.sum_type_index'
 	}, 'c', 'interface.v', 'c__FlatGen__sum_type_index', false)
 	assert !g.should_emit_fn_node_in_module_known(flat.Node{
-		kind:  .fn_decl
+		kind: .fn_decl
 		value: 'Transformer.sum_type_index'
 	}, 'transform', 'sum.v', 'transform__Transformer__sum_type_index', false)
 }
@@ -561,8 +559,7 @@ fn test_objective_c_header_detection() {
 	], false, pref.host_target())
 	linux := pref.target_from('linux', 'amd64') or { panic(err) }
 	private_platform_header := '#if defined(__APPLE__)\n#define _LIB_MACOS 1\n#elif defined(__linux__)\n#define _LIB_LINUX 1\n#endif\n#if defined(_LIB_MACOS)\n@interface MacOnly\n@end\n#endif\n'
-	assert !c_header_text_needs_objective_c_for_target(private_platform_header, []string{}, false,
-		linux)
+	assert !c_header_text_needs_objective_c_for_target(private_platform_header, []string{}, false, linux)
 	assert c_header_text_needs_objective_c_for_target(private_platform_header, [
 		'-D_LIB_MACOS=1',
 	], false, linux)
@@ -942,8 +939,7 @@ fn test_header_owned_scan_expands_pasting_macros_inside_typedef_replacements() {
 		macro_values: map[string]string{}
 		function_macro_values: map[string]string{}
 	}
-	scan := c_header_definitely_active_scan('#define CAT(x) x##_t\n#define DECL(name) typedef struct Impl CAT(name);\nDECL(Alias)\n',
-		state, false, pref.Target{
+	scan := c_header_definitely_active_scan('#define CAT(x) x##_t\n#define DECL(name) typedef struct Impl CAT(name);\nDECL(Alias)\n', state, false, pref.Target{
 		os: 'linux'
 	})
 	assert scan.typedef_macro_expansions.trim_space() == 'typedef struct Impl Alias_t;'
@@ -964,8 +960,7 @@ fn test_header_owned_scan_evaluates_logical_object_macro_conditions() {
 		}
 		function_macro_values: map[string]string{}
 	}
-	scan := c_header_definitely_active_scan('#define SUPPORTED (__GNUC__ >= 4 && __GNUC_MINOR__ >= 1)\n#if SUPPORTED\ntypedef struct Active SupportedAlias;\n#else\ntypedef struct Inactive InactiveAlias;\n#endif\n',
-		state, false, pref.Target{
+	scan := c_header_definitely_active_scan('#define SUPPORTED (__GNUC__ >= 4 && __GNUC_MINOR__ >= 1)\n#if SUPPORTED\ntypedef struct Active SupportedAlias;\n#else\ntypedef struct Inactive InactiveAlias;\n#endif\n', state, false, pref.Target{
 		os: 'linux'
 	})
 	assert c_header_owned_typedef_aliases(scan.text) == ['SupportedAlias'], scan.text
@@ -985,8 +980,7 @@ fn test_header_owned_scan_evaluates_logical_or_object_macro_conditions() {
 		}
 		function_macro_values: map[string]string{}
 	}
-	scan := c_header_definitely_active_scan('#define SUPPORTED (__GNUC__ >= 4 || __GNUC_MINOR__ >= 5)\n#if SUPPORTED\ntypedef struct Active SupportedAlias;\n#else\ntypedef struct Inactive InactiveAlias;\n#endif\n',
-		state, false, pref.Target{
+	scan := c_header_definitely_active_scan('#define SUPPORTED (__GNUC__ >= 4 || __GNUC_MINOR__ >= 5)\n#if SUPPORTED\ntypedef struct Active SupportedAlias;\n#else\ntypedef struct Inactive InactiveAlias;\n#endif\n', state, false, pref.Target{
 		os: 'linux'
 	})
 	assert c_header_owned_typedef_aliases(scan.text) == ['SupportedAlias'], scan.text
@@ -1000,8 +994,7 @@ fn test_header_owned_scan_excludes_function_scoped_typedef_macro_invocations() {
 		macro_values: map[string]string{}
 		function_macro_values: map[string]string{}
 	}
-	scan := c_header_definitely_active_scan('#define DECLARE(name) typedef struct Impl name;\nvoid helper(void) {\nDECLARE(LocalAlias)\n}\nDECLARE(GlobalAlias)\n',
-		state, false, pref.Target{
+	scan := c_header_definitely_active_scan('#define DECLARE(name) typedef struct Impl name;\nvoid helper(void) {\nDECLARE(LocalAlias)\n}\nDECLARE(GlobalAlias)\n', state, false, pref.Target{
 		os: 'linux'
 	})
 	assert !scan.typedef_macro_expansions.contains('LocalAlias')
@@ -1050,8 +1043,7 @@ fn test_header_owned_scan_restores_pushed_macro_definition() {
 		macro_values: map[string]string{}
 		function_macro_values: map[string]string{}
 	}
-	scan := c_header_definitely_active_scan('#define SELECT 1\n#pragma push_macro("SELECT")\n#undef SELECT\n#pragma pop_macro("SELECT")\n#if SELECT\ntypedef struct Active RestoredAlias;\n#else\ntypedef struct Wrong WrongAlias;\n#endif\n',
-		state, false, pref.Target{
+	scan := c_header_definitely_active_scan('#define SELECT 1\n#pragma push_macro("SELECT")\n#undef SELECT\n#pragma pop_macro("SELECT")\n#if SELECT\ntypedef struct Active RestoredAlias;\n#else\ntypedef struct Wrong WrongAlias;\n#endif\n', state, false, pref.Target{
 		os: 'linux'
 	})
 	assert c_header_owned_typedef_aliases(scan.text) == ['RestoredAlias'], scan.text
@@ -1059,8 +1051,7 @@ fn test_header_owned_scan_restores_pushed_macro_definition() {
 
 fn test_header_owned_scan_resolves_compiler_feature_predicates() {
 	text := '#if __has_builtin(__builtin_expect)\ntypedef struct Builtin BuiltinAlias;\n#endif\n#if __has_feature(v3_missing_feature) || __has_extension(v3_missing_extension)\ntypedef struct Wrong WrongAlias;\n#endif\n'
-	values := c_header_compiler_feature_predicate_values('cc', []string{}, false, pref.Target{},
-		text)
+	values := c_header_compiler_feature_predicate_values('cc', []string{}, false, pref.Target{}, text)
 	assert values['__has_builtin(__builtin_expect)'] == 1
 	assert values['__has_feature(v3_missing_feature)'] == -1
 	assert values['__has_extension(v3_missing_extension)'] == -1
@@ -1087,8 +1078,7 @@ fn test_header_owned_feature_predicate_invocations_probe_macro_wrappers() {
 
 fn test_header_owned_scan_resolves_wrapped_feature_predicates() {
 	text := '#define HAS_BUILTIN(x) __has_builtin(x)\n#if HAS_BUILTIN(__builtin_expect)\ntypedef struct Builtin BuiltinAlias;\n#else\ntypedef struct Wrong WrongAlias;\n#endif\n'
-	values := c_header_compiler_feature_predicate_values('cc', []string{}, false, pref.Target{},
-		text)
+	values := c_header_compiler_feature_predicate_values('cc', []string{}, false, pref.Target{}, text)
 	assert values['__has_builtin(__builtin_expect)'] == 1
 	state := CHeaderMacroState{
 		defined: map[string]bool{}
@@ -1173,8 +1163,7 @@ fn test_header_owned_scan_resolves_msvc_version_guard() {
 		}
 		function_macro_values: map[string]string{}
 	}
-	scan := c_header_definitely_active_scan('#if _MSC_VER >= 1900\ntypedef struct Modern ModernAlias;\n#else\ntypedef struct Legacy LegacyAlias;\n#endif\n',
-		state, false, pref.Target{
+	scan := c_header_definitely_active_scan('#if _MSC_VER >= 1900\ntypedef struct Modern ModernAlias;\n#else\ntypedef struct Legacy LegacyAlias;\n#endif\n', state, false, pref.Target{
 		os: 'windows'
 	})
 	assert c_header_owned_typedef_aliases(scan.text) == ['ModernAlias'], scan.text

--- a/vlib/v3/migrations/migrations_test.v
+++ b/vlib/v3/migrations/migrations_test.v
@@ -336,25 +336,25 @@ fn create_accounts(mut ctx Context) ! {
 		name: 'organizations'
 	})!
 	ctx.create_table(Table{
-		name:         'accounts'
-		columns:      [
+		name: 'accounts'
+		columns: [
 			Column{
-				name:     'email'
-				kind:     .varchar
+				name: 'email'
+				kind: .varchar
 				nullable: false
 			},
 			Column{
-				name:     'organization_id'
-				kind:     .bigint
+				name: 'organization_id'
+				kind: .bigint
 				nullable: false
 			},
 		]
 		foreign_keys: [
 			ForeignKey{
 				from_table: 'accounts'
-				column:     'organization_id'
-				to_table:   'organizations'
-				on_delete:  'cascade'
+				column: 'organization_id'
+				to_table: 'organizations'
+				on_delete: 'cascade'
 			},
 		]
 	})!
@@ -367,15 +367,15 @@ fn drop_accounts(mut ctx Context) ! {
 
 fn add_account_name(mut ctx Context) ! {
 	ctx.add_column('accounts', Column{
-		name:        'name'
-		kind:        .text
+		name: 'name'
+		kind: .text
 		default_sql: "''"
-		nullable:    false
+		nullable: false
 	})!
 	ctx.add_index(Index{
-		table:   'accounts'
+		table: 'accounts'
 		columns: ['name']
-		name:    'index_accounts_on_name'
+		name: 'index_accounts_on_name'
 	})!
 }
 
@@ -519,15 +519,15 @@ fn test_migrate_rollback_redo_and_status() {
 	mut runner := new(mut db, [
 		Migration{
 			version: 202608160001
-			name:    'create_accounts'
-			up:      create_accounts
-			down:    drop_accounts
+			name: 'create_accounts'
+			up: create_accounts
+			down: drop_accounts
 		},
 		Migration{
 			version: 202608160002
-			name:    'add_account_name'
-			up:      add_account_name
-			down:    remove_account_name
+			name: 'add_account_name'
+			up: add_account_name
+			down: remove_account_name
 		},
 	], Config{ dialect: .sqlite })!
 
@@ -568,6 +568,7 @@ fn test_migrate_rollback_redo_and_status() {
 	}
 	assert false
 }
+
 fn test_failed_migration_rolls_back_schema_and_history() {
 	mut db := sqlite.connect(':memory:')!
 	defer {
@@ -576,9 +577,9 @@ fn test_failed_migration_rolls_back_schema_and_history() {
 	mut runner := new(mut db, [
 		Migration{
 			version: 1
-			name:    'fail_after_create'
-			up:      fail_after_create
-			down:    drop_should_rollback
+			name: 'fail_after_create'
+			up: fail_after_create
+			down: drop_should_rollback
 		},
 	], Config{ dialect: .sqlite })!
 
@@ -599,9 +600,9 @@ fn test_context_supports_v3_orm_sql_blocks() {
 	mut runner := new(mut db, [
 		Migration{
 			version: 1
-			name:    'create_widget_with_orm_dsl'
-			up:      create_widget_with_orm_dsl
-			down:    drop_widget_with_orm_dsl
+			name: 'create_widget_with_orm_dsl'
+			up: create_widget_with_orm_dsl
+			down: drop_widget_with_orm_dsl
 		},
 	], Config{ dialect: .sqlite })!
 
@@ -617,9 +618,9 @@ fn test_mutating_runner_holds_dialect_lock_around_callbacks() {
 		mut runner := new(mut recorder, [
 			Migration{
 				version: 1
-				name:    'locked'
-				up:      record_locked_migration
-				down:    record_locked_migration
+				name: 'locked'
+				up: record_locked_migration
+				down: record_locked_migration
 			},
 		], Config{
 			dialect: dialect
@@ -644,8 +645,7 @@ fn test_mutating_runner_holds_dialect_lock_around_callbacks() {
 				assert 'ORM COMMIT' in recorder.queries
 			}
 			.mysql {
-				name := mysql_migration_lock_name(recorder.database, 'schema_migrations',
-					recorder.lower_case_table_names)
+				name := mysql_migration_lock_name(recorder.database, 'schema_migrations', recorder.lower_case_table_names)
 				assert recorder.queries[0] == 'SELECT @@autocommit;'
 				assert recorder.queries[1] == 'SELECT DATABASE();'
 				assert recorder.queries[2] == 'SELECT @@lower_case_table_names;'
@@ -664,16 +664,16 @@ fn test_locked_history_table_survives_callback_namespace_changes() {
 	for dialect in [Dialect.pg, .mysql] {
 		migration := Migration{
 			version: 1
-			name:    'change_namespace'
-			up:      change_connection_namespace
-			down:    change_connection_namespace
+			name: 'change_namespace'
+			up: change_connection_namespace
+			down: change_connection_namespace
 		}
 		mut up_recorder := &RecordingConnection{
 			database: 'app'
-			schema:   'app'
+			schema: 'app'
 		}
 		mut up_runner := new(mut up_recorder, [migration], Config{
-			dialect:          dialect
+			dialect: dialect
 			transaction_mode: .never
 		})!
 		up_runner.migrate()!
@@ -719,8 +719,8 @@ fn test_locked_history_table_survives_callback_namespace_changes() {
 		}
 
 		mut down_recorder := &RecordingConnection{
-			database:     'app'
-			schema:       'app'
+			database: 'app'
+			schema: 'app'
 			history_rows: [
 				orm.Row{
 					vals: ['1', migration.name, '2026-08-16T00:00:00Z']
@@ -728,7 +728,7 @@ fn test_locked_history_table_survives_callback_namespace_changes() {
 			]
 		}
 		mut down_runner := new(mut down_recorder, [migration], Config{
-			dialect:          dialect
+			dialect: dialect
 			transaction_mode: .never
 		})!
 		down_runner.rollback(1)!
@@ -752,10 +752,10 @@ fn test_postgresql_open_transaction_is_rejected_in_every_mode_without_being_fini
 	for mode in [TransactionMode.automatic, .always, .never] {
 		mut recorder := &RecordingConnection{
 			in_transaction: true
-			savepoints:     ['v3_migrations_transaction_probe']
+			savepoints: ['v3_migrations_transaction_probe']
 		}
 		mut runner := new(mut recorder, []Migration{}, Config{
-			dialect:          .pg
+			dialect: .pg
 			transaction_mode: mode
 		})!
 		mut error_message := ''
@@ -774,7 +774,7 @@ fn test_mysql_open_transaction_is_rejected_in_every_mode_without_being_finished(
 			in_transaction: true
 		}
 		mut runner := new(mut recorder, []Migration{}, Config{
-			dialect:          .mysql
+			dialect: .mysql
 			transaction_mode: mode
 		})!
 		mut error_message := ''
@@ -796,7 +796,7 @@ fn test_mysql_disabled_autocommit_is_rejected_before_locking_or_inspection() {
 			autocommit: false
 		}
 		mut runner := new(mut recorder, []Migration{}, Config{
-			dialect:          .mysql
+			dialect: .mysql
 			transaction_mode: mode
 		})!
 		mut error_message := ''
@@ -817,12 +817,12 @@ fn test_mysql_callback_session_state_is_rechecked_before_unlocking() {
 		mut autocommit_runner := new(mut autocommit_recorder, [
 			Migration{
 				version: 1
-				name:    'disable_autocommit'
-				up:      disable_mysql_autocommit
-				down:    disable_mysql_autocommit
+				name: 'disable_autocommit'
+				up: disable_mysql_autocommit
+				down: disable_mysql_autocommit
 			},
 		], Config{
-			dialect:          .mysql
+			dialect: .mysql
 			transaction_mode: mode
 		})!
 		mut error_message := ''
@@ -841,12 +841,12 @@ fn test_mysql_callback_session_state_is_rechecked_before_unlocking() {
 		mut transaction_runner := new(mut transaction_recorder, [
 			Migration{
 				version: 1
-				name:    'start_transaction'
-				up:      start_mysql_transaction
-				down:    start_mysql_transaction
+				name: 'start_transaction'
+				up: start_mysql_transaction
+				down: start_mysql_transaction
 			},
 		], Config{
-			dialect:          .mysql
+			dialect: .mysql
 			transaction_mode: mode
 		})!
 		error_message = ''
@@ -867,13 +867,13 @@ fn test_mysql_callback_session_state_is_rechecked_before_unlocking() {
 fn test_postgresql_callback_transactions_are_rolled_back_before_unlocking() {
 	migration := Migration{
 		version: 1
-		name:    'start_transaction'
-		up:      start_postgresql_transaction
-		down:    start_postgresql_transaction
+		name: 'start_transaction'
+		up: start_postgresql_transaction
+		down: start_postgresql_transaction
 	}
 	mut up_recorder := &RecordingConnection{}
 	mut up_runner := new(mut up_recorder, [migration], Config{
-		dialect:          .pg
+		dialect: .pg
 		transaction_mode: .never
 	})!
 	mut error_message := ''
@@ -896,7 +896,7 @@ fn test_postgresql_callback_transactions_are_rolled_back_before_unlocking() {
 		]
 	}
 	mut down_runner := new(mut down_recorder, [migration], Config{
-		dialect:          .pg
+		dialect: .pg
 		transaction_mode: .never
 	})!
 	error_message = ''
@@ -914,13 +914,13 @@ fn test_postgresql_callback_transactions_are_rolled_back_before_unlocking() {
 fn test_postgresql_lock_verification_errors_rollback_callback_transaction_state() {
 	migration := Migration{
 		version: 1
-		name:    'aborted_transaction'
-		up:      abort_postgresql_transaction_and_catch_error
-		down:    abort_postgresql_transaction_and_catch_error
+		name: 'aborted_transaction'
+		up: abort_postgresql_transaction_and_catch_error
+		down: abort_postgresql_transaction_and_catch_error
 	}
 	mut up_recorder := &RecordingConnection{}
 	mut up_runner := new(mut up_recorder, [migration], Config{
-		dialect:          .pg
+		dialect: .pg
 		transaction_mode: .never
 	})!
 	mut error_message := ''
@@ -946,7 +946,7 @@ fn test_postgresql_lock_verification_errors_rollback_callback_transaction_state(
 		]
 	}
 	mut down_runner := new(mut down_recorder, [migration], Config{
-		dialect:          .pg
+		dialect: .pg
 		transaction_mode: .never
 	})!
 	error_message = ''
@@ -966,14 +966,14 @@ fn test_postgresql_lock_verification_errors_rollback_callback_transaction_state(
 fn test_postgresql_owned_transaction_is_verified_before_history_writes() {
 	migration := Migration{
 		version: 1
-		name:    'rollback_transaction'
-		up:      rollback_callback_transaction
-		down:    rollback_callback_transaction
+		name: 'rollback_transaction'
+		up: rollback_callback_transaction
+		down: rollback_callback_transaction
 	}
 	for mode in [TransactionMode.automatic, .always] {
 		mut up_recorder := &RecordingConnection{}
 		mut up_runner := new(mut up_recorder, [migration], Config{
-			dialect:          .pg
+			dialect: .pg
 			transaction_mode: mode
 		})!
 		mut error_message := ''
@@ -993,7 +993,7 @@ fn test_postgresql_owned_transaction_is_verified_before_history_writes() {
 			]
 		}
 		mut down_runner := new(mut down_recorder, [migration], Config{
-			dialect:          .pg
+			dialect: .pg
 			transaction_mode: mode
 		})!
 		error_message = ''
@@ -1008,22 +1008,22 @@ fn test_postgresql_advisory_lock_is_verified_before_history_writes() {
 	migrations := [
 		Migration{
 			version: 1
-			name:    'unlock_all'
-			up:      unlock_all_postgresql_advisory_locks
-			down:    unlock_all_postgresql_advisory_locks
+			name: 'unlock_all'
+			up: unlock_all_postgresql_advisory_locks
+			down: unlock_all_postgresql_advisory_locks
 		},
 		Migration{
 			version: 1
-			name:    'unlock_migration_lock'
-			up:      unlock_postgresql_migration_lock
-			down:    unlock_postgresql_migration_lock
+			name: 'unlock_migration_lock'
+			up: unlock_postgresql_migration_lock
+			down: unlock_postgresql_migration_lock
 		},
 	]
 	for migration in migrations {
 		for mode in [TransactionMode.automatic, .always, .never] {
 			mut up_recorder := &RecordingConnection{}
 			mut up_runner := new(mut up_recorder, [migration], Config{
-				dialect:          .pg
+				dialect: .pg
 				transaction_mode: mode
 			})!
 			mut error_message := ''
@@ -1048,7 +1048,7 @@ fn test_postgresql_advisory_lock_is_verified_before_history_writes() {
 				]
 			}
 			mut down_runner := new(mut down_recorder, [migration], Config{
-				dialect:          .pg
+				dialect: .pg
 				transaction_mode: mode
 			})!
 			error_message = ''
@@ -1069,16 +1069,16 @@ fn test_postgresql_advisory_lock_is_verified_before_history_writes() {
 fn test_postgresql_transaction_lock_cannot_replace_session_lock_before_history_writes() {
 	migration := Migration{
 		version: 1
-		name:    'replace_session_lock'
-		up:      replace_postgresql_migration_lock_with_transaction_lock
-		down:    replace_postgresql_migration_lock_with_transaction_lock
+		name: 'replace_session_lock'
+		up: replace_postgresql_migration_lock_with_transaction_lock
+		down: replace_postgresql_migration_lock_with_transaction_lock
 	}
 	key := postgresql_migration_lock_key('public', 'schema_migrations')
 	lock_check := postgresql_migration_lock_owned_query(key)
 	for mode in [TransactionMode.automatic, .always] {
 		mut up_recorder := &RecordingConnection{}
 		mut up_runner := new(mut up_recorder, [migration], Config{
-			dialect:          .pg
+			dialect: .pg
 			transaction_mode: mode
 		})!
 		mut error_message := ''
@@ -1098,7 +1098,7 @@ fn test_postgresql_transaction_lock_cannot_replace_session_lock_before_history_w
 			]
 		}
 		mut down_runner := new(mut down_recorder, [migration], Config{
-			dialect:          .pg
+			dialect: .pg
 			transaction_mode: mode
 		})!
 		error_message = ''
@@ -1116,13 +1116,13 @@ fn test_postgresql_transaction_lock_cannot_replace_session_lock_before_history_w
 fn test_mysql_owned_transaction_is_verified_before_history_writes() {
 	migration := Migration{
 		version: 1
-		name:    'rollback_transaction'
-		up:      rollback_callback_transaction
-		down:    rollback_callback_transaction
+		name: 'rollback_transaction'
+		up: rollback_callback_transaction
+		down: rollback_callback_transaction
 	}
 	mut up_recorder := &RecordingConnection{}
 	mut up_runner := new(mut up_recorder, [migration], Config{
-		dialect:          .mysql
+		dialect: .mysql
 		transaction_mode: .always
 	})!
 	mut error_message := ''
@@ -1140,7 +1140,7 @@ fn test_mysql_owned_transaction_is_verified_before_history_writes() {
 		]
 	}
 	mut down_runner := new(mut down_recorder, [migration], Config{
-		dialect:          .mysql
+		dialect: .mysql
 		transaction_mode: .always
 	})!
 	error_message = ''
@@ -1155,22 +1155,22 @@ fn test_mysql_named_lock_is_verified_before_history_writes() {
 	migrations := [
 		Migration{
 			version: 1
-			name:    'unlock_all'
-			up:      unlock_all_mysql_named_locks
-			down:    unlock_all_mysql_named_locks
+			name: 'unlock_all'
+			up: unlock_all_mysql_named_locks
+			down: unlock_all_mysql_named_locks
 		},
 		Migration{
 			version: 1
-			name:    'unlock_migration_lock'
-			up:      unlock_mysql_migration_lock
-			down:    unlock_mysql_migration_lock
+			name: 'unlock_migration_lock'
+			up: unlock_mysql_migration_lock
+			down: unlock_mysql_migration_lock
 		},
 	]
 	for migration in migrations {
 		for mode in [TransactionMode.automatic, .always, .never] {
 			mut up_recorder := &RecordingConnection{}
 			mut up_runner := new(mut up_recorder, [migration], Config{
-				dialect:          .mysql
+				dialect: .mysql
 				transaction_mode: mode
 			})!
 			mut error_message := ''
@@ -1196,7 +1196,7 @@ fn test_mysql_named_lock_is_verified_before_history_writes() {
 				]
 			}
 			mut down_runner := new(mut down_recorder, [migration], Config{
-				dialect:          .mysql
+				dialect: .mysql
 				transaction_mode: mode
 			})!
 			error_message = ''
@@ -1216,9 +1216,9 @@ fn test_sqlite_callback_cannot_end_lock_transaction_before_history_writes() {
 	mut up_runner := new(mut up_db, [
 		Migration{
 			version: 1
-			name:    'rollback_transaction'
-			up:      create_sqlite_table_then_rollback
-			down:    drop_sqlite_table_then_rollback
+			name: 'rollback_transaction'
+			up: create_sqlite_table_then_rollback
+			down: drop_sqlite_table_then_rollback
 		},
 	], Config{
 		dialect: .sqlite
@@ -1237,9 +1237,9 @@ fn test_sqlite_callback_cannot_end_lock_transaction_before_history_writes() {
 	mut down_runner := new(mut down_db, [
 		Migration{
 			version: 1
-			name:    'rollback_transaction'
-			up:      create_sqlite_table_then_rollback
-			down:    drop_sqlite_table_then_rollback
+			name: 'rollback_transaction'
+			up: create_sqlite_table_then_rollback
+			down: drop_sqlite_table_then_rollback
 		},
 	], Config{
 		dialect: .sqlite
@@ -1261,9 +1261,9 @@ fn test_sqlite_callback_cannot_replace_lock_transaction_before_history_write() {
 	mut runner := new(mut db, [
 		Migration{
 			version: 1
-			name:    'replace_transaction'
-			up:      create_sqlite_table_then_replace_transaction
-			down:    drop_sqlite_table_then_rollback
+			name: 'replace_transaction'
+			up: create_sqlite_table_then_replace_transaction
+			down: drop_sqlite_table_then_rollback
 		},
 	], Config{
 		dialect: .sqlite
@@ -1307,9 +1307,9 @@ fn test_sqlite_failed_lock_commit_rolls_back_and_cleans_up_transaction_probe() {
 	mut runner := new(mut recorder, [
 		Migration{
 			version: 1
-			name:    'deferred_foreign_key_violation'
-			up:      record_locked_migration
-			down:    record_locked_migration
+			name: 'deferred_foreign_key_violation'
+			up: record_locked_migration
+			down: record_locked_migration
 		},
 	], Config{
 		dialect: .sqlite
@@ -1346,9 +1346,9 @@ fn test_sqlite_history_table_is_pinned_to_main() {
 		mut runner := new(mut db, [
 			Migration{
 				version: 1
-				name:    'persistent_history'
-				up:      create_sqlite_temp_history_shadow
-				down:    drop_sqlite_temp_history_shadow
+				name: 'persistent_history'
+				up: create_sqlite_temp_history_shadow
+				down: drop_sqlite_temp_history_shadow
 			},
 		], Config{
 			dialect: .sqlite
@@ -1371,9 +1371,9 @@ fn test_migration_names_reject_nul_bytes_before_database_access() {
 	new(mut recorder, [
 		Migration{
 			version: 1
-			name:    'before\x00after'
-			up:      record_locked_migration
-			down:    record_locked_migration
+			name: 'before\x00after'
+			up: record_locked_migration
+			down: record_locked_migration
 		},
 	], Config{ dialect: .sqlite }) or {
 		assert err.msg() == 'migration 1 name must not contain NUL bytes'
@@ -1421,7 +1421,7 @@ fn test_mysql_migration_locks_are_namespaced_by_database() {
 	}
 	mut qualified_first_runner := new(mut qualified_first_recorder, []Migration{}, Config{
 		dialect: .mysql
-		table:   qualified_table
+		table: qualified_table
 	})!
 	qualified_first_runner.acquire_migration_lock()!
 	qualified_first_runner.release_migration_lock(true)!
@@ -1437,7 +1437,7 @@ fn test_mysql_migration_locks_are_namespaced_by_database() {
 	}
 	mut qualified_second_runner := new(mut qualified_second_recorder, []Migration{}, Config{
 		dialect: .mysql
-		table:   qualified_table
+		table: qualified_table
 	})!
 	qualified_second_runner.acquire_migration_lock()!
 	qualified_second_runner.release_migration_lock(true)!
@@ -1455,8 +1455,7 @@ fn test_mysql_migration_locks_are_namespaced_by_database() {
 }
 
 fn test_mysql_migration_locks_follow_lower_case_table_names() {
-	assert mysql_migration_lock_name('app', 'app.schema_migrations', 0) != mysql_migration_lock_name('APP',
-		'APP.Schema_Migrations', 0)
+	assert mysql_migration_lock_name('app', 'app.schema_migrations', 0) != mysql_migration_lock_name('APP', 'APP.Schema_Migrations', 0)
 	for mode in [1, 2] {
 		lower_name := mysql_migration_lock_name('app', 'app.schema_migrations', mode)
 		upper_name := mysql_migration_lock_name('APP', 'APP.Schema_Migrations', mode)
@@ -1467,7 +1466,7 @@ fn test_mysql_migration_locks_follow_lower_case_table_names() {
 		}
 		mut lower_runner := new(mut lower_recorder, []Migration{}, Config{
 			dialect: .mysql
-			table:   'app.schema_migrations'
+			table: 'app.schema_migrations'
 		})!
 		lower_runner.acquire_migration_lock()!
 		lower_runner.release_migration_lock(true)!
@@ -1477,7 +1476,7 @@ fn test_mysql_migration_locks_follow_lower_case_table_names() {
 		}
 		mut upper_runner := new(mut upper_recorder, []Migration{}, Config{
 			dialect: .mysql
-			table:   'APP.Schema_Migrations'
+			table: 'APP.Schema_Migrations'
 		})!
 		upper_runner.acquire_migration_lock()!
 		upper_runner.release_migration_lock(true)!
@@ -1501,7 +1500,7 @@ fn test_postgresql_migration_locks_use_full_64bit_keys() {
 	mut recorder := &RecordingConnection{}
 	mut runner := new(mut recorder, []Migration{}, Config{
 		dialect: .pg
-		table:   first_table
+		table: first_table
 	})!
 	runner.acquire_migration_lock()!
 	runner.release_migration_lock(true)!
@@ -1518,7 +1517,7 @@ fn test_postgresql_migration_locks_canonicalize_history_table() {
 	assert key == postgresql_migration_lock_key('public', 'public.schema_migrations')
 
 	mut unqualified_recorder := &RecordingConnection{
-		schema:                    'tenant'
+		schema: 'tenant'
 		postgresql_history_schema: 'public'
 	}
 	mut unqualified_runner := new(mut unqualified_recorder, []Migration{}, Config{
@@ -1539,7 +1538,7 @@ fn test_postgresql_migration_locks_canonicalize_history_table() {
 	}
 	mut qualified_runner := new(mut qualified_recorder, []Migration{}, Config{
 		dialect: .pg
-		table:   'public.schema_migrations'
+		table: 'public.schema_migrations'
 	})!
 	qualified_runner.acquire_migration_lock()!
 	qualified_runner.release_migration_lock(true)!
@@ -1553,7 +1552,7 @@ fn test_postgresql_migration_locks_canonicalize_history_table() {
 	mut temp_recorder := &RecordingConnection{}
 	mut temp_runner := new(mut temp_recorder, []Migration{}, Config{
 		dialect: .pg
-		table:   'pg_temp.schema_migrations'
+		table: 'pg_temp.schema_migrations'
 	})!
 	temp_runner.acquire_migration_lock()!
 	temp_runner.release_migration_lock(true)!
@@ -1566,9 +1565,9 @@ fn test_postgresql_migration_locks_canonicalize_history_table() {
 
 fn test_postgresql_inspection_resolves_and_retains_existing_history_schema() {
 	mut recorder := &RecordingConnection{
-		schema:                    'tenant'
+		schema: 'tenant'
 		postgresql_history_schema: 'public'
-		history_rows:              [
+		history_rows: [
 			orm.Row{
 				vals: ['7', 'already_applied', '2026-08-16T00:00:00Z']
 			},
@@ -1605,7 +1604,7 @@ fn test_postgresql_inspection_resolves_and_retains_existing_history_schema() {
 
 fn test_postgresql_inspection_rejects_active_transaction_without_retaining_schema() {
 	mut recorder := &RecordingConnection{
-		schema:         'transaction_schema'
+		schema: 'transaction_schema'
 		in_transaction: true
 	}
 	mut runner := new(mut recorder, []Migration{}, Config{
@@ -1640,7 +1639,7 @@ fn test_postgresql_inspection_rejects_active_transaction_without_retaining_schem
 
 fn test_mysql_inspection_resolves_and_retains_history_database() {
 	mut recorder := &RecordingConnection{
-		database:     'app'
+		database: 'app'
 		history_rows: [
 			orm.Row{
 				vals: ['7', 'already_applied', '2026-08-16T00:00:00Z']
@@ -1678,9 +1677,9 @@ fn test_mysql_history_literals_are_backslash_safe() {
 	name := "quote\\'and_trailing\\"
 	migration := Migration{
 		version: 7
-		name:    name
-		up:      record_locked_migration
-		down:    record_locked_migration
+		name: name
+		up: record_locked_migration
+		down: record_locked_migration
 	}
 	runner := new(mut recorder, [migration], Config{
 		dialect: .mysql
@@ -1695,9 +1694,9 @@ fn test_postgresql_history_literals_are_backslash_mode_independent() {
 	name := "quote\\'and_trailing\\"
 	migration := Migration{
 		version: 8
-		name:    name
-		up:      record_locked_migration
-		down:    record_locked_migration
+		name: name
+		up: record_locked_migration
+		down: record_locked_migration
 	}
 	runner := new(mut recorder, [migration], Config{
 		dialect: .pg
@@ -1712,8 +1711,8 @@ fn test_postgresql_change_column_rejects_constraint_options_before_sql() {
 	mut recorder := &RecordingConnection{}
 	mut ctx := new_context(recorder, .pg)
 	ctx.change_column('accounts', Column{
-		name:  'score'
-		kind:  .bigint
+		name: 'score'
+		kind: .bigint
 		limit: 64
 	})!
 	assert recorder.queries == [
@@ -1721,12 +1720,12 @@ fn test_postgresql_change_column_rejects_constraint_options_before_sql() {
 	]
 
 	ctx.change_column('accounts', Column{
-		name:           'score'
-		kind:           .bigint
-		nullable:       false
-		default_sql:    '0'
-		unique:         true
-		primary_key:    true
+		name: 'score'
+		kind: .bigint
+		nullable: false
+		default_sql: '0'
+		unique: true
+		primary_key: true
 		auto_increment: true
 	}) or {
 		assert err.msg() == 'PostgreSQL change_column only supports type, limit, precision, and scale; unsupported options: nullable, default_sql, unique, primary_key, auto_increment; use ctx.execute() for constraint changes'
@@ -1740,12 +1739,12 @@ fn test_postgresql_change_column_rejects_explicit_constraint_removals() {
 	mut recorder := &RecordingConnection{}
 	mut ctx := new_context(recorder, .pg)
 	ctx.change_column('accounts', Column{
-		name:           'score'
-		kind:           .bigint
-		nullable:       true
-		default_sql:    ''
-		unique:         false
-		primary_key:    false
+		name: 'score'
+		kind: .bigint
+		nullable: true
+		default_sql: ''
+		unique: false
+		primary_key: false
 		auto_increment: false
 	}) or {
 		assert err.msg() == 'PostgreSQL change_column only supports type, limit, precision, and scale; unsupported options: nullable, default_sql, unique, primary_key, auto_increment; use ctx.execute() for constraint changes'
@@ -1760,10 +1759,10 @@ fn test_mysql_change_column_rejects_lossy_redefinitions() {
 	mut ctx := new_context(recorder, .mysql)
 	mut error_message := ''
 	ctx.change_column('accounts', Column{
-		name:           'score'
-		kind:           .bigint
-		nullable:       false
-		default_sql:    '0'
+		name: 'score'
+		kind: .bigint
+		nullable: false
+		default_sql: '0'
 		auto_increment: false
 	}) or { error_message = err.msg() }
 	assert error_message == 'MySQL change_column cannot safely preserve attributes outside Column; use ctx.execute() with a complete MODIFY COLUMN definition'
@@ -1775,10 +1774,10 @@ fn test_mysql_change_column_rejects_auto_increment_redefinitions() {
 	mut ctx := new_context(recorder, .mysql)
 	mut error_message := ''
 	ctx.change_column('accounts', Column{
-		name:           'id'
-		kind:           .bigint
-		nullable:       false
-		default_sql:    ''
+		name: 'id'
+		kind: .bigint
+		nullable: false
+		default_sql: ''
 		auto_increment: true
 	}) or { error_message = err.msg() }
 	assert error_message == 'MySQL change_column cannot safely preserve attributes outside Column; use ctx.execute() with a complete MODIFY COLUMN definition'
@@ -1790,20 +1789,20 @@ fn test_mysql_auto_increment_requires_a_key() {
 	mut ctx := new_context(recorder, .mysql)
 	mut add_error := ''
 	ctx.add_column('accounts', Column{
-		name:           'sequence'
-		kind:           .bigint
+		name: 'sequence'
+		kind: .bigint
 		auto_increment: true
 	}) or { add_error = err.msg() }
 	assert add_error == 'MySQL auto-increment column `sequence` must be a primary key or unique'
 
 	mut create_error := ''
 	ctx.create_table(Table{
-		name:    'events'
-		id:      false
+		name: 'events'
+		id: false
 		columns: [
 			Column{
-				name:           'sequence'
-				kind:           .bigint
+				name: 'sequence'
+				kind: .bigint
 				auto_increment: true
 			},
 		]
@@ -1812,10 +1811,10 @@ fn test_mysql_auto_increment_requires_a_key() {
 	assert recorder.queries.len == 0
 
 	ctx.add_column('accounts', Column{
-		name:           'sequence'
-		kind:           .bigint
+		name: 'sequence'
+		kind: .bigint
 		auto_increment: true
-		unique:         true
+		unique: true
 	})!
 	assert recorder.queries == [
 		'ALTER TABLE `accounts` ADD COLUMN `sequence` BIGINT AUTO_INCREMENT UNIQUE;',
@@ -1827,13 +1826,13 @@ fn test_mysql_create_table_rejects_multiple_auto_increment_columns() {
 	mut ctx := new_context(recorder, .mysql)
 	mut error_message := ''
 	ctx.create_table(Table{
-		name:    'events'
+		name: 'events'
 		columns: [
 			Column{
-				name:           'sequence'
-				kind:           .bigint
+				name: 'sequence'
+				kind: .bigint
 				auto_increment: true
-				unique:         true
+				unique: true
 			},
 		]
 	}) or { error_message = err.msg() }
@@ -1841,14 +1840,14 @@ fn test_mysql_create_table_rejects_multiple_auto_increment_columns() {
 	assert recorder.queries.len == 0
 
 	ctx.create_table(Table{
-		name:    'single_sequence'
-		id:      false
+		name: 'single_sequence'
+		id: false
 		columns: [
 			Column{
-				name:           'sequence'
-				kind:           .bigint
+				name: 'sequence'
+				kind: .bigint
 				auto_increment: true
-				unique:         true
+				unique: true
 			},
 		]
 	})!
@@ -1861,7 +1860,7 @@ fn test_sqlite_and_mysql_reject_case_insensitive_duplicate_columns() {
 		mut ctx := new_context(recorder, dialect)
 		mut error_message := ''
 		ctx.create_table(Table{
-			name:    'records'
+			name: 'records'
 			columns: [
 				Column{
 					name: 'ID'
@@ -1874,8 +1873,8 @@ fn test_sqlite_and_mysql_reject_case_insensitive_duplicate_columns() {
 
 		error_message = ''
 		ctx.create_table(Table{
-			name:    'contacts'
-			id:      false
+			name: 'contacts'
+			id: false
 			columns: [
 				Column{
 					name: 'email'
@@ -1894,8 +1893,8 @@ fn test_sqlite_and_mysql_reject_case_insensitive_duplicate_columns() {
 	mut postgres_recorder := &RecordingConnection{}
 	mut postgres_ctx := new_context(postgres_recorder, .pg)
 	postgres_ctx.create_table(Table{
-		name:    'contacts'
-		id:      false
+		name: 'contacts'
+		id: false
 		columns: [
 			Column{
 				name: 'email'
@@ -1985,17 +1984,17 @@ fn test_postgresql_add_index_rejects_qualified_names() {
 	mut ctx := new_context(recorder, .pg)
 	mut error_message := ''
 	ctx.add_index(Index{
-		table:   'reporting.users'
+		table: 'reporting.users'
 		columns: ['email']
-		name:    'reporting.users_email_idx'
+		name: 'reporting.users_email_idx'
 	}) or { error_message = err.msg() }
 	assert error_message == 'PostgreSQL add_index name `reporting.users_email_idx` must be unqualified'
 	assert recorder.queries.len == 0
 
 	ctx.add_index(Index{
-		table:   'reporting.users'
+		table: 'reporting.users'
 		columns: ['email']
-		name:    'users_email_idx'
+		name: 'users_email_idx'
 	})!
 	assert recorder.queries == [
 		'CREATE INDEX "users_email_idx" ON "reporting"."users" ("email");',
@@ -2007,17 +2006,17 @@ fn test_mysql_index_names_must_be_unqualified() {
 	mut ctx := new_context(recorder, .mysql)
 	mut error_message := ''
 	ctx.add_index(Index{
-		table:   'app.users'
+		table: 'app.users'
 		columns: ['email']
-		name:    'app.users_email_idx'
+		name: 'app.users_email_idx'
 	}) or { error_message = err.msg() }
 	assert error_message == 'MySQL add_index name `app.users_email_idx` must be unqualified'
 	assert recorder.queries.len == 0
 
 	ctx.add_index(Index{
-		table:   'app.users'
+		table: 'app.users'
 		columns: ['email']
-		name:    'users_email_idx'
+		name: 'users_email_idx'
 	})!
 	assert recorder.queries == [
 		'CREATE INDEX `users_email_idx` ON `app`.`users` (`email`);',
@@ -2041,17 +2040,17 @@ fn test_mysql_foreign_keys_reject_set_default_actions() {
 	mut error_message := ''
 	ctx.add_foreign_key(ForeignKey{
 		from_table: 'accounts'
-		column:     'organization_id'
-		to_table:   'organizations'
-		on_delete:  'set_default'
+		column: 'organization_id'
+		to_table: 'organizations'
+		on_delete: 'set_default'
 	}) or { error_message = err.msg() }
 	assert error_message == 'MySQL does not support SET DEFAULT for foreign-key actions'
 
 	error_message = ''
 	ctx.create_table(Table{
-		name:         'accounts'
-		id:           false
-		columns:      [
+		name: 'accounts'
+		id: false
+		columns: [
 			Column{
 				name: 'organization_id'
 				kind: .bigint
@@ -2060,9 +2059,9 @@ fn test_mysql_foreign_keys_reject_set_default_actions() {
 		foreign_keys: [
 			ForeignKey{
 				from_table: 'accounts'
-				column:     'organization_id'
-				to_table:   'organizations'
-				on_update:  'SET DEFAULT'
+				column: 'organization_id'
+				to_table: 'organizations'
+				on_update: 'SET DEFAULT'
 			},
 		]
 	}) or { error_message = err.msg() }
@@ -2076,35 +2075,35 @@ fn test_column_sql_rejects_postgresql_serial_defaults_and_scale_without_precisio
 	mut ctx := new_context(recorder, .pg)
 	mut error_message := ''
 	ctx.add_column('accounts', Column{
-		name:           'sequence'
-		kind:           .bigint
+		name: 'sequence'
+		kind: .bigint
 		auto_increment: true
-		default_sql:    '5'
+		default_sql: '5'
 	}) or { error_message = err.msg() }
 	assert error_message == 'PostgreSQL auto-increment column `sequence` cannot specify default_sql'
 
 	error_message = ''
 	ctx.add_column('accounts', Column{
-		name:      'amount'
-		kind:      .decimal
+		name: 'amount'
+		kind: .decimal
 		precision: 0
-		scale:     2
+		scale: 2
 	}) or { error_message = err.msg() }
 	assert error_message == 'decimal scale requires a positive precision'
 	assert recorder.queries.len == 0
 
 	assert column_sql(.pg, Column{
-		name:           'sequence'
-		kind:           .bigint
-		primary_key:    true
+		name: 'sequence'
+		kind: .bigint
+		primary_key: true
 		auto_increment: true
-		default_sql:    ''
+		default_sql: ''
 	})! == '"sequence" BIGSERIAL PRIMARY KEY'
 	assert column_type_sql(.mysql, Column{
-		name:      'amount'
-		kind:      .decimal
+		name: 'amount'
+		kind: .decimal
 		precision: 8
-		scale:     2
+		scale: 2
 	})! == 'DECIMAL(8, 2)'
 }
 
@@ -2113,16 +2112,16 @@ fn test_sqlite_add_column_rejects_unsupported_constraints() {
 	mut ctx := new_context(recorder, .sqlite)
 	mut error_message := ''
 	ctx.add_column('accounts', Column{
-		name:        'owner_id'
-		kind:        .bigint
+		name: 'owner_id'
+		kind: .bigint
 		primary_key: true
 	}) or { error_message = err.msg() }
 	assert error_message == 'SQLite add_column does not support primary-key, unique, or auto-increment columns; rebuild the table in the migration'
 
 	error_message = ''
 	ctx.add_column('accounts', Column{
-		name:   'email'
-		kind:   .text
+		name: 'email'
+		kind: .text
 		unique: true
 	}) or { error_message = err.msg() }
 	assert error_message == 'SQLite add_column does not support primary-key, unique, or auto-increment columns; rebuild the table in the migration'
@@ -2147,9 +2146,9 @@ fn test_sqlite_add_column_rejects_unsupported_constraints() {
 	for default_sql in invalid_defaults {
 		error_message = ''
 		ctx.add_column('accounts', Column{
-			name:        'label'
-			kind:        .text
-			nullable:    false
+			name: 'label'
+			kind: .text
+			nullable: false
 			default_sql: default_sql
 		}) or { error_message = err.msg() }
 		assert error_message == 'SQLite add_column requires a non-NULL default for a NOT NULL column; rebuild the table in the migration'
@@ -2162,8 +2161,8 @@ fn test_sqlite_add_column_rejects_unsupported_constraints() {
 		'((+CURRENT_DATE)) /* now */ COLLATE binary'] {
 		error_message = ''
 		ctx.add_column('accounts', Column{
-			name:        'created_at'
-			kind:        .timestamp
+			name: 'created_at'
+			kind: .timestamp
 			default_sql: default_sql
 		}) or { error_message = err.msg() }
 		assert error_message == 'SQLite add_column does not support nonconstant default `${default_sql}`; rebuild the table in the migration'
@@ -2171,25 +2170,25 @@ fn test_sqlite_add_column_rejects_unsupported_constraints() {
 	assert recorder.queries.len == 0
 
 	ctx.add_column('accounts', Column{
-		name:        'label'
-		kind:        .text
-		nullable:    false
+		name: 'label'
+		kind: .text
+		nullable: false
 		default_sql: "''"
 	})!
 	assert recorder.queries == [
 		'ALTER TABLE "accounts" ADD COLUMN "label" TEXT NOT NULL DEFAULT \'\';',
 	]
 	ctx.add_column('accounts', Column{
-		name:        'literal_comment'
-		kind:        .text
-		nullable:    false
+		name: 'literal_comment'
+		kind: .text
+		nullable: false
 		default_sql: "'CURRENT_TIMESTAMP /* literal */'"
 	})!
 	assert recorder.queries[1] == 'ALTER TABLE "accounts" ADD COLUMN "literal_comment" TEXT NOT NULL DEFAULT \'CURRENT_TIMESTAMP /* literal */\';'
 	for i, default_sql in ['(0)', "('x')", '(NULL)'] {
 		ctx.add_column('accounts', Column{
-			name:        'parenthesized_${i}'
-			kind:        .text
+			name: 'parenthesized_${i}'
+			kind: .text
 			default_sql: default_sql
 		})!
 	}
@@ -2199,9 +2198,9 @@ fn test_sqlite_add_column_rejects_unsupported_constraints() {
 		'ALTER TABLE "accounts" ADD COLUMN "parenthesized_2" TEXT DEFAULT (NULL);',
 	]
 	ctx.add_column('accounts', Column{
-		name:        'cast_null_text'
-		kind:        .text
-		nullable:    false
+		name: 'cast_null_text'
+		kind: .text
+		nullable: false
 		default_sql: "(CAST('NULL' AS TEXT))"
 	})!
 	assert recorder.queries.last() == 'ALTER TABLE "accounts" ADD COLUMN "cast_null_text" TEXT NOT NULL DEFAULT (CAST(\'NULL\' AS TEXT));'
@@ -2216,58 +2215,58 @@ fn test_sqlite_add_column_accepts_parenthesized_literal_defaults() {
 	db.exec('INSERT INTO accounts (id) VALUES (1);')!
 	mut ctx := new_context(db, .sqlite)
 	ctx.add_column('accounts', Column{
-		name:        'count'
-		kind:        .integer
+		name: 'count'
+		kind: .integer
 		default_sql: '(0)'
 	})!
 	ctx.add_column('accounts', Column{
-		name:        'label'
-		kind:        .text
+		name: 'label'
+		kind: .text
 		default_sql: "('x')"
 	})!
 	ctx.add_column('accounts', Column{
-		name:        'optional'
-		kind:        .text
+		name: 'optional'
+		kind: .text
 		default_sql: '(NULL)'
 	})!
 	assert db.q_int('SELECT count FROM accounts WHERE id = 1;')! == 0
 	assert db.q_string('SELECT label FROM accounts WHERE id = 1;')! == 'x'
 	assert db.q_int('SELECT count(*) FROM accounts WHERE optional IS NULL;')! == 1
 	ctx.add_column('accounts', Column{
-		name:        'signed_count'
-		kind:        .integer
+		name: 'signed_count'
+		kind: .integer
 		default_sql: '(-1)'
 	})!
 	ctx.add_column('accounts', Column{
-		name:        'signed_label'
-		kind:        .text
+		name: 'signed_label'
+		kind: .text
 		default_sql: "(+'signed')"
 	})!
 	assert db.q_int('SELECT signed_count FROM accounts WHERE id = 1;')! == -1
 	assert db.q_string('SELECT signed_label FROM accounts WHERE id = 1;')! == 'signed'
 	ctx.add_column('accounts', Column{
-		name:        'collated_count'
-		kind:        .integer
+		name: 'collated_count'
+		kind: .integer
 		default_sql: '(0) COLLATE binary'
 	})!
 	ctx.add_column('accounts', Column{
-		name:        'collated_label'
-		kind:        .text
+		name: 'collated_label'
+		kind: .text
 		default_sql: "('collated') COLLATE binary"
 	})!
 	ctx.add_column('accounts', Column{
-		name:        'cast_count'
-		kind:        .integer
+		name: 'cast_count'
+		kind: .integer
 		default_sql: '(CAST(42 AS INTEGER))'
 	})!
 	ctx.add_column('accounts', Column{
-		name:        'signed_cast_count'
-		kind:        .integer
+		name: 'signed_cast_count'
+		kind: .integer
 		default_sql: '(+CAST(42 AS INTEGER))'
 	})!
 	ctx.add_column('accounts', Column{
-		name:        'nested_signed_cast_count'
-		kind:        .integer
+		name: 'nested_signed_cast_count'
+		kind: .integer
 		default_sql: '(CAST(-CAST(42 AS INTEGER) AS INTEGER))'
 	})!
 	assert db.q_int('SELECT collated_count FROM accounts WHERE id = 1;')! == 0
@@ -2290,8 +2289,8 @@ fn test_sqlite_constant_cast_default_classification() {
 }
 
 fn test_sqlite_accepts_numeric_literal_digit_separators() {
-	for literal in ['1_000', '(1_000)', '1_2.3_4e5_6', '1e+1_0', '0xCA_FE', '(0xA_B_C)', '.5',
-		'1.', '1e-2'] {
+	for literal in ['1_000', '(1_000)', '1_2.3_4e5_6', '1e+1_0', '0xCA_FE', '(0xA_B_C)', '.5', '1.',
+		'1e-2'] {
 		assert sqlite_is_literal_default(literal)
 	}
 	for literal in ['_1000', '1000_', '1__000', '1_.0', '0x_FF', '0xFF_', '0xA__B', 'e1', 'E+1',
@@ -2302,18 +2301,18 @@ fn test_sqlite_accepts_numeric_literal_digit_separators() {
 	mut recorder := &RecordingConnection{}
 	mut ctx := new_context(recorder, .sqlite)
 	ctx.add_column('accounts', Column{
-		name:        'population'
-		kind:        .integer
+		name: 'population'
+		kind: .integer
 		default_sql: '(1_000)'
 	})!
 	ctx.add_column('accounts', Column{
-		name:        'mask'
-		kind:        .integer
+		name: 'mask'
+		kind: .integer
 		default_sql: '(0xCA_FE)'
 	})!
 	ctx.add_column('accounts', Column{
-		name:        'cast_population'
-		kind:        .integer
+		name: 'cast_population'
+		kind: .integer
 		default_sql: '(CAST(1_000 AS INTEGER))'
 	})!
 	assert recorder.queries == [
@@ -2324,8 +2323,8 @@ fn test_sqlite_accepts_numeric_literal_digit_separators() {
 	]
 	mut error_message := ''
 	ctx.add_column('accounts', Column{
-		name:        'invalid_exponent'
-		kind:        .real
+		name: 'invalid_exponent'
+		kind: .real
 		default_sql: '(e1)'
 	}) or { error_message = err.msg() }
 	assert error_message == 'SQLite add_column does not support nonconstant default `(e1)`; rebuild the table in the migration'
@@ -2337,16 +2336,16 @@ fn test_sqlite_accepts_numeric_literal_digit_separators() {
 	mut old_ctx := new_context(old_recorder, .sqlite)
 	error_message = ''
 	old_ctx.add_column('accounts', Column{
-		name:        'population'
-		kind:        .integer
+		name: 'population'
+		kind: .integer
 		default_sql: '(1_000)'
 	}) or { error_message = err.msg() }
 	assert error_message == 'SQLite add_column default `(1_000)` uses numeric digit separators, which require SQLite 3.46.0 or newer'
 	assert old_recorder.queries == ['SELECT sqlite_version();']
 	error_message = ''
 	old_ctx.add_column('accounts', Column{
-		name:        'cast_population'
-		kind:        .integer
+		name: 'cast_population'
+		kind: .integer
 		default_sql: '(CAST(1_000 AS INTEGER))'
 	}) or { error_message = err.msg() }
 	assert error_message == 'SQLite add_column default `(CAST(1_000 AS INTEGER))` uses numeric digit separators, which require SQLite 3.46.0 or newer'
@@ -2358,7 +2357,7 @@ fn test_sqlite_requires_unqualified_index_and_foreign_key_tables() {
 	mut ctx := new_context(recorder, .sqlite)
 	mut error_message := ''
 	ctx.add_index(Index{
-		table:   'main.users'
+		table: 'main.users'
 		columns: ['email']
 	}) or { error_message = err.msg() }
 	assert error_message == 'SQLite add_index table `main.users` must be unqualified'
@@ -2366,22 +2365,22 @@ fn test_sqlite_requires_unqualified_index_and_foreign_key_tables() {
 
 	error_message = ''
 	generated_name := index_name(.sqlite, Index{
-		table:   'users'
+		table: 'users'
 		columns: ['email']
 	})!
 	ctx.add_index(Index{
-		table:   'users'
+		table: 'users'
 		columns: ['email']
-		name:    'main.aux.users_email_idx'
+		name: 'main.aux.users_email_idx'
 	}) or { error_message = err.msg() }
 	assert error_message == 'SQLite index name `main.aux.users_email_idx` must not exceed 2 components'
 	assert recorder.queries.len == 0
 
 	error_message = ''
 	ctx.create_table(Table{
-		name:         'main.children'
-		id:           false
-		columns:      [
+		name: 'main.children'
+		id: false
+		columns: [
 			Column{
 				name: 'parent_id'
 				kind: .bigint
@@ -2390,8 +2389,8 @@ fn test_sqlite_requires_unqualified_index_and_foreign_key_tables() {
 		foreign_keys: [
 			ForeignKey{
 				from_table: 'main.children'
-				column:     'parent_id'
-				to_table:   'main.parents'
+				column: 'parent_id'
+				to_table: 'main.parents'
 			},
 		]
 	}) or { error_message = err.msg() }
@@ -2399,13 +2398,13 @@ fn test_sqlite_requires_unqualified_index_and_foreign_key_tables() {
 	assert recorder.queries.len == 0
 
 	ctx.add_index(Index{
-		table:   'users'
+		table: 'users'
 		columns: ['email']
 	})!
 	ctx.create_table(Table{
-		name:         'main.children'
-		id:           false
-		columns:      [
+		name: 'main.children'
+		id: false
+		columns: [
 			Column{
 				name: 'parent_id'
 				kind: .bigint
@@ -2414,8 +2413,8 @@ fn test_sqlite_requires_unqualified_index_and_foreign_key_tables() {
 		foreign_keys: [
 			ForeignKey{
 				from_table: 'main.children'
-				column:     'parent_id'
-				to_table:   'parents'
+				column: 'parent_id'
+				to_table: 'parents'
 			},
 		]
 	})!
@@ -2437,13 +2436,13 @@ fn test_sqlite_add_index_uses_the_resolved_table_schema() {
 	db.exec('CREATE TABLE aux.users (email TEXT);')!
 	mut ctx := new_context(db, .sqlite)
 	ctx.add_index(Index{
-		table:   'users'
+		table: 'users'
 		columns: ['email']
 	})!
 	ctx.add_index(Index{
-		table:   'users'
+		table: 'users'
 		columns: ['email']
-		name:    'aux.custom_users_email_idx'
+		name: 'aux.custom_users_email_idx'
 	})!
 	assert db.q_int("SELECT count(*) FROM main.sqlite_master WHERE type = 'index';")! == 0
 	assert db.q_int("SELECT count(*) FROM aux.sqlite_master WHERE type = 'index';")! == 2
@@ -2451,12 +2450,12 @@ fn test_sqlite_add_index_uses_the_resolved_table_schema() {
 
 fn test_sqlite_autoincrement_precedes_other_constraints() {
 	definition := column_sql(.sqlite, Column{
-		name:           'id'
-		kind:           .integer
-		primary_key:    true
+		name: 'id'
+		kind: .integer
+		primary_key: true
 		auto_increment: true
-		unique:         true
-		default_sql:    '5'
+		unique: true
+		default_sql: '5'
 	})!
 	assert definition == '"id" INTEGER PRIMARY KEY AUTOINCREMENT UNIQUE DEFAULT 5'
 	mut db := sqlite.connect(':memory:')!
@@ -2468,14 +2467,14 @@ fn test_sqlite_autoincrement_precedes_other_constraints() {
 
 fn test_sqlite_non_integer_primary_keys_are_not_null() {
 	text_definition := column_sql(.sqlite, Column{
-		name:        'code'
-		kind:        .text
+		name: 'code'
+		kind: .text
 		primary_key: true
 	})!
 	assert text_definition == '"code" TEXT PRIMARY KEY NOT NULL'
 	integer_definition := column_sql(.sqlite, Column{
-		name:        'id'
-		kind:        .integer
+		name: 'id'
+		kind: .integer
 		primary_key: true
 	})!
 	assert integer_definition == '"id" INTEGER PRIMARY KEY'
@@ -2509,18 +2508,18 @@ fn test_column_level_identifiers_must_be_unqualified() {
 
 	error_message = ''
 	ctx.add_index(Index{
-		table:   'public.users'
+		table: 'public.users'
 		columns: ['users.email']
 	}) or { error_message = err.msg() }
 	assert error_message == 'column name `users.email` must be unqualified'
 
 	error_message = ''
 	ctx.add_foreign_key(ForeignKey{
-		from_table:  'public.posts'
-		column:      'posts.author_id'
-		to_table:    'public.users'
+		from_table: 'public.posts'
+		column: 'posts.author_id'
+		to_table: 'public.users'
 		primary_key: 'id'
-		name:        'fk_posts_author'
+		name: 'fk_posts_author'
 	}) or { error_message = err.msg() }
 	assert error_message == 'column name `posts.author_id` must be unqualified'
 	assert recorder.queries.len == 0
@@ -2534,22 +2533,22 @@ fn test_validation_and_portable_sql_generation() {
 	new(mut db, [
 		Migration{
 			version: 7
-			name:    'one'
-			up:      create_accounts
-			down:    drop_accounts
+			name: 'one'
+			up: create_accounts
+			down: drop_accounts
 		},
 		Migration{
 			version: 7
-			name:    'two'
-			up:      create_accounts
-			down:    drop_accounts
+			name: 'two'
+			up: create_accounts
+			down: drop_accounts
 		},
 	], Config{ dialect: .sqlite }) or {
 		assert err.msg() == 'duplicate migration version 7'
 		assert column_type_sql(.pg, Column{ name: 'payload', kind: .jsonb })! == 'JSONB'
 		assert column_type_sql(.mysql, Column{ name: 'amount', kind: .double_precision })! == 'DOUBLE'
 		generated_name := index_name(.sqlite, Index{
-			table:   'accounts'
+			table: 'accounts'
 			columns: ['email', 'name']
 		})!
 		assert generated_name.starts_with('index_accounts_on_email_and_name_')
@@ -2560,7 +2559,7 @@ fn test_validation_and_portable_sql_generation() {
 
 fn test_generated_index_names_respect_dialect_limits() {
 	index := Index{
-		table:   'customer_account_records_archive'
+		table: 'customer_account_records_archive'
 		columns: ['external_customer_reference', 'external_organization_reference']
 	}
 	raw_base := 'index_customer_account_records_archive_on_external_customer_reference_and_external_organization_reference'
@@ -2580,7 +2579,7 @@ fn test_generated_index_names_respect_dialect_limits() {
 	]
 
 	other_mysql_name := index_name(.mysql, Index{
-		table:   index.table
+		table: index.table
 		columns: ['external_customer_reference', 'external_organization_identifier']
 	})!
 	assert other_mysql_name != mysql_name
@@ -2588,20 +2587,20 @@ fn test_generated_index_names_respect_dialect_limits() {
 	long_explicit_name := 'x'.repeat(65)
 	mut error_message := ''
 	index_name(.mysql, Index{
-		table:   'accounts'
+		table: 'accounts'
 		columns: ['email']
-		name:    long_explicit_name
+		name: long_explicit_name
 	}) or { error_message = err.msg() }
 	assert error_message == 'MySQL index name component `${long_explicit_name}` must not exceed 64 bytes'
 }
 
 fn test_generated_index_names_distinguish_column_boundaries() {
 	single_column := Index{
-		table:   'users'
+		table: 'users'
 		columns: ['a_and_b']
 	}
 	composite := Index{
-		table:   'users'
+		table: 'users'
 		columns: ['a', 'b']
 	}
 	single_name := index_name(.sqlite, single_column)!
@@ -2610,32 +2609,31 @@ fn test_generated_index_names_distinguish_column_boundaries() {
 	assert single_name.starts_with('index_users_on_a_and_b_')
 	assert composite_name.starts_with('index_users_on_a_and_b_')
 	case_variant_name := index_name(.mysql, Index{
-		table:   'users'
+		table: 'users'
 		columns: ['a_AnD_b']
 	})!
 	assert case_variant_name != index_name(.mysql, composite)!
 	table_boundary := Index{
-		table:   'a_on_b'
+		table: 'a_on_b'
 		columns: ['c']
 	}
 	column_boundary := Index{
-		table:   'a'
+		table: 'a'
 		columns: ['b_on_c']
 	}
 	for dialect in [Dialect.sqlite, .pg] {
 		assert index_name(dialect, table_boundary)! != index_name(dialect, column_boundary)!
 	}
 	fragment_table_boundary := Index{
-		table:   'a_on'
+		table: 'a_on'
 		columns: ['b']
 	}
 	fragment_column_boundary := Index{
-		table:   'a'
+		table: 'a'
 		columns: ['on_b']
 	}
 	for dialect in [Dialect.sqlite, .pg] {
-		assert index_name(dialect, fragment_table_boundary)! != index_name(dialect,
-			fragment_column_boundary)!
+		assert index_name(dialect, fragment_table_boundary)! != index_name(dialect, fragment_column_boundary)!
 	}
 
 	mut db := sqlite.connect(':memory:')!
@@ -2660,8 +2658,8 @@ fn test_generated_index_names_distinguish_column_boundaries() {
 fn test_generated_foreign_key_names_respect_dialect_limits() {
 	key := ForeignKey{
 		from_table: 'customer_account_records_archive'
-		column:     'external_organization_reference'
-		to_table:   'organizations'
+		column: 'external_organization_reference'
+		to_table: 'organizations'
 	}
 	raw_name := 'fk_customer_account_records_archive_external_organization_reference'
 	mysql_name := foreign_key_name(.mysql, key)!
@@ -2673,8 +2671,8 @@ fn test_generated_foreign_key_names_respect_dialect_limits() {
 
 	other_mysql_name := foreign_key_name(.mysql, ForeignKey{
 		from_table: key.from_table
-		column:     'external_organization_identifier'
-		to_table:   key.to_table
+		column: 'external_organization_identifier'
+		to_table: key.to_table
 	})!
 	assert other_mysql_name != mysql_name
 
@@ -2682,9 +2680,9 @@ fn test_generated_foreign_key_names_respect_dialect_limits() {
 	mut ctx := new_context(recorder, .mysql)
 	ctx.add_foreign_key(key)!
 	ctx.create_table(Table{
-		name:         key.from_table
-		id:           false
-		columns:      [
+		name: key.from_table
+		id: false
+		columns: [
 			Column{
 				name: key.column
 				kind: .bigint
@@ -2699,9 +2697,9 @@ fn test_generated_foreign_key_names_respect_dialect_limits() {
 	mut error_message := ''
 	ctx.add_foreign_key(ForeignKey{
 		from_table: 'accounts'
-		column:     'organization_id'
-		to_table:   'organizations'
-		name:       long_explicit_name
+		column: 'organization_id'
+		to_table: 'organizations'
+		name: long_explicit_name
 	}) or { error_message = err.msg() }
 	assert error_message == 'MySQL foreign key name `${long_explicit_name}` must not exceed 64 bytes'
 	assert recorder.queries.len == 2
@@ -2710,13 +2708,13 @@ fn test_generated_foreign_key_names_respect_dialect_limits() {
 fn test_generated_mysql_foreign_key_names_distinguish_component_boundaries() {
 	first := ForeignKey{
 		from_table: 'a_b'
-		column:     'c'
-		to_table:   'parents'
+		column: 'c'
+		to_table: 'parents'
 	}
 	second := ForeignKey{
 		from_table: 'a'
-		column:     'b_c'
-		to_table:   'parents'
+		column: 'b_c'
+		to_table: 'parents'
 	}
 	first_name := foreign_key_name(.mysql, first)!
 	second_name := foreign_key_name(.mysql, second)!
@@ -2735,8 +2733,8 @@ fn test_generated_mysql_foreign_key_names_distinguish_component_boundaries() {
 fn test_generated_foreign_key_names_include_targets() {
 	parent_key := ForeignKey{
 		from_table: 'accounts'
-		column:     'owner_id'
-		to_table:   'parents'
+		column: 'owner_id'
+		to_table: 'parents'
 	}
 	other_table := ForeignKey{
 		...parent_key
@@ -2757,9 +2755,9 @@ fn test_generated_foreign_key_names_include_targets() {
 		mut recorder := &RecordingConnection{}
 		mut ctx := new_context(recorder, dialect)
 		ctx.create_table(Table{
-			name:         'accounts'
-			id:           false
-			columns:      [
+			name: 'accounts'
+			id: false
+			columns: [
 				Column{
 					name: 'owner_id'
 					kind: .bigint
@@ -2768,10 +2766,8 @@ fn test_generated_foreign_key_names_include_targets() {
 			foreign_keys: [parent_key, other_table, other_primary_key]
 		})!
 		assert recorder.queries[0].contains('CONSTRAINT ${quote_identifier(dialect, parent_name)} FOREIGN KEY')
-		assert recorder.queries[0].contains('CONSTRAINT ${quote_identifier(dialect,
-			other_table_name)} FOREIGN KEY')
-		assert recorder.queries[0].contains('CONSTRAINT ${quote_identifier(dialect,
-			other_primary_key_name)} FOREIGN KEY')
+		assert recorder.queries[0].contains('CONSTRAINT ${quote_identifier(dialect, other_table_name)} FOREIGN KEY')
+		assert recorder.queries[0].contains('CONSTRAINT ${quote_identifier(dialect, other_primary_key_name)} FOREIGN KEY')
 	}
 }
 
@@ -2781,8 +2777,8 @@ fn test_caller_supplied_identifiers_respect_dialect_limits() {
 	mut mysql_recorder := &RecordingConnection{}
 	mut mysql_ctx := new_context(mysql_recorder, .mysql)
 	mysql_ctx.create_table(Table{
-		name:    mysql_limit_name
-		id:      false
+		name: mysql_limit_name
+		id: false
 		columns: [
 			Column{
 				name: mysql_limit_name
@@ -2820,13 +2816,13 @@ fn test_caller_supplied_identifiers_respect_dialect_limits() {
 	mut history_recorder := &RecordingConnection{}
 	runner := new(mut history_recorder, []Migration{}, Config{
 		dialect: .mysql
-		table:   '${mysql_limit_name}.${mysql_limit_name}'
+		table: '${mysql_limit_name}.${mysql_limit_name}'
 	})!
 	assert runner.config.table == '${mysql_limit_name}.${mysql_limit_name}'
 	error_message = ''
 	new(mut history_recorder, []Migration{}, Config{
 		dialect: .mysql
-		table:   'app.${mysql_long_name}'
+		table: 'app.${mysql_long_name}'
 	}) or { error_message = err.msg() }
 	assert error_message == 'MySQL migration history table name component `${mysql_long_name}` must not exceed 64 bytes'
 	assert history_recorder.queries.len == 0
@@ -2848,7 +2844,7 @@ fn test_caller_supplied_identifiers_respect_dialect_limits() {
 	error_message = ''
 	new(mut history_recorder, []Migration{}, Config{
 		dialect: .mysql
-		table:   'application.archive.schema_migrations'
+		table: 'application.archive.schema_migrations'
 	}) or { error_message = err.msg() }
 	assert error_message == 'MySQL migration history table name `application.archive.schema_migrations` must not exceed 2 components'
 	assert history_recorder.queries.len == 0
@@ -2876,15 +2872,15 @@ fn test_rails_and_v_history_tables_are_interoperable() {
 	mut rails_runner := new(mut rails_db, [
 		Migration{
 			version: 1
-			name:    'already_applied'
-			up:      no_op_migration
-			down:    no_op_migration
+			name: 'already_applied'
+			up: no_op_migration
+			down: no_op_migration
 		},
 		Migration{
 			version: 2
-			name:    'pending'
-			up:      no_op_migration
-			down:    no_op_migration
+			name: 'pending'
+			up: no_op_migration
+			down: no_op_migration
 		},
 	], Config{ dialect: .sqlite })!
 	assert rails_runner.applied()!.map(it.name) == ['already_applied']
@@ -2899,7 +2895,7 @@ fn test_rails_and_v_history_tables_are_interoperable() {
 	}
 	mut v_runner := new(mut v_db, []Migration{}, Config{ dialect: .sqlite })!
 	assert v_runner.applied()!.len == 0
-	v_db.exec("INSERT INTO schema_migrations (version) VALUES (99);")!
+	v_db.exec('INSERT INTO schema_migrations (version) VALUES (99);')!
 	assert v_runner.applied()!.map(it.version) == [i64(99)]
 }
 
@@ -2913,9 +2909,9 @@ fn test_rails_history_rejects_aliased_and_nonpositive_versions() {
 	mut runner := new(mut db, [
 		Migration{
 			version: 1
-			name:    'one'
-			up:      no_op_migration
-			down:    no_op_migration
+			name: 'one'
+			up: no_op_migration
+			down: no_op_migration
 		},
 	], Config{ dialect: .sqlite })!
 	mut error_message := ''
@@ -2953,7 +2949,7 @@ fn test_history_shape_fallback_does_not_cache_unrelated_errors() {
 			vals: ['1']
 		}]
 		history_metadata_error: 'no such column: name'
-		history_version_error:  'database connection timed out'
+		history_version_error: 'database connection timed out'
 	}
 	mut fallback_runner := new(mut fallback_recorder, []Migration{}, Config{ dialect: .sqlite })!
 	error_message = ''
@@ -3001,9 +2997,9 @@ fn test_legacy_v_history_tables_keep_metadata_writes() {
 	mut runner := new(mut db, [
 		Migration{
 			version: 1
-			name:    'legacy_metadata'
-			up:      no_op_migration
-			down:    no_op_migration
+			name: 'legacy_metadata'
+			up: no_op_migration
+			down: no_op_migration
 		},
 	], Config{ dialect: .sqlite })!
 	runner.migrate()!
@@ -3018,9 +3014,9 @@ fn test_migrate_to_requires_an_exact_registered_target() {
 	mut runner := new(mut recorder, [
 		Migration{
 			version: 10
-			name:    'ten'
-			up:      no_op_migration
-			down:    no_op_migration
+			name: 'ten'
+			up: no_op_migration
+			down: no_op_migration
 		},
 	], Config{ dialect: .sqlite })!
 	mut error_message := ''
@@ -3033,14 +3029,14 @@ fn test_migration_transaction_mode_overrides_config() {
 	mut always_recorder := &RecordingConnection{}
 	mut always_runner := new(mut always_recorder, [
 		Migration{
-			version:          1
-			name:             'always'
-			up:               no_op_migration
-			down:             no_op_migration
+			version: 1
+			name: 'always'
+			up: no_op_migration
+			down: no_op_migration
 			transaction_mode: .always
 		},
 	], Config{
-		dialect:          .pg
+		dialect: .pg
 		transaction_mode: .never
 	})!
 	always_runner.migrate()!
@@ -3050,14 +3046,14 @@ fn test_migration_transaction_mode_overrides_config() {
 	mut never_recorder := &RecordingConnection{}
 	mut never_runner := new(mut never_recorder, [
 		Migration{
-			version:          1
-			name:             'never'
-			up:               no_op_migration
-			down:             no_op_migration
+			version: 1
+			name: 'never'
+			up: no_op_migration
+			down: no_op_migration
 			transaction_mode: .never
 		},
 	], Config{
-		dialect:          .pg
+		dialect: .pg
 		transaction_mode: .always
 	})!
 	never_runner.migrate()!
@@ -3070,15 +3066,15 @@ fn test_duplicate_migration_names_are_rejected() {
 	new(mut recorder, [
 		Migration{
 			version: 1
-			name:    'duplicate'
-			up:      no_op_migration
-			down:    no_op_migration
+			name: 'duplicate'
+			up: no_op_migration
+			down: no_op_migration
 		},
 		Migration{
 			version: 2
-			name:    'duplicate'
-			up:      no_op_migration
-			down:    no_op_migration
+			name: 'duplicate'
+			up: no_op_migration
+			down: no_op_migration
 		},
 	], Config{ dialect: .sqlite }) or {
 		assert err.msg() == 'duplicate migration name `duplicate`'

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -68,16 +68,16 @@ mut:
 	cur_module            string
 	cur_fn                string
 	cur_veb_ctx_name      string // source-level name of the active veb request context
-	veb_tmpl_counter      int    // monotonic id for unique `$veb.html`/`$tmpl` builder var names
+	veb_tmpl_counter      int // monotonic id for unique `$veb.html`/`$tmpl` builder var names
 	has_veb_template      bool
 	may_have_local_types  bool
-	cur_struct            string   // receiver type name of the current method, for `@STRUCT`
-	cur_method_is_static  bool     // distinguishes `Type.method()` from `(x Type) method()` for `@LOCATION`
-	defer_depth           int      // >0 while parsing a `defer` block body; gates `$res()` to defer contexts only
-	defer_result_allowed  bool     // true when the active defer is guaranteed to run during function return
-	nested_block_depth    int      // lexical block depth below the current function body's outer scope
+	cur_struct            string // receiver type name of the current method, for `@STRUCT`
+	cur_method_is_static  bool // distinguishes `Type.method()` from `(x Type) method()` for `@LOCATION`
+	defer_depth           int // >0 while parsing a `defer` block body; gates `$res()` to defer contexts only
+	defer_result_allowed  bool // true when the active defer is guaranteed to run during function return
+	nested_block_depth    int // lexical block depth below the current function body's outer scope
 	comptime_for_vars     []string // active `$for` loop variables; a `$if` that reads one is deferred to unroll time
-	comptime_method_var   string   // innermost active `$for method in Type.methods` loop variable
+	comptime_method_var   string // innermost active `$for method in Type.methods` loop variable
 	comptime_const_values map[string]string
 	comptime_local_values map[string]string
 	imported_module_names map[string]bool // import aliases in the current file; not captured by inlined template closures
@@ -162,37 +162,37 @@ struct ParsedFieldAttrs {
 // new creates a Parser value for parser.
 pub fn Parser.new(prefs &pref.Preferences) &Parser {
 	return &Parser{
-		prefs:                         unsafe { prefs }
-		s:                             scanner.new_scanner(prefs, .normal)
-		local_type_names:              map[string]string{}
-		anonymous_struct_types:        map[string][]string{}
-		comptime_const_values:         map[string]string{}
-		comptime_local_values:         map[string]string{}
-		imported_module_names:         map[string]bool{}
-		local_binding_counts:          map[string]int{}
+		prefs: unsafe { prefs }
+		s: scanner.new_scanner(prefs, .normal)
+		local_type_names: map[string]string{}
+		anonymous_struct_types: map[string][]string{}
+		comptime_const_values: map[string]string{}
+		comptime_local_values: map[string]string{}
+		imported_module_names: map[string]bool{}
+		local_binding_counts: map[string]int{}
 		unsupported_inline_asm_guards: map[int]bool{}
-		sql_query_data_aliases:        map[string]bool{}
-		a:                             &flat.FlatAst{
-			nodes:                    []flat.Node{cap: 256}
-			children:                 []flat.NodeId{cap: 512}
-			disabled_fns:             map[string]bool{}
-			export_fn_names:          map[string]string{}
-			source_files:             map[int]&token.File{}
-			template_call_sites:      map[int]token.Pos{}
-			template_actions:         map[int]string{}
-			missing_imports:          map[int]string{}
-			formatter_sources:        map[int]string{}
-			formatter_file_sources:   map[int]string{}
-			formatter_node_ends:      map[int]int{}
+		sql_query_data_aliases: map[string]bool{}
+		a: &flat.FlatAst{
+			nodes: []flat.Node{cap: 256}
+			children: []flat.NodeId{cap: 512}
+			disabled_fns: map[string]bool{}
+			export_fn_names: map[string]string{}
+			source_files: map[int]&token.File{}
+			template_call_sites: map[int]token.Pos{}
+			template_actions: map[int]string{}
+			missing_imports: map[int]string{}
+			formatter_sources: map[int]string{}
+			formatter_file_sources: map[int]string{}
+			formatter_node_ends: map[int]int{}
 			formatter_expanded_calls: map[int]bool{}
 			formatter_assignment_ops: map[int]string{}
 			formatter_param_list_end: map[int]int{}
-			formatter_for_in_mut:     map[int]u8{}
-			formatter_local_sels:     map[int]bool{}
-			text_ids:                 map[string]flat.TextId{}
-			specialized_fn_nodes:     map[int]bool{}
-			specialized_fn_modules:   map[int]string{}
-			specialized_fn_files:     map[int]string{}
+			formatter_for_in_mut: map[int]u8{}
+			formatter_local_sels: map[int]bool{}
+			text_ids: map[string]flat.TextId{}
+			specialized_fn_nodes: map[int]bool{}
+			specialized_fn_modules: map[int]string{}
+			specialized_fn_files: map[int]string{}
 		}
 	}
 }
@@ -295,7 +295,7 @@ pub fn (mut p Parser) parse_into(path string) {
 	p.sql_query_data_aliases.clear()
 	// File marker before content so import resolver can track source files
 	marker_id := p.add_node(flat.Node{
-		kind:  .file
+		kind: .file
 		value: path
 	})
 	p.a.file_node_ids << int(marker_id)
@@ -348,12 +348,11 @@ pub fn (mut p Parser) parse_into(path string) {
 			}
 			if p.tok == .name && module_end <= p.tok_pos
 				&& p.s.src[module_end..p.tok_pos].contains('\n') {
-				p.record_diagnostic_span('`module` and `${p.lit}` must be at same line', p.tok_pos,
-					p.tok_end)
+				p.record_diagnostic_span('`module` and `${p.lit}` must be at same line', p.tok_pos, p.tok_end)
 			}
 			p.cur_module = p.lit
 			mod_id := p.add_node(flat.Node{
-				kind:  .module_decl
+				kind: .module_decl
 				value: p.lit
 			})
 			ids << mod_id
@@ -374,11 +373,11 @@ pub fn (mut p Parser) parse_into(path string) {
 	}
 	start := p.add_children(ids)
 	trailing_id := p.add_node(flat.Node{
-		kind:           .file
-		value:          path
+		kind: .file
+		value: path
 		children_start: start
 		children_count: flat.child_count(ids.len)
-		pos:            token.new_span(p.cur_file_id, 0, stable_src.len)
+		pos: token.new_span(p.cur_file_id, 0, stable_src.len)
 	})
 	p.a.file_node_ids << int(trailing_id)
 	if p.prefs.is_fmt {
@@ -397,7 +396,7 @@ fn (mut p Parser) collect_formatter_comments(file &token.File, source string) {
 		if tok == .comment {
 			p.a.comments << flat.Comment{
 				text: s.lit.replace('\r\n', '\n').trim_right('\r')
-				pos:  token.new_span(p.cur_file_id, s.pos, s.offset)
+				pos: token.new_span(p.cur_file_id, s.pos, s.offset)
 			}
 		}
 		if tok == .eof {
@@ -447,14 +446,14 @@ fn (mut p Parser) add_id(kind_id int) flat.NodeId {
 
 fn (mut p Parser) add_val(kind flat.NodeKind, value string) flat.NodeId {
 	return p.add_node(flat.Node{
-		kind:  kind
+		kind: kind
 		value: value
 	})
 }
 
 fn (mut p Parser) add_val_id(kind_id int, value string) flat.NodeId {
 	return p.add_node(flat.Node{
-		kind:  flat.node_kind_from_id(kind_id)
+		kind: flat.node_kind_from_id(kind_id)
 		value: value
 	})
 }
@@ -477,9 +476,9 @@ fn (p &Parser) span_to(start int) token.Pos {
 // add_val_id_at builds a leaf value node with an explicit, already-captured span.
 fn (mut p Parser) add_val_id_at(kind_id int, value string, pos token.Pos) flat.NodeId {
 	return p.a.add_node(flat.Node{
-		kind:  flat.node_kind_from_id(kind_id)
+		kind: flat.node_kind_from_id(kind_id)
 		value: value
-		pos:   pos
+		pos: pos
 	})
 }
 
@@ -487,7 +486,7 @@ fn (mut p Parser) add_val_id_at(kind_id int, value string, pos token.Pos) flat.N
 fn (mut p Parser) add_id_at(kind_id int, pos token.Pos) flat.NodeId {
 	return p.a.add_node(flat.Node{
 		kind: flat.node_kind_from_id(kind_id)
-		pos:  pos
+		pos: pos
 	})
 }
 
@@ -525,10 +524,10 @@ fn (mut p Parser) record_diagnostic(message string, offset int) {
 		line, column = p.s.current_file().find_line_and_column(clamped_offset)
 	}
 	p.append_diagnostic(Diagnostic{
-		file:    p.cur_file
-		pos:     token.new_pos(p.cur_file_id, clamped_offset)
-		line:    line
-		column:  column
+		file: p.cur_file
+		pos: token.new_pos(p.cur_file_id, clamped_offset)
+		line: line
+		column: column
 		message: message
 	})
 }
@@ -542,10 +541,10 @@ fn (mut p Parser) record_diagnostic_span(message string, start int, end int) {
 		line, column = p.s.current_file().find_line_and_column(clamped_start)
 	}
 	p.append_diagnostic(Diagnostic{
-		file:    p.cur_file
-		pos:     token.new_span(p.cur_file_id, clamped_start, clamped_end)
-		line:    line
-		column:  column
+		file: p.cur_file
+		pos: token.new_span(p.cur_file_id, clamped_start, clamped_end)
+		line: line
+		column: column
 		message: message
 	})
 }
@@ -559,12 +558,12 @@ fn (mut p Parser) record_warning_span(message string, start int, end int) {
 		line, column = p.s.current_file().find_line_and_column(clamped_start)
 	}
 	p.append_diagnostic(Diagnostic{
-		file:     p.cur_file
-		pos:      token.new_span(p.cur_file_id, clamped_start, clamped_end)
-		line:     line
-		column:   column
+		file: p.cur_file
+		pos: token.new_span(p.cur_file_id, clamped_start, clamped_end)
+		line: line
+		column: column
 		severity: 'warning:'
-		message:  message
+		message: message
 	})
 }
 
@@ -574,10 +573,10 @@ fn (mut p Parser) append_diagnostic(diagnostic Diagnostic) {
 	}
 	if p.diagnostics.len >= max_parse_diagnostics {
 		p.diagnostics << Diagnostic{
-			file:    diagnostic.file
-			pos:     diagnostic.pos
-			line:    diagnostic.line
-			column:  diagnostic.column
+			file: diagnostic.file
+			pos: diagnostic.pos
+			line: diagnostic.line
+			column: diagnostic.column
 			message: 'too many errors; stopping after ${max_parse_diagnostics} diagnostics'
 		}
 		p.diagnostic_limit_reached = true
@@ -593,8 +592,8 @@ fn (mut p Parser) collect_scanner_diagnostics() {
 			&& scanner_diagnostic_starts_assignment(p.s.src, diagnostic.end) {
 			malformed_declarations << MalformedScannerDeclaration{
 				message: diagnostic.message
-				offset:  diagnostic.offset
-				scope:   p.scanner_diagnostic_lexical_scope(diagnostic.offset, diagnostic.end)
+				offset: diagnostic.offset
+				scope: p.scanner_diagnostic_lexical_scope(diagnostic.offset, diagnostic.end)
 			}
 		}
 	}
@@ -1028,9 +1027,9 @@ fn (mut p Parser) apply_decl_attrs(id flat.NodeId) {
 		return
 	}
 	attr_id := p.add_node(flat.Node{
-		kind:    .directive
-		value:   '@attributes:${int(id)}'
-		typ:     p.pending_decl_attr_kinds.map(it.str()).join(',')
+		kind: .directive
+		value: '@attributes:${int(id)}'
+		typ: p.pending_decl_attr_kinds.map(it.str()).join(',')
 		payload: flat.node_payload(p.pending_decl_attrs.clone())
 	})
 	if p.prefs.is_fmt && p.pending_decl_attr_sources.len > 0 {
@@ -1140,15 +1139,13 @@ fn (mut p Parser) fn_decl() flat.NodeId {
 					p.next()
 					op_name = '[]='
 				}
-				return p.fn_operator_overload(receiver_name, receiver_type, receiver_is_mut,
-					op_name, name_pos)
+				return p.fn_operator_overload(receiver_name, receiver_type, receiver_is_mut, op_name, name_pos)
 			}
 			if p.tok.is_overloadable() {
 				name_pos = p.tok_pos
 				op_name := overload_token_name(p.tok)
 				p.next()
-				return p.fn_operator_overload(receiver_name, receiver_type, receiver_is_mut,
-					op_name, name_pos)
+				return p.fn_operator_overload(receiver_name, receiver_type, receiver_is_mut, op_name, name_pos)
 			}
 			if p.tok == .lsbr && p.peek() == .rsbr {
 				name_pos = p.tok_pos
@@ -1156,11 +1153,9 @@ fn (mut p Parser) fn_decl() flat.NodeId {
 				p.next()
 				if p.tok == .assign {
 					p.next()
-					return p.fn_operator_overload(receiver_name, receiver_type, receiver_is_mut,
-						'[]=', name_pos)
+					return p.fn_operator_overload(receiver_name, receiver_type, receiver_is_mut, '[]=', name_pos)
 				}
-				return p.fn_operator_overload(receiver_name, receiver_type, receiver_is_mut, '[]',
-					name_pos)
+				return p.fn_operator_overload(receiver_name, receiver_type, receiver_is_mut, '[]', name_pos)
 			}
 		}
 	}
@@ -1184,8 +1179,7 @@ fn (mut p Parser) fn_decl() flat.NodeId {
 					clean_type := method_receiver_type_name(receiver_type)
 					name = '${clean_type}.${name}'
 				}
-				return p.fn_decl_body(name, receiver_name, receiver_type, receiver_is_mut,
-					is_method, interop_prefix, name_pos)
+				return p.fn_decl_body(name, receiver_name, receiver_type, receiver_is_mut, is_method, interop_prefix, name_pos)
 			}
 			// module.func or Type.static_method
 			name_pos = p.tok_pos
@@ -1207,8 +1201,7 @@ fn (mut p Parser) fn_decl() flat.NodeId {
 		name = '${clean_type}.${name}'
 	}
 
-	return p.fn_decl_body(name, receiver_name, receiver_type, receiver_is_mut, is_method, '',
-		name_pos)
+	return p.fn_decl_body(name, receiver_name, receiver_type, receiver_is_mut, is_method, '', name_pos)
 }
 
 fn (mut p Parser) fn_operator_overload(receiver_name string, receiver_type string, receiver_is_mut bool, op_name string, name_pos int) flat.NodeId {
@@ -1221,11 +1214,11 @@ fn (mut p Parser) fn_operator_overload(receiver_name string, receiver_type strin
 	mut param_ids := []flat.NodeId{}
 	// receiver
 	param_ids << p.add_node(flat.Node{
-		kind:   .param
-		value:  receiver_name
-		typ:    receiver_type
+		kind: .param
+		value: receiver_name
+		typ: receiver_type
 		is_mut: receiver_is_mut
-		op:     .dot // receiver marker; ordinary declared parameters use `.none`
+		op: .dot // receiver marker; ordinary declared parameters use `.none`
 	})
 	// operator param
 	for p.tok != .rpar && p.tok != .eof {
@@ -1250,8 +1243,7 @@ fn (mut p Parser) fn_operator_overload(receiver_name string, receiver_type strin
 			ret_type += '?'
 			p.next()
 		} else if p.tok == .not {
-			p.record_diagnostic_span('wrong syntax, it must be !${ret_type}, not ${ret_type}!',
-				ret_type_start, p.tok_pos)
+			p.record_diagnostic_span('wrong syntax, it must be !${ret_type}, not ${ret_type}!', ret_type_start, p.tok_pos)
 			p.next()
 		}
 	}
@@ -1329,11 +1321,11 @@ fn (mut p Parser) fn_operator_overload(receiver_name string, receiver_type strin
 	}
 	start := p.add_children(all_ids)
 	id := p.add_node(flat.Node{
-		kind:           .fn_decl
-		op:             if is_pub { .arrow } else { .none }
-		value:          name
-		typ:            ret_type
-		pos:            token.new_pos(p.cur_file_id, name_pos)
+		kind: .fn_decl
+		op: if is_pub { .arrow } else { .none }
+		value: name
+		typ: ret_type
+		pos: token.new_pos(p.cur_file_id, name_pos)
 		children_start: start
 		children_count: flat.child_count(all_ids.len)
 	})
@@ -1361,11 +1353,11 @@ fn (mut p Parser) fn_decl_body(name string, receiver_name string, receiver_type 
 	mut param_ids := []flat.NodeId{}
 	if is_method && receiver_name.len > 0 {
 		param_ids << p.add_node(flat.Node{
-			kind:   .param
-			value:  receiver_name
-			typ:    receiver_type
+			kind: .param
+			value: receiver_name
+			typ: receiver_type
 			is_mut: receiver_is_mut
-			op:     .dot // receiver marker; static methods do not inject this parameter
+			op: .dot // receiver marker; static methods do not inject this parameter
 		})
 	}
 	for p.tok != .rpar && p.tok != .eof {
@@ -1391,8 +1383,7 @@ fn (mut p Parser) fn_decl_body(name string, receiver_name string, receiver_type 
 			ret_type += '?'
 			p.next()
 		} else if p.tok == .not {
-			p.record_diagnostic_span('wrong syntax, it must be !${ret_type}, not ${ret_type}!',
-				ret_type_start, p.tok_pos)
+			p.record_diagnostic_span('wrong syntax, it must be !${ret_type}, not ${ret_type}!', ret_type_start, p.tok_pos)
 			p.next()
 		}
 	}
@@ -1412,16 +1403,16 @@ fn (mut p Parser) fn_decl_body(name string, receiver_name string, receiver_type 
 			p.mark_disabled_fn(name)
 		}
 		id := p.add_node(flat.Node{
-			kind:           if is_v_header_decl { .fn_decl } else { .c_fn_decl }
-			op:             if is_pub { .arrow } else { .none }
-			value:          if p.prefs.is_fmt {
+			kind: if is_v_header_decl { .fn_decl } else { .c_fn_decl }
+			op: if is_pub { .arrow } else { .none }
+			value: if p.prefs.is_fmt {
 				if interop_prefix.len > 0 { '${interop_prefix}:${name}' } else { 'V:${name}' }
 			} else {
 				name
 			}
-			typ:            ret_type
-			pos:            token.new_pos(p.cur_file_id, name_pos)
-			payload:        flat.node_payload(generic_params)
+			typ: ret_type
+			pos: token.new_pos(p.cur_file_id, name_pos)
+			payload: flat.node_payload(generic_params)
 			children_start: start
 			children_count: flat.child_count(param_ids.len)
 			// Function nodes do not otherwise use is_mut. On a .vh declaration it
@@ -1510,12 +1501,12 @@ fn (mut p Parser) fn_decl_body(name string, receiver_name string, receiver_type 
 	}
 	start := p.add_children(all_ids)
 	id := p.add_node(flat.Node{
-		kind:           .fn_decl
-		op:             if is_pub { .arrow } else { .none }
-		value:          name
-		typ:            ret_type
-		pos:            token.new_pos(p.cur_file_id, name_pos)
-		payload:        flat.node_payload(generic_params)
+		kind: .fn_decl
+		op: if is_pub { .arrow } else { .none }
+		value: name
+		typ: ret_type
+		pos: token.new_pos(p.cur_file_id, name_pos)
+		payload: flat.node_payload(generic_params)
 		children_start: start
 		children_count: flat.child_count(all_ids.len)
 	})
@@ -1614,7 +1605,7 @@ fn (mut p Parser) register_pending_export(name string) {
 	}
 	p.a.export_fn_names[qname] = p.pending_export
 	p.export_records << ExportRecord{
-		name:  name
+		name: name
 		qname: qname
 		value: p.pending_export
 	}
@@ -1653,11 +1644,11 @@ fn (mut p Parser) parse_param_group(is_c_decl bool) []flat.NodeId {
 	if p.tok == .ellipsis {
 		typ := p.parse_type_name()
 		id := p.add_node(flat.Node{
-			kind:   .param
-			value:  ''
-			typ:    typ
+			kind: .param
+			value: ''
+			typ: typ
 			is_mut: is_mut
-			pos:    if p.prefs.is_fmt { param_start } else { token.Pos{} }
+			pos: if p.prefs.is_fmt { param_start } else { token.Pos{} }
 		})
 		ids << id
 		p.record_formatter_param_end(id, p.prev_tok_end)
@@ -1678,11 +1669,11 @@ fn (mut p Parser) parse_param_group(is_c_decl bool) []flat.NodeId {
 			typ = 'atomic ' + typ
 		}
 		id := p.add_node(flat.Node{
-			kind:   .param
-			value:  ''
-			typ:    typ
+			kind: .param
+			value: ''
+			typ: typ
 			is_mut: is_mut
-			pos:    if p.prefs.is_fmt { param_start } else { token.Pos{} }
+			pos: if p.prefs.is_fmt { param_start } else { token.Pos{} }
 		})
 		ids << id
 		p.record_formatter_param_end(id, p.prev_tok_end)
@@ -1717,12 +1708,12 @@ fn (mut p Parser) parse_param_group(is_c_decl bool) []flat.NodeId {
 	}
 	for i, name in names {
 		id := p.add_node(flat.Node{
-			kind:   .param
-			op:     if explicit_mut_ref { .amp } else { .none }
-			value:  name
-			typ:    typ
+			kind: .param
+			op: if explicit_mut_ref { .amp } else { .none }
+			value: name
+			typ: typ
 			is_mut: is_mut
-			pos:    name_positions[i]
+			pos: name_positions[i]
 		})
 		ids << id
 		param_end := if i < names.len - 1 { name_positions[i].end } else { param_group_end }
@@ -1818,13 +1809,12 @@ fn (mut p Parser) struct_decl() flat.NodeId {
 			p.next()
 		}
 		return p.add_node(flat.Node{
-			kind:    .struct_decl
-			op:      if is_pub { .arrow } else { .none }
-			value:   name
-			typ:     struct_decl_typ(is_union, is_generic, is_params, is_typedef, is_soa,
-				is_aligned, aligned, implements_types)
+			kind: .struct_decl
+			op: if is_pub { .arrow } else { .none }
+			value: name
+			typ: struct_decl_typ(is_union, is_generic, is_params, is_typedef, is_soa, is_aligned, aligned, implements_types)
 			payload: flat.node_payload(generic_params)
-			pos:     p.span_to(struct_start)
+			pos: p.span_to(struct_start)
 		})
 	}
 	p.check(.lcbr)
@@ -1934,13 +1924,12 @@ fn (mut p Parser) struct_decl() flat.NodeId {
 				full_type := '${field_name}.${second}'
 				field_type := full_type + p.parse_type_generic_suffix()
 				fid := p.add_node(flat.Node{
-					kind:  .field_decl
+					kind: .field_decl
 					value: field_type
-					typ:   field_type
-					pos:   p.span_to(field_start)
+					typ: field_type
+					pos: p.span_to(field_start)
 				})
-				p.apply_field_meta(fid, sect_is_mut, sect_is_pub, sect_is_global, pending_attrs,
-					true)
+				p.apply_field_meta(fid, sect_is_mut, sect_is_pub, sect_is_global, pending_attrs, true)
 				pending_attrs = []string{}
 				ids << fid
 				if p.tok == .semicolon {
@@ -1961,13 +1950,12 @@ fn (mut p Parser) struct_decl() flat.NodeId {
 				if suffix.len > 0 && (p.tok == .semicolon || p.tok == .rcbr) {
 					embedded_type := p.resolve_local_type_name(field_name + suffix)
 					fid := p.a.add_node(flat.Node{
-						kind:  .field_decl
+						kind: .field_decl
 						value: embedded_type
-						typ:   embedded_type
-						pos:   p.span_to(field_start)
+						typ: embedded_type
+						pos: p.span_to(field_start)
 					})
-					p.apply_field_meta(fid, sect_is_mut, sect_is_pub, sect_is_global, pending_attrs,
-						true)
+					p.apply_field_meta(fid, sect_is_mut, sect_is_pub, sect_is_global, pending_attrs, true)
 					pending_attrs = []string{}
 					ids << fid
 					if p.tok == .semicolon {
@@ -1988,13 +1976,12 @@ fn (mut p Parser) struct_decl() flat.NodeId {
 			if p.tok == .semicolon || p.tok == .rcbr {
 				embedded_type := p.resolve_local_type_name(field_name)
 				fid := p.add_node(flat.Node{
-					kind:  .field_decl
+					kind: .field_decl
 					value: embedded_type
-					typ:   embedded_type
-					pos:   p.span_to(field_start)
+					typ: embedded_type
+					pos: p.span_to(field_start)
 				})
-				p.apply_field_meta(fid, sect_is_mut, sect_is_pub, sect_is_global, pending_attrs,
-					true)
+				p.apply_field_meta(fid, sect_is_mut, sect_is_pub, sect_is_global, pending_attrs, true)
 				pending_attrs = []string{}
 				ids << fid
 				if p.tok == .semicolon {
@@ -2018,13 +2005,12 @@ fn (mut p Parser) struct_decl() flat.NodeId {
 				}
 				for n in names {
 					fid := p.add_node(flat.Node{
-						kind:  .field_decl
+						kind: .field_decl
 						value: n
-						typ:   field_type
-						pos:   p.span_to(field_start)
+						typ: field_type
+						pos: p.span_to(field_start)
 					})
-					p.apply_field_meta(fid, sect_is_mut, sect_is_pub, sect_is_global, group_attrs,
-						false)
+					p.apply_field_meta(fid, sect_is_mut, sect_is_pub, sect_is_global, group_attrs, false)
 					ids << fid
 				}
 				if p.tok == .semicolon {
@@ -2054,12 +2040,12 @@ fn (mut p Parser) struct_decl() flat.NodeId {
 				fattrs << p.parse_field_attrs()
 			}
 			fid := p.add_node(flat.Node{
-				kind:           .field_decl
-				value:          field_name
-				typ:            field_type
+				kind: .field_decl
+				value: field_name
+				typ: field_type
 				children_start: children_start
 				children_count: flat.child_count(children_count)
-				pos:            p.span_to(field_start)
+				pos: p.span_to(field_start)
 			})
 			p.apply_field_meta(fid, sect_is_mut, sect_is_pub, sect_is_global, fattrs, false)
 			ids << fid
@@ -2074,13 +2060,12 @@ fn (mut p Parser) struct_decl() flat.NodeId {
 	p.pending_params = false
 	start := p.add_children(ids)
 	return p.add_node(flat.Node{
-		kind:           .struct_decl
-		op:             if is_pub { .arrow } else { .none }
-		value:          name
-		typ:            struct_decl_typ(is_union, is_generic, is_params, is_typedef, is_soa,
-			is_aligned, aligned, implements_types)
-		payload:        flat.node_payload(generic_params)
-		pos:            p.span_to(struct_start)
+		kind: .struct_decl
+		op: if is_pub { .arrow } else { .none }
+		value: name
+		typ: struct_decl_typ(is_union, is_generic, is_params, is_typedef, is_soa, is_aligned, aligned, implements_types)
+		payload: flat.node_payload(generic_params)
+		pos: p.span_to(struct_start)
 		children_start: start
 		children_count: flat.child_count(ids.len)
 	})
@@ -2177,23 +2162,23 @@ fn (mut p Parser) global_decl() flat.NodeId {
 			if int(val_id) >= 0 {
 				vstart := p.add_child(val_id)
 				ids << p.add_node(flat.Node{
-					kind:           .field_decl
-					value:          full_name
-					typ:            gtype
-					op:             if field_is_pub { .arrow } else { .none }
-					payload:        flat.node_payload(if is_const { ['const'] } else { []string{} })
+					kind: .field_decl
+					value: full_name
+					typ: gtype
+					op: if field_is_pub { .arrow } else { .none }
+					payload: flat.node_payload(if is_const { ['const'] } else { []string{} })
 					children_start: vstart
 					children_count: 1
-					pos:            p.span_to(field_start)
+					pos: p.span_to(field_start)
 				})
 			} else {
 				ids << p.add_node(flat.Node{
-					kind:    .field_decl
-					value:   full_name
-					typ:     gtype
-					op:      if field_is_pub { .arrow } else { .none }
+					kind: .field_decl
+					value: full_name
+					typ: gtype
+					op: if field_is_pub { .arrow } else { .none }
 					payload: flat.node_payload(if is_const { ['const'] } else { []string{} })
-					pos:     p.span_to(field_start)
+					pos: p.span_to(field_start)
 				})
 			}
 			if p.tok == .semicolon {
@@ -2224,12 +2209,12 @@ fn (mut p Parser) global_decl() flat.NodeId {
 	}
 	start := p.add_children(ids)
 	return p.add_node(flat.Node{
-		kind:           .global_decl
-		value:          if p.prefs.is_fmt && !is_grouped { 'ungrouped' } else { '' }
-		op:             if is_pub { .arrow } else { .none }
+		kind: .global_decl
+		value: if p.prefs.is_fmt && !is_grouped { 'ungrouped' } else { '' }
+		op: if is_pub { .arrow } else { .none }
 		children_start: start
 		children_count: flat.child_count(ids.len)
-		pos:            if p.prefs.is_fmt { p.span_to(global_start) } else { header_pos }
+		pos: if p.prefs.is_fmt { p.span_to(global_start) } else { header_pos }
 	})
 }
 
@@ -2275,20 +2260,20 @@ fn (mut p Parser) const_decl() flat.NodeId {
 				}
 				vstart := p.add_child(val_id)
 				ids << p.add_node(flat.Node{
-					kind:           .const_field
-					value:          full_name
+					kind: .const_field
+					value: full_name
 					children_start: vstart
 					children_count: 1
-					pos:            p.span_to(field_start)
+					pos: p.span_to(field_start)
 				})
 			} else {
 				// const with type only (header files)
 				ctype := p.parse_type_name()
 				ids << p.add_node(flat.Node{
-					kind:  .const_field
+					kind: .const_field
 					value: full_name
-					typ:   ctype
-					pos:   p.span_to(field_start)
+					typ: ctype
+					pos: p.span_to(field_start)
 				})
 			}
 			if p.tok == .semicolon {
@@ -2319,11 +2304,11 @@ fn (mut p Parser) const_decl() flat.NodeId {
 	}
 	start := p.add_children(ids)
 	return p.add_node(flat.Node{
-		kind:           .const_decl
-		op:             if is_pub { .arrow } else { .none }
+		kind: .const_decl
+		op: if is_pub { .arrow } else { .none }
 		children_start: start
 		children_count: flat.child_count(ids.len)
-		pos:            p.span_to(const_start)
+		pos: p.span_to(const_start)
 	})
 }
 
@@ -2368,9 +2353,9 @@ fn (mut p Parser) enum_decl() flat.NodeId {
 			attrs << p.parse_field_attrs()
 		}
 		mut field := flat.Node{
-			kind:           .enum_field
-			value:          field_name
-			pos:            field_pos
+			kind: .enum_field
+			value: field_name
+			pos: field_pos
 			children_start: children_start
 			children_count: children_count
 		}
@@ -2391,11 +2376,11 @@ fn (mut p Parser) enum_decl() flat.NodeId {
 		p.pending_flag = false
 	}
 	mut enum_node := flat.Node{
-		kind:           .enum_decl
-		op:             if is_pub { .arrow } else { .none }
-		value:          name
-		typ:            typ
-		pos:            name_pos
+		kind: .enum_decl
+		op: if is_pub { .arrow } else { .none }
+		value: name
+		typ: typ
+		pos: name_pos
 		children_start: start
 		children_count: flat.child_count(ids.len)
 	}
@@ -2442,9 +2427,9 @@ fn (mut p Parser) type_decl() flat.NodeId {
 	if p.tok == .pipe || (p.tok == .semicolon && p.peek_is(token.Token.pipe)) {
 		mut variants := []flat.NodeId{}
 		variants << p.add_node(flat.Node{
-			kind:  .ident
+			kind: .ident
 			value: first_type
-			pos:   p.span_to(type_start)
+			pos: p.span_to(type_start)
 		})
 		for p.tok == .pipe || (p.tok == .semicolon && p.peek_is(token.Token.pipe)) {
 			if p.tok == .semicolon {
@@ -2454,9 +2439,9 @@ fn (mut p Parser) type_decl() flat.NodeId {
 			variant_start := p.span_start()
 			variant_type := p.parse_type_name()
 			variants << p.add_node(flat.Node{
-				kind:  .ident
+				kind: .ident
 				value: variant_type
-				pos:   p.span_to(variant_start)
+				pos: p.span_to(variant_start)
 			})
 		}
 		if p.tok == .semicolon {
@@ -2464,13 +2449,13 @@ fn (mut p Parser) type_decl() flat.NodeId {
 		}
 		start := p.add_children(variants)
 		return p.add_node(flat.Node{
-			kind:           .type_decl
-			op:             if is_pub { .arrow } else { .none }
-			value:          name
-			payload:        flat.node_payload(generic_params)
+			kind: .type_decl
+			op: if is_pub { .arrow } else { .none }
+			value: name
+			payload: flat.node_payload(generic_params)
 			children_start: start
 			children_count: flat.child_count(variants.len)
-			pos:            p.span_to(type_start)
+			pos: p.span_to(type_start)
 		})
 	}
 	if p.tok == .semicolon {
@@ -2478,12 +2463,12 @@ fn (mut p Parser) type_decl() flat.NodeId {
 	}
 	// type alias
 	return p.add_node(flat.Node{
-		kind:    .type_decl
-		op:      if is_pub { .arrow } else { .none }
-		value:   name
-		typ:     first_type
+		kind: .type_decl
+		op: if is_pub { .arrow } else { .none }
+		value: name
+		typ: first_type
 		payload: flat.node_payload(generic_params)
-		pos:     p.span_to(type_start)
+		pos: p.span_to(type_start)
 	})
 }
 
@@ -2592,12 +2577,12 @@ fn (mut p Parser) interface_decl() flat.NodeId {
 					param_pos = param_start_pos
 				}
 				param_id := p.add_node(flat.Node{
-					kind:   .param
-					value:  param_name
-					typ:    ptype
-					op:     if explicit_mut_ref { .amp } else { .none }
+					kind: .param
+					value: param_name
+					typ: ptype
+					op: if explicit_mut_ref { .amp } else { .none }
 					is_mut: param_is_mut
-					pos:    param_pos
+					pos: param_pos
 				})
 				params << param_id
 				p.record_formatter_param_end(param_id, param_end)
@@ -2616,35 +2601,35 @@ fn (mut p Parser) interface_decl() flat.NodeId {
 			}
 			start := p.add_children(params)
 			method_id := p.add_node(flat.Node{
-				kind:           .interface_field
-				op:             .dot
-				is_mut:         fields_are_mut
-				value:          field_name
-				typ:            ret_type
-				payload:        flat.node_payload(method_generic_params)
+				kind: .interface_field
+				op: .dot
+				is_mut: fields_are_mut
+				value: field_name
+				typ: ret_type
+				payload: flat.node_payload(method_generic_params)
 				children_start: start
 				children_count: flat.child_count(params.len)
-				pos:            p.span_to(method_start)
+				pos: p.span_to(method_start)
 			})
 			ids << method_id
 			p.record_formatter_param_list_end(method_id, param_list_end)
 		} else if p.tok == .semicolon || p.tok == .rcbr {
 			// embedded type or field without explicit type
 			ids << p.add_node(flat.Node{
-				kind:   .interface_field
+				kind: .interface_field
 				is_mut: fields_are_mut
-				value:  field_name
-				pos:    p.span_to(method_start)
+				value: field_name
+				pos: p.span_to(method_start)
 			})
 		} else {
 			// field: name type
 			ftype := p.parse_type_name()
 			ids << p.add_node(flat.Node{
-				kind:   .interface_field
+				kind: .interface_field
 				is_mut: fields_are_mut
-				value:  field_name
-				typ:    ftype
-				pos:    p.span_to(method_start)
+				value: field_name
+				typ: ftype
+				pos: p.span_to(method_start)
 			})
 		}
 		if p.tok == .semicolon {
@@ -2654,13 +2639,13 @@ fn (mut p Parser) interface_decl() flat.NodeId {
 	p.check(.rcbr)
 	start := p.add_children(ids)
 	return p.add_node(flat.Node{
-		kind:           .interface_decl
-		op:             if is_pub { .arrow } else { .none }
-		value:          name
-		payload:        flat.node_payload(generic_params)
+		kind: .interface_decl
+		op: if is_pub { .arrow } else { .none }
+		value: name
+		payload: flat.node_payload(generic_params)
 		children_start: start
 		children_count: flat.child_count(ids.len)
-		pos:            p.span_to(interface_start)
+		pos: p.span_to(interface_start)
 	})
 }
 
@@ -2697,9 +2682,9 @@ fn (mut p Parser) import_stmt() flat.NodeId {
 			sym_pos := p.current_pos()
 			sym := p.expect_name_or_keyword()
 			selective_ids << p.add_node(flat.Node{
-				kind:  .ident
+				kind: .ident
 				value: sym
-				pos:   sym_pos
+				pos: sym_pos
 			})
 			if p.tok == .comma {
 				p.next()
@@ -2712,16 +2697,15 @@ fn (mut p Parser) import_stmt() flat.NodeId {
 	}
 	import_pos := p.span_to(import_start)
 	if !p.prefs.is_fmt && !p.cur_file.ends_with('.vh') && alias.len > 1 && alias[0] == `_` {
-		p.record_diagnostic_span('module alias `${alias}` cannot start with `_`',
-			import_pos.offset, import_pos.end)
+		p.record_diagnostic_span('module alias `${alias}` cannot start with `_`', import_pos.offset, import_pos.end)
 	}
 	return p.add_node(flat.Node{
-		kind:           .import_decl
-		value:          name
-		typ:            alias
+		kind: .import_decl
+		value: name
+		typ: alias
 		children_start: p.add_children(selective_ids)
 		children_count: flat.child_count(selective_ids.len)
-		pos:            import_pos
+		pos: import_pos
 	})
 }
 
@@ -2734,9 +2718,9 @@ fn (mut p Parser) module_stmt() flat.NodeId {
 		p.next()
 	}
 	return p.add_node(flat.Node{
-		kind:  .module_decl
+		kind: .module_decl
 		value: name
-		pos:   p.span_to(module_start)
+		pos: p.span_to(module_start)
 	})
 }
 
@@ -2759,10 +2743,10 @@ fn (mut p Parser) directive() flat.NodeId {
 		p.next()
 	}
 	return p.a.add_node(flat.Node{
-		kind:  .directive
+		kind: .directive
 		value: name
-		typ:   value
-		pos:   token.new_span(p.cur_file_id, directive_start, directive_end)
+		typ: value
+		pos: token.new_span(p.cur_file_id, directive_start, directive_end)
 	})
 }
 
@@ -2945,8 +2929,7 @@ fn (mut p Parser) parse_field_attrs_with_kinds() ParsedFieldAttrs {
 	for p.tok == .attribute || p.tok == .lsbr {
 		group_start := p.span_start()
 		if groups > 0 {
-			p.record_diagnostic_span('multiple attributes should be in the same @[], with ; separators', int_max(0,
-				p.tok_pos - 1), p.tok_pos + 1)
+			p.record_diagnostic_span('multiple attributes should be in the same @[], with ; separators', int_max(0, p.tok_pos - 1), p.tok_pos + 1)
 		}
 		groups++
 		p.next() // consume `@[` / `[`
@@ -3035,8 +3018,8 @@ fn (mut p Parser) parse_field_attrs_with_kinds() ParsedFieldAttrs {
 		}
 	}
 	return ParsedFieldAttrs{
-		attrs:   attrs
-		kinds:   kinds
+		attrs: attrs
+		kinds: kinds
 		sources: sources
 	}
 }
@@ -3112,7 +3095,7 @@ fn (mut p Parser) parse_comptime_if() flat.NodeId {
 			if p.prefs.is_fmt {
 				expr := p.parse_formatter_comptime_match(dollar_start)
 				return p.add_node_from(flat.Node{
-					kind:           .expr_stmt
+					kind: .expr_stmt
 					children_start: p.add_child(expr)
 					children_count: 1
 				}, expr)
@@ -3128,7 +3111,7 @@ fn (mut p Parser) parse_comptime_if() flat.NodeId {
 		if p.prefs.is_fmt && p.formatter_comptime_call_starts() {
 			call := p.parse_formatter_comptime_call(dollar_start)
 			return p.add_node_from(flat.Node{
-				kind:           .expr_stmt
+				kind: .expr_stmt
 				children_start: p.add_child(call)
 				children_count: 1
 			}, call)
@@ -3279,7 +3262,7 @@ fn (p &Parser) known_bare_comptime_flag(name string) bool {
 fn (mut p Parser) parse_compile_error_stmt(directive_start int) flat.NodeId {
 	call := p.parse_compile_error_call(directive_start)
 	return p.add_node_from(flat.Node{
-		kind:           .expr_stmt
+		kind: .expr_stmt
 		children_start: p.add_child(call)
 		children_count: 1
 	}, call)
@@ -3292,7 +3275,7 @@ fn (mut p Parser) parse_compile_error_call(directive_start int) flat.NodeId {
 fn (mut p Parser) parse_compile_warn_stmt(directive_start int) flat.NodeId {
 	call := p.parse_compile_message_call(directive_start, '__v_compile_warn')
 	return p.add_node_from(flat.Node{
-		kind:           .expr_stmt
+		kind: .expr_stmt
 		children_start: p.add_child(call)
 		children_count: 1
 	}, call)
@@ -3338,12 +3321,11 @@ fn (mut p Parser) make_compile_message_call(message flat.NodeId, start int, end 
 	callee := p.a.add_val(.ident, name)
 	cstart := p.add_children2(callee, message)
 	return p.a.add_node(flat.Node{
-		kind:           .call
-		value:          sentinel
+		kind: .call
+		value: sentinel
 		children_start: cstart
 		children_count: 2
-		pos:            token.new_span(p.cur_file_id, clamp_source_offset(start, p.s.src.len), clamp_source_offset(end,
-			p.s.src.len))
+		pos: token.new_span(p.cur_file_id, clamp_source_offset(start, p.s.src.len), clamp_source_offset(end, p.s.src.len))
 	})
 }
 
@@ -3351,7 +3333,7 @@ fn (mut p Parser) parse_top_level_compile_error(directive_start int) flat.NodeId
 	call := p.parse_compile_error_call(directive_start)
 	if p.prefs.is_fmt {
 		return p.add_node_from(flat.Node{
-			kind:           .expr_stmt
+			kind: .expr_stmt
 			children_start: p.add_child(call)
 			children_count: 1
 		}, call)
@@ -3361,15 +3343,15 @@ fn (mut p Parser) parse_top_level_compile_error(directive_start int) flat.NodeId
 
 fn (mut p Parser) make_top_level_compile_error(call flat.NodeId) flat.NodeId {
 	stmt := p.add_node_from(flat.Node{
-		kind:           .expr_stmt
+		kind: .expr_stmt
 		children_start: p.add_child(call)
 		children_count: 1
 	}, call)
 	start := p.add_child(stmt)
 	return p.a.add_node(flat.Node{
-		kind:           .fn_decl
-		value:          '__v_top_level_compile_error_${p.a.nodes.len}'
-		typ:            'void'
+		kind: .fn_decl
+		value: '__v_top_level_compile_error_${p.a.nodes.len}'
+		typ: 'void'
 		children_start: start
 		children_count: 1
 	})
@@ -3407,12 +3389,12 @@ fn (mut p Parser) parse_comptime_for(dollar_start int) flat.NodeId {
 	p.comptime_for_vars.pop()
 	start := p.add_children([body])
 	return p.add_node(flat.Node{
-		kind:           .comptime_for
-		value:          '${val_var}|${kind}'
-		typ:            base
+		kind: .comptime_for
+		value: '${val_var}|${kind}'
+		typ: base
 		children_start: start
 		children_count: 1
-		pos:            p.span_to(dollar_start)
+		pos: p.span_to(dollar_start)
 	})
 }
 
@@ -3421,7 +3403,7 @@ fn (mut p Parser) parse_top_level_comptime_if() flat.NodeId {
 	p.next() // skip $
 	if p.tok != .key_if {
 		if p.tok == .key_fn {
-			p.record_diagnostic_span('unexpected token `$`', dollar_start, dollar_start + 1)
+			p.record_diagnostic_span('unexpected token `\$`', dollar_start, dollar_start + 1)
 			p.skip_top_level_stmt()
 			return flat.empty_node
 		}
@@ -3432,7 +3414,7 @@ fn (mut p Parser) parse_top_level_comptime_if() flat.NodeId {
 			if p.prefs.is_fmt {
 				expr := p.parse_formatter_comptime_match(dollar_start)
 				return p.add_node_from(flat.Node{
-					kind:           .expr_stmt
+					kind: .expr_stmt
 					children_start: p.add_child(expr)
 					children_count: 1
 				}, expr)
@@ -3446,7 +3428,7 @@ fn (mut p Parser) parse_top_level_comptime_if() flat.NodeId {
 			call := p.parse_compile_message_call(dollar_start, '__v_compile_warn')
 			if p.prefs.is_fmt {
 				return p.add_node_from(flat.Node{
-					kind:           .expr_stmt
+					kind: .expr_stmt
 					children_start: p.add_child(call)
 					children_count: 1
 				}, call)
@@ -3520,8 +3502,7 @@ fn (mut p Parser) parse_comptime_match(is_top_level bool, is_expr bool) flat.Nod
 		}
 	}
 	if subject.starts_with('@') {
-		return p.parse_known_comptime_match_value(p.resolve_comptime_at_values(subject),
-			is_top_level, is_expr)
+		return p.parse_known_comptime_match_value(p.resolve_comptime_at_values(subject), is_top_level, is_expr)
 	}
 	mut branch_patterns := [][]string{}
 	mut blocks := []flat.NodeId{}
@@ -3619,7 +3600,7 @@ fn comptime_match_pattern_kind(pattern string) string {
 fn (mut p Parser) parse_comptime_match_subject() (string, bool) {
 	if p.tok == .dollar {
 		p.next()
-		return '$' + p.expect_name_or_keyword(), false
+		return '\$' + p.expect_name_or_keyword(), false
 	}
 	if p.tok == .name && p.lit.starts_with('@') {
 		name_pos := p.tok_pos
@@ -3714,7 +3695,7 @@ fn (mut p Parser) parse_known_comptime_match_value(value string, is_top_level bo
 fn (mut p Parser) parse_comptime_match_pattern() string {
 	if p.tok == .dollar {
 		p.next()
-		return '$' + p.expect_name_or_keyword()
+		return '\$' + p.expect_name_or_keyword()
 	}
 	if p.tok == .name && p.lit.starts_with('@') {
 		name_pos := p.tok_pos
@@ -3769,8 +3750,8 @@ fn (mut p Parser) comptime_if_node_at(cond string, then_block flat.NodeId, else_
 	}
 	start := p.add_children(ids)
 	node := flat.Node{
-		kind:           .comptime_if
-		value:          cond
+		kind: .comptime_if
+		value: cond
 		children_start: start
 		children_count: flat.child_count(ids.len)
 	}
@@ -3784,7 +3765,7 @@ fn (mut p Parser) top_level_block_stmt() flat.NodeId {
 	ids := p.parse_top_level_block_body()
 	start := p.add_children(ids)
 	return p.add_node(flat.Node{
-		kind:           .block
+		kind: .block
 		children_start: start
 		children_count: flat.child_count(ids.len)
 	})
@@ -3881,15 +3862,12 @@ fn (mut p Parser) resolve_comptime_at_values_at(cond string, pseudo_pos int) str
 					write_comptime_cond_string(mut out, os.real_path(os.dir(p.cur_file)))
 				}
 				'@VMODROOT' {
-					write_comptime_cond_string(mut out,
-						os.real_path(vmod_root_for_file(p.cur_file)))
+					write_comptime_cond_string(mut out, os.real_path(vmod_root_for_file(p.cur_file)))
 				}
 				'@VMOD_FILE' {
 					vmod_file := os.join_path_single(vmod_root_for_file(p.cur_file), 'v.mod')
 					content := os.read_file(vmod_file) or {
-						p.record_diagnostic_span('@VMOD_FILE can only be used in projects that have a v.mod file',
-
-							pseudo_pos + start, pseudo_pos + i)
+						p.record_diagnostic_span('@VMOD_FILE can only be used in projects that have a v.mod file', pseudo_pos + start, pseudo_pos + i)
 						''
 					}
 					write_comptime_cond_string(mut out, content.replace('\r\n', '\n'))
@@ -3897,8 +3875,7 @@ fn (mut p Parser) resolve_comptime_at_values_at(cond string, pseudo_pos int) str
 				'@VMODHASH' {
 					hash := vmod_hash_for_file(p.cur_file) or {
 						message := p.a.add_val_id(5, err.msg())
-						call := p.make_compile_error_call(message, pseudo_pos + start, pseudo_pos +
-							i)
+						call := p.make_compile_error_call(message, pseudo_pos + start, pseudo_pos + i)
 						_ = p.make_top_level_compile_error(call)
 						''
 					}
@@ -3918,8 +3895,7 @@ fn (mut p Parser) resolve_comptime_at_values_at(cond string, pseudo_pos int) str
 					write_comptime_cond_string(mut out, p.column_for_pos(pseudo_pos + start).str())
 				}
 				'@FILE_LINE' {
-					write_comptime_cond_string(mut out,
-						'${os.file_name(p.cur_file)}:${p.line_nr_for_pos(pseudo_pos)}')
+					write_comptime_cond_string(mut out, '${os.file_name(p.cur_file)}:${p.line_nr_for_pos(pseudo_pos)}')
 				}
 				'@METHOD' {
 					write_comptime_cond_string(mut out, method_name)
@@ -3942,8 +3918,7 @@ fn (mut p Parser) resolve_comptime_at_values_at(cond string, pseudo_pos int) str
 							location_method = '${module_name}.${p.cur_struct}{}.${fn_name}'
 						}
 					}
-					write_comptime_cond_string(mut out,
-						'${p.cur_file}:${p.line_nr_for_pos(pseudo_pos)}, ${location_method}')
+					write_comptime_cond_string(mut out, '${p.cur_file}:${p.line_nr_for_pos(pseudo_pos)}, ${location_method}')
 				}
 				'@BUILD_DATE' {
 					write_comptime_cond_string(mut out, p.prefs.build_date)
@@ -4103,7 +4078,7 @@ fn (p &Parser) comptime_cond_token_text() string {
 		return '!in'
 	}
 	if tok == .dollar {
-		return '$'
+		return '\$'
 	}
 	if tok == .lsbr {
 		return '['
@@ -4158,7 +4133,7 @@ fn comptime_cond_needs_space(prev string, cur string) bool {
 	if cur == '?' || cur == ']' || cur == '[' || cur == '.' || cur == ',' {
 		return false
 	}
-	if prev == '$' || prev == '[' || prev == ']' || prev == '.' {
+	if prev == '\$' || prev == '[' || prev == ']' || prev == '.' {
 		return false
 	}
 	return true
@@ -4409,8 +4384,7 @@ fn (mut p Parser) parse_top_level_comptime_else() flat.NodeId {
 }
 
 fn (p &Parser) eval_comptime_cond(cond string) bool {
-	return p.eval_comptime_cond_with_target_override(cond,
-		p.tok_pos in p.unsupported_inline_asm_guards)
+	return p.eval_comptime_cond_with_target_override(cond, p.tok_pos in p.unsupported_inline_asm_guards)
 }
 
 fn (p &Parser) eval_attribute_comptime_cond(cond string) bool {
@@ -4463,7 +4437,7 @@ fn (p &Parser) eval_comptime_cond_with_target_override(cond string, disable_targ
 	if c == 'false' {
 		return false
 	}
-	if c.starts_with('pkgconfig') || c.starts_with('$pkgconfig') {
+	if c.starts_with('pkgconfig') || c.starts_with('\$pkgconfig') {
 		return eval_pkgconfig_cond(c)
 	}
 	if value := eval_comptime_define_cond(p.prefs, c) {
@@ -4580,9 +4554,9 @@ fn (mut p Parser) precollect_unsupported_inline_asm_guards(source string, target
 		kind := s.scan()
 		tokens << InlineAsmScanToken{
 			kind: kind
-			lit:  s.lit
-			pos:  s.pos
-			end:  s.offset
+			lit: s.lit
+			pos: s.pos
+			end: s.offset
 		}
 		if kind == .eof {
 			break
@@ -4606,8 +4580,7 @@ fn (mut p Parser) inline_asm_scan_range(source string, tokens []InlineAsmScanTok
 			continue
 		}
 		if tokens[i].kind == .dollar && i + 1 < end && tokens[i + 1].kind == .key_if {
-			result := p.inline_asm_scan_comptime_if(source, tokens, i, end, target_arch, true,
-				collect_consts)
+			result := p.inline_asm_scan_comptime_if(source, tokens, i, end, target_arch, true, collect_consts)
 			if result.unguarded {
 				unguarded = true
 			}
@@ -4621,7 +4594,7 @@ fn (mut p Parser) inline_asm_scan_range(source string, tokens []InlineAsmScanTok
 	}
 	return InlineAsmScanResult{
 		unguarded: unguarded
-		next:      end
+		next: end
 	}
 }
 
@@ -4650,10 +4623,8 @@ fn (mut p Parser) inline_asm_scan_comptime_if(source string, tokens []InlineAsmS
 	mut unguarded := false
 	if inspect && (!known || taken) {
 		collect_then_consts := collect_consts && known && taken
-		then_result := p.inline_asm_scan_range(source, tokens, open + 1, close, target_arch,
-			collect_then_consts)
-		then_unguarded := p.inline_asm_guard_branch(resolved_condition, tokens[open].pos, true,
-			known, then_result.unguarded, target_arch)
+		then_result := p.inline_asm_scan_range(source, tokens, open + 1, close, target_arch, collect_then_consts)
+		then_unguarded := p.inline_asm_guard_branch(resolved_condition, tokens[open].pos, true, known, then_result.unguarded, target_arch)
 		if then_unguarded {
 			unguarded = true
 		}
@@ -4662,45 +4633,41 @@ fn (mut p Parser) inline_asm_scan_comptime_if(source string, tokens []InlineAsmS
 	if next + 1 >= end || tokens[next].kind != .dollar || tokens[next + 1].kind != .key_else {
 		return InlineAsmScanResult{
 			unguarded: unguarded
-			next:      close + 1
+			next: close + 1
 		}
 	}
 	next = inline_asm_skip_semicolons(tokens, next + 2, end)
 	if next + 1 < end && tokens[next].kind == .dollar && tokens[next + 1].kind == .key_if {
 		inspect_else := inspect && (!known || !taken)
 		collect_else_consts := collect_consts && inspect && known && !taken
-		else_result := p.inline_asm_scan_comptime_if(source, tokens, next, end, target_arch,
-			inspect_else, collect_else_consts)
-		else_unguarded := p.inline_asm_guard_branch(resolved_condition, tokens[open].pos, false,
-			known, else_result.unguarded, target_arch)
+		else_result := p.inline_asm_scan_comptime_if(source, tokens, next, end, target_arch, inspect_else, collect_else_consts)
+		else_unguarded := p.inline_asm_guard_branch(resolved_condition, tokens[open].pos, false, known, else_result.unguarded, target_arch)
 		if else_unguarded {
 			unguarded = true
 		}
 		return InlineAsmScanResult{
 			unguarded: unguarded
-			next:      else_result.next
+			next: else_result.next
 		}
 	}
 	if next >= end || tokens[next].kind != .lcbr {
 		return InlineAsmScanResult{
 			unguarded: unguarded
-			next:      next
+			next: next
 		}
 	}
 	else_close := inline_asm_matching_close_brace(tokens, next, end)
 	if inspect && (!known || !taken) && else_close < end {
 		collect_else_consts := collect_consts && known && !taken
-		else_result := p.inline_asm_scan_range(source, tokens, next + 1, else_close, target_arch,
-			collect_else_consts)
-		else_unguarded := p.inline_asm_guard_branch(resolved_condition, tokens[open].pos, false,
-			known, else_result.unguarded, target_arch)
+		else_result := p.inline_asm_scan_range(source, tokens, next + 1, else_close, target_arch, collect_else_consts)
+		else_unguarded := p.inline_asm_guard_branch(resolved_condition, tokens[open].pos, false, known, else_result.unguarded, target_arch)
 		if else_unguarded {
 			unguarded = true
 		}
 	}
 	return InlineAsmScanResult{
 		unguarded: unguarded
-		next:      if else_close < end { else_close + 1 } else { end }
+		next: if else_close < end { else_close + 1 } else { end }
 	}
 }
 
@@ -5037,13 +5004,7 @@ fn (p &Parser) comptime_cond_name_is_flag(cond string, name string, end int) boo
 		return true
 	}
 	match name {
-		'macos', 'darwin', 'mac', 'linux', 'windows', 'freebsd', 'openbsd', 'netbsd', 'dragonfly',
-		'android', 'termux', 'wasm32_emscripten', 'posix', 'unix', 'bsd', 'x64', 'x32', 'amd64',
-		'i386', 'x86', 'arm64', 'aarch64', 'arm32', 'rv64', 'riscv64', 's390x', 'ppc64', 'ppc64le',
-		'loongarch64', 'wasm32', 'little_endian', 'big_endian', 'debug', 'test', 'native',
-		'builtin_write_buf_to_fd_should_use_c_write', 'tinyc', 'no_backtrace', 'gcboehm', 'gcc',
-		'clang', 'mingw', 'msvc', 'cplusplus', 'gcboehm_opt', 'prealloc', 'autofree',
-		'no_bounds_checking', 'freestanding', 'nofloat', 'threads' {
+		'macos', 'darwin', 'mac', 'linux', 'windows', 'freebsd', 'openbsd', 'netbsd', 'dragonfly', 'android', 'termux', 'wasm32_emscripten', 'posix', 'unix', 'bsd', 'x64', 'x32', 'amd64', 'i386', 'x86', 'arm64', 'aarch64', 'arm32', 'rv64', 'riscv64', 's390x', 'ppc64', 'ppc64le', 'loongarch64', 'wasm32', 'little_endian', 'big_endian', 'debug', 'test', 'native', 'builtin_write_buf_to_fd_should_use_c_write', 'tinyc', 'no_backtrace', 'gcboehm', 'gcc', 'clang', 'mingw', 'msvc', 'cplusplus', 'gcboehm_opt', 'prealloc', 'autofree', 'no_bounds_checking', 'freestanding', 'nofloat', 'threads' {
 			return true
 		}
 		else {}
@@ -5150,8 +5111,7 @@ fn (p &Parser) comptime_join_path_value(node flat.Node) ?string {
 		return none
 	}
 	callee := p.a.nodes[int(p.a.children[int(node.children_start)])]
-	if callee.kind != .selector || callee.value !in ['join_path', 'join_path_single']
-		|| callee.children_count < 1 {
+	if callee.kind != .selector || callee.value !in ['join_path', 'join_path_single'] || callee.children_count < 1 {
 		return none
 	}
 	base := p.a.nodes[int(p.a.children[int(callee.children_start)])]
@@ -5257,7 +5217,7 @@ fn (mut p Parser) set_comptime_local_value(name string, value string) {
 	had_value := name in p.comptime_local_values
 	old_value := p.comptime_local_values[name]
 	p.comptime_value_undos << ComptimeValueUndo{
-		name:      name
+		name: name
 		old_value: old_value
 		had_value: had_value
 	}
@@ -5274,7 +5234,7 @@ fn (mut p Parser) forget_comptime_local_value(name string) {
 		return
 	}
 	p.comptime_value_undos << ComptimeValueUndo{
-		name:      name
+		name: name
 		old_value: old_value
 		had_value: true
 	}
@@ -5327,7 +5287,7 @@ fn comptime_cond_value(value string) string {
 // still uses the supplied default.
 fn eval_comptime_define_cond(prefs &pref.Preferences, cond string) ?bool {
 	clean := cond.replace(' ', '')
-	if !clean.starts_with('$d(') || !clean.ends_with(')') {
+	if !clean.starts_with('\$d(') || !clean.ends_with(')') {
 		return none
 	}
 	inner := clean[3..clean.len - 1]
@@ -5641,11 +5601,11 @@ fn (mut p Parser) parse_comptime_expr() flat.NodeId {
 			}
 			p.check(.rpar)
 			return p.add_node(flat.Node{
-				kind:           .paren
-				value:          '__v3_comptime_d'
+				kind: .paren
+				value: '__v3_comptime_d'
 				children_start: p.add_child(value_expr)
 				children_count: 1
-				pos:            p.span_to(dollar_pos)
+				pos: p.span_to(dollar_pos)
 			})
 		}
 		p.check(.rpar)
@@ -5656,7 +5616,7 @@ fn (mut p Parser) parse_comptime_expr() flat.NodeId {
 		mut defer_index := -1
 		invalid_context := p.defer_depth == 0 || !p.defer_result_allowed
 		if p.tok != .lpar {
-			p.record_diagnostic('expected `(` after `$res`', p.tok_pos)
+			p.record_diagnostic('expected `(` after `\$res`', p.tok_pos)
 		} else {
 			p.next()
 			if p.tok != .rpar && p.tok != .eof {
@@ -5667,19 +5627,16 @@ fn (mut p Parser) parse_comptime_expr() flat.NodeId {
 					if parsed_index := defer_result_index_literal(index_text) {
 						defer_index = parsed_index
 					} else {
-						p.record_diagnostic('`res` index must be a non-negative integer literal',
-							index_pos)
+						p.record_diagnostic('`res` index must be a non-negative integer literal', index_pos)
 					}
 					if p.tok != .rpar {
-						p.record_diagnostic('expected `)` immediately after the `$res` index',
-							p.tok_pos)
+						p.record_diagnostic('expected `)` immediately after the `\$res` index', p.tok_pos)
 						p.skip_defer_result_arguments()
 					} else {
 						p.next()
 					}
 				} else {
-					p.record_diagnostic('`res` index must be a non-negative integer literal',
-						p.tok_pos)
+					p.record_diagnostic('`res` index must be a non-negative integer literal', p.tok_pos)
 					p.skip_defer_result_arguments()
 				}
 			} else {
@@ -5688,17 +5645,15 @@ fn (mut p Parser) parse_comptime_expr() flat.NodeId {
 		}
 		res_pos := p.span_to(dollar_pos)
 		if p.defer_depth == 0 {
-			p.record_diagnostic_span('`res` can only be used in defer blocks', res_pos.offset,
-				res_pos.end)
+			p.record_diagnostic_span('`res` can only be used in defer blocks', res_pos.offset, res_pos.end)
 		} else if !p.defer_result_allowed {
-			p.record_diagnostic_span('`res` can only be used in function-exit defer blocks',
-				res_pos.offset, res_pos.end)
+			p.record_diagnostic_span('`res` can only be used in function-exit defer blocks', res_pos.offset, res_pos.end)
 		}
 		return p.add_node(flat.Node{
-			kind:  .defer_result
+			kind: .defer_result
 			value: if defer_index < 0 { '' } else { defer_index.str() }
-			typ:   if invalid_context { 'invalid' } else { '' }
-			pos:   res_pos
+			typ: if invalid_context { 'invalid' } else { '' }
+			pos: res_pos
 		})
 	}
 	if p.tok == .name && p.lit == 'env' {
@@ -5732,9 +5687,9 @@ fn (mut p Parser) parse_comptime_expr() flat.NodeId {
 		type_expr := p.parse_comptime_type_arg()
 		p.check(.rpar)
 		return p.a.add_node(flat.Node{
-			kind:           .string_literal
-			value:          '__v3_comptime_${name}'
-			typ:            'string'
+			kind: .string_literal
+			value: '__v3_comptime_${name}'
+			typ: 'string'
 			children_start: p.add_child(type_expr)
 			children_count: 1
 		})
@@ -5781,9 +5736,9 @@ fn (mut p Parser) parse_formatter_comptime_call(start int) flat.NodeId {
 	}
 	end := clamp_source_offset(p.prev_tok_end, p.s.src.len)
 	return p.a.add_node(flat.Node{
-		kind:  .ident
+		kind: .ident
 		value: p.s.src[start..end]
-		pos:   token.new_span(p.cur_file_id, start, end)
+		pos: token.new_span(p.cur_file_id, start, end)
 	})
 }
 
@@ -5807,10 +5762,10 @@ fn (mut p Parser) parse_formatter_comptime_match(start int) flat.NodeId {
 	end := clamp_source_offset(p.prev_tok_end, p.s.src.len)
 	source := p.s.src[start..end]
 	id := p.a.add_node(flat.Node{
-		kind:  .ident
+		kind: .ident
 		value: source
-		typ:   '__v3_formatter_raw'
-		pos:   token.new_span(p.cur_file_id, start, end)
+		typ: '__v3_formatter_raw'
+		pos: token.new_span(p.cur_file_id, start, end)
 	})
 	p.a.formatter_sources[int(id)] = source
 	return id
@@ -5890,7 +5845,7 @@ fn (mut p Parser) parse_comptime_type_arg() flat.NodeId {
 			p.check(.rcbr)
 		}
 		return p.add_node(flat.Node{
-			kind:  .ident
+			kind: .ident
 			value: typ
 		})
 	}
@@ -5901,7 +5856,7 @@ fn (mut p Parser) parse_comptime_type_arg() flat.NodeId {
 			p.check(.rcbr)
 		}
 		return p.add_node(flat.Node{
-			kind:  .ident
+			kind: .ident
 			value: typ
 		})
 	}
@@ -5912,7 +5867,7 @@ fn (mut p Parser) parse_comptime_type_arg() flat.NodeId {
 			p.check(.rcbr)
 		}
 		return p.add_node(flat.Node{
-			kind:  .ident
+			kind: .ident
 			value: typ
 		})
 	}
@@ -5924,7 +5879,7 @@ fn (mut p Parser) parse_comptime_type_arg() flat.NodeId {
 				p.check(.rcbr)
 			}
 			return p.add_node(flat.Node{
-				kind:  .ident
+				kind: .ident
 				value: typ
 			})
 		}
@@ -5937,7 +5892,7 @@ fn (mut p Parser) parse_comptime_type_arg() flat.NodeId {
 		elem = p.parse_comptime_type_arg()
 	} else if p.tok == .name {
 		elem = p.add_node(flat.Node{
-			kind:  .ident
+			kind: .ident
 			value: p.parse_type_name()
 		})
 	} else {
@@ -5951,8 +5906,8 @@ fn (mut p Parser) parse_comptime_type_arg() flat.NodeId {
 		p.check(.rcbr)
 	}
 	return p.add_node(flat.Node{
-		kind:           .array_init
-		value:          '__v3_comptime_type_array'
+		kind: .array_init
+		value: '__v3_comptime_type_array'
 		children_start: p.add_child(elem)
 		children_count: 1
 	})
@@ -6050,18 +6005,18 @@ fn (mut p Parser) parse_embed_file_expr() flat.NodeId {
 	}
 	if compression_type !in ['none', 'zlib'] {
 		field_ids << p.a.add_node(flat.Node{
-			kind:  .directive
+			kind: .directive
 			value: 'embed_invalid_compression:${compression_type}'
-			pos:   p.span_to(embed_start)
+			pos: p.span_to(embed_start)
 		})
 	}
 	return p.a.add_node(flat.Node{
-		kind:           .struct_init
-		value:          'embed_file.EmbedFileData'
-		typ:            'embed_file.EmbedFileData'
+		kind: .struct_init
+		value: 'embed_file.EmbedFileData'
+		typ: 'embed_file.EmbedFileData'
 		children_start: p.add_children(field_ids)
 		children_count: flat.child_count(field_ids.len)
-		pos:            p.span_to(embed_start)
+		pos: p.span_to(embed_start)
 	})
 }
 
@@ -6072,10 +6027,10 @@ fn (mut p Parser) embed_file_uncompressed_data(apath string) ?flat.NodeId {
 	bytes := os.read_bytes(apath) or { return none }
 	data := p.add_val_id(5, bytes.bytestr().clone())
 	return p.add_node(flat.Node{
-		kind:           .cast_expr
-		value:          '&u8'
-		typ:            '&u8'
-		is_mut:         true // marks this compiler-generated trusted embed buffer cast
+		kind: .cast_expr
+		value: '&u8'
+		typ: '&u8'
+		is_mut: true // marks this compiler-generated trusted embed buffer cast
 		children_start: p.add_child(data)
 		children_count: 1
 	})
@@ -6083,8 +6038,8 @@ fn (mut p Parser) embed_file_uncompressed_data(apath string) ?flat.NodeId {
 
 fn (mut p Parser) embed_file_field(name string, val flat.NodeId) flat.NodeId {
 	return p.add_node(flat.Node{
-		kind:           .field_init
-		value:          name
+		kind: .field_init
+		value: name
 		children_start: p.add_child(val)
 		children_count: 1
 	})
@@ -6100,8 +6055,7 @@ fn (p &Parser) embed_file_abs_path(path string) string {
 	} else if full_path == '@VEXEROOT' {
 		full_path = p.prefs.vroot
 	} else if full_path.starts_with('@VMODROOT/') {
-		full_path = os.join_path_single(vmod_root_for_file(p.cur_file),
-			full_path['@VMODROOT/'.len..])
+		full_path = os.join_path_single(vmod_root_for_file(p.cur_file), full_path['@VMODROOT/'.len..])
 	} else if full_path == '@VMODROOT' {
 		full_path = vmod_root_for_file(p.cur_file)
 	} else if !os.is_abs_path(full_path) {
@@ -6182,7 +6136,7 @@ fn (mut p Parser) parse_comptime_expr_block() flat.NodeId {
 	if ids.len > 1 {
 		start := p.add_children(ids)
 		return p.a.add_node(flat.Node{
-			kind:           .block
+			kind: .block
 			children_start: start
 			children_count: flat.child_count(ids.len)
 		})
@@ -6212,7 +6166,7 @@ fn (mut p Parser) stmt() flat.NodeId {
 				}
 				estart := p.add_child(expr_id)
 				return p.add_node_from(flat.Node{
-					kind:           .expr_stmt
+					kind: .expr_stmt
 					children_start: estart
 					children_count: 1
 				}, expr_id)
@@ -6255,7 +6209,7 @@ fn (mut p Parser) stmt() flat.NodeId {
 			// already past the `}` of an inline block (`x := f() or { break } // note`), and the
 			// formatter would then move the note inside the braces and comment the `}` out.
 			return p.add_node(flat.Node{
-				kind:  .break_stmt
+				kind: .break_stmt
 				value: label
 			}.with_pos(p.span_to(kw_pos)))
 		}
@@ -6274,7 +6228,7 @@ fn (mut p Parser) stmt() flat.NodeId {
 			// already past the `}` of an inline block (`x := f() or { continue } // note`), and the
 			// formatter would then move the note inside the braces and comment the `}` out.
 			return p.add_node(flat.Node{
-				kind:  .continue_stmt
+				kind: .continue_stmt
 				value: label
 			}.with_pos(p.span_to(kw_pos)))
 		}
@@ -6357,14 +6311,14 @@ fn (mut p Parser) stmt() flat.NodeId {
 			}
 			spawn_start := p.add_child(inner)
 			spawn_expr := p.add_node(flat.Node{
-				kind:           .spawn_expr
-				value:          keyword
+				kind: .spawn_expr
+				value: keyword
 				children_start: spawn_start
 				children_count: 1
 			})
 			sstart := p.add_child(spawn_expr)
 			return p.add_node(flat.Node{
-				kind:           .expr_stmt
+				kind: .expr_stmt
 				children_start: sstart
 				children_count: 1
 			})
@@ -6408,9 +6362,9 @@ fn (mut p Parser) stmt() flat.NodeId {
 					p.next()
 				}
 				return p.a.add_node(flat.Node{
-					kind:  .label_stmt
+					kind: .label_stmt
 					value: label_name
-					pos:   label_pos
+					pos: label_pos
 				})
 			}
 			return p.assign_or_expr_stmt()
@@ -6430,7 +6384,7 @@ fn (mut p Parser) debugger_stmt() flat.NodeId {
 	}
 	return p.a.add_node(flat.Node{
 		kind: .debugger_stmt
-		pos:  p.span_to(start)
+		pos: p.span_to(start)
 	})
 }
 
@@ -6593,10 +6547,10 @@ fn (mut p Parser) static_decl_stmt() flat.NodeId {
 		}
 		istart := p.add_children2(lhs, rhs)
 		return p.add_node(flat.Node{
-			kind:           .decl_assign
-			op:             .assign
-			value:          'static'
-			is_mut:         is_mut
+			kind: .decl_assign
+			op: .assign
+			value: 'static'
+			is_mut: is_mut
 			children_start: istart
 			children_count: 2
 		})
@@ -6606,7 +6560,7 @@ fn (mut p Parser) static_decl_stmt() flat.NodeId {
 	}
 	estart := p.add_child(lhs)
 	return p.add_node(flat.Node{
-		kind:           .expr_stmt
+		kind: .expr_stmt
 		children_start: estart
 		children_count: 1
 	})
@@ -6624,8 +6578,7 @@ fn (mut p Parser) return_stmt() flat.NodeId {
 	if p.tok == .semicolon && p.tok_pos >= 0 && p.tok_pos < p.s.src.len
 		&& p.s.src[p.tok_pos] == `\n` {
 		_ = p.peek()
-		if p.peek_tok !in [.eof, .rcbr]
-			&& p.column_for_pos(p.peek_pos) > p.column_for_pos(return_pos) {
+		if p.peek_tok !in [.eof, .rcbr] && p.column_for_pos(p.peek_pos) > p.column_for_pos(return_pos) {
 			p.next()
 		}
 	}
@@ -6646,7 +6599,7 @@ fn (mut p Parser) return_stmt() flat.NodeId {
 	// then reads the note as directly following the `return` and moves it inside the braces,
 	// leaving the `}` commented out and the file unparseable.
 	return p.add_node(flat.Node{
-		kind:           .return_stmt
+		kind: .return_stmt
 		children_start: start
 		children_count: flat.child_count(ids.len)
 	}.with_pos(p.span_to(return_pos)))
@@ -6671,8 +6624,8 @@ fn (mut p Parser) if_stmt() flat.NodeId {
 			guard_lhs_ids << guard_cond
 			istart := p.add_children2(guard_cond, rhs)
 			guard_cond = p.add_node(flat.Node{
-				kind:           .decl_assign
-				op:             .assign
+				kind: .decl_assign
+				op: .assign
 				children_start: istart
 				children_count: 2
 			})
@@ -6695,9 +6648,9 @@ fn (mut p Parser) if_stmt() flat.NodeId {
 				}
 				istart := p.add_children(all_ids)
 				guard_cond = p.add_node(flat.Node{
-					kind:           .decl_assign
-					op:             .assign
-					value:          '${lhs_ids.len}'
+					kind: .decl_assign
+					op: .assign
+					value: '${lhs_ids.len}'
 					children_start: istart
 					children_count: flat.child_count(all_ids.len)
 				})
@@ -6739,10 +6692,10 @@ fn (mut p Parser) if_stmt() flat.NodeId {
 	}
 	start := p.add_children(ids)
 	return p.add_node(flat.Node{
-		kind:           .if_expr
+		kind: .if_expr
 		children_start: start
 		children_count: flat.child_count(ids.len)
-		pos:            p.span_to(if_start)
+		pos: p.span_to(if_start)
 	})
 }
 
@@ -6755,7 +6708,7 @@ fn (mut p Parser) for_stmt() flat.NodeId {
 		post_empty := p.add(flat.NodeKind.empty)
 		start := p.add_children([init_empty, condition, post_empty])
 		return p.record_formatter_for_span(p.add_node(flat.Node{
-			kind:           .for_stmt
+			kind: .for_stmt
 			children_start: start
 			children_count: 3
 		}), for_start)
@@ -6775,7 +6728,7 @@ fn (mut p Parser) for_stmt() flat.NodeId {
 		}
 		start := p.add_children(ids)
 		return p.record_formatter_for_span(p.add_node(flat.Node{
-			kind:           .for_stmt
+			kind: .for_stmt
 			children_start: start
 			children_count: flat.child_count(ids.len)
 		}), for_start)
@@ -6794,9 +6747,9 @@ fn (mut p Parser) for_stmt() flat.NodeId {
 		if p.tok_can_be_decl_name() {
 			name_pos := p.tok_pos
 			ident := p.a.add_node(flat.Node{
-				kind:  .ident
+				kind: .ident
 				value: p.expect_name_or_keyword()
-				pos:   p.span_to(name_pos)
+				pos: p.span_to(name_pos)
 			})
 			if p.tok == .key_in || p.tok == .comma {
 				first_expr = ident
@@ -6825,7 +6778,7 @@ fn (mut p Parser) for_stmt() flat.NodeId {
 			}
 			start := p.add_children(ids)
 			return p.record_formatter_for_span(p.add_node(flat.Node{
-				kind:           .for_stmt
+				kind: .for_stmt
 				children_start: start
 				children_count: flat.child_count(ids.len)
 			}), for_start)
@@ -6857,8 +6810,8 @@ fn (mut p Parser) for_stmt() flat.NodeId {
 		}
 		start := p.add_children(ids)
 		return p.record_formatter_for_span(p.add_node(flat.Node{
-			kind:           .for_stmt
-			value:          'c_style'
+			kind: .for_stmt
+			value: 'c_style'
 			children_start: start
 			children_count: flat.child_count(ids.len)
 		}), for_start)
@@ -6902,7 +6855,7 @@ fn (mut p Parser) for_stmt() flat.NodeId {
 			// first_expr becomes init as expr_stmt
 			init_start := p.add_child(first_expr)
 			init_id := p.add_node(flat.Node{
-				kind:           .expr_stmt
+				kind: .expr_stmt
 				children_start: init_start
 				children_count: 1
 			})
@@ -6915,8 +6868,8 @@ fn (mut p Parser) for_stmt() flat.NodeId {
 			}
 			start := p.add_children(ids)
 			return p.record_formatter_for_span(p.add_node(flat.Node{
-				kind:           .for_stmt
-				value:          'c_style'
+				kind: .for_stmt
+				value: 'c_style'
 				children_start: start
 				children_count: flat.child_count(ids.len)
 			}), for_start)
@@ -6937,7 +6890,7 @@ fn (mut p Parser) for_stmt() flat.NodeId {
 		}
 		start := p.add_children(ids)
 		return p.record_formatter_for_span(p.add_node(flat.Node{
-			kind:           .for_stmt
+			kind: .for_stmt
 			children_start: start
 			children_count: flat.child_count(ids.len)
 		}), for_start)
@@ -6999,15 +6952,15 @@ fn (mut p Parser) invalid_for_in_header(for_id flat.NodeId) flat.NodeId {
 	rhs := p.add(flat.NodeKind.empty)
 	marker_start := p.add_children2(lhs, rhs)
 	marker_id := p.add_node(flat.Node{
-		kind:           .assign
-		value:          'for init assignment mismatch: invalid for-in header: expected identifiers before `in`'
-		op:             .assign
+		kind: .assign
+		value: 'for init assignment mismatch: invalid for-in header: expected identifiers before `in`'
+		op: .assign
 		children_start: marker_start
 		children_count: 2
 	})
 	block_start := p.add_children2(marker_id, for_id)
 	return p.add_node(flat.Node{
-		kind:           .block
+		kind: .block
 		children_start: block_start
 		children_count: 2
 	})
@@ -7038,10 +6991,10 @@ fn (mut p Parser) for_c_style_multi(lhs_ids []flat.NodeId) flat.NodeId {
 	}
 	init_start := p.add_children(all_ids)
 	init_id := p.add_node(flat.Node{
-		kind:           if is_decl { flat.NodeKind.decl_assign } else { flat.NodeKind.assign }
-		value:          if arity_msg.len > 0 { arity_msg } else { '${lhs_ids.len}' }
-		op:             if is_decl { .assign } else { token_id_to_op(op_id) }
-		is_mut:         is_decl
+		kind: if is_decl { flat.NodeKind.decl_assign } else { flat.NodeKind.assign }
+		value: if arity_msg.len > 0 { arity_msg } else { '${lhs_ids.len}' }
+		op: if is_decl { .assign } else { token_id_to_op(op_id) }
+		is_mut: is_decl
 		children_start: init_start
 		children_count: flat.child_count(all_ids.len)
 	})
@@ -7082,15 +7035,15 @@ fn (mut p Parser) for_c_style_multi(lhs_ids []flat.NodeId) flat.NodeId {
 	}
 	for_start := p.add_children(for_ids)
 	for_id := p.add_node(flat.Node{
-		kind:           .for_stmt
-		value:          'c_style'
+		kind: .for_stmt
+		value: 'c_style'
 		children_start: for_start
 		children_count: flat.child_count(for_ids.len)
 	})
 	block_start := p.add_children2(init_id, for_id)
 	return p.add_node(flat.Node{
-		kind:           .block
-		value:          'for_c_style_multi'
+		kind: .block
+		value: 'for_c_style_multi'
 		children_start: block_start
 		children_count: 2
 	})
@@ -7107,17 +7060,17 @@ fn (mut p Parser) for_c_style(lhs_expr flat.NodeId) flat.NodeId {
 	if is_decl {
 		istart := p.add_children2(lhs_expr, rhs)
 		init_id = p.add_node(flat.Node{
-			kind:           .decl_assign
-			op:             .assign
-			is_mut:         true
+			kind: .decl_assign
+			op: .assign
+			is_mut: true
 			children_start: istart
 			children_count: 2
 		})
 	} else {
 		istart := p.add_children2(lhs_expr, rhs)
 		init_id = p.add_node(flat.Node{
-			kind:           .assign
-			op:             token_id_to_op(op_id)
+			kind: .assign
+			op: token_id_to_op(op_id)
 			children_start: istart
 			children_count: 2
 		})
@@ -7159,8 +7112,8 @@ fn (mut p Parser) for_c_style(lhs_expr flat.NodeId) flat.NodeId {
 	}
 	start := p.add_children(ids)
 	return p.add_node(flat.Node{
-		kind:           .for_stmt
-		value:          'c_style'
+		kind: .for_stmt
+		value: 'c_style'
 		children_start: start
 		children_count: flat.child_count(ids.len)
 	})
@@ -7216,8 +7169,7 @@ fn (mut p Parser) for_in_parts(key_id flat.NodeId, val_id flat.NodeId, value_is_
 		p.next()
 		range_end = p.expr(.lowest)
 	} else if p.tok == .ellipsis {
-		p.record_diagnostic_span('for loop only supports exclusive (`..`) ranges, not inclusive (`...`)',
-			p.tok_pos, p.tok_end)
+		p.record_diagnostic_span('for loop only supports exclusive (`..`) ranges, not inclusive (`...`)', p.tok_pos, p.tok_end)
 		p.next()
 		range_end = p.expr(.lowest)
 	}
@@ -7241,13 +7193,13 @@ fn (mut p Parser) for_in_parts(key_id flat.NodeId, val_id flat.NodeId, value_is_
 	}
 	start := p.add_children(ids)
 	return p.add_node(flat.Node{
-		kind:           .for_in_stmt
+		kind: .for_in_stmt
 		children_start: start
 		children_count: flat.child_count(ids.len)
 		// value field stores the count of header elements (key, val, container, [range_end])
 		// so gen knows where body starts
 		value: if int(range_end) >= 0 { '4' } else { '3' }
-		op:    if value_is_mut { .amp } else { .none }
+		op: if value_is_mut { .amp } else { .none }
 	})
 }
 
@@ -7271,17 +7223,17 @@ fn (mut p Parser) match_stmt() flat.NodeId {
 
 	start := p.add_children(ids)
 	match_id := p.add_node(flat.Node{
-		kind:           .match_stmt
+		kind: .match_stmt
 		children_start: start
 		children_count: flat.child_count(ids.len)
-		pos:            p.span_to(match_start)
+		pos: p.span_to(match_start)
 	})
 	if p.tok == .key_or {
 		p.next()
 		or_body := p.block_stmt()
 		ostart := p.add_children2(match_id, or_body)
 		return p.add_node(flat.Node{
-			kind:           .or_expr
+			kind: .or_expr
 			children_start: ostart
 			children_count: 2
 		})
@@ -7306,9 +7258,9 @@ fn (mut p Parser) match_branch_cond() flat.NodeId {
 		typ := p.parse_type_name()
 		elem_type := if typ.starts_with('[]') { typ[2..] } else { typ }
 		return p.add_node(flat.Node{
-			kind:  .array_init
+			kind: .array_init
 			value: elem_type
-			typ:   typ
+			typ: typ
 		})
 	}
 	if p.tok == .name && p.lit == 'map' && p.peek() == .lsbr {
@@ -7328,8 +7280,8 @@ fn (mut p Parser) match_branch_cond() flat.NodeId {
 			mod_id := p.add_val(.ident, mod_name)
 			start := p.add_child(mod_id)
 			return p.add_node(flat.Node{
-				kind:           .selector
-				value:          field_name
+				kind: .selector
+				value: field_name
 				children_start: start
 				children_count: 1
 			})
@@ -7337,8 +7289,8 @@ fn (mut p Parser) match_branch_cond() flat.NodeId {
 		base_id := p.add_val(.ident, mod_name)
 		start := p.add_child(base_id)
 		sel := p.add_node(flat.Node{
-			kind:           .selector
-			value:          field_name
+			kind: .selector
+			value: field_name
 			children_start: start
 			children_count: 1
 		})
@@ -7371,8 +7323,8 @@ fn (mut p Parser) match_branch_cond() flat.NodeId {
 		// and the formatter would then read a comment written after that brace as directly
 		// following the pattern and pull it above the brace.
 		return p.add_node_from(flat.Node{
-			kind:           .range
-			value:          if p.prefs.is_fmt { '...' } else { '' }
+			kind: .range
+			value: if p.prefs.is_fmt { '...' } else { '' }
 			children_start: rstart
 			children_count: 2
 		}, cond)
@@ -7387,8 +7339,8 @@ fn (mut p Parser) match_type_pattern_node(type_name string) flat.NodeId {
 		base_id := p.add_val(.ident, base)
 		start := p.add_child(base_id)
 		return p.add_node(flat.Node{
-			kind:           .selector
-			value:          name
+			kind: .selector
+			value: name
 			children_start: start
 			children_count: 1
 		})
@@ -7480,11 +7432,11 @@ fn (mut p Parser) match_branch() flat.NodeId {
 
 	bstart := p.add_children(branch_ids)
 	return p.add_node(flat.Node{
-		kind:           .match_branch
-		value:          if is_else { 'else' } else { '${n_conds}' }
+		kind: .match_branch
+		value: if is_else { 'else' } else { '${n_conds}' }
 		children_start: bstart
 		children_count: flat.child_count(branch_ids.len)
-		pos:            p.span_to(branch_start)
+		pos: p.span_to(branch_start)
 	})
 }
 
@@ -7500,18 +7452,17 @@ fn (mut p Parser) block_stmt() flat.NodeId {
 	ids := p.parse_block_body()
 	start := p.add_children(ids)
 	return p.add_node(flat.Node{
-		kind:           .block
+		kind: .block
 		children_start: start
 		children_count: flat.child_count(ids.len)
-		pos:            p.span_to(block_start)
+		pos: p.span_to(block_start)
 	})
 }
 
 fn (mut p Parser) unsafe_block_stmt(unsafe_start int) flat.NodeId {
 	id := p.block_stmt()
 	if int(id) >= 0 && int(id) < p.a.nodes.len {
-		mut node := p.a.nodes[int(id)].with_pos(token.new_span(p.cur_file_id, unsafe_start, int_max(unsafe_start,
-			p.a.nodes[int(id)].pos.end - 1)))
+		mut node := p.a.nodes[int(id)].with_pos(token.new_span(p.cur_file_id, unsafe_start, int_max(unsafe_start, p.a.nodes[int(id)].pos.end - 1)))
 		node.value = 'unsafe'
 		p.a.nodes[int(id)] = node
 	}
@@ -7555,8 +7506,7 @@ fn (mut p Parser) assign_or_expr_stmt() flat.NodeId {
 		lhs_node := p.a.node(lhs)
 		if lhs_node.kind == .ident && lhs_node.value.len > 0
 			&& p.s.src[p.tok_pos..line_end].contains(':=') {
-			p.record_diagnostic_span('unexpected name `${lhs_node.value}`', lhs_node.pos.offset,
-				lhs_node.pos.end)
+			p.record_diagnostic_span('unexpected name `${lhs_node.value}`', lhs_node.pos.offset, lhs_node.pos.end)
 			for p.tok == .name {
 				p.next()
 			}
@@ -7572,7 +7522,7 @@ fn (mut p Parser) assign_or_expr_stmt() flat.NodeId {
 				}
 				start := p.add_child(rhs)
 				return p.add_node(flat.Node{
-					kind:           .expr_stmt
+					kind: .expr_stmt
 					children_start: start
 					children_count: 1
 				})
@@ -7627,13 +7577,13 @@ fn (mut p Parser) assign_or_expr_stmt() flat.NodeId {
 			}
 			istart := p.add_children(all_ids)
 			id := p.add_node(flat.Node{
-				kind:           if op_id == 12 {
+				kind: if op_id == 12 {
 					flat.NodeKind.decl_assign
 				} else {
 					flat.NodeKind.assign
 				}
-				op:             token_id_to_op(op_id)
-				value:          '${lhs_ids.len}'
+				op: token_id_to_op(op_id)
+				value: '${lhs_ids.len}'
 				children_start: istart
 				children_count: flat.child_count(all_ids.len)
 			})
@@ -7647,7 +7597,7 @@ fn (mut p Parser) assign_or_expr_stmt() flat.NodeId {
 		for expr_id in lhs_ids {
 			estart := p.add_child(expr_id)
 			stmt_ids << p.add_node(flat.Node{
-				kind:           .expr_stmt
+				kind: .expr_stmt
 				children_start: estart
 				children_count: 1
 			})
@@ -7655,8 +7605,8 @@ fn (mut p Parser) assign_or_expr_stmt() flat.NodeId {
 		bstart := p.add_children(stmt_ids)
 		// Preserve comma grouping so match tails do not absorb preceding statements.
 		return p.add_node(flat.Node{
-			kind:           .block
-			value:          'comma_exprs'
+			kind: .block
+			value: 'comma_exprs'
 			children_start: bstart
 			children_count: flat.child_count(stmt_ids.len)
 		})
@@ -7682,9 +7632,9 @@ fn (mut p Parser) assign_or_expr_stmt() flat.NodeId {
 		all_ids << rhs_ids
 		istart := p.add_children(all_ids)
 		id := p.add_node(flat.Node{
-			kind:           .decl_assign
-			op:             .assign
-			value:          if rhs_ids.len > 1 { '1' } else { '' }
+			kind: .decl_assign
+			op: .assign
+			value: if rhs_ids.len > 1 { '1' } else { '' }
 			children_start: istart
 			children_count: flat.child_count(all_ids.len)
 		})
@@ -7707,8 +7657,8 @@ fn (mut p Parser) assign_or_expr_stmt() flat.NodeId {
 		}
 		istart := p.add_children2(lhs, rhs)
 		id := p.add_node(flat.Node{
-			kind:           kind
-			op:             token_id_to_op(op_id)
+			kind: kind
+			op: token_id_to_op(op_id)
 			children_start: istart
 			children_count: 2
 		})
@@ -7722,7 +7672,7 @@ fn (mut p Parser) assign_or_expr_stmt() flat.NodeId {
 
 	estart := p.add_child(lhs)
 	return p.add_node(flat.Node{
-		kind:           .expr_stmt
+		kind: .expr_stmt
 		children_start: estart
 		children_count: 1
 	})
@@ -7969,7 +7919,8 @@ fn (mut p Parser) current_lcbr_looks_query_data_literal() bool {
 				looks_query_data = false
 				break
 			}
-			if p.tok in [.assign, .eq, .ne, .lt, .le, .gt, .ge, .key_in, .not_in, .key_is, .not_is, .key_if]
+			if p.tok in [.assign, .eq, .ne, .lt, .le, .gt, .ge, .key_in, .not_in, .key_is, .not_is,
+				.key_if]
 				|| (p.tok == .name && p.lit in ['like', 'ilike']) {
 				looks_query_data = true
 			}
@@ -8007,8 +7958,8 @@ fn (mut p Parser) assign_or_expr_inline() flat.NodeId {
 		}
 		istart := p.add_children2(lhs, rhs)
 		id := p.add_node(flat.Node{
-			kind:           kind
-			op:             token_id_to_op(op_id)
+			kind: kind
+			op: token_id_to_op(op_id)
 			children_start: istart
 			children_count: 2
 		})
@@ -8017,7 +7968,7 @@ fn (mut p Parser) assign_or_expr_inline() flat.NodeId {
 
 	estart := p.add_child(lhs)
 	return p.add_node(flat.Node{
-		kind:           .expr_stmt
+		kind: .expr_stmt
 		children_start: estart
 		children_count: 1
 	})
@@ -8032,8 +7983,7 @@ fn (mut p Parser) for_post_clause() flat.NodeId {
 	exprs << p.expr(.lowest)
 	ends << p.prev_tok_end
 	if p.tok == .decl_assign {
-		p.record_diagnostic_span('for loop post statement cannot be a variable declaration',
-			p.tok_pos, p.tok_end)
+		p.record_diagnostic_span('for loop post statement cannot be a variable declaration', p.tok_pos, p.tok_end)
 	}
 	if p.tok == .comma {
 		for p.tok == .comma {
@@ -8080,9 +8030,9 @@ fn (mut p Parser) for_post_multi_assign(lhs_ids []flat.NodeId) flat.NodeId {
 	start := p.add_children(all_ids)
 	anchor := if all_ids.len > 0 { all_ids[0] } else { flat.empty_node }
 	id := p.add_node_from(flat.Node{
-		kind:           .assign
-		value:          if arity_msg.len > 0 { arity_msg } else { '${lhs_ids.len}' }
-		op:             token_id_to_op(op_id)
+		kind: .assign
+		value: if arity_msg.len > 0 { arity_msg } else { '${lhs_ids.len}' }
+		op: token_id_to_op(op_id)
 		children_start: start
 		children_count: flat.child_count(all_ids.len)
 	}, anchor)
@@ -8109,13 +8059,13 @@ fn (mut p Parser) for_post_assign(lhs flat.NodeId) flat.NodeId {
 	}
 	start := p.add_children2(lhs, rhs_ids[0])
 	id := p.add_node_from(flat.Node{
-		kind:           kind
-		value:          if rhs_ids.len == 1 {
+		kind: kind
+		value: if rhs_ids.len == 1 {
 			''
 		} else {
 			'for post assignment mismatch: 1 variables but ${rhs_ids.len} values'
 		}
-		op:             token_id_to_op(op_id)
+		op: token_id_to_op(op_id)
 		children_start: start
 		children_count: 2
 	}, lhs)
@@ -8125,7 +8075,7 @@ fn (mut p Parser) for_post_assign(lhs flat.NodeId) flat.NodeId {
 fn (mut p Parser) for_post_expr_stmt(expr flat.NodeId) flat.NodeId {
 	start := p.add_child(expr)
 	return p.add_node_from(flat.Node{
-		kind:           .expr_stmt
+		kind: .expr_stmt
 		children_start: start
 		children_count: 1
 	}, expr)
@@ -8140,13 +8090,12 @@ fn (mut p Parser) for_post_expr_stmt_ending(expr flat.NodeId, end int) flat.Node
 	if start_off < 0 {
 		start_off = end
 	}
-	span := token.new_span(p.cur_file_id, clamp_source_offset(start_off, p.s.src.len), clamp_source_offset(end,
-		p.s.src.len))
+	span := token.new_span(p.cur_file_id, clamp_source_offset(start_off, p.s.src.len), clamp_source_offset(end, p.s.src.len))
 	return p.a.add_node(flat.Node{
-		kind:           .expr_stmt
+		kind: .expr_stmt
 		children_start: start
 		children_count: 1
-		pos:            span
+		pos: span
 	})
 }
 
@@ -8158,7 +8107,7 @@ fn (mut p Parser) for_post_block_from_exprs(exprs []flat.NodeId, ends []int) fla
 	start := p.add_children(stmts)
 	anchor := if stmts.len > 0 { stmts[0] } else { flat.empty_node }
 	return p.add_node_from(flat.Node{
-		kind:           .block
+		kind: .block
 		children_start: start
 		children_count: flat.child_count(stmts.len)
 	}, anchor)
@@ -8191,11 +8140,11 @@ fn (mut p Parser) defer_stmt() flat.NodeId {
 	p.defer_result_allowed = outer_defer_result_allowed
 	dstart := p.add_child(body)
 	return p.add_node(flat.Node{
-		kind:           .defer_stmt
+		kind: .defer_stmt
 		children_start: dstart
 		children_count: 1
-		value:          mode
-		pos:            p.span_to(defer_start)
+		value: mode
+		pos: p.span_to(defer_start)
 	})
 }
 
@@ -8222,10 +8171,10 @@ fn (mut p Parser) assert_stmt() flat.NodeId {
 	}
 	astart := p.add_children(ids)
 	return p.add_node(flat.Node{
-		kind:           .assert_stmt
+		kind: .assert_stmt
 		children_start: astart
 		children_count: flat.child_count(ids.len)
-		pos:            p.span_to(assert_start)
+		pos: p.span_to(assert_start)
 	})
 }
 
@@ -8237,9 +8186,9 @@ fn (mut p Parser) goto_stmt() flat.NodeId {
 		p.next()
 	}
 	return p.a.add_node(flat.Node{
-		kind:  .goto_stmt
+		kind: .goto_stmt
 		value: label
-		pos:   label_pos
+		pos: label_pos
 	})
 }
 
@@ -8309,16 +8258,16 @@ fn (mut p Parser) asm_stmt() flat.NodeId {
 	// it lowers to a compiler barrier even when the block names another ISA.
 	can_lower := (!has_unsupported_content && has_memory_clobber)
 		|| (p.supports_c_inline_asm_lowering()
-		&& comptime_flag_is_target_arch(asm_arch, p.prefs.target.arch))
+			&& comptime_flag_is_target_arch(asm_arch, p.prefs.target.arch))
 	if !p.prefs.supports_inline_asm && !can_lower && (has_memory_clobber || has_unsupported_content) {
 		p.record_diagnostic('inline assembly is not supported by the selected V3 backend', asm_pos)
 	}
 	id := p.add_node(flat.Node{
-		kind:           .asm_stmt
-		value:          raw_source
+		kind: .asm_stmt
+		value: raw_source
 		children_start: p.add_children(io_exprs)
 		children_count: flat.child_count(io_exprs.len)
-		pos:            p.span_to(asm_pos)
+		pos: p.span_to(asm_pos)
 	})
 	if p.prefs.is_fmt {
 		end := int_min(p.a.node(id).pos.end, p.s.src.len)
@@ -8381,7 +8330,7 @@ fn (mut p Parser) expr_with_lhs_context(first flat.NodeId, min_bp token.BindingP
 			or_body := p.block_stmt()
 			ostart := p.add_children2(lhs, or_body)
 			lhs = p.add_node_from(flat.Node{
-				kind:           .or_expr
+				kind: .or_expr
 				children_start: ostart
 				children_count: 2
 			}, lhs)
@@ -8404,9 +8353,9 @@ fn (mut p Parser) expr_with_lhs_context(first flat.NodeId, min_bp token.BindingP
 				p.next() // skip `{`
 				p.check(.rcbr)
 				lhs = p.add_node_from(flat.Node{
-					kind:           .string_literal
-					value:          '__v3_comptime_zero'
-					typ:            'string'
+					kind: .string_literal
+					value: '__v3_comptime_zero'
+					typ: 'string'
 					children_start: p.add_child(lhs)
 					children_count: 1
 				}, lhs)
@@ -8440,8 +8389,8 @@ fn (mut p Parser) expr_with_lhs_context(first flat.NodeId, min_bp token.BindingP
 					inner := p.expr(.lowest)
 					p.check(.rpar)
 					lhs = p.add_node(flat.Node{
-						kind:           .cast_expr
-						value:          full_name
+						kind: .cast_expr
+						value: full_name
 						children_start: p.add_child(inner)
 						children_count: 1
 					})
@@ -8458,8 +8407,8 @@ fn (mut p Parser) expr_with_lhs_context(first flat.NodeId, min_bp token.BindingP
 					p.check(.rpar)
 					cstart := p.add_child(inner)
 					lhs = p.add_node(flat.Node{
-						kind:           .cast_expr
-						value:          full_name
+						kind: .cast_expr
+						value: full_name
 						children_start: cstart
 						children_count: 1
 					})
@@ -8490,8 +8439,8 @@ fn (mut p Parser) expr_with_lhs_context(first flat.NodeId, min_bp token.BindingP
 			p.next()
 			pstart := p.add_child(lhs)
 			lhs = p.add_node_from(flat.Node{
-				kind:           .postfix
-				op:             token_id_to_op(op_id)
+				kind: .postfix
+				op: token_id_to_op(op_id)
 				children_start: pstart
 				children_count: 1
 			}, lhs)
@@ -8502,8 +8451,8 @@ fn (mut p Parser) expr_with_lhs_context(first flat.NodeId, min_bp token.BindingP
 			p.next()
 			ostart := p.add_children2(lhs, p.add(flat.NodeKind.empty))
 			lhs = p.add_node_from(flat.Node{
-				kind:           .or_expr
-				value:          '!'
+				kind: .or_expr
+				value: '!'
 				children_start: ostart
 				children_count: 2
 			}, lhs)
@@ -8514,8 +8463,8 @@ fn (mut p Parser) expr_with_lhs_context(first flat.NodeId, min_bp token.BindingP
 			p.next()
 			ostart := p.add_children2(lhs, p.add(flat.NodeKind.empty))
 			lhs = p.add_node_from(flat.Node{
-				kind:           .or_expr
-				value:          '?'
+				kind: .or_expr
+				value: '?'
 				children_start: ostart
 				children_count: 2
 			}, lhs)
@@ -8527,8 +8476,8 @@ fn (mut p Parser) expr_with_lhs_context(first flat.NodeId, min_bp token.BindingP
 			type_name := p.parse_type_name()
 			astart := p.add_child(lhs)
 			lhs = p.add_node(flat.Node{
-				kind:           .as_expr
-				value:          type_name
+				kind: .as_expr
+				value: type_name
 				children_start: astart
 				children_count: 1
 			})
@@ -8543,7 +8492,7 @@ fn (mut p Parser) expr_with_lhs_context(first flat.NodeId, min_bp token.BindingP
 			rhs := p.expr(.lowest)
 			rstart := p.add_children2(lhs, rhs)
 			lhs = p.add_node(flat.Node{
-				kind:           .range
+				kind: .range
 				children_start: rstart
 				children_count: 2
 			})
@@ -8560,16 +8509,16 @@ fn (mut p Parser) expr_with_lhs_context(first flat.NodeId, min_bp token.BindingP
 			type_name := p.parse_type_name()
 			istart := p.add_child(lhs)
 			is_node := p.add_node(flat.Node{
-				kind:           .is_expr
-				value:          type_name
+				kind: .is_expr
+				value: type_name
 				children_start: istart
 				children_count: 1
 			})
 			if is_negated {
 				nstart := p.add_child(is_node)
 				lhs = p.add_node(flat.Node{
-					kind:           .prefix
-					op:             .not
+					kind: .prefix
+					op: .not
 					children_start: nstart
 					children_count: 1
 				})
@@ -8588,15 +8537,15 @@ fn (mut p Parser) expr_with_lhs_context(first flat.NodeId, min_bp token.BindingP
 			type_name := p.parse_type_name()
 			istart := p.add_child(lhs)
 			is_node := p.add_node(flat.Node{
-				kind:           .is_expr
-				value:          type_name
+				kind: .is_expr
+				value: type_name
 				children_start: istart
 				children_count: 1
 			})
 			nstart := p.add_child(is_node)
 			lhs = p.add_node(flat.Node{
-				kind:           .prefix
-				op:             .not
+				kind: .prefix
+				op: .not
 				children_start: nstart
 				children_count: 1
 			})
@@ -8617,22 +8566,22 @@ fn (mut p Parser) expr_with_lhs_context(first flat.NodeId, min_bp token.BindingP
 				range_lhs := rhs
 				rstart := p.add_children2(range_lhs, range_rhs)
 				rhs = p.add_node_from(flat.Node{
-					kind:           .range
+					kind: .range
 					children_start: rstart
 					children_count: 2
 				}, range_lhs)
 			}
 			istart := p.add_children2(lhs, rhs)
 			in_node := p.add_node_from(flat.Node{
-				kind:           .in_expr
+				kind: .in_expr
 				children_start: istart
 				children_count: 2
 			}, lhs)
 			if is_negated {
 				nstart := p.add_child(in_node)
 				lhs = p.add_node(flat.Node{
-					kind:           .prefix
-					op:             .not
+					kind: .prefix
+					op: .not
 					children_start: nstart
 					children_count: 1
 				})
@@ -8654,21 +8603,21 @@ fn (mut p Parser) expr_with_lhs_context(first flat.NodeId, min_bp token.BindingP
 				range_rhs := p.expr(.sum)
 				rstart := p.add_children2(rhs, range_rhs)
 				rhs = p.add_node(flat.Node{
-					kind:           .range
+					kind: .range
 					children_start: rstart
 					children_count: 2
 				})
 			}
 			istart := p.add_children2(lhs, rhs)
 			in_node := p.add_node(flat.Node{
-				kind:           .in_expr
+				kind: .in_expr
 				children_start: istart
 				children_count: 2
 			})
 			nstart := p.add_child(in_node)
 			lhs = p.add_node(flat.Node{
-				kind:           .prefix
-				op:             .not
+				kind: .prefix
+				op: .not
 				children_start: nstart
 				children_count: 1
 			})
@@ -8703,8 +8652,8 @@ fn (mut p Parser) expr_with_lhs_context(first flat.NodeId, min_bp token.BindingP
 			rhs := p.expr(.lowest)
 			istart := p.add_children2(lhs, rhs)
 			lhs = p.add_node_from(flat.Node{
-				kind:           .infix
-				op:             token_id_to_op(op_id)
+				kind: .infix
+				op: token_id_to_op(op_id)
 				children_start: istart
 				children_count: 2
 			}, lhs)
@@ -8723,8 +8672,8 @@ fn (mut p Parser) expr_with_lhs_context(first flat.NodeId, min_bp token.BindingP
 		rhs := p.expr(token_id_right_binding_power(op_id))
 		istart := p.add_children2(lhs, rhs)
 		lhs = p.add_node_from(flat.Node{
-			kind:           .infix
-			op:             token_id_to_op(op_id)
+			kind: .infix
+			op: token_id_to_op(op_id)
 			children_start: istart
 			children_count: 2
 		}, lhs)
@@ -8742,7 +8691,8 @@ fn (p &Parser) is_comptime_type_accessor(id flat.NodeId) bool {
 		return true
 	}
 	if node.kind != .selector || node.children_count == 0
-		|| node.value !in ['typ', 'unaliased_typ', 'payload_type', 'pointee_type', 'element_type', 'key_type', 'value_type'] {
+		|| node.value !in ['typ', 'unaliased_typ', 'payload_type', 'pointee_type', 'element_type',
+			'key_type', 'value_type'] {
 		return false
 	}
 	return p.is_comptime_type_accessor(p.a.child(&node, 0))
@@ -8844,12 +8794,12 @@ fn (mut p Parser) sql_expr(sql_pos int) flat.NodeId {
 		children_count = 1
 	}
 	id := p.add_node(flat.Node{
-		kind:           .sql_expr
-		value:          tokens.join(' ')
-		typ:            typ
+		kind: .sql_expr
+		value: tokens.join(' ')
+		typ: typ
 		children_start: children_start
 		children_count: flat.child_count(children_count)
-		pos:            p.span_to(sql_pos)
+		pos: p.span_to(sql_pos)
 	})
 	if p.prefs.is_fmt {
 		end := int_min(p.a.node(id).pos.end, p.s.src.len)
@@ -8861,9 +8811,9 @@ fn (mut p Parser) sql_expr(sql_pos int) flat.NodeId {
 fn (mut p Parser) sql_query_data_literal_expr() flat.NodeId {
 	tokens := p.sql_block_tokens()
 	return p.add_node(flat.Node{
-		kind:  .sql_expr
+		kind: .sql_expr
 		value: 'querydata ${tokens.join(' ')}'
-		typ:   'orm.QueryData'
+		typ: 'orm.QueryData'
 	})
 }
 
@@ -8929,8 +8879,7 @@ fn (mut p Parser) sql_block_tokens() []string {
 				continue
 			}
 			if p.tok == .amp {
-				p.record_diagnostic_span('unexpected `&` in SQL expression; use `&&` for logical conjunction',
-					p.tok_pos, p.tok_end)
+				p.record_diagnostic_span('unexpected `&` in SQL expression; use `&&` for logical conjunction', p.tok_pos, p.tok_end)
 			}
 			text := p.sql_token_text()
 			if text.len > 0 {
@@ -9233,9 +9182,9 @@ fn (mut p Parser) keyword_ident_expr() flat.NodeId {
 	name := p.tok.str()
 	p.next()
 	return p.a.add_node(flat.Node{
-		kind:  .ident
+		kind: .ident
 		value: name
-		pos:   p.span_to(name_pos)
+		pos: p.span_to(name_pos)
 	})
 }
 
@@ -9274,11 +9223,11 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 		p.next()
 		operand := p.expr(.power)
 		return p.a.add_node(flat.Node{
-			kind:           .prefix
-			op:             .plus
+			kind: .prefix
+			op: .plus
 			children_start: p.add_child(operand)
 			children_count: 1
-			pos:            p.span_to(op_start)
+			pos: p.span_to(op_start)
 		})
 	}
 	if tok_id == 92 {
@@ -9334,18 +9283,18 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 			or_body := p.block_stmt()
 			ostart := p.add_children2(operand, or_body)
 			operand = p.a.add_node(flat.Node{
-				kind:           .or_expr
+				kind: .or_expr
 				children_start: ostart
 				children_count: 2
 			})
 		}
 		pstart := p.add_child(operand)
 		return p.a.add_node(flat.Node{
-			kind:           .prefix
-			op:             token_id_to_op(tok_id)
+			kind: .prefix
+			op: token_id_to_op(tok_id)
 			children_start: pstart
 			children_count: 1
-			pos:            p.span_to(op_start)
+			pos: p.span_to(op_start)
 		})
 	}
 	match p.tok {
@@ -9407,9 +9356,9 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 				name_end := p.tok_end
 				p.next()
 				return p.add_node(flat.Node{
-					kind:  .ident
+					kind: .ident
 					value: 'shared'
-					pos:   token.new_span(p.cur_file_id, name_pos, name_end)
+					pos: token.new_span(p.cur_file_id, name_pos, name_end)
 				})
 			}
 			p.next()
@@ -9419,17 +9368,15 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 			name_pos := p.tok_pos
 			name_end := p.tok_end
 			name := p.lit
-			if p.peek() == .string && name !in ['c', 'r', 'js']
-				&& !p.s.src[name_end..p.peek_pos].contains('\n') {
-				p.record_diagnostic_span('only `c`, `r`, `js` are recognized string prefixes, but you tried to use `${name}`',
-					name_pos, name_end)
+			if p.peek() == .string && name !in ['c', 'r', 'js'] && !p.s.src[name_end..p.peek_pos].contains('\n') {
+				p.record_diagnostic_span('only `c`, `r`, `js` are recognized string prefixes, but you tried to use `${name}`', name_pos, name_end)
 			}
 			p.next()
 			if p.prefs.is_fmt && name.starts_with('@') {
 				return p.a.add_node(flat.Node{
-					kind:  .ident
+					kind: .ident
 					value: name
-					pos:   token.new_span(p.cur_file_id, name_pos, name_end)
+					pos: token.new_span(p.cur_file_id, name_pos, name_end)
 				})
 			}
 			if name == 'sql' && p.starts_sql_expr() {
@@ -9447,8 +9394,7 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 			if name == '@VMOD_FILE' {
 				vmod_file := os.join_path_single(vmod_root_for_file(p.cur_file), 'v.mod')
 				content := os.read_file(vmod_file) or {
-					message := p.add_val_id(5,
-						'@VMOD_FILE can only be used in projects that have a v.mod file')
+					message := p.add_val_id(5, '@VMOD_FILE can only be used in projects that have a v.mod file')
 					// name_pos was captured before @VMOD_FILE was consumed, so the
 					// sentinel call is reported at the directive, not the next token.
 					// prev_tok_end is the end of the just-consumed @VMOD_FILE token.
@@ -9512,8 +9458,7 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 						method_name = '${module_name}.${p.cur_struct}{}.${fn_name}'
 					}
 				}
-				return p.add_val_id(5,
-					'${p.cur_file}:${p.line_nr_for_pos(name_pos)}, ${method_name}')
+				return p.add_val_id(5, '${p.cur_file}:${p.line_nr_for_pos(name_pos)}, ${method_name}')
 			}
 			if name == '@BUILD_DATE' {
 				return p.add_val_id(5, p.prefs.build_date)
@@ -9545,9 +9490,7 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 			}
 			if name == 'chan' && p.can_start_type_name() {
 				if p.tok == .not {
-					p.record_diagnostic_span('cannot use chan with Result type', p.tok_pos,
-
-						p.tok_pos + 1)
+					p.record_diagnostic_span('cannot use chan with Result type', p.tok_pos, p.tok_pos + 1)
 				}
 				elem_type := p.parse_fixed_array_literal_type_name()
 				chan_type := 'chan ${elem_type}'
@@ -9567,9 +9510,9 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 					return p.map_init_after_type(map_type, name_pos)
 				}
 				return p.a.add_node(flat.Node{
-					kind:  .map_init
+					kind: .map_init
 					value: map_type
-					pos:   p.span_to(name_pos)
+					pos: p.span_to(name_pos)
 				})
 			}
 			local_type_name := p.resolve_local_type_name(name)
@@ -9578,31 +9521,31 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 			if p.tok == .lcbr && local_type_name.len > 0
 				&& (!p.in_for_container || p.current_lcbr_is_attached())
 				&& ((local_type_name[0] >= `A` && local_type_name[0] <= `Z`)
-				|| name in ['any', 'array', 'string', 'map', 'mapnode', '_result', '_option']) {
+					|| name in ['any', 'array', 'string', 'map', 'mapnode', '_result', '_option']) {
 				return p.struct_init(local_type_name)
 			}
 			// type cast: TypeName(expr) or builtin_type(expr)
 			if p.tok == .lpar && local_type_name.len > 0
 				&& ((local_type_name[0] >= `A` && local_type_name[0] <= `Z`)
-				|| is_builtin_type(name)) {
+					|| is_builtin_type(name)) {
 				p.next() // skip (
 				inner := p.expr(.lowest)
 				p.check(.rpar)
 				cstart := p.add_child(inner)
 				return p.add_node(flat.Node{
-					kind:           .cast_expr
-					value:          local_type_name
+					kind: .cast_expr
+					value: local_type_name
 					children_start: cstart
 					children_count: 1
-					pos:            p.span_to(name_pos)
+					pos: p.span_to(name_pos)
 				})
 			}
 			// name_pos was captured before the name token was consumed, so the
 			// identifier spans the name itself rather than the following token.
 			return p.a.add_node(flat.Node{
-				kind:  .ident
+				kind: .ident
 				value: name
-				pos:   p.span_to(name_pos)
+				pos: p.span_to(name_pos)
 			})
 		}
 		.lpar {
@@ -9612,10 +9555,10 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 			p.check(.rpar)
 			pstart := p.add_child(inner)
 			return p.a.add_node(flat.Node{
-				kind:           .paren
+				kind: .paren
 				children_start: pstart
 				children_count: 1
-				pos:            p.span_to(paren_start)
+				pos: p.span_to(paren_start)
 			})
 		}
 		.lcbr {
@@ -9641,10 +9584,10 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 			p.check(.rcbr)
 			start := p.add_children(ids)
 			return p.add_node(flat.Node{
-				kind:           .map_init
+				kind: .map_init
 				children_start: start
 				children_count: flat.child_count(ids.len)
-				pos:            p.span_to(map_start)
+				pos: p.span_to(map_start)
 			})
 		}
 		.amp {
@@ -9667,27 +9610,27 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 						p.check(.rpar)
 						cstart := p.add_child(inner)
 						return p.add_node(flat.Node{
-							kind:           .cast_expr
-							value:          type_name
+							kind: .cast_expr
+							value: type_name
 							children_start: cstart
 							children_count: 1
-							pos:            p.span_to(amp_start)
+							pos: p.span_to(amp_start)
 						})
 					}
 					id := p.add_val(.ident, base_name)
 					first := p.add_node(flat.Node{
-						kind:           .prefix
-						op:             .amp
+						kind: .prefix
+						op: .amp
 						children_start: p.add_child(id)
 						children_count: 1
-						pos:            p.span_to(amp_start)
+						pos: p.span_to(amp_start)
 					})
 					return p.add_node(flat.Node{
-						kind:           .prefix
-						op:             .amp
+						kind: .prefix
+						op: .amp
 						children_start: p.add_child(first)
 						children_count: 1
-						pos:            p.span_to(amp_start)
+						pos: p.span_to(amp_start)
 					})
 				}
 			} else if p.tok == .name && p.peek() == .dot {
@@ -9714,12 +9657,12 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 					if p.tok == .lcbr {
 						inner := p.struct_init(full_name)
 						return p.a.add_node(flat.Node{
-							kind:           .prefix
-							op:             .amp
-							typ:            '&${full_name}'
+							kind: .prefix
+							op: .amp
+							typ: '&${full_name}'
 							children_start: p.add_child(inner)
 							children_count: 1
-							pos:            p.span_to(amp_start)
+							pos: p.span_to(amp_start)
 						})
 					}
 				}
@@ -9730,11 +9673,11 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 					p.check(.rpar)
 					cstart := p.add_child(inner)
 					return p.add_node(flat.Node{
-						kind:           .cast_expr
-						value:          type_name
+						kind: .cast_expr
+						value: type_name
 						children_start: cstart
 						children_count: 1
-						pos:            p.span_to(amp_start)
+						pos: p.span_to(amp_start)
 					})
 				}
 				if p.tok == .semicolon && p.peek() == .lcbr {
@@ -9743,11 +9686,11 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 				if p.tok == .lcbr {
 					inner := p.struct_init(name)
 					return p.add_node(flat.Node{
-						kind:           .prefix
-						op:             .amp
+						kind: .prefix
+						op: .amp
 						children_start: p.add_child(inner)
 						children_count: 1
-						pos:            p.span_to(amp_start)
+						pos: p.span_to(amp_start)
 					})
 				}
 				p.s = saved_s
@@ -9783,11 +9726,11 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 					if p.s.offset != before_suffix_offset && p.tok == .lcbr {
 						inner := p.struct_init(p.resolve_local_type_name(local_type_name + suffix))
 						return p.a.add_node(flat.Node{
-							kind:           .prefix
-							op:             .amp
+							kind: .prefix
+							op: .amp
 							children_start: p.add_child(inner)
 							children_count: 1
-							pos:            p.span_to(amp_start)
+							pos: p.span_to(amp_start)
 						})
 					}
 				}
@@ -9797,11 +9740,11 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 					p.check(.rpar)
 					cstart := p.add_child(inner)
 					return p.a.add_node(flat.Node{
-						kind:           .cast_expr
-						value:          '&${local_type_name}'
+						kind: .cast_expr
+						value: '&${local_type_name}'
 						children_start: cstart
 						children_count: 1
-						pos:            p.span_to(amp_start)
+						pos: p.span_to(amp_start)
 					})
 				}
 				if p.tok == .semicolon && p.peek() == .lcbr {
@@ -9810,11 +9753,11 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 				if p.tok == .lcbr && local_type_name.len > 0 {
 					inner := p.struct_init(local_type_name)
 					return p.a.add_node(flat.Node{
-						kind:           .prefix
-						op:             .amp
+						kind: .prefix
+						op: .amp
 						children_start: p.add_child(inner)
 						children_count: 1
-						pos:            p.span_to(amp_start)
+						pos: p.span_to(amp_start)
 					})
 				}
 				p.s = saved_s
@@ -9834,22 +9777,22 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 					p.check(.rpar)
 					cstart := p.add_child(inner)
 					return p.add_node(flat.Node{
-						kind:           .cast_expr
-						value:          type_name
+						kind: .cast_expr
+						value: type_name
 						children_start: cstart
 						children_count: 1
-						pos:            p.span_to(amp_start)
+						pos: p.span_to(amp_start)
 					})
 				}
 				if p.tok == .lcbr && type_name.starts_with('&[]') {
 					inner := p.array_init_after_element_type(type_name[3..], arr_start)
 					return p.a.add_node(flat.Node{
-						kind:           .prefix
-						op:             .amp
-						typ:            type_name
+						kind: .prefix
+						op: .amp
+						typ: type_name
 						children_start: p.add_child(inner)
 						children_count: 1
-						pos:            p.span_to(amp_start)
+						pos: p.span_to(amp_start)
 					})
 				}
 			}
@@ -9857,40 +9800,39 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 				p.record_diagnostic_span('expected expression after `&`', amp_start, p.span_start())
 				empty := p.add(.empty)
 				return p.a.add_node(flat.Node{
-					kind:           .prefix
-					op:             .amp
+					kind: .prefix
+					op: .amp
 					children_start: p.add_child(empty)
 					children_count: 1
-					pos:            p.span_to(amp_start)
+					pos: p.span_to(amp_start)
 				})
 			}
 			operand := p.expr(.highest)
 			operand_node := p.a.node(operand)
-			if operand_node.kind == .or_expr && operand_node.value !in ['?', '!']
-				&& operand_node.children_count == 2 {
+			if operand_node.kind == .or_expr && operand_node.value !in ['?', '!'] && operand_node.children_count == 2 {
 				source := p.a.child(operand_node, 0)
 				fallback := p.a.child(operand_node, 1)
 				address := p.add_node(flat.Node{
-					kind:           .prefix
-					op:             .amp
+					kind: .prefix
+					op: .amp
 					children_start: p.add_child(source)
 					children_count: 1
-					pos:            p.span_to(amp_start)
+					pos: p.span_to(amp_start)
 				})
 				return p.add_node(flat.Node{
-					kind:           .or_expr
+					kind: .or_expr
 					children_start: p.add_children2(address, fallback)
 					children_count: 2
-					pos:            p.span_to(amp_start)
+					pos: p.span_to(amp_start)
 				})
 			}
 			pstart := p.add_child(operand)
 			return p.a.add_node(flat.Node{
-				kind:           .prefix
-				op:             .amp
+				kind: .prefix
+				op: .amp
 				children_start: pstart
 				children_count: 1
-				pos:            p.span_to(amp_start)
+				pos: p.span_to(amp_start)
 			})
 		}
 		.and {
@@ -9918,8 +9860,8 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 					p.check(.rpar)
 					cstart := p.add_child(inner)
 					return p.add_node(flat.Node{
-						kind:           .cast_expr
-						value:          type_name
+						kind: .cast_expr
+						value: type_name
 						children_start: cstart
 						children_count: 1
 					})
@@ -9933,8 +9875,8 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 			operand := p.expr(.power)
 			pstart := p.add_child(operand)
 			return p.a.add_node(flat.Node{
-				kind:           .prefix
-				op:             token_id_to_op(op_id)
+				kind: .prefix
+				op: token_id_to_op(op_id)
 				children_start: pstart
 				children_count: 1
 			})
@@ -9945,8 +9887,8 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 			operand := p.expr(.power)
 			pstart := p.add_child(operand)
 			return p.add_node(flat.Node{
-				kind:           .prefix
-				op:             token_id_to_op(op_id)
+				kind: .prefix
+				op: token_id_to_op(op_id)
 				children_start: pstart
 				children_count: 1
 			})
@@ -9959,14 +9901,14 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 			p.next()
 			operand := p.expr(.power)
 			inner := p.add_node(flat.Node{
-				kind:           .prefix
-				op:             .mul
+				kind: .prefix
+				op: .mul
 				children_start: p.add_child(operand)
 				children_count: 1
 			})
 			return p.add_node(flat.Node{
-				kind:           .prefix
-				op:             .mul
+				kind: .prefix
+				op: .mul
 				children_start: p.add_child(inner)
 				children_count: 1
 			})
@@ -9982,8 +9924,8 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 				p.check(.rpar)
 				cstart := p.add_child(inner)
 				return p.add_node(flat.Node{
-					kind:           .cast_expr
-					value:          type_name
+					kind: .cast_expr
+					value: type_name
 					children_start: cstart
 					children_count: 1
 				})
@@ -10038,8 +9980,8 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 			inner := p.expr(.lowest)
 			sstart := p.add_child(inner)
 			return p.add_node(flat.Node{
-				kind:           .spawn_expr
-				value:          keyword
+				kind: .spawn_expr
+				value: keyword
 				children_start: sstart
 				children_count: 1
 			})
@@ -10077,11 +10019,11 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 			p.check(.rpar)
 			pstart := p.add_child(inner)
 			return p.a.add_node(flat.Node{
-				kind:           .paren
-				value:          hint
+				kind: .paren
+				value: hint
 				children_start: pstart
 				children_count: 1
-				pos:            p.span_to(paren_start)
+				pos: p.span_to(paren_start)
 			})
 		}
 		.key_isreftype {
@@ -10101,9 +10043,9 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 			p.next()
 			member := p.expect_name_or_keyword()
 			return p.a.add_node(flat.Node{
-				kind:  .enum_val
+				kind: .enum_val
 				value: member
-				pos:   p.span_to(dot_start)
+				pos: p.span_to(dot_start)
 			})
 		}
 		.lsbr {
@@ -10120,9 +10062,9 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 			inner := p.expr(.lowest)
 			pstart := p.add_child(inner)
 			return p.add_node(flat.Node{
-				kind:           .prefix
-				op:             .none
-				value:          '...'
+				kind: .prefix
+				op: .none
+				value: '...'
 				children_start: pstart
 				children_count: 1
 			})
@@ -10143,26 +10085,26 @@ fn (mut p Parser) channel_receive_expr(inner flat.NodeId, op_start int) flat.Nod
 		source := p.a.child(inner_node, 0)
 		fallback := p.a.child(inner_node, 1)
 		receive := p.a.add_node(flat.Node{
-			kind:           .prefix
-			op:             .arrow
+			kind: .prefix
+			op: .arrow
 			children_start: p.add_child(source)
 			children_count: 1
-			pos:            p.span_to(op_start)
+			pos: p.span_to(op_start)
 		})
 		return p.a.add_node(flat.Node{
-			kind:           .or_expr
-			value:          '?'
+			kind: .or_expr
+			value: '?'
 			children_start: p.add_children2(receive, fallback)
 			children_count: 2
-			pos:            p.span_to(op_start)
+			pos: p.span_to(op_start)
 		})
 	}
 	return p.a.add_node(flat.Node{
-		kind:           .prefix
-		op:             .arrow
+		kind: .prefix
+		op: .arrow
 		children_start: p.add_child(inner)
 		children_count: 1
-		pos:            p.span_to(op_start)
+		pos: p.span_to(op_start)
 	})
 }
 
@@ -10188,19 +10130,18 @@ fn (mut p Parser) map_init_after_type(map_type string, start int) flat.NodeId {
 	p.check(.rcbr)
 	children_start := p.add_children(ids)
 	return p.add_node(flat.Node{
-		kind:           .map_init
-		value:          map_type
+		kind: .map_init
+		value: map_type
 		children_start: children_start
 		children_count: flat.child_count(ids.len)
-		pos:            p.span_to(start)
+		pos: p.span_to(start)
 	})
 }
 
 fn (mut p Parser) empty_map_init_after_type(map_type string, start int) flat.NodeId {
 	p.next() // skip {
 	if p.tok != .rcbr {
-		p.record_diagnostic_span('`}` expected; explicit `map` initialization does not support parameters',
-			p.tok_pos, p.tok_end)
+		p.record_diagnostic_span('`}` expected; explicit `map` initialization does not support parameters', p.tok_pos, p.tok_end)
 		mut nested_braces := 0
 		for p.tok != .eof {
 			if p.tok == .lcbr {
@@ -10216,9 +10157,9 @@ fn (mut p Parser) empty_map_init_after_type(map_type string, start int) flat.Nod
 	}
 	p.check(.rcbr)
 	return p.add_node(flat.Node{
-		kind:  .map_init
+		kind: .map_init
 		value: map_type
-		pos:   p.span_to(start)
+		pos: p.span_to(start)
 	})
 }
 
@@ -10243,8 +10184,8 @@ fn (mut p Parser) pointer_cast_expr_from_current_depth(depth int) ?flat.NodeId {
 		p.check(.rpar)
 		cstart := p.add_child(inner)
 		return p.add_node(flat.Node{
-			kind:           .cast_expr
-			value:          type_name
+			kind: .cast_expr
+			value: type_name
 			children_start: cstart
 			children_count: 1
 		})
@@ -10270,7 +10211,7 @@ fn (mut p Parser) selector_or_method(lhs flat.NodeId) flat.NodeId {
 		// innermost methods loop. Valid selectors use marker `$`; unresolved shorthand keeps its
 		// spelling in the marker so the checker reports it instead of deferring it to cgen.
 		p.next() // skip $
-		mut selector_value := '$'
+		mut selector_value := '\$'
 		mut formatter_shorthand := ''
 		inner := if p.tok == .lpar {
 			p.next()
@@ -10280,12 +10221,12 @@ fn (mut p Parser) selector_or_method(lhs flat.NodeId) flat.NodeId {
 		} else {
 			name := p.expect_name_or_keyword()
 			if p.prefs.is_fmt {
-				formatter_shorthand = '$${name}'
+				formatter_shorthand = '\$${name}'
 			}
 			valid_method_name := p.comptime_method_var.len > 0
 				&& name in ['method', p.comptime_method_var]
 			if !valid_method_name {
-				selector_value = '$${name}'
+				selector_value = '\$${name}'
 			}
 			resolved_name := if name == 'method' && valid_method_name {
 				p.comptime_method_var
@@ -10296,8 +10237,8 @@ fn (mut p Parser) selector_or_method(lhs flat.NodeId) flat.NodeId {
 		}
 		sel_start := p.add_children2(lhs, inner)
 		sel := p.add_node_from(flat.Node{
-			kind:           .selector
-			value:          selector_value
+			kind: .selector
+			value: selector_value
 			children_start: sel_start
 			children_count: 2
 		}, lhs)
@@ -10315,8 +10256,8 @@ fn (mut p Parser) selector_or_method(lhs flat.NodeId) flat.NodeId {
 	// Anchor the selector at its receiver (lhs) so it spans `recv.field` rather
 	// than the `(`/`[` that follows; call/index nodes built on it inherit this.
 	sel := p.add_node_from(flat.Node{
-		kind:           .selector
-		value:          field_name
+		kind: .selector
+		value: field_name
 		children_start: sel_start
 		children_count: 1
 	}, lhs)
@@ -10334,8 +10275,8 @@ fn (mut p Parser) selector_or_method(lhs flat.NodeId) flat.NodeId {
 			p.check(.rpar)
 			cstart := p.add_child(inner)
 			return p.add_node_from(flat.Node{
-				kind:           .cast_expr
-				value:          full_name
+				kind: .cast_expr
+				value: full_name
 				children_start: cstart
 				children_count: 1
 			}, lhs)
@@ -10377,11 +10318,11 @@ fn (mut p Parser) call_args(fn_expr flat.NodeId) flat.NodeId {
 			p.check(.colon)
 			val := p.expr(.lowest)
 			ids << p.a.add_node(flat.Node{
-				kind:           .field_init
-				value:          fname
+				kind: .field_init
+				value: fname
 				children_start: p.add_child(val)
 				children_count: 1
-				pos:            p.span_to(fname_start)
+				pos: p.span_to(fname_start)
 			})
 			if p.tok == .semicolon {
 				p.next()
@@ -10410,9 +10351,9 @@ fn (mut p Parser) call_args(fn_expr flat.NodeId) flat.NodeId {
 			inner := p.expr(.lowest)
 			sstart := p.add_child(inner)
 			ids << p.add_node(flat.Node{
-				kind:           .prefix
-				op:             .none
-				value:          '...'
+				kind: .prefix
+				op: .none
+				value: '...'
 				children_start: sstart
 				children_count: 1
 			})
@@ -10425,8 +10366,7 @@ fn (mut p Parser) call_args(fn_expr flat.NodeId) flat.NodeId {
 		} else {
 			mut arg := p.expr(.lowest)
 			if p.tok == .name && p.lit in ['like', 'ilike'] {
-				p.record_diagnostic_span('unexpected name `${p.lit}`, expecting `)`', p.tok_pos,
-					p.tok_end)
+				p.record_diagnostic_span('unexpected name `${p.lit}`, expecting `)`', p.tok_pos, p.tok_end)
 				for p.tok != .rpar && p.tok != .eof {
 					p.next()
 				}
@@ -10436,8 +10376,8 @@ fn (mut p Parser) call_args(fn_expr flat.NodeId) flat.NodeId {
 			}
 			if arg_is_shared {
 				arg = p.add_node(flat.Node{
-					kind:           .prefix
-					value:          'shared'
+					kind: .prefix
+					value: 'shared'
 					children_start: p.add_child(arg)
 					children_count: 1
 				})
@@ -10449,8 +10389,8 @@ fn (mut p Parser) call_args(fn_expr flat.NodeId) flat.NodeId {
 				arg_node := p.a.nodes[int(arg)]
 				vstart := p.add_child(val)
 				ids << p.add_node(flat.Node{
-					kind:           .field_init
-					value:          arg_node.value
+					kind: .field_init
+					value: arg_node.value
 					children_start: vstart
 					children_count: 1
 				})
@@ -10476,8 +10416,7 @@ fn (mut p Parser) call_args(fn_expr flat.NodeId) flat.NodeId {
 		for arg_id in ids[1..] {
 			arg := p.a.nodes[int(arg_id)]
 			if arg.kind == .defer_result && arg.typ == 'invalid' {
-				p.record_diagnostic_span('`${fn_node.value}` can not print void expressions',
-					fn_node.pos.offset, p.prev_tok_end)
+				p.record_diagnostic_span('`${fn_node.value}` can not print void expressions', fn_node.pos.offset, p.prev_tok_end)
 				break
 			}
 		}
@@ -10487,7 +10426,7 @@ fn (mut p Parser) call_args(fn_expr flat.NodeId) flat.NodeId {
 	// Anchor the completed call at its callee (fn_expr) so unknown-function and
 	// argument diagnostics point at the call, not the token after `)`.
 	id := p.add_node_from(flat.Node{
-		kind:           .call
+		kind: .call
 		children_start: cstart
 		children_count: flat.child_count(ids.len)
 	}, fn_expr)
@@ -10546,10 +10485,10 @@ fn (mut p Parser) lambda_expr_no_args() flat.NodeId {
 	lambda_body := p.lambda_body_expr()
 	lstart := p.add_child(lambda_body)
 	return p.a.add_node(flat.Node{
-		kind:           .lambda_expr
+		kind: .lambda_expr
 		children_start: lstart
 		children_count: 1
-		pos:            p.span_to(op_start)
+		pos: p.span_to(op_start)
 	})
 }
 
@@ -10570,10 +10509,10 @@ fn (mut p Parser) pipe_lambda_expr() flat.NodeId {
 	ids << lambda_body
 	lstart := p.add_children(ids)
 	return p.a.add_node(flat.Node{
-		kind:           .lambda_expr
+		kind: .lambda_expr
 		children_start: lstart
 		children_count: flat.child_count(ids.len)
-		pos:            p.span_to(op_start)
+		pos: p.span_to(op_start)
 	})
 }
 
@@ -10604,9 +10543,9 @@ fn (mut p Parser) lambda_param_ident() flat.NodeId {
 	name_pos := p.current_pos()
 	name := p.expect_name()
 	id := p.a.add_node(flat.Node{
-		kind:  .ident
+		kind: .ident
 		value: name
-		pos:   name_pos
+		pos: name_pos
 	})
 	if is_mut {
 		p.a.set_node_is_mut(id, true)
@@ -10621,8 +10560,7 @@ fn (mut p Parser) index_expr(lhs flat.NodeId) flat.NodeId {
 	if p.tok == .rsbr {
 		lhs_node := p.a.node(lhs)
 		if lhs_node.kind == .array_init && lhs_node.typ.starts_with('[]') {
-			p.record_warning_span('use `x := []Type{}` instead of `x := []Type`',
-				lhs_node.pos.offset, p.tok_pos)
+			p.record_warning_span('use `x := []Type{}` instead of `x := []Type`', lhs_node.pos.offset, p.tok_pos)
 		}
 		p.record_diagnostic('invalid expression: unexpected token `]`', p.tok_pos)
 		p.next()
@@ -10632,8 +10570,8 @@ fn (mut p Parser) index_expr(lhs flat.NodeId) flat.NodeId {
 		}
 		istart := p.add_children2(lhs, flat.empty_node)
 		return p.add_node_from(flat.Node{
-			kind:           .index
-			op:             gated_op
+			kind: .index
+			op: gated_op
 			children_start: istart
 			children_count: 2
 		}, lhs)
@@ -10647,8 +10585,8 @@ fn (mut p Parser) index_expr(lhs flat.NodeId) flat.NodeId {
 		type_arg := if p.tok == .lpar { p.generic_call_type_arg_id(first) } else { first }
 		istart := p.add_children2(lhs, type_arg)
 		return p.add_node_from(flat.Node{
-			kind:           .index
-			op:             gated_op
+			kind: .index
+			op: gated_op
 			children_start: istart
 			children_count: 2
 		}, lhs)
@@ -10673,8 +10611,8 @@ fn (mut p Parser) index_expr(lhs flat.NodeId) flat.NodeId {
 	}
 	istart := p.add_children(ids)
 	return p.add_node_from(flat.Node{
-		kind:           .index
-		op:             gated_op
+		kind: .index
+		op: gated_op
 		children_start: istart
 		children_count: flat.child_count(ids.len)
 	}, lhs)
@@ -10691,10 +10629,10 @@ fn (mut p Parser) index_part_expr() flat.NodeId {
 		start := p.span_start()
 		type_name := p.parse_type_name()
 		return p.add_node(flat.Node{
-			kind:  .ident
+			kind: .ident
 			value: type_name
-			typ:   type_name
-			pos:   p.span_to(start)
+			typ: type_name
+			pos: p.span_to(start)
 		})
 	}
 	if p.tok == .dotdot {
@@ -10743,10 +10681,10 @@ fn (mut p Parser) make_index_range_part(low flat.NodeId, high flat.NodeId, start
 	}
 	cstart := p.add_children(ids)
 	return p.a.add_node(flat.Node{
-		kind:           .range
+		kind: .range
 		children_start: cstart
 		children_count: flat.child_count(ids.len)
-		pos:            p.span_to(start)
+		pos: p.span_to(start)
 	})
 }
 
@@ -10762,9 +10700,9 @@ fn (mut p Parser) index_range_expr(lhs flat.NodeId, range_id flat.NodeId, gated_
 	}
 	istart := p.add_children(ids)
 	return p.add_node_from(flat.Node{
-		kind:           .index
-		op:             gated_op
-		value:          'range'
+		kind: .index
+		op: gated_op
+		value: 'range'
 		children_start: istart
 		children_count: flat.child_count(ids.len)
 	}, lhs)
@@ -10777,10 +10715,10 @@ fn (mut p Parser) generic_call_type_arg_id(id flat.NodeId) flat.NodeId {
 			source := p.s.src[node.pos.offset..node.pos.end].trim_space()
 			if source.len > 0 {
 				return p.add_node(flat.Node{
-					kind:  .ident
+					kind: .ident
 					value: source
-					typ:   source
-					pos:   node.pos
+					typ: source
+					pos: node.pos
 				})
 			}
 		}
@@ -10791,7 +10729,7 @@ fn (mut p Parser) generic_call_type_arg_id(id flat.NodeId) flat.NodeId {
 		return id
 	}
 	return p.add_node(flat.Node{
-		kind:  .ident
+		kind: .ident
 		value: resolved
 	})
 }
@@ -10992,8 +10930,8 @@ fn (mut p Parser) struct_init(name string) flat.NodeId {
 			p.in_struct_init_value--
 			vstart := p.add_child(val)
 			field_ids << p.add_node(flat.Node{
-				kind:           .field_init
-				value:          fname
+				kind: .field_init
+				value: fname
 				children_start: vstart
 				children_count: 1
 			})
@@ -11004,11 +10942,11 @@ fn (mut p Parser) struct_init(name string) flat.NodeId {
 		p.check(.rcbr)
 		start := p.add_children(field_ids)
 		return p.add_node(flat.Node{
-			kind:           .assoc
-			value:          name
+			kind: .assoc
+			value: name
 			children_start: start
 			children_count: flat.child_count(field_ids.len)
-			pos:            p.span_to(init_start)
+			pos: p.span_to(init_start)
 		})
 	}
 	for p.tok != .rcbr && p.tok != .eof {
@@ -11025,8 +10963,8 @@ fn (mut p Parser) struct_init(name string) flat.NodeId {
 			p.in_struct_init_value--
 			vstart := p.add_child(val)
 			ids << p.add_node(flat.Node{
-				kind:           .field_init
-				value:          fname
+				kind: .field_init
+				value: fname
 				children_start: vstart
 				children_count: 1
 			})
@@ -11035,7 +10973,7 @@ fn (mut p Parser) struct_init(name string) flat.NodeId {
 			val := p.expr(.lowest)
 			vstart := p.add_child(val)
 			ids << p.add_node(flat.Node{
-				kind:           .field_init
+				kind: .field_init
 				children_start: vstart
 				children_count: 1
 			})
@@ -11050,11 +10988,11 @@ fn (mut p Parser) struct_init(name string) flat.NodeId {
 	p.check(.rcbr)
 	start := p.add_children(ids)
 	return p.add_node(flat.Node{
-		kind:           .struct_init
-		value:          name
+		kind: .struct_init
+		value: name
 		children_start: start
 		children_count: flat.child_count(ids.len)
-		pos:            p.span_to(init_start)
+		pos: p.span_to(init_start)
 	})
 }
 
@@ -11075,16 +11013,16 @@ fn (mut p Parser) string_literal() flat.NodeId {
 	if p.tok != .str_dollar {
 		val := strip_quotes(lit)
 		return p.add_node(flat.Node{
-			kind:  .string_literal
+			kind: .string_literal
 			value: val
-			typ:   if lit.len > 2 && lit.starts_with('js') {
+			typ: if lit.len > 2 && lit.starts_with('js') {
 				'js:${lit[2].ascii_str()}'
 			} else if lit.len > 1 && lit[0] == `r` {
 				'raw:${lit[1].ascii_str()}'
 			} else {
 				''
 			}
-			pos:   start_pos
+			pos: start_pos
 		})
 	}
 	// string interpolation
@@ -11122,12 +11060,12 @@ fn (mut p Parser) string_interp(first_part string, quote u8, start_pos token.Pos
 			if fmt.len > 0 {
 				start := p.add_child(expr_id)
 				part_id = p.add_node(flat.Node{
-					kind:           .directive
-					value:          'string_interp_format'
-					typ:            fmt
+					kind: .directive
+					value: 'string_interp_format'
+					typ: fmt
 					children_start: start
 					children_count: 1
-					pos:            p.span_to(format_start)
+					pos: p.span_to(format_start)
 				})
 			}
 		}
@@ -11144,8 +11082,8 @@ fn (mut p Parser) string_interp(first_part string, quote u8, start_pos token.Pos
 	}
 	start := p.add_children(ids)
 	return p.add_node(flat.Node{
-		kind:           .string_interp
-		pos:            token.new_span(start_pos.id, start_pos.offset, p.prev_tok_end)
+		kind: .string_interp
+		pos: token.new_span(start_pos.id, start_pos.offset, p.prev_tok_end)
 		children_start: start
 		children_count: flat.child_count(ids.len)
 	})
@@ -11187,7 +11125,7 @@ fn (mut p Parser) array_literal() flat.NodeId {
 		if !p.can_start_type_name() {
 			return p.a.add_node(flat.Node{
 				kind: .array_literal
-				pos:  p.span_to(bracket_start)
+				pos: p.span_to(bracket_start)
 			})
 		}
 		was_inside_array_init_type_expr := p.inside_array_init_type_expr
@@ -11200,11 +11138,11 @@ fn (mut p Parser) array_literal() flat.NodeId {
 			p.check(.rpar)
 			cstart := p.add_child(inner)
 			return p.add_node(flat.Node{
-				kind:           .cast_expr
-				value:          '[]${elem_type}'
+				kind: .cast_expr
+				value: '[]${elem_type}'
 				children_start: cstart
 				children_count: 1
-				pos:            p.span_to(bracket_start)
+				pos: p.span_to(bracket_start)
 			})
 		}
 		// array init: []Type{len: n, cap: c, init: v}
@@ -11212,10 +11150,10 @@ fn (mut p Parser) array_literal() flat.NodeId {
 			return p.array_init_after_element_type(elem_type, bracket_start)
 		}
 		return p.add_node(flat.Node{
-			kind:  .array_init
+			kind: .array_init
 			value: elem_type
-			typ:   if elem_type.starts_with('typeof(') { '' } else { '[]${elem_type}' }
-			pos:   p.span_to(bracket_start)
+			typ: if elem_type.starts_with('typeof(') { '' } else { '[]${elem_type}' }
+			pos: p.span_to(bracket_start)
 		})
 	}
 	// array literal: [1, 2, 3]
@@ -11243,11 +11181,11 @@ fn (mut p Parser) array_literal() flat.NodeId {
 				p.check(.rpar)
 				cstart := p.add_child(inner)
 				return p.a.add_node(flat.Node{
-					kind:           .cast_expr
-					value:          fixed_type
+					kind: .cast_expr
+					value: fixed_type
 					children_start: cstart
 					children_count: 1
-					pos:            p.span_to(bracket_start)
+					pos: p.span_to(bracket_start)
 				})
 			}
 			if p.tok == .lsbr {
@@ -11269,11 +11207,11 @@ fn (mut p Parser) array_literal() flat.NodeId {
 						val := p.expr(.lowest)
 						vstart := p.add_child(val)
 						init_ids << p.a.add_node(flat.Node{
-							kind:           .field_init
-							value:          fname
+							kind: .field_init
+							value: fname
 							children_start: vstart
 							children_count: 1
-							pos:            p.span_to(fname_start)
+							pos: p.span_to(fname_start)
 						})
 					} else {
 						init_ids << p.expr(.lowest)
@@ -11285,19 +11223,19 @@ fn (mut p Parser) array_literal() flat.NodeId {
 				p.check(.rcbr)
 				start := p.add_children(init_ids)
 				return p.add_node(flat.Node{
-					kind:           .array_init
-					value:          fixed_type
-					typ:            fixed_type
+					kind: .array_init
+					value: fixed_type
+					typ: fixed_type
 					children_start: start
 					children_count: flat.child_count(init_ids.len)
-					pos:            p.span_to(bracket_start)
+					pos: p.span_to(bracket_start)
 				})
 			}
 			return p.add_node(flat.Node{
-				kind:  .array_init
+				kind: .array_init
 				value: fixed_type
-				typ:   fixed_type
-				pos:   p.span_to(bracket_start)
+				typ: fixed_type
+				pos: p.span_to(bracket_start)
 			})
 		}
 		// single-element array: [expr]
@@ -11308,26 +11246,26 @@ fn (mut p Parser) array_literal() flat.NodeId {
 			p.next()
 			start := p.add_child(ids[0])
 			lit := p.add_node(flat.Node{
-				kind:           .array_literal
+				kind: .array_literal
 				children_start: start
 				children_count: 1
-				pos:            lit_pos
+				pos: lit_pos
 			})
 			pstart := p.add_child(lit)
 			return p.add_node(flat.Node{
-				kind:           .postfix
-				op:             .not
+				kind: .postfix
+				op: .not
 				children_start: pstart
 				children_count: 1
-				pos:            p.span_to(bracket_start)
+				pos: p.span_to(bracket_start)
 			})
 		}
 		start := p.add_children(ids)
 		return p.add_node(flat.Node{
-			kind:           .array_literal
+			kind: .array_literal
 			children_start: start
 			children_count: flat.child_count(ids.len)
-			pos:            p.span_to(bracket_start)
+			pos: p.span_to(bracket_start)
 		})
 	}
 	// multi-element array: `[a, b, c]` or newline-separated const tables.
@@ -11372,19 +11310,19 @@ fn (mut p Parser) array_literal() flat.NodeId {
 	}
 	start := p.add_children(ids)
 	lit := p.add_node(flat.Node{
-		kind:           .array_literal
+		kind: .array_literal
 		children_start: start
 		children_count: flat.child_count(ids.len)
-		pos:            lit_pos
+		pos: lit_pos
 	})
 	if is_fixed_literal {
 		pstart := p.add_child(lit)
 		return p.add_node(flat.Node{
-			kind:           .postfix
-			op:             .not
+			kind: .postfix
+			op: .not
 			children_start: pstart
 			children_count: 1
-			pos:            p.span_to(bracket_start)
+			pos: p.span_to(bracket_start)
 		})
 	}
 	return lit
@@ -11504,11 +11442,11 @@ fn (mut p Parser) fixed_array_value_literal(fixed_type string, start int) flat.N
 	p.check(.rsbr)
 	cstart := p.add_children(vals)
 	id := p.a.add_node(flat.Node{
-		kind:           .array_literal
-		typ:            fixed_type
+		kind: .array_literal
+		typ: fixed_type
 		children_start: cstart
 		children_count: flat.child_count(vals.len)
-		pos:            p.span_to(start)
+		pos: p.span_to(start)
 	})
 	if p.prefs.is_fmt && prefix_end > start {
 		p.a.formatter_sources[int(id)] = p.s.src[start..prefix_end]
@@ -11534,11 +11472,11 @@ fn (mut p Parser) array_init_after_element_type(elem_type string, start int) fla
 			p.check(.colon)
 			val := p.expr(.lowest)
 			ids << p.a.add_node(flat.Node{
-				kind:           .field_init
-				value:          fname
+				kind: .field_init
+				value: fname
 				children_start: p.add_child(val)
 				children_count: 1
-				pos:            p.span_to(fname_start)
+				pos: p.span_to(fname_start)
 			})
 		} else {
 			ids << p.expr(.lowest)
@@ -11549,12 +11487,12 @@ fn (mut p Parser) array_init_after_element_type(elem_type string, start int) fla
 	}
 	p.check(.rcbr)
 	return p.a.add_node(flat.Node{
-		kind:           .array_init
-		value:          elem_type
-		typ:            if elem_type.starts_with('typeof(') { '' } else { '[]${elem_type}' }
+		kind: .array_init
+		value: elem_type
+		typ: if elem_type.starts_with('typeof(') { '' } else { '[]${elem_type}' }
 		children_start: p.add_children(ids)
 		children_count: flat.child_count(ids.len)
-		pos:            p.span_to(start)
+		pos: p.span_to(start)
 	})
 }
 
@@ -11575,8 +11513,7 @@ fn (mut p Parser) inferred_fixed_array_literal_values(base_elem_type string, dim
 		}
 		if dimensions > 1 {
 			row_start := p.span_start()
-			val, nested_type := p.inferred_fixed_array_literal_values(base_elem_type,
-				dimensions - 1, row_start)
+			val, nested_type := p.inferred_fixed_array_literal_values(base_elem_type, dimensions - 1, row_start)
 			vals << val
 			if vals.len == 1 {
 				elem_type = nested_type
@@ -11594,24 +11531,24 @@ fn (mut p Parser) inferred_fixed_array_literal_values(base_elem_type string, dim
 	fixed_type := '[${vals.len}]${elem_type}'
 	cstart := p.add_children(vals)
 	lit := p.a.add_node(flat.Node{
-		kind:           .array_literal
-		typ:            fixed_type
+		kind: .array_literal
+		typ: fixed_type
 		children_start: cstart
 		children_count: flat.child_count(vals.len)
-		pos:            p.span_to(start)
+		pos: p.span_to(start)
 	})
 	if p.prefs.is_fmt && prefix_end > start {
 		p.a.formatter_sources[int(lit)] = p.s.src[start..prefix_end]
 	}
 	pstart := p.add_child(lit)
 	return p.a.add_node(flat.Node{
-		kind:           .postfix
-		op:             .not
-		value:          if has_ragged_rows { 'ragged_inferred_fixed_array' } else { '' }
-		typ:            fixed_type
+		kind: .postfix
+		op: .not
+		value: if has_ragged_rows { 'ragged_inferred_fixed_array' } else { '' }
+		typ: fixed_type
 		children_start: pstart
 		children_count: 1
-		pos:            p.span_to(start)
+		pos: p.span_to(start)
 	}), fixed_type
 }
 
@@ -11765,12 +11702,12 @@ fn (mut p Parser) fn_literal() flat.NodeId {
 	}
 	start := p.add_children(all_ids)
 	id := p.add_node(flat.Node{
-		kind:           .fn_literal
-		value:          if has_body { '' } else { 'missing_body' }
-		typ:            ret_type
+		kind: .fn_literal
+		value: if has_body { '' } else { 'missing_body' }
+		typ: ret_type
 		children_start: start
 		children_count: flat.child_count(all_ids.len)
-		pos:            p.span_to(fn_start)
+		pos: p.span_to(fn_start)
 	})
 	p.a.nodes[int(id)].set_generic_params(generic_params)
 	p.record_formatter_param_list_end(id, param_list_end)
@@ -11819,11 +11756,11 @@ fn (mut p Parser) lock_expr() flat.NodeId {
 		if is_rlock { 'rlock' } else { 'lock' }
 	}
 	return p.add_node(flat.Node{
-		kind:           .lock_expr
-		value:          lock_value
+		kind: .lock_expr
+		value: lock_value
 		children_start: lstart
 		children_count: flat.child_count(ids.len)
-		pos:            p.span_to(lock_start)
+		pos: p.span_to(lock_start)
 	})
 }
 
@@ -11843,10 +11780,10 @@ fn (mut p Parser) select_expr() flat.NodeId {
 	p.check(.rcbr)
 	start := p.add_children(ids)
 	return p.add_node(flat.Node{
-		kind:           .select_stmt
+		kind: .select_stmt
 		children_start: start
 		children_count: flat.child_count(ids.len)
-		pos:            p.span_to(select_start)
+		pos: p.span_to(select_start)
 	})
 }
 
@@ -11905,11 +11842,11 @@ fn (mut p Parser) select_branch() flat.NodeId {
 		''
 	}
 	return p.add_node(flat.Node{
-		kind:           .select_branch
-		value:          branch_value
+		kind: .select_branch
+		value: branch_value
 		children_start: start
 		children_count: flat.child_count(all_ids.len)
-		pos:            p.span_to(branch_start)
+		pos: p.span_to(branch_start)
 	})
 }
 
@@ -11933,9 +11870,9 @@ fn (mut p Parser) sizeof_expr() flat.NodeId {
 			p.check(.rpar)
 		}
 		return p.a.add_node(flat.Node{
-			kind:  .sizeof_expr
+			kind: .sizeof_expr
 			value: type_name
-			pos:   p.span_to(sizeof_start)
+			pos: p.span_to(sizeof_start)
 		})
 	}
 	p.check(.lpar)
@@ -11951,7 +11888,7 @@ fn (mut p Parser) sizeof_expr() flat.NodeId {
 		}
 		id := p.add_node(flat.Node{
 			kind: .sizeof_expr
-			pos:  p.span_to(sizeof_start)
+			pos: p.span_to(sizeof_start)
 		})
 		p.a.formatter_sources[int(id)] = p.s.src[sizeof_start..p.prev_tok_end]
 		return id
@@ -11959,9 +11896,9 @@ fn (mut p Parser) sizeof_expr() flat.NodeId {
 	type_name := p.parse_type_name()
 	p.check(.rpar)
 	return p.a.add_node(flat.Node{
-		kind:  .sizeof_expr
+		kind: .sizeof_expr
 		value: type_name
-		pos:   p.span_to(sizeof_start)
+		pos: p.span_to(sizeof_start)
 	})
 }
 
@@ -11996,16 +11933,16 @@ fn (mut p Parser) isreftype_expr() flat.NodeId {
 	callee := p.a.add_val(.ident, '__v3_isreftype')
 	start := p.add_children([callee, arg])
 	return p.a.add_node(flat.Node{
-		kind:           .call
-		value:          if p.prefs.is_fmt {
+		kind: .call
+		value: if p.prefs.is_fmt {
 			'__v3_formatter_isreftype:${formatter_form}'
 		} else {
 			''
 		}
 		children_start: start
 		children_count: 2
-		typ:            'bool'
-		pos:            p.span_to(iref_start)
+		typ: 'bool'
+		pos: p.span_to(iref_start)
 	})
 }
 
@@ -12144,7 +12081,7 @@ fn (mut p Parser) typeof_expr() flat.NodeId {
 			p.check(.rpar)
 		}
 		return p.add_node(flat.Node{
-			kind:  .typeof_expr
+			kind: .typeof_expr
 			value: type_name
 		})
 	}
@@ -12153,12 +12090,11 @@ fn (mut p Parser) typeof_expr() flat.NodeId {
 	p.check(.rpar)
 	if !p.inside_array_init_type_expr && p.tok != .dot && (start == 0 || p.s.src[start - 1] != `$`)
 		&& p.line_nr_for_pos(start) == p.line_nr_for_pos(p.tok_pos) {
-		p.record_warning_span('use e.g. `typeof(expr).name` or `sum_type_instance.type_name()` instead',
-			start, start + 'typeof'.len)
+		p.record_warning_span('use e.g. `typeof(expr).name` or `sum_type_instance.type_name()` instead', start, start + 'typeof'.len)
 	}
 	tstart := p.add_child(inner)
 	return p.add_node(flat.Node{
-		kind:           .typeof_expr
+		kind: .typeof_expr
 		children_start: tstart
 		children_count: 1
 	})
@@ -12180,11 +12116,11 @@ fn (mut p Parser) dump_expr() flat.NodeId {
 	}
 	dstart := p.add_child(inner)
 	return p.a.add_node(flat.Node{
-		kind:           .dump_expr
+		kind: .dump_expr
 		children_start: dstart
 		children_count: 1
-		value:          value
-		pos:            p.span_to(start)
+		value: value
+		pos: p.span_to(start)
 	})
 }
 
@@ -12197,9 +12133,9 @@ fn (mut p Parser) offsetof_expr() flat.NodeId {
 	field_name := p.expect_name()
 	p.check(.rpar)
 	return p.add_node(flat.Node{
-		kind:  .offsetof_expr
+		kind: .offsetof_expr
 		value: type_name
-		typ:   field_name
+		typ: field_name
 	})
 }
 
@@ -12968,9 +12904,9 @@ fn (mut p Parser) anonymous_struct_type_for_literal(init flat.Node) ?string {
 		mut ids := []flat.NodeId{cap: field_names.len}
 		for i, field_name in field_names {
 			ids << p.a.add_node(flat.Node{
-				kind:  .field_decl
+				kind: .field_decl
 				value: field_name
-				typ:   field_types[i]
+				typ: field_types[i]
 			})
 		}
 		return p.register_anonymous_aggregate_type(ids, field_names, field_types, true, false, -1)
@@ -13125,14 +13061,13 @@ fn (mut p Parser) register_anonymous_struct_type(field_names []string, field_typ
 	mut ids := []flat.NodeId{cap: field_names.len}
 	for i, field_name in field_names {
 		ids << p.a.add_node(flat.Node{
-			kind:  .field_decl
+			kind: .field_decl
 			value: field_name
-			typ:   field_types[i]
-			pos:   field_positions[i]
+			typ: field_types[i]
+			pos: field_positions[i]
 		})
 	}
-	return p.register_anonymous_aggregate_type(ids, field_names, field_types, !allow_name_shape,
-		false, -1)
+	return p.register_anonymous_aggregate_type(ids, field_names, field_types, !allow_name_shape, false, -1)
 }
 
 fn (p &Parser) infer_anonymous_struct_literal_type(node flat.Node) ?string {
@@ -13337,13 +13272,12 @@ fn (mut p Parser) parse_anonymous_aggregate_type(is_union bool) string {
 			}
 			for index, name in names {
 				fid := p.add_node(flat.Node{
-					kind:  .field_decl
+					kind: .field_decl
 					value: name
-					typ:   field_type
-					pos:   p.span_to(name_starts[index])
+					typ: field_type
+					pos: p.span_to(name_starts[index])
 				})
-				p.apply_field_meta(fid, sect_is_mut || !is_union, sect_is_pub, sect_is_global,
-					attrs, false)
+				p.apply_field_meta(fid, sect_is_mut || !is_union, sect_is_pub, sect_is_global, attrs, false)
 				ids << fid
 				field_names << name
 				field_types << field_type
@@ -13366,10 +13300,10 @@ fn (mut p Parser) parse_anonymous_aggregate_type(is_union bool) string {
 			children_count = 1
 		}
 		fid := p.add_node(flat.Node{
-			kind:           .field_decl
-			value:          field_name
-			typ:            field_type
-			pos:            p.span_to(field_start)
+			kind: .field_decl
+			value: field_name
+			typ: field_type
+			pos: p.span_to(field_start)
 			children_start: children_start
 			children_count: flat.child_count(children_count)
 		})
@@ -13378,12 +13312,15 @@ fn (mut p Parser) parse_anonymous_aggregate_type(is_union bool) string {
 			if field_is_volatile {
 				attrs << '__v3_volatile_field'
 			}
-			p.apply_field_meta(fid, sect_is_mut || !is_union, sect_is_pub, sect_is_global, attrs,
-				false)
+			p.apply_field_meta(fid, sect_is_mut || !is_union, sect_is_pub, sect_is_global, attrs, false)
 		} else {
-			p.apply_field_meta(fid, sect_is_mut || !is_union, sect_is_pub, sect_is_global, if field_is_volatile { [
+			p.apply_field_meta(fid, sect_is_mut || !is_union, sect_is_pub, sect_is_global, if field_is_volatile {
+				[
 					'__v3_volatile_field',
-				] } else { []string{} }, false)
+				]
+			} else {
+				[]string{}
+			}, false)
 		}
 		ids << fid
 		field_names << field_name
@@ -13393,8 +13330,7 @@ fn (mut p Parser) parse_anonymous_aggregate_type(is_union bool) string {
 		}
 	}
 	p.check(.rcbr)
-	return p.register_anonymous_aggregate_type(ids, field_names, field_types, false, is_union,
-		aggregate_start)
+	return p.register_anonymous_aggregate_type(ids, field_names, field_types, false, is_union, aggregate_start)
 }
 
 fn (mut p Parser) register_anonymous_aggregate_type(ids []flat.NodeId, field_names []string, field_types []string, inferred bool, is_union bool, aggregate_start int) string {
@@ -13403,10 +13339,10 @@ fn (mut p Parser) register_anonymous_aggregate_type(ids []flat.NodeId, field_nam
 	name := '${name_prefix}_${local_type_scope_part(p.cur_file)}_${p.anonymous_struct_count}'
 	start := p.add_children(ids)
 	decl_id := p.add_node(flat.Node{
-		kind:           .struct_decl
-		value:          name
-		typ:            if is_union { 'union' } else { '' }
-		pos:            if aggregate_start >= 0 {
+		kind: .struct_decl
+		value: name
+		typ: if is_union { 'union' } else { '' }
+		pos: if aggregate_start >= 0 {
 			p.span_to(aggregate_start)
 		} else {
 			p.current_pos()
@@ -13805,9 +13741,9 @@ fn write_utf8_codepoint(buf &u8, j int, code u32) int {
 }
 
 fn is_builtin_type(name string) bool {
-	return name in ['int', 'i8', 'i16', 'i32', 'i64', 'u8', 'u16', 'u32', 'u64', 'f32', 'f64',
-		'byte', 'bool', 'string', 'rune', 'char', 'voidptr', 'charptr', 'byteptr', 'usize', 'isize',
-		'array', 'map', 'mapnode', '_result', '_option', 'any']
+	return name in ['int', 'i8', 'i16', 'i32', 'i64', 'u8', 'u16', 'u32', 'u64', 'f32', 'f64', 'byte',
+		'bool', 'string', 'rune', 'char', 'voidptr', 'charptr', 'byteptr', 'usize', 'isize', 'array',
+		'map', 'mapnode', '_result', '_option', 'any']
 }
 
 fn parser_name_can_start_pointer_type(name string) bool {

--- a/vlib/v3/tests/fn_value_decl_type_test.v
+++ b/vlib/v3/tests/fn_value_decl_type_test.v
@@ -552,6 +552,30 @@ fn main() {
 	assert out == '42\n42'
 }
 
+fn test_address_of_local_fn_value_stores_the_callable_value() {
+	v3_bin := build_v3()
+	out := run_good(v3_bin, 'address_of_local_fn_value', 'struct Holder {
+	f fn (int) int = unsafe { nil }
+}
+
+fn make_holder() Holder {
+	offset := 4
+	local := fn [offset] (value int) int {
+		return value + offset
+	}
+	return Holder{
+		f: &local
+	}
+}
+
+fn main() {
+	holder := make_holder()
+	println(holder.f(3))
+}
+')
+	assert out == '7'
+}
+
 fn test_const_generic_fn_factory_value_call_uses_const_storage() {
 	v3_bin := build_v3()
 	out := run_good(v3_bin, 'const_generic_fn_factory_value_call', '

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -12170,6 +12170,19 @@ fn main() {
 	assert out == '[][]int'
 }
 
+fn test_for_in_generic_call_keeps_nested_array_element_type() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'for_in_generic_call_nested_array_element', 'import arrays
+
+fn main() {
+	for part in arrays.chunk("ABCD".bytes(), 2) {
+		println(part[0])
+	}
+}
+')
+	assert out == '65\n67'
+}
+
 fn test_flag_enum_struct_field_defaults_to_zero() {
 	v3_bin := build_v3_review_transform()
 	out := run_good(v3_bin, 'flag_enum_struct_field_default', '@[flag]

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -470,7 +470,11 @@ fn (t &Transformer) resolve_receiver_method_for_type_uncached(receiver_type stri
 	}
 	if clean_type.starts_with('[]') {
 		elem_type := clean_type[2..]
-		short_elem := if elem_type.contains('.') { elem_type.all_after_last('.') } else { elem_type }
+		short_elem := if elem_type.contains('.') {
+			elem_type.all_after_last('.')
+		} else {
+			elem_type
+		}
 		short_array := '[]${short_elem}.${method}'
 		if t.is_known_fn_name(short_array) {
 			return short_array
@@ -497,9 +501,7 @@ fn (t &Transformer) resolve_receiver_method_for_type_uncached(receiver_type stri
 			return qualified_short_method
 		}
 	}
-	if method_name := t.unique_receiver_method_suffix_match(t.receiver_method_candidates(clean_type,
-		method))
-	{
+	if method_name := t.unique_receiver_method_suffix_match(t.receiver_method_candidates(clean_type, method)) {
 		return method_name
 	}
 	if !isnil(t.tc) {
@@ -584,9 +586,7 @@ fn (t &Transformer) resolve_specialized_generic_receiver_method(receiver_type st
 	if !base.contains('.') && !t.bare_struct_name_is_local_to_current_module(base) {
 		if qualified := t.qualified_types[base] {
 			if qualified != base {
-				if resolved := t.resolve_specialized_generic_receiver_method('${qualified}[${args.join(', ')}]',
-					method)
-				{
+				if resolved := t.resolve_specialized_generic_receiver_method('${qualified}[${args.join(', ')}]', method) {
 					return resolved
 				}
 			}
@@ -876,13 +876,13 @@ fn (mut t Transformer) normalize_implicit_receiver_generic_call(id flat.NodeId, 
 		start := t.a.children.len
 		t.a.children << children
 		return t.a.add_node(flat.Node{
-			kind:           .call
-			op:             node.op
+			kind: .call
+			op: node.op
 			children_start: start
 			children_count: flat.child_count(children.len)
-			pos:            node.pos
-			value:          node.value
-			typ:            node.typ
+			pos: node.pos
+			value: node.value
+			typ: node.typ
 		})
 	}
 	return id
@@ -929,17 +929,17 @@ fn (mut t Transformer) normalize_generic_call_expr(id flat.NodeId, node flat.Nod
 		}
 	}
 	return t.a.add_node(flat.Node{
-		kind:           .call
-		op:             node.op
+		kind: .call
+		op: node.op
 		children_start: start
 		children_count: flat.child_count(children.len)
-		pos:            node.pos
-		value:          if !resolved_named_call && t.generic_call_base_is_fn_value(base_id, base) {
+		pos: node.pos
+		value: if !resolved_named_call && t.generic_call_base_is_fn_value(base_id, base) {
 			''
 		} else {
 			type_arg
 		}
-		typ:            node.typ
+		typ: node.typ
 	})
 }
 
@@ -1129,11 +1129,11 @@ fn transform_type_is_indexable(typ types.Type) bool {
 fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.NodeId {
 	if node.children_count == 0 {
 		return t.a.add_node(flat.Node{
-			kind:  .call
-			op:    node.op
-			pos:   node.pos
+			kind: .call
+			op: node.op
+			pos: node.pos
 			value: node.value
-			typ:   node.typ
+			typ: node.typ
 		})
 	}
 	if addr := t.transform_builtin_addr_call(node) {
@@ -1195,9 +1195,7 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 	}
 	mut transformed_callee := t.const_fn_call_target(callee_id) or {
 		if param_offset == 1 && params.len > 0 {
-			if converted_callee := t.transform_method_callee_receiver_for_param(callee_id,
-				t.semantic_type_name(params[0]))
-			{
+			if converted_callee := t.transform_method_callee_receiver_for_param(callee_id, t.semantic_type_name(params[0])) {
 				converted_callee
 			} else {
 				t.transform_expr(callee_id)
@@ -1221,8 +1219,7 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 			}
 			closure_name := t.new_temp('immediate_closure')
 			t.set_var_type(closure_name, closure_type)
-			t.pending_stmts << t.make_decl_assign_typed(closure_name, transformed_callee,
-				closure_type)
+			t.pending_stmts << t.make_decl_assign_typed(closure_name, transformed_callee, closure_type)
 			if t.in_spawn_expr {
 				// The spawn argument packet owns this runtime closure until the worker
 				// has invoked it.
@@ -1242,14 +1239,15 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 		param_idx := arg_idx + param_offset
 		arg_id := t.a.child(&node, i)
 		arg_node := t.a.nodes[int(arg_id)]
-		param_type := if param_idx < param_type_names.len { param_type_names[param_idx] } else { '' }
-		if spread_args := t.transform_spread_arg_over_fixed_variadic_tail(arg_node, param_idx,
-			variadic_idx, params)
-		{
+		param_type := if param_idx < param_type_names.len {
+			param_type_names[param_idx]
+		} else {
+			''
+		}
+		if spread_args := t.transform_spread_arg_over_fixed_variadic_tail(arg_node, param_idx, variadic_idx, params) {
 			variadic_type := params[variadic_idx]
 			if variadic_type is types.Array {
-				new_children << t.fixed_variadic_spread_args_with_trailing(spread_args, node,
-					i + 1, variadic_type)
+				new_children << t.fixed_variadic_spread_args_with_trailing(spread_args, node, i + 1, variadic_type)
 			} else {
 				new_children << spread_args
 			}
@@ -1284,8 +1282,7 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 				if arg_node.kind == .prefix && arg_node.value == '...'
 					&& arg_node.children_count > 0 {
 					spread_id := t.a.child(&arg_node, 0)
-					new_children << t.transform_variadic_spread_arg_for_param(spread_id,
-						variadic_type, param_type)
+					new_children << t.transform_variadic_spread_arg_for_param(spread_id, variadic_type, param_type)
 					i++
 					break
 				}
@@ -1294,8 +1291,7 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 					arg_type := t.node_type(arg_id)
 					if arg_type.starts_with('[]')
 						&& !t.variadic_interface_single_array_should_box(arg_type, variadic_type) {
-						new_children << t.transform_call_arg_for_named_param(arg_id, param_type,
-							call_name)
+						new_children << t.transform_call_arg_for_named_param(arg_id, param_type, call_name)
 					} else {
 						new_children << t.pack_variadic_args(node, i, variadic_type.elem_type)
 					}
@@ -1312,8 +1308,7 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 			spread_count := params.len - param_idx
 			for spread_offset in 0 .. spread_count {
 				expected := t.semantic_type_name(params[param_idx + spread_offset])
-				index_arg := t.make_spread_index_for_expected_param(spread_base, spread_offset,
-					expected)
+				index_arg := t.make_spread_index_for_expected_param(spread_base, spread_offset, expected)
 				new_children << t.transform_call_arg_for_named_param(index_arg, expected, call_name)
 			}
 			i++
@@ -1324,17 +1319,14 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 			if arg_type is types.MultiReturn && arg_type.types.len == params.len - param_idx {
 				items := arg_type.types
 				multi_type := t.multi_return_type_name(items)
-				value := t.stable_transformed_expr_for_reuse(t.transform_expr(arg_id), multi_type,
-					'multi_arg')
+				value := t.stable_transformed_expr_for_reuse(t.transform_expr(arg_id), multi_type, 'multi_arg')
 				for multi_idx, item_type in items {
 					expected_idx := param_idx + multi_idx
 					if expected_idx >= params.len {
 						break
 					}
-					field := t.make_selector(value, 'arg${multi_idx}',
-						t.semantic_type_name(item_type))
-					new_children << t.transform_call_arg_for_named_param(field,
-						param_type_names[expected_idx], call_name)
+					field := t.make_selector(value, 'arg${multi_idx}', t.semantic_type_name(item_type))
+					new_children << t.transform_call_arg_for_named_param(field, param_type_names[expected_idx], call_name)
 				}
 				i++
 				continue
@@ -1346,8 +1338,7 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 	if variadic_idx >= 0 && !variadic_tail_supplied && explicit_args == variadic_idx - param_offset {
 		variadic_type := params[variadic_idx]
 		if variadic_type is types.Array {
-			new_children << t.pack_variadic_args(node, int(node.children_count),
-				variadic_type.elem_type)
+			new_children << t.pack_variadic_args(node, int(node.children_count), variadic_type.elem_type)
 		}
 	}
 	t.append_missing_params_struct_args(mut new_children, params, param_offset)
@@ -1362,25 +1353,24 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 		if typ != t.a.nodes[int(id)].typ {
 			t.set_node_typ(int(id), typ)
 		}
-		return t.finish_immediate_closure_call(id, immediate_closure_cleanup, typ,
-			immediate_closure_capture_may_escape)
+		return t.finish_immediate_closure_call(id, immediate_closure_cleanup, typ, immediate_closure_capture_may_escape)
 	}
 	start := t.a.children.len
 	for nc in new_children {
 		t.a.children << nc
 	}
 	new_id := t.a.add_node(flat.Node{
-		kind:           .call
-		op:             node.op
+		kind: .call
+		op: node.op
 		children_start: start
 		children_count: flat.child_count(new_children.len)
-		pos:            node.pos
-		value:          if int(id) >= 0 && int(id) < t.a.nodes.len {
+		pos: node.pos
+		value: if int(id) >= 0 && int(id) < t.a.nodes.len {
 			t.a.nodes[int(id)].value
 		} else {
 			node.value
 		}
-		typ:            typ
+		typ: typ
 	})
 	t.copy_cloned_resolution(id, new_id)
 	if spec := t.generic_call_spec_cache[int(id)] {
@@ -1395,11 +1385,10 @@ fn (mut t Transformer) transform_call_args(id flat.NodeId, node flat.Node) flat.
 		}
 		t.generic_call_spec_cache[int(new_id)] = GenericCallSpec{
 			decl_key: spec.decl_key
-			args:     cached_args
+			args: cached_args
 		}
 	}
-	return t.finish_immediate_closure_call(new_id, immediate_closure_cleanup, typ,
-		immediate_closure_capture_may_escape)
+	return t.finish_immediate_closure_call(new_id, immediate_closure_cleanup, typ, immediate_closure_capture_may_escape)
 }
 
 fn (mut t Transformer) finish_immediate_closure_call(call_id flat.NodeId, closure_name string, typ string, capture_may_escape bool) flat.NodeId {
@@ -1466,8 +1455,7 @@ fn (t &Transformer) immediate_fn_literal_capture_may_escape(id flat.NodeId) bool
 			child_id := t.a.child(&node, i)
 			child := t.a.nodes[int(child_id)]
 			if child.kind !in [.ident, .param] {
-				t.collect_capture_address_derived_names(child_id, capture_aliases, mut
-					capture_address_aliases)
+				t.collect_capture_address_derived_names(child_id, capture_aliases, mut capture_address_aliases)
 			}
 		}
 		if capture_address_aliases.len == alias_count {
@@ -1477,8 +1465,7 @@ fn (t &Transformer) immediate_fn_literal_capture_may_escape(id flat.NodeId) bool
 	for i in 0 .. node.children_count {
 		child_id := t.a.child(&node, i)
 		child := t.a.nodes[int(child_id)]
-		if child.kind !in [.ident, .param]
-			&& t.expr_may_escape_any_named_capture(child_id, capture_aliases, capture_address_aliases) {
+		if child.kind !in [.ident, .param] && t.expr_may_escape_any_named_capture(child_id, capture_aliases, capture_address_aliases) {
 			return true
 		}
 	}
@@ -1572,9 +1559,7 @@ fn (t &Transformer) expr_may_escape_any_named_capture(id flat.NodeId, captures m
 		}
 	}
 	for i in 0 .. node.children_count {
-		if t.expr_may_escape_any_named_capture(t.a.child(&node, i), captures,
-			capture_address_aliases)
-		{
+		if t.expr_may_escape_any_named_capture(t.a.child(&node, i), captures, capture_address_aliases) {
 			return true
 		}
 	}
@@ -1714,13 +1699,13 @@ fn (mut t Transformer) transform_cgen_json_encode_call(id flat.NodeId, node flat
 	start := t.a.children.len
 	t.a.children << children
 	new_id := t.a.add_node(flat.Node{
-		kind:           .call
-		op:             node.op
+		kind: .call
+		op: node.op
 		children_start: start
 		children_count: flat.child_count(children.len)
-		pos:            node.pos
-		value:          node.value
-		typ:            node.typ
+		pos: node.pos
+		value: node.value
+		typ: node.typ
 	})
 	t.copy_cloned_resolution(id, new_id)
 	return new_id
@@ -1769,8 +1754,7 @@ fn (mut t Transformer) fixed_variadic_spread_args_with_trailing(spread_args []fl
 	mut args := spread_args.clone()
 	if trailing_start < node.children_count && args.len > 0 {
 		tail_idx := args.len - 1
-		args[tail_idx] = t.append_trailing_args_to_variadic_tail(args[tail_idx], node,
-			trailing_start, variadic_type)
+		args[tail_idx] = t.append_trailing_args_to_variadic_tail(args[tail_idx], node, trailing_start, variadic_type)
 	}
 	return args
 }
@@ -1790,12 +1774,10 @@ fn (mut t Transformer) transform_spread_arg_over_fixed_variadic_tail(arg_node fl
 	variadic_array_type := t.semantic_type_name(variadic_type)
 	spread_type0 := t.node_type(spread_id)
 	spread_type := if spread_type0.len > 0 { spread_type0 } else { variadic_array_type }
-	spread_expr := t.stable_transformed_expr_for_reuse(t.transform_call_arg_for_param(spread_id,
-		spread_type), spread_type, 'varargs_spread')
+	spread_expr := t.stable_transformed_expr_for_reuse(t.transform_call_arg_for_param(spread_id, spread_type), spread_type, 'varargs_spread')
 	mut args := []flat.NodeId{cap: variadic_idx - param_idx + 1}
 	for fixed_idx in param_idx .. variadic_idx {
-		elem := t.make_index(spread_expr, t.make_int_literal(fixed_idx - param_idx),
-			t.semantic_type_name(params[fixed_idx]))
+		elem := t.make_index(spread_expr, t.make_int_literal(fixed_idx - param_idx), t.semantic_type_name(params[fixed_idx]))
 		args << elem
 	}
 	tail_start := variadic_idx - param_idx
@@ -1803,8 +1785,7 @@ fn (mut t Transformer) transform_spread_arg_over_fixed_variadic_tail(arg_node fl
 	if spread_elem_type == t.normalize_type_alias(variadic_array_type) {
 		args << t.make_index(spread_expr, t.make_int_literal(tail_start), variadic_array_type)
 	} else {
-		args << t.make_range_index(spread_expr, t.make_int_literal(tail_start), flat.empty_node,
-			variadic_array_type)
+		args << t.make_range_index(spread_expr, t.make_int_literal(tail_start), flat.empty_node, variadic_array_type)
 	}
 	return args
 }
@@ -1829,8 +1810,7 @@ fn (mut t Transformer) transform_variadic_spread_arg_for_param(spread_id flat.No
 			expected_elem := t.normalize_type_alias(t.semantic_type_name(variadic_type.elem_type))
 			if actual_elem != expected_elem
 				&& t.sum_target_accepts_variant_type(expected_elem, actual_elem) {
-				return t.convert_forwarded_array_to_dynamic(spread_id, actual, actual.elem_type,
-					expected, variadic_type.elem_type, false)
+				return t.convert_forwarded_array_to_dynamic(spread_id, actual, actual.elem_type, expected, variadic_type.elem_type, false)
 			}
 		}
 	}
@@ -1849,11 +1829,11 @@ fn (mut t Transformer) make_range_index(base flat.NodeId, start_id flat.NodeId, 
 		t.a.children << child
 	}
 	return t.a.add_node(flat.Node{
-		kind:           .index
-		value:          'range'
+		kind: .index
+		value: 'range'
 		children_start: start
 		children_count: flat.child_count(children.len)
-		typ:            typ
+		typ: typ
 	})
 }
 
@@ -1937,11 +1917,11 @@ fn (mut t Transformer) transform_trailing_field_init_struct_arg(node flat.Node, 
 		t.a.children << field_id
 	}
 	struct_id := t.a.add_node(flat.Node{
-		kind:           .struct_init
+		kind: .struct_init
 		children_start: start
 		children_count: flat.child_count(field_ids.len)
-		value:          struct_type
-		typ:            struct_type
+		value: struct_type
+		typ: struct_type
 	})
 	return t.transform_struct_fields(struct_id, t.a.nodes[int(struct_id)])
 }
@@ -2180,12 +2160,12 @@ fn (mut t Transformer) transform_method_callee_receiver_for_param(callee_id flat
 	start := t.a.children.len
 	t.a.children << new_base
 	return t.a.add_node(flat.Node{
-		kind:           .selector
+		kind: .selector
 		children_start: start
 		children_count: 1
-		pos:            callee.pos
-		value:          callee.value
-		typ:            callee.typ
+		pos: callee.pos
+		value: callee.value
+		typ: callee.typ
 	})
 }
 
@@ -2605,8 +2585,8 @@ fn (mut t Transformer) add_call_param_types_decl_key(key string, idx int, file s
 	t.call_param_types_prepared = false
 	if key !in t.call_param_types_decl_index {
 		t.call_param_types_decl_index[key] = FnParamDeclRef{
-			idx:    idx
-			file:   file
+			idx: idx
+			file: file
 			module: module_name
 		}
 	}
@@ -2614,8 +2594,8 @@ fn (mut t Transformer) add_call_param_types_decl_key(key string, idx int, file s
 	cname := c_name(key)
 	if cname != key && cname !in t.call_param_types_decl_index {
 		t.call_param_types_decl_index[cname] = FnParamDeclRef{
-			idx:    idx
-			file:   file
+			idx: idx
+			file: file
 			module: module_name
 		}
 	}
@@ -2674,8 +2654,7 @@ fn (t &Transformer) decl_param_type_in_module(typ string, module_name string) st
 	if clean.starts_with('[') {
 		bracket_end := generic_matching_bracket(clean, 0)
 		if bracket_end < clean.len {
-			return clean[..bracket_end + 1] + t.decl_param_type_in_module(clean[bracket_end +
-				1..], module_name)
+			return clean[..bracket_end + 1] + t.decl_param_type_in_module(clean[bracket_end + 1..], module_name)
 		}
 	}
 	if clean.starts_with('fn(') || clean.starts_with('fn (') {
@@ -3097,7 +3076,7 @@ fn (mut t Transformer) transform_call_arg_for_param_isolated(arg_id flat.NodeId,
 	}
 	if param_type.starts_with('&')
 		&& ((arg_node.kind == .int_literal && (arg_node.value == '0' || arg_node.value.len == 0))
-		|| arg_node.kind == .nil_literal) {
+			|| arg_node.kind == .nil_literal) {
 		// A zero/nil pointer argument is already the C null pointer value. It is
 		// not an addressable value to borrow (for example `C.wait(0)`).
 		return t.transform_expr(arg_id)
@@ -3111,17 +3090,14 @@ fn (mut t Transformer) transform_call_arg_for_param_isolated(arg_id flat.NodeId,
 			// Evaluate the optional once, keeping it addressable so mutations
 			// through the reference still write back to the payload (a stable
 			// ident/selector is reused directly, a call is materialized once).
-			opt_expr := t.stable_transformed_expr_for_reuse(t.transform_expr(source_id),
-				source_type, 'opt_ref')
+			opt_expr := t.stable_transformed_expr_for_reuse(t.transform_expr(source_id), source_type, 'opt_ref')
 			if t.is_optional_type_name(t.cur_fn_ret_type) {
 				// `opt?` propagates: return none/err when it is none, instead of
 				// unconditionally treating it as present.
 				not_ok := t.make_prefix(.not, t.make_selector(opt_expr, 'ok', 'bool'))
 				err_expr := t.make_selector(opt_expr, 'err', 'IError')
-				else_stmts := t.lower_or_body_to_stmts_with_err_expr(flat.empty_node, '',
-					payload_type, '?', err_expr)
-				t.pending_stmts << t.make_if(not_ok, t.make_block_skip_scope_drops(else_stmts),
-					t.make_empty())
+				else_stmts := t.lower_or_body_to_stmts_with_err_expr(flat.empty_node, '', payload_type, '?', err_expr)
+				t.pending_stmts << t.make_if(not_ok, t.make_block_skip_scope_drops(else_stmts), t.make_empty())
 			} else {
 				// Comptime option-payload-mut (e.g. `decode(mut result.field?)` in a
 				// `$for` decoder): the callee fills the payload, so mark it present and
@@ -3473,19 +3449,19 @@ fn (mut t Transformer) lift_lambda_expr_for_fn_param(_id flat.NodeId, node flat.
 		param_node := t.a.nodes[int(param_id)]
 		param_type_name := t.semantic_type_name(fn_type.params[i])
 		children << t.a.add_node(flat.Node{
-			kind:  .param
+			kind: .param
 			value: param_node.value
-			typ:   param_type_name
-			op:    if param_type_name.starts_with('&') { .amp } else { .none }
+			typ: param_type_name
+			op: if param_type_name.starts_with('&') { .amp } else { .none }
 		})
 	}
 	for i in lambda_param_count .. fn_type.params.len {
 		param_type_name := t.semantic_type_name(fn_type.params[i])
 		children << t.a.add_node(flat.Node{
-			kind:  .param
+			kind: .param
 			value: '_unused_${i}'
-			typ:   param_type_name
-			op:    if param_type_name.starts_with('&') { .amp } else { .none }
+			typ: param_type_name
+			op: if param_type_name.starts_with('&') { .amp } else { .none }
 		})
 	}
 	ret_type := t.semantic_type_name(fn_type.return_type)
@@ -3516,11 +3492,11 @@ fn (mut t Transformer) lift_lambda_expr_for_fn_param(_id flat.NodeId, node flat.
 		t.a.children << child
 	}
 	fn_id := t.a.add_node(flat.Node{
-		kind:           .fn_literal
-		typ:            ret_type
+		kind: .fn_literal
+		typ: ret_type
 		children_start: start
 		children_count: flat.child_count(children.len)
-		pos:            node.pos
+		pos: node.pos
 	})
 	return t.lift_fn_literal(fn_id, t.a.nodes[int(fn_id)])
 }
@@ -3556,10 +3532,10 @@ fn (mut t Transformer) lift_fn_literal_for_fn_param(_id flat.NodeId, node flat.N
 			children << param_id
 		} else {
 			children << t.a.add_node(flat.Node{
-				kind:   .param
-				value:  param.value
-				typ:    param_type_name
-				op:     if param_type_name.starts_with('&') { .amp } else { param.op }
+				kind: .param
+				value: param.value
+				typ: param_type_name
+				op: if param_type_name.starts_with('&') { .amp } else { param.op }
 				is_mut: param.is_mut
 			})
 		}
@@ -3567,10 +3543,10 @@ fn (mut t Transformer) lift_fn_literal_for_fn_param(_id flat.NodeId, node flat.N
 	for i in param_ids.len .. fn_type.params.len {
 		param_type_name := t.semantic_type_name(fn_type.params[i])
 		children << t.a.add_node(flat.Node{
-			kind:  .param
+			kind: .param
 			value: '_unused_${i}'
-			typ:   param_type_name
-			op:    if param_type_name.starts_with('&') { .amp } else { .none }
+			typ: param_type_name
+			op: if param_type_name.starts_with('&') { .amp } else { .none }
 		})
 	}
 	children << body_ids
@@ -3584,11 +3560,11 @@ fn (mut t Transformer) lift_fn_literal_for_fn_param(_id flat.NodeId, node flat.N
 		t.semantic_type_name(fn_type.return_type)
 	}
 	fn_id := t.a.add_node(flat.Node{
-		kind:           .fn_literal
-		typ:            ret_type
+		kind: .fn_literal
+		typ: ret_type
 		children_start: start
 		children_count: flat.child_count(children.len)
-		pos:            node.pos
+		pos: node.pos
 	})
 	return t.lift_fn_literal(fn_id, t.a.nodes[int(fn_id)])
 }
@@ -3802,8 +3778,7 @@ fn (mut t Transformer) collect_lambda_condition_captures(id flat.NodeId, locals 
 				then_scope[name] = true
 			}
 		}
-		t.collect_lambda_condition_captures(t.a.child(&node, 1), lhs_scope, mut then_scope, mut
-			names)
+		t.collect_lambda_condition_captures(t.a.child(&node, 1), lhs_scope, mut then_scope, mut names)
 		return
 	}
 	t.collect_lambda_capture_names(id, locals, mut names)
@@ -3916,7 +3891,7 @@ fn (t &Transformer) c_type_nil_call_for_type(node flat.Node, value_type string) 
 		base := t.a.child_node(callee, 0)
 		return base.kind == .ident && callee.value.len > 0
 			&& ((base.value == 'C' && (value_type.starts_with('C.') || callee.value == short_type))
-			|| '${base.value}.${callee.value}' == value_type)
+				|| '${base.value}.${callee.value}' == value_type)
 	}
 	return false
 }
@@ -3946,7 +3921,7 @@ fn (mut t Transformer) append_missing_params_struct_args(mut args []flat.NodeId,
 		} else if params[param_idx] is types.OptionType {
 			args << t.a.add_node(flat.Node{
 				kind: .none_expr
-				typ:  param_type
+				typ: param_type
 			})
 		} else {
 			break
@@ -4102,8 +4077,7 @@ fn (t &Transformer) const_expr_for_arg(arg_id flat.NodeId) ?flat.NodeId {
 	if node.kind == .selector && node.children_count > 0 {
 		if !t.selector_const_base_is_value(node) {
 			base := t.a.child_node(&node, 0)
-			return t.const_expr_for_name_in_context('${base.value}.${node.value}', t.cur_module,
-				t.cur_file)
+			return t.const_expr_for_name_in_context('${base.value}.${node.value}', t.cur_module, t.cur_file)
 		}
 	}
 	return none
@@ -4164,8 +4138,7 @@ fn (mut t Transformer) pack_variadic_args(node flat.Node, first_arg int, elem_ty
 			return t.make_array_literal_typed([named_arg], array_type)
 		}
 		tmp_name := t.new_temp('varargs')
-		t.pending_stmts << t.make_decl_assign_typed(tmp_name, t.make_array_new_call(expected_enum,
-			t.make_int_literal(0), t.make_int_literal(1)), array_type)
+		t.pending_stmts << t.make_decl_assign_typed(tmp_name, t.make_array_new_call(expected_enum, t.make_int_literal(0), t.make_int_literal(1)), array_type)
 		value_name := t.new_temp('vararg')
 		t.pending_stmts << t.make_decl_assign_typed(value_name, named_arg, expected_enum)
 		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('array_push', [
@@ -4198,9 +4171,7 @@ fn (mut t Transformer) pack_variadic_args(node flat.Node, first_arg int, elem_ty
 		return t.make_array_literal_typed(values, array_type)
 	}
 	tmp_name := t.new_temp('varargs')
-	t.pending_stmts << t.make_decl_assign_typed(tmp_name, t.make_array_new_call(expected_enum,
-		t.make_int_literal(0), t.make_int_literal(int(node.children_count) - first_arg)),
-		array_type)
+	t.pending_stmts << t.make_decl_assign_typed(tmp_name, t.make_array_new_call(expected_enum, t.make_int_literal(0), t.make_int_literal(int(node.children_count) - first_arg)), array_type)
 	mut i := first_arg
 	for i < node.children_count {
 		if named_arg := t.transform_variadic_struct_fields(node, i, elem_type) {
@@ -4225,12 +4196,9 @@ fn (mut t Transformer) append_trailing_args_to_variadic_tail(tail flat.NodeId, n
 	tail_value := t.stable_transformed_expr_for_reuse(tail, array_type, 'varargs_tail')
 	tmp_name := t.new_temp('varargs')
 	extra_count := int(node.children_count) - first_arg
-	cap_expr := t.make_infix(.plus, t.make_selector(tail_value, 'len', 'int'),
-		t.make_int_literal(extra_count))
-	t.pending_stmts << t.make_decl_assign_typed(tmp_name, t.make_array_new_call(expected_elem,
-		t.make_int_literal(0), cap_expr), array_type)
-	t.pending_stmts << t.make_expr_stmt(t.make_array_push_many_call(t.make_prefix(.amp,
-		t.make_ident(tmp_name)), tail_value, array_type))
+	cap_expr := t.make_infix(.plus, t.make_selector(tail_value, 'len', 'int'), t.make_int_literal(extra_count))
+	t.pending_stmts << t.make_decl_assign_typed(tmp_name, t.make_array_new_call(expected_elem, t.make_int_literal(0), cap_expr), array_type)
+	t.pending_stmts << t.make_expr_stmt(t.make_array_push_many_call(t.make_prefix(.amp, t.make_ident(tmp_name)), tail_value, array_type))
 	mut i := first_arg
 	for i < node.children_count {
 		if named_arg := t.transform_variadic_struct_fields(node, i, elem_type) {
@@ -4365,11 +4333,11 @@ fn (mut t Transformer) transform_variadic_struct_fields(node flat.Node, field_st
 		t.a.children << field_id
 	}
 	struct_id := t.a.add_node(flat.Node{
-		kind:           .struct_init
+		kind: .struct_init
 		children_start: start
 		children_count: flat.child_count(field_ids.len)
-		value:          t.semantic_type_name(elem_type)
-		typ:            t.semantic_type_name(elem_type)
+		value: t.semantic_type_name(elem_type)
+		typ: t.semantic_type_name(elem_type)
 	})
 	return t.transform_struct_fields(struct_id, t.a.nodes[int(struct_id)])
 }
@@ -4381,10 +4349,10 @@ fn (mut t Transformer) make_array_literal_typed(values []flat.NodeId, typ string
 		t.a.children << value
 	}
 	return t.a.add_node(flat.Node{
-		kind:           .array_literal
+		kind: .array_literal
 		children_start: start
 		children_count: flat.child_count(values.len)
-		typ:            typ
+		typ: typ
 	})
 }
 
@@ -4589,9 +4557,7 @@ fn (t &Transformer) reliable_infix_stringify_type(node flat.Node) string {
 		.plus, .minus, .mul, .power, .div, .mod, .amp, .pipe, .xor {
 			if lhs_type.len > 0 && rhs_type.len > 0 && t.is_numeric_stringify_type(lhs_type)
 				&& t.is_numeric_stringify_type(rhs_type) {
-				if promoted := promote_numeric_literal_infix_type(t.a.nodes[int(lhs_id)], lhs_type,
-					t.a.nodes[int(rhs_id)], rhs_type)
-				{
+				if promoted := promote_numeric_literal_infix_type(t.a.nodes[int(lhs_id)], lhs_type, t.a.nodes[int(rhs_id)], rhs_type) {
 					return promoted
 				}
 				// Use the promoted result type, not the lhs, so e.g.
@@ -4669,8 +4635,12 @@ fn unsigned_type_text_accepts_int_literal(typ string, value int) bool {
 	max := match typ {
 		'u8', 'byte' { 255 }
 		'u16' { 65535 }
-		'u32', 'u64', 'usize' { return true }
-		else { return false }
+		'u32', 'u64', 'usize' {
+			return true
+		}
+		else {
+			return false
+		}
 	}
 
 	return value <= max
@@ -4936,8 +4906,7 @@ fn (mut t Transformer) wrap_string_conversion(expr flat.NodeId, typ string) flat
 				return t.make_string_literal(typeof_display_type_text(clean_typ))
 			}
 			if parsed is types.MultiReturn {
-				return t.lower_multi_return_str(expr, parsed,
-					t.multi_return_type_name(parsed.types))
+				return t.lower_multi_return_str(expr, parsed, t.multi_return_type_name(parsed.types))
 			}
 			if parsed is types.Enum {
 				if method := t.enum_str_method_name(clean_typ) {
@@ -5038,8 +5007,7 @@ fn (mut t Transformer) wrap_string_conversion(expr flat.NodeId, typ string) flat
 			// param (`u8(255) + u8(1)` is 256 in C); cast back to the value
 			// type first so the arithmetic wraps at the V type's width.
 			truncated := t.make_cast(clean_typ, expr, clean_typ)
-			return t.make_call_typed('strconv__format_uint', [truncated, t.make_int_literal(10)],
-				'string')
+			return t.make_call_typed('strconv__format_uint', [truncated, t.make_int_literal(10)], 'string')
 		}
 		'u64' {
 			return t.make_call_typed('u64.str', [expr], 'string')
@@ -5060,11 +5028,12 @@ fn (mut t Transformer) wrap_string_conversion(expr flat.NodeId, typ string) flat
 			return t.make_call_typed('i64.str', [expr], 'string')
 		}
 		'char' {
-			return t.make_call_typed('v3_char_string', [t.make_cast('int', expr, 'int')], 'string')
+			return t.make_call_typed('v3_char_string', [
+				t.make_cast('int', expr, 'int'),
+			], 'string')
 		}
 		'isize' {
-			return t.make_call_typed('strconv__format_int', [expr, t.make_int_literal(10)],
-				'string')
+			return t.make_call_typed('strconv__format_int', [expr, t.make_int_literal(10)], 'string')
 		}
 		'f32' {
 			return t.make_call_typed('f32.str', [expr], 'string')
@@ -5130,7 +5099,7 @@ fn (mut t Transformer) lower_interface_auto_str(expr flat.NodeId, iface_name str
 fn (mut t Transformer) lower_interface_auto_str_with_nil(expr flat.NodeId, iface_name string, allow_nil bool) flat.NodeId {
 	if t.stringify_stack_count(iface_name) > 0
 		|| (t.stringify_stack.len >= t.stringify_depth_cap
-		&& !t.stringify_types_match(t.auto_str_synthesis_type, iface_name)) {
+			&& !t.stringify_types_match(t.auto_str_synthesis_type, iface_name)) {
 		return t.request_auto_str_helper(expr, iface_name)
 	}
 	t.stringify_stack << iface_name
@@ -5144,12 +5113,10 @@ fn (mut t Transformer) lower_interface_auto_str_with_nil(expr flat.NodeId, iface
 	t.refresh_interface_impl_indexes_for_boxed_types()
 	value := t.stable_transformed_expr_for_reuse(expr, iface_name, 'iface_str')
 	result_name := t.new_temp('iface_str')
-	t.pending_stmts << t.make_decl_assign_typed(result_name,
-		t.make_string_literal('unknown interface value'), 'string')
+	t.pending_stmts << t.make_decl_assign_typed(result_name, t.make_string_literal('unknown interface value'), 'string')
 	tag := t.make_selector(value, '_typ', 'int')
 	if allow_nil {
-		object_is_nil := t.make_infix(.eq, t.make_selector(value, '_object', 'voidptr'),
-			t.make_int_literal(0))
+		object_is_nil := t.make_infix(.eq, t.make_selector(value, '_object', 'voidptr'), t.make_int_literal(0))
 		tag_is_zero := t.make_infix(.eq, tag, t.make_int_literal(0))
 		nil_cond := t.make_infix(.logical_and, tag_is_zero, object_is_nil)
 		t.pending_stmts << t.make_if(nil_cond, t.make_block([
@@ -5190,8 +5157,7 @@ fn (mut t Transformer) lower_interface_auto_str_with_nil(expr flat.NodeId, iface
 			type_id := t.interface_impl_type_id(iface_name, concrete_type) or {
 				t.interface_impl_type_id(iface_name, impl_name) or { continue }
 			}
-			object := t.make_cast('&${concrete_type}',
-				t.make_selector(value, '_object', 'voidptr'), '&${concrete_type}')
+			object := t.make_cast('&${concrete_type}', t.make_selector(value, '_object', 'voidptr'), '&${concrete_type}')
 			concrete := t.make_prefix(.mul, object)
 			t.set_node_typ(int(concrete), concrete_type)
 			saved := t.pending_stmts.clone()
@@ -5211,14 +5177,11 @@ fn (mut t Transformer) lower_interface_auto_str_with_nil(expr flat.NodeId, iface
 				mut inner := t.wrap_string_conversion(concrete, inner_type)
 				quote_type := t.normalize_type_alias(inner_type)
 				if quote_type == 'string' {
-					inner = t.string_plus(t.string_plus(t.make_string_literal("'"), inner),
-						t.make_string_literal("'"))
+					inner = t.string_plus(t.string_plus(t.make_string_literal("'"), inner), t.make_string_literal("'"))
 				} else if quote_type == 'rune' {
-					inner = t.string_plus(t.string_plus(t.make_string_literal('`'), inner),
-						t.make_string_literal('`'))
+					inner = t.string_plus(t.string_plus(t.make_string_literal('`'), inner), t.make_string_literal('`'))
 				}
-				t.string_plus(t.string_plus(t.make_string_literal('${display_name}('), inner),
-					t.make_string_literal(')'))
+				t.string_plus(t.string_plus(t.make_string_literal('${display_name}('), inner), t.make_string_literal(')'))
 			}
 			mut render_body := []flat.NodeId{}
 			t.drain_pending(mut render_body)
@@ -5237,8 +5200,7 @@ fn (mut t Transformer) lower_interface_auto_str_with_nil(expr flat.NodeId, iface
 				]
 				live_body << render_body
 				live_body << t.make_expr_stmt(t.make_call_typed('autostr_addr_pop', [], 'void'))
-				seen := t.make_call_typed('autostr_addr_type_in_stack', [object_addr, object_type],
-					'bool')
+				seen := t.make_call_typed('autostr_addr_type_in_stack', [object_addr, object_type], 'bool')
 				seen_body := t.make_block([
 					t.make_assign(t.make_ident(result_name), t.make_string_literal('<circular>')),
 				])
@@ -5300,8 +5262,7 @@ fn (mut t Transformer) lower_ref_interface_str(expr flat.NodeId, iface_name stri
 	t.drain_pending(mut then_body)
 	t.pending_stmts = saved
 	t.unset_var_type(ptr_name)
-	then_body << t.make_assign(t.make_ident(res_name), t.string_plus(t.make_string_literal('&'),
-		inner))
+	then_body << t.make_assign(t.make_ident(res_name), t.string_plus(t.make_string_literal('&'), inner))
 	cond := t.make_infix(.ne, t.make_ident(ptr_name), t.a.add(.nil_literal))
 	t.pending_stmts << t.make_if(cond, t.make_block(then_body), t.make_empty())
 	result := t.make_ident(res_name)
@@ -5397,7 +5358,7 @@ fn (mut t Transformer) request_auto_str_helper(expr flat.NodeId, aggregate strin
 	if aggregate !in t.auto_str_types {
 		t.auto_str_types[aggregate] = AutoStrRequest{
 			module: t.cur_module
-			file:   t.cur_file
+			file: t.cur_file
 			// The helper name contains the fully qualified C type, while the module
 			// assignment keeps its definition with the cached object that owns it.
 			helper_module: t.auto_str_helper_owner_module(aggregate)
@@ -5411,11 +5372,9 @@ fn (mut t Transformer) request_auto_str_helper(expr flat.NodeId, aggregate strin
 	address := t.make_cast('voidptr', t.make_prefix(.amp, value), 'voidptr')
 	address_type := t.make_int_literal(t.type_index_for_type_name(aggregate))
 	result_name := t.new_temp('autostr')
-	t.pending_stmts << t.make_decl_assign_typed(result_name, t.make_string_literal('<circular>'),
-		'string')
+	t.pending_stmts << t.make_decl_assign_typed(result_name, t.make_string_literal('<circular>'), 'string')
 	live_body := t.make_block([
-		t.make_expr_stmt(t.make_call_typed('autostr_addr_type_push', [address, address_type],
-			'void')),
+		t.make_expr_stmt(t.make_call_typed('autostr_addr_type_push', [address, address_type], 'void')),
 		t.make_assign(t.make_ident(result_name), t.make_call_typed(helper, [value], 'string')),
 		t.make_expr_stmt(t.make_call_typed('autostr_addr_pop', [], 'void')),
 	])
@@ -5513,9 +5472,9 @@ fn (mut t Transformer) build_auto_str_helper_fn(aggregate string) {
 	t.cur_fn_ret_type = 'string'
 	param_name := '__auto_str_value'
 	param := t.a.add_node(flat.Node{
-		kind:  .param
+		kind: .param
 		value: param_name
-		typ:   aggregate
+		typ: aggregate
 	})
 	t.set_var_type(param_name, aggregate)
 	value := t.make_ident(param_name)
@@ -5536,16 +5495,16 @@ fn (mut t Transformer) build_auto_str_helper_fn(aggregate string) {
 	t.cur_fn_name = saved_fn_name
 	t.cur_fn_ret_type = saved_ret_type
 	t.a.add_node(flat.Node{
-		kind:  .module_decl
+		kind: .module_decl
 		value: if t.auto_str_helper_module.len > 0 { t.auto_str_helper_module } else { 'main' }
 	})
 	start := t.a.children.len
 	t.a.children << param
 	t.a.children << stmts
 	t.a.add_node(flat.Node{
-		kind:           .fn_decl
-		value:          helper
-		typ:            'string'
+		kind: .fn_decl
+		value: helper
+		typ: 'string'
 		children_start: i32(start)
 		children_count: flat.child_count(1 + stmts.len)
 	})
@@ -5562,7 +5521,9 @@ fn (mut t Transformer) build_auto_str_helper_fn(aggregate string) {
 		t.tc.fn_ret_types[helper] = t.tc.parse_type('string')
 		t.tc.fn_ret_types[helper_key] = t.tc.parse_type('string')
 		t.tc.register_generated_fn_param_types(helper, [t.tc.parse_type(aggregate)])
-		t.tc.register_generated_fn_param_types(helper_key, [t.tc.parse_type(aggregate)])
+		t.tc.register_generated_fn_param_types(helper_key, [
+			t.tc.parse_type(aggregate),
+		])
 		t.tc.fn_variadic[helper] = false
 		t.tc.fn_variadic[helper_key] = false
 		t.tc_signature_names_log << helper
@@ -5601,8 +5562,7 @@ fn (mut t Transformer) lower_ref_collection_str(expr flat.NodeId, collection_typ
 	t.drain_pending(mut then_body)
 	t.pending_stmts = saved
 	t.unset_var_type(ptr_name)
-	then_body << t.make_assign(t.make_ident(res_name), t.string_plus(t.make_string_literal('&'),
-		value_str))
+	then_body << t.make_assign(t.make_ident(res_name), t.string_plus(t.make_string_literal('&'), value_str))
 	cond := t.make_infix(.ne, t.make_ident(ptr_name), t.a.add(.nil_literal))
 	t.pending_stmts << t.make_if(cond, t.make_block(then_body), t.make_empty())
 	return t.make_ident(res_name)
@@ -5643,8 +5603,7 @@ fn (mut t Transformer) lower_ref_str_guarded(expr flat.NodeId, aggregate string,
 		address := t.make_cast('voidptr', t.make_ident(ptr_name), 'voidptr')
 		address_type := t.make_int_literal(t.type_index_for_type_name(aggregate))
 		mut live_body := [
-			t.make_expr_stmt(t.make_call_typed('autostr_addr_type_push', [address, address_type],
-				'void')),
+			t.make_expr_stmt(t.make_call_typed('autostr_addr_type_push', [address, address_type], 'void')),
 		]
 		live_body << then_body
 		live_body << t.make_expr_stmt(t.make_call_typed('autostr_addr_pop', [], 'void'))
@@ -5684,8 +5643,7 @@ fn (mut t Transformer) lower_interface_smartcast_ref_str(expr flat.NodeId, inter
 	t.pending_stmts = saved
 	t.unset_var_type(ptr_name)
 	boxed_value := t.make_assign(t.make_ident(res_name), value_str)
-	pointer_value := t.make_assign(t.make_ident(res_name), t.string_plus(t.make_string_literal('&'),
-		value_str))
+	pointer_value := t.make_assign(t.make_ident(res_name), t.string_plus(t.make_string_literal('&'), value_str))
 	then_body << t.make_if(t.make_ident(boxed_name), t.make_block([boxed_value]), t.make_block([
 		pointer_value,
 	]))
@@ -5741,24 +5699,20 @@ fn (mut t Transformer) lower_ref_value_str_with_custom_prefix(expr flat.NodeId, 
 		quote_elem = quote_elem.all_after_last('.')
 	}
 	if quote_elem == 'string' {
-		value_str = t.string_plus(t.string_plus(t.make_string_literal("'"), value_str),
-			t.make_string_literal("'"))
+		value_str = t.string_plus(t.string_plus(t.make_string_literal("'"), value_str), t.make_string_literal("'"))
 	} else if quote_elem == 'rune' {
-		value_str = t.string_plus(t.string_plus(t.make_string_literal('`'), value_str),
-			t.make_string_literal('`'))
+		value_str = t.string_plus(t.string_plus(t.make_string_literal('`'), value_str), t.make_string_literal('`'))
 	}
 	mut then_body := []flat.NodeId{}
 	t.drain_pending(mut then_body)
 	t.pending_stmts = saved
 	t.unset_var_type(ptr_name)
-	then_body << t.make_assign(t.make_ident(res_name), t.string_plus(t.make_string_literal('&'),
-		value_str))
+	then_body << t.make_assign(t.make_ident(res_name), t.string_plus(t.make_string_literal('&'), value_str))
 	if _ := t.stringify_aggregate_type_name(elem_type) {
 		address := t.make_cast('voidptr', t.make_ident(ptr_name), 'voidptr')
 		address_type := t.make_int_literal(t.type_index_for_type_name(elem_type))
 		mut live_body := [
-			t.make_expr_stmt(t.make_call_typed('autostr_addr_type_push', [address, address_type],
-				'void')),
+			t.make_expr_stmt(t.make_call_typed('autostr_addr_type_push', [address, address_type], 'void')),
 		]
 		live_body << then_body
 		live_body << t.make_expr_stmt(t.make_call_typed('autostr_addr_pop', [], 'void'))
@@ -5910,8 +5864,7 @@ fn (mut t Transformer) alias_str_wrap(expr flat.NodeId, alias_name string, base_
 		return inner
 	}
 	display := struct_string_display_name(alias_name)
-	return t.string_plus(t.string_plus(t.make_string_literal('${display}('), inner),
-		t.make_string_literal(')'))
+	return t.string_plus(t.string_plus(t.make_string_literal('${display}('), inner), t.make_string_literal(')'))
 }
 
 fn (t &Transformer) is_fn_stringify_type(typ string) bool {
@@ -5973,9 +5926,7 @@ fn (mut t Transformer) alias_custom_str_method_name(alias_name string) ?string {
 		}
 		str_fn := '${c_name(qname)}__str'
 		v_str_fn := '${qname}.str'
-		if method_name, generic_args := t.generic_str_method_specialization(v_str_fn, qname,
-			alias_target)
-		{
+		if method_name, generic_args := t.generic_str_method_specialization(v_str_fn, qname, alias_target) {
 			t.mark_generic_str_method_specialization(method_name, generic_args)
 			return method_name
 		}
@@ -6138,8 +6089,7 @@ fn (mut t Transformer) lower_struct_str(expr flat.NodeId, struct_type string) ?f
 		if pointer_type.len == 0 {
 			pointer_type = '&${struct_type}'
 		}
-		deref_address_source = t.stable_transformed_expr_for_reuse(pointer_id, pointer_type,
-			'struct_str_ptr')
+		deref_address_source = t.stable_transformed_expr_for_reuse(pointer_id, pointer_type, 'struct_str_ptr')
 		value_expr = t.make_prefix(.mul, deref_address_source)
 		t.set_node_typ(int(value_expr), struct_type)
 	}
@@ -6162,8 +6112,7 @@ fn (mut t Transformer) lower_struct_str(expr flat.NodeId, struct_type string) ?f
 	}
 	display := struct_string_display_name(struct_type)
 	mut result := t.make_string_literal('${display}{\n')
-	decl_metas := t.struct_field_decl_metas_in_module(comptime_struct_info_cache_key(info),
-		info.module)
+	decl_metas := t.struct_field_decl_metas_in_module(comptime_struct_info_cache_key(info), info.module)
 	for field in info.fields {
 		if meta := decl_metas[field.name] {
 			if auto_str_field_is_skipped(meta) {
@@ -6183,12 +6132,10 @@ fn (mut t Transformer) lower_struct_str(expr flat.NodeId, struct_type string) ?f
 		mut field_str := if field_type == struct_type {
 			t.make_string_literal('${struct_string_display_name(field_type)}{}')
 		} else {
-			t.struct_field_str_value(t.make_selector(base, field.name, field_type), raw_field_type,
-				field_type)
+			t.struct_field_str_value(t.make_selector(base, field.name, field_type), raw_field_type, field_type)
 		}
 		if raw_field_type == 'string' || raw_field_type == 'builtin.string' {
-			field_str = t.string_plus(t.string_plus(t.make_string_literal("'"), field_str),
-				t.make_string_literal("'"))
+			field_str = t.string_plus(t.string_plus(t.make_string_literal("'"), field_str), t.make_string_literal("'"))
 		}
 		if t.struct_str_field_needs_indent(raw_field_type) {
 			t.mark_fn_used_name('string.replace')
@@ -6367,8 +6314,7 @@ fn (mut t Transformer) struct_field_str_value(expr flat.NodeId, raw_field_type s
 		}
 	}
 	display := struct_string_display_name(alias_name)
-	return t.string_plus(t.string_plus(t.make_string_literal('${display}('), inner),
-		t.make_string_literal(')'))
+	return t.string_plus(t.string_plus(t.make_string_literal('${display}('), inner), t.make_string_literal(')'))
 }
 
 fn (mut t Transformer) lower_charptr_struct_field_str(expr flat.NodeId) flat.NodeId {
@@ -6379,8 +6325,7 @@ fn (mut t Transformer) lower_charptr_struct_field_str(expr flat.NodeId) flat.Nod
 	t.mark_fn_used_name('charptr.vstring')
 	t.mark_fn_used_name('charptr__vstring')
 	raw := t.make_call_typed('charptr.vstring', [t.make_ident(ptr_name)], 'string')
-	quoted := t.string_plus(t.string_plus(t.make_string_literal('C"'), raw),
-		t.make_string_literal('"'))
+	quoted := t.string_plus(t.string_plus(t.make_string_literal('C"'), raw), t.make_string_literal('"'))
 	then_body := t.make_block([t.make_assign(t.make_ident(res_name), quoted)])
 	cond := t.make_infix(.ne, t.make_ident(ptr_name), t.a.add(.nil_literal))
 	t.pending_stmts << t.make_if(cond, then_body, t.make_empty())
@@ -6445,14 +6390,11 @@ fn (mut t Transformer) lower_multi_return_str(expr flat.NodeId, multi types.Mult
 			result = t.string_plus(result, t.make_string_literal(', '))
 		}
 		item_type := t.semantic_type_name(item)
-		mut item_str := t.wrap_string_conversion(t.make_selector(base, 'arg${i}', item_type),
-			item_type)
+		mut item_str := t.wrap_string_conversion(t.make_selector(base, 'arg${i}', item_type), item_type)
 		if item is types.String {
-			item_str = t.string_plus(t.string_plus(t.make_string_literal("'"), item_str),
-				t.make_string_literal("'"))
+			item_str = t.string_plus(t.string_plus(t.make_string_literal("'"), item_str), t.make_string_literal("'"))
 		} else if item is types.Rune {
-			item_str = t.string_plus(t.string_plus(t.make_string_literal('`'), item_str),
-				t.make_string_literal('`'))
+			item_str = t.string_plus(t.string_plus(t.make_string_literal('`'), item_str), t.make_string_literal('`'))
 		}
 		result = t.string_plus(result, item_str)
 	}
@@ -6491,8 +6433,7 @@ fn (mut t Transformer) stringify_expansion_estimate_at(typ string, depth_left in
 	if clean.starts_with('map[') {
 		bracket_end := generic_matching_bracket(clean, 3)
 		if bracket_end > 3 && bracket_end < clean.len - 1 {
-			return t.stringify_expansion_estimate_at(clean[4..bracket_end], depth_left) +
-				t.stringify_expansion_estimate_at(clean[bracket_end + 1..], depth_left)
+			return t.stringify_expansion_estimate_at(clean[4..bracket_end], depth_left) + t.stringify_expansion_estimate_at(clean[bracket_end + 1..], depth_left)
 		}
 	}
 	if clean.starts_with('[') {
@@ -6666,7 +6607,7 @@ fn (mut t Transformer) string_interp_expr_needs_deferred_lowering(id flat.NodeId
 		str_key := '${iface_name}.str'
 		has_bounded_str := !isnil(t.tc)
 			&& ('str' in t.tc.interface_abstract_method_names(iface_name)
-			|| str_key in t.fn_ret_types || str_key in t.tc.fn_ret_types)
+				|| str_key in t.fn_ret_types || str_key in t.tc.fn_ret_types)
 		if !has_bounded_str {
 			return true
 		}
@@ -6751,8 +6692,7 @@ fn (mut t Transformer) runtime_type_metadata_call_expands(id flat.NodeId, node f
 		return false
 	}
 	fn_node := t.a.nodes[int(fn_id)]
-	if fn_node.kind != .selector || fn_node.value !in ['type_name', 'type_idx']
-		|| fn_node.children_count == 0 {
+	if fn_node.kind != .selector || fn_node.value !in ['type_name', 'type_idx'] || fn_node.children_count == 0 {
 		return false
 	}
 	base_id := t.a.child(&fn_node, 0)
@@ -6928,7 +6868,9 @@ fn decode_single_generic_specialized_type_args_for_base(name string, base string
 			continue
 		}
 		decoded := generic_type_arg_from_suffix_with_containers(name[prefix.len + 1..])
-		if decoded.len > 0 && generic_specialized_type_matches_flat_name(name, base, [decoded]) {
+		if decoded.len > 0 && generic_specialized_type_matches_flat_name(name, base, [
+			decoded,
+		]) {
 			return [decoded]
 		}
 	}
@@ -6989,10 +6931,8 @@ fn generic_specialized_type_matches_flat_name(flat_name string, base string, arg
 		if module_name == 'main' {
 			add_generic_specialized_type_candidate(mut candidates, '${short_base}_${suffix}')
 		}
-		add_generic_specialized_type_candidate(mut candidates,
-			'${module_name}.${short_base}_${suffix}')
-		add_generic_specialized_type_candidate(mut candidates,
-			c_name('${module_name}.${short_base}_${suffix}'))
+		add_generic_specialized_type_candidate(mut candidates, '${module_name}.${short_base}_${suffix}')
+		add_generic_specialized_type_candidate(mut candidates, c_name('${module_name}.${short_base}_${suffix}'))
 	}
 	return flat_name in candidates
 }
@@ -7099,13 +7039,13 @@ fn (t &Transformer) split_fixed_array_c_name_payload(payload string) ?FixedArray
 		if fallback.elem.len == 0 {
 			fallback = FixedArrayCNameParts{
 				elem: elem
-				len:  len
+				len: len
 			}
 		}
 		if t.fixed_array_c_name_len_is_known(len) {
 			return FixedArrayCNameParts{
 				elem: elem
-				len:  len
+				len: len
 			}
 		}
 	}
@@ -7245,8 +7185,11 @@ fn (mut t Transformer) build_sum_str_chain(base flat.NodeId, tag flat.NodeId, su
 	field := t.sum_field_name(variant)
 	variant_base := t.normalize_type_alias(variant)
 	direct_pointer := t.sum_variant_is_direct_pointer(variant)
-	field_sel := t.make_selector_op(base, field,
-		if direct_pointer { variant } else { '&${variant}' }, .dot)
+	field_sel := t.make_selector_op(base, field, if direct_pointer {
+		variant
+	} else {
+		'&${variant}'
+	}, .dot)
 	t.mark_generated_variant_access(field_sel, variant)
 	// Only statements created for THIS branch's payload conversion belong inside
 	// the branch; earlier pending statements (e.g. the base temp decl from
@@ -7277,18 +7220,14 @@ fn (mut t Transformer) build_sum_str_chain(base flat.NodeId, tag flat.NodeId, su
 	// already carries its type name for structs; string/rune payloads are quoted.
 	// An alias variant keeps its alias-name wrapper (`Res(Ints([1, 2]))`).
 	if variant_base == 'string' {
-		value_text = t.string_plus(t.string_plus(t.make_string_literal("'"), value_text),
-			t.make_string_literal("'"))
+		value_text = t.string_plus(t.string_plus(t.make_string_literal("'"), value_text), t.make_string_literal("'"))
 	} else if variant_base == 'rune' {
-		value_text = t.string_plus(t.string_plus(t.make_string_literal('`'), value_text),
-			t.make_string_literal('`'))
+		value_text = t.string_plus(t.string_plus(t.make_string_literal('`'), value_text), t.make_string_literal('`'))
 	} else if variant_base != variant {
 		display := if variant.contains('.') { variant.all_after_last('.') } else { variant }
-		value_text = t.string_plus(t.string_plus(t.make_string_literal('${display}('), value_text),
-			t.make_string_literal(')'))
+		value_text = t.string_plus(t.string_plus(t.make_string_literal('${display}('), value_text), t.make_string_literal(')'))
 	}
-	value_text = t.string_plus(t.string_plus(t.make_string_literal('${sum_display}('), value_text),
-		t.make_string_literal(')'))
+	value_text = t.string_plus(t.string_plus(t.make_string_literal('${sum_display}('), value_text), t.make_string_literal(')'))
 	mut then_stmts := t.pending_stmts[pending_start..].clone()
 	t.pending_stmts = t.pending_stmts[..pending_start].clone()
 	then_stmts << t.make_expr_stmt(value_text)
@@ -7301,10 +7240,10 @@ fn (mut t Transformer) build_sum_str_chain(base flat.NodeId, tag flat.NodeId, su
 	t.a.children << then_block
 	t.a.children << else_block
 	return t.a.add_node(flat.Node{
-		kind:           .if_expr
+		kind: .if_expr
 		children_start: start
 		children_count: 3
-		typ:            'string'
+		typ: 'string'
 	})
 }
 
@@ -7340,8 +7279,7 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 	if repeat_count, upper := string_repeat_format(format) {
 		if clean_typ == 'string' || normalized_typ == 'string' {
 			t.mark_fn_used('string__repeat')
-			repeated := t.make_call_typed('string__repeat',
-				[expr, t.make_int_literal(repeat_count)], 'string')
+			repeated := t.make_call_typed('string__repeat', [expr, t.make_int_literal(repeat_count)], 'string')
 			return if upper {
 				t.make_call_typed('v3_string_upper_ascii', [repeated], 'string')
 			} else {
@@ -7374,8 +7312,7 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 	// u64 so values above i64.max are not rendered as negative.
 	if format[format.len - 1] in [`x`, `b`, `o`, `d`] && t.is_formatted_enum_type(clean_typ) {
 		int_type := if t.enum_backing_is_unsigned(clean_typ) { 'u64' } else { 'i64' }
-		return t.wrap_formatted_string_conversion(t.make_cast(int_type, expr, int_type), int_type,
-			format)
+		return t.wrap_formatted_string_conversion(t.make_cast(int_type, expr, int_type), int_type, format)
 	}
 	if decimal_format := fixed_decimal_format(format) {
 		if clean_typ in ['f32', 'f64', 'float_literal'] {
@@ -7389,8 +7326,7 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 			if decimal_format.width > 0 || decimal_format.left {
 				left := if decimal_format.left { 1 } else { 0 }
 				formatted = t.make_call_typed('v3_string_pad', [formatted,
-					t.make_int_literal(decimal_format.width),
-					t.make_int_literal(left)], 'string')
+					t.make_int_literal(decimal_format.width), t.make_int_literal(left)], 'string')
 			}
 			return formatted
 		}
@@ -7403,13 +7339,11 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 				t.make_cast('f64', expr, 'f64')
 			}
 			mut formatted := t.make_call_typed('v3_f64_exp', [arg,
-				t.make_int_literal(exp_format.precision),
-				t.make_int_literal(if exp_format.upper {
+				t.make_int_literal(exp_format.precision), t.make_int_literal(if exp_format.upper {
 					1
 				} else {
 					0
-				})],
-				'string')
+				})], 'string')
 			if exp_format.width > 0 || exp_format.left {
 				left := if exp_format.left { 1 } else { 0 }
 				formatted = t.make_call_typed('v3_string_pad', [formatted,
@@ -7441,18 +7375,15 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 				t.make_cast('f64', expr, 'f64')
 			}
 			mut formatted := t.make_call_typed('v3_f64_general', [arg,
-				t.make_int_literal(general_format.precision),
-				t.make_int_literal(if general_format.upper {
+				t.make_int_literal(general_format.precision), t.make_int_literal(if general_format.upper {
 					1
 				} else {
 					0
-				})],
-				'string')
+				})], 'string')
 			if general_format.width > 0 || general_format.left {
 				left := if general_format.left { 1 } else { 0 }
 				formatted = t.make_call_typed('v3_string_pad', [formatted,
-					t.make_int_literal(general_format.width),
-					t.make_int_literal(left)], 'string')
+					t.make_int_literal(general_format.width), t.make_int_literal(left)], 'string')
 			}
 			return formatted
 		}
@@ -7468,13 +7399,11 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 			mut converted := t.make_call_typed('v3_char_string', [arg], 'string')
 			if char_format.width > 1 || char_format.left {
 				converted = t.make_call_typed('v3_string_pad', [converted,
-					t.make_int_literal(char_format.width),
-					t.make_int_literal(if char_format.left {
+					t.make_int_literal(char_format.width), t.make_int_literal(if char_format.left {
 						1
 					} else {
 						0
-					})],
-					'string')
+					})], 'string')
 			}
 			return converted
 		}
@@ -7482,8 +7411,7 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 	if base := integer_format_base(format) {
 		if clean_typ in ['u8', 'byte', 'u16', 'u32', 'u64', 'usize'] {
 			arg := t.widened_unsigned_format_arg(expr, clean_typ)
-			formatted := t.make_call_typed('strconv__format_uint', [arg, t.make_int_literal(base)],
-				'string')
+			formatted := t.make_call_typed('strconv__format_uint', [arg, t.make_int_literal(base)], 'string')
 			return if format == 'X' {
 				t.make_call_typed('v3_string_upper_ascii', [formatted], 'string')
 			} else {
@@ -7491,8 +7419,7 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 			}
 		}
 		if clean_typ in ['int', 'i8', 'i16', 'i32', 'i64', 'isize', 'rune'] {
-			formatted := t.make_call_typed('strconv__format_int', [expr, t.make_int_literal(base)],
-				'string')
+			formatted := t.make_call_typed('strconv__format_int', [expr, t.make_int_literal(base)], 'string')
 			return if format == 'X' {
 				t.make_call_typed('v3_string_upper_ascii', [formatted], 'string')
 			} else {
@@ -7503,26 +7430,22 @@ fn (mut t Transformer) wrap_formatted_string_conversion(expr flat.NodeId, typ st
 	if base_format := zero_padded_integer_base_format(format) {
 		converted := if clean_typ in ['u8', 'byte', 'u16', 'u32', 'u64', 'usize'] {
 			arg := t.widened_unsigned_format_arg(expr, clean_typ)
-			t.make_call_typed('strconv__format_uint', [arg, t.make_int_literal(base_format.base)],
-				'string')
+			t.make_call_typed('strconv__format_uint', [arg, t.make_int_literal(base_format.base)], 'string')
 		} else if clean_typ in ['int', 'i8', 'i16', 'i32', 'i64', 'isize', 'rune'] {
 			arg := if clean_typ == 'i64' {
 				expr
 			} else {
 				t.make_cast('i64', expr, 'i64')
 			}
-			t.make_call_typed('strconv__format_int', [arg, t.make_int_literal(base_format.base)],
-				'string')
+			t.make_call_typed('strconv__format_int', [arg, t.make_int_literal(base_format.base)], 'string')
 		} else {
 			t.wrap_string_conversion(expr, typ)
 		}
-		return t.make_call_typed('v3_string_zpad',
-			[converted, t.make_int_literal(base_format.width)], 'string')
+		return t.make_call_typed('v3_string_zpad', [converted, t.make_int_literal(base_format.width)], 'string')
 	}
 	if width := left_zero_padded_decimal_width(format) {
 		converted := t.wrap_formatted_string_conversion(expr, typ, 'd')
-		return t.make_call_typed('v3_string_rpad_zero', [converted, t.make_int_literal(width)],
-			'string')
+		return t.make_call_typed('v3_string_rpad_zero', [converted, t.make_int_literal(width)], 'string')
 	}
 	if width := zero_padded_decimal_width(format) {
 		if clean_typ in ['int', 'i8', 'i16', 'i32', 'i64', 'isize', 'rune', 'usize', 'u8', 'byte',
@@ -7600,8 +7523,7 @@ fn (mut t Transformer) lower_pointer_format_s(expr flat.NodeId, typ string, elem
 	t.pending_stmts << t.make_decl_assign_typed(res_name, t.make_string_literal(''), 'string')
 	value := t.make_prefix(.mul, t.make_ident(ptr_name))
 	t.set_node_typ(int(value), elem_type)
-	value_str := t.string_plus(t.make_string_literal('&'), t.wrap_string_conversion(value,
-		elem_type))
+	value_str := t.string_plus(t.make_string_literal('&'), t.wrap_string_conversion(value, elem_type))
 	then_body := t.make_block([t.make_assign(t.make_ident(res_name), value_str)])
 	cond := t.make_infix(.ne, t.make_ident(ptr_name), t.a.add(.nil_literal))
 	t.pending_stmts << t.make_if(cond, then_body, t.make_empty())
@@ -7611,8 +7533,7 @@ fn (mut t Transformer) lower_pointer_format_s(expr flat.NodeId, typ string, elem
 fn (mut t Transformer) dynamic_format_conversion(expr flat.NodeId, typ string, clean_typ string, format string) ?flat.NodeId {
 	if width := t.dynamic_width_expr(format) {
 		converted := t.wrap_string_conversion(expr, typ)
-		return t.make_call_typed('v3_string_pad', [converted, width, t.make_int_literal(0)],
-			'string')
+		return t.make_call_typed('v3_string_pad', [converted, width, t.make_int_literal(0)], 'string')
 	}
 	if width := t.dynamic_zero_width_expr(format) {
 		if clean_typ in ['int', 'i8', 'i16', 'i32', 'i64', 'isize', 'rune', 'usize', 'u8', 'byte',
@@ -7624,8 +7545,7 @@ fn (mut t Transformer) dynamic_format_conversion(expr flat.NodeId, typ string, c
 	if width := t.dynamic_plus_width_expr(format) {
 		if clean_typ in ['int', 'i8', 'i16', 'i32', 'i64', 'isize', 'rune'] {
 			converted := t.signed_plus_string(expr, clean_typ)
-			return t.make_call_typed('v3_string_pad', [converted, width, t.make_int_literal(0)],
-				'string')
+			return t.make_call_typed('v3_string_pad', [converted, width, t.make_int_literal(0)], 'string')
 		}
 	}
 	if width_name, precision_name := dynamic_float_width_precision(format) {
@@ -7635,8 +7555,7 @@ fn (mut t Transformer) dynamic_format_conversion(expr flat.NodeId, typ string, c
 			} else {
 				t.make_cast('f64', expr, 'f64')
 			}
-			formatted := t.make_call_typed('v3_f64_fixed', [arg, t.make_ident(precision_name)],
-				'string')
+			formatted := t.make_call_typed('v3_f64_fixed', [arg, t.make_ident(precision_name)], 'string')
 			return t.make_call_typed('v3_string_pad', [formatted, t.make_ident(width_name),
 				t.make_int_literal(0)], 'string')
 		}
@@ -7706,8 +7625,7 @@ fn (mut t Transformer) signed_plus_string(expr flat.NodeId, typ string) flat.Nod
 	t.pending_stmts << t.make_decl_assign_typed(text_name, base_text, 'string')
 	cond := t.make_infix(.ge, value, t.make_int_literal(0))
 	then_body := t.make_block([
-		t.make_assign(t.make_ident(text_name), t.string_plus(t.make_string_literal('+'),
-			t.make_ident(text_name))),
+		t.make_assign(t.make_ident(text_name), t.string_plus(t.make_string_literal('+'), t.make_ident(text_name))),
 	])
 	t.pending_stmts << t.make_if(cond, then_body, t.make_empty())
 	return t.make_ident(text_name)
@@ -7758,7 +7676,7 @@ fn character_format(format string) ?CharacterFormat {
 	}
 	return CharacterFormat{
 		width: width
-		left:  left
+		left: left
 	}
 }
 
@@ -7820,9 +7738,9 @@ fn fixed_decimal_format(format string) ?FixedDecimalFormat {
 		return none
 	}
 	return FixedDecimalFormat{
-		width:     width
+		width: width
 		precision: precision
-		left:      left
+		left: left
 	}
 }
 
@@ -7864,10 +7782,10 @@ fn exponent_decimal_format(format string) ?ExponentDecimalFormat {
 		return none
 	}
 	return ExponentDecimalFormat{
-		width:     width
+		width: width
 		precision: precision
-		left:      left
-		upper:     upper
+		left: left
+		upper: upper
 	}
 }
 
@@ -7909,10 +7827,10 @@ fn general_float_format(format string) ?GeneralFloatFormat {
 		return none
 	}
 	return GeneralFloatFormat{
-		width:     width
+		width: width
 		precision: precision
-		left:      left
-		upper:     upper
+		left: left
+		upper: upper
 	}
 }
 
@@ -7957,9 +7875,15 @@ fn integer_format_base_suffix(format string) ?int {
 		return none
 	}
 	match format[format.len - 1] {
-		`b` { return 2 }
-		`x` { return 16 }
-		`o` { return 8 }
+		`b` {
+			return 2
+		}
+		`x` {
+			return 16
+		}
+		`o` {
+			return 8
+		}
 		else {}
 	}
 
@@ -8010,7 +7934,9 @@ fn zero_padded_integer_base_format(format string) ?ZeroPaddedIntegerBaseFormat {
 		`b` { 2 }
 		`x` { 16 }
 		`o` { 8 }
-		else { return none }
+		else {
+			return none
+		}
 	}
 
 	mut width := 0
@@ -8026,7 +7952,7 @@ fn zero_padded_integer_base_format(format string) ?ZeroPaddedIntegerBaseFormat {
 	}
 	return ZeroPaddedIntegerBaseFormat{
 		width: width
-		base:  base
+		base: base
 	}
 }
 
@@ -8432,8 +8358,7 @@ fn (mut t Transformer) lower_map_str(map_expr flat.NodeId, map_type string) flat
 		t.transform_expr_for_type(map_expr, map_type)
 	}
 	return t.make_call_typed('v3_map_str', [lowered, t.make_int_literal(key_kind),
-		t.make_int_literal(value_kind), t.make_int_literal(t.map_str_fixed_len_for_type(value_type))],
-		'string')
+		t.make_int_literal(value_kind), t.make_int_literal(t.map_str_fixed_len_for_type(value_type))], 'string')
 }
 
 fn (t &Transformer) map_str_types_need_typed_lowering(key_type string, value_type string) bool {
@@ -8476,8 +8401,7 @@ fn (mut t Transformer) lower_typed_map_str(map_expr flat.NodeId, map_type string
 	prefix << t.make_decl_assign_typed(result_name, t.make_string_literal('{'), 'string')
 	prefix << t.make_decl_assign_typed(keys_name, keys_call, keys_type)
 	init := t.make_decl_assign_typed(idx_name, t.make_int_literal(0), 'int')
-	cond := t.make_infix(.lt, t.make_ident(idx_name), t.make_selector(t.make_ident(keys_name),
-		'len', 'int'))
+	cond := t.make_infix(.lt, t.make_ident(idx_name), t.make_selector(t.make_ident(keys_name), 'len', 'int'))
 	post := t.make_expr_stmt(t.make_postfix(t.make_ident(idx_name), .inc))
 	key_expr := t.array_get_value(t.make_ident(keys_name), t.make_ident(idx_name), key_storage_type)
 	key_decl := t.make_decl_assign_typed(key_name, key_expr, key_storage_type)
@@ -8495,8 +8419,7 @@ fn (mut t Transformer) lower_typed_map_str(map_expr flat.NodeId, map_type string
 	t.drain_pending(mut loop_body)
 	loop_body << t.append_string(result_name, key_str)
 	loop_body << t.append_string(result_name, t.make_string_literal(': '))
-	value_str := t.map_str_loop_piece(value_name, value_type, value_kind,
-		t.map_str_fixed_len_for_type(value_type))
+	value_str := t.map_str_loop_piece(value_name, value_type, value_kind, t.map_str_fixed_len_for_type(value_type))
 	t.drain_pending(mut loop_body)
 	loop_body << t.append_string(result_name, value_str)
 	prefix << t.make_for_stmt(init, cond, post, loop_body, src)
@@ -8626,12 +8549,10 @@ fn (mut t Transformer) wrap_optional_string_conversion(expr flat.NodeId, typ str
 	}
 	opt_name := t.new_temp('opt_str')
 	res_name := t.new_temp('opt_str_text')
-	t.pending_stmts << t.make_decl_assign_typed(opt_name, t.transform_optional_wrapper_expr(expr),
-		opt_type)
+	t.pending_stmts << t.make_decl_assign_typed(opt_name, t.transform_optional_wrapper_expr(expr), opt_type)
 	pointer_payload := value_type.starts_with('&')
 	option_prefix := if pointer_payload { '&Option(' } else { 'Option(' }
-	t.pending_stmts << t.make_decl_assign_typed(res_name,
-		t.make_string_literal('${option_prefix}none)'), 'string')
+	t.pending_stmts << t.make_decl_assign_typed(res_name, t.make_string_literal('${option_prefix}none)'), 'string')
 	value := t.make_selector(t.make_ident(opt_name), 'value', value_type)
 	display_value := if pointer_payload {
 		deref := t.make_prefix(.mul, value)
@@ -8643,11 +8564,9 @@ fn (mut t Transformer) wrap_optional_string_conversion(expr flat.NodeId, typ str
 	display_type := if pointer_payload { value_type[1..] } else { value_type }
 	mut value_str := t.wrap_string_conversion(display_value, display_type)
 	if display_type == 'string' {
-		value_str = t.string_plus(t.string_plus(t.make_string_literal("'"), value_str),
-			t.make_string_literal("'"))
+		value_str = t.string_plus(t.string_plus(t.make_string_literal("'"), value_str), t.make_string_literal("'"))
 	}
-	some_str := t.string_plus(t.string_plus(t.make_string_literal(option_prefix), value_str),
-		t.make_string_literal(')'))
+	some_str := t.string_plus(t.string_plus(t.make_string_literal(option_prefix), value_str), t.make_string_literal(')'))
 	assign_some := t.make_assign(t.make_ident(res_name), some_str)
 	t.pending_stmts << t.make_if(t.make_selector(t.make_ident(opt_name), 'ok', 'bool'), t.make_block([
 		assign_some,
@@ -8846,7 +8765,10 @@ fn (mut t Transformer) try_lower_flag_enum_call(call_id flat.NodeId, node flat.N
 	}
 	fn_id := t.a.children[node.children_start]
 	fn_node := t.a.nodes[int(fn_id)]
-	if fn_node.kind != .selector || fn_node.children_count == 0 || fn_node.value !in ['has', 'all'] {
+	if fn_node.kind != .selector || fn_node.children_count == 0 || fn_node.value !in [
+		'has',
+		'all',
+	] {
 		return none
 	}
 	base_id := t.a.children[fn_node.children_start]
@@ -8923,10 +8845,10 @@ fn (t &Transformer) compiler_default_clone_call_info(node flat.Node) ?CompilerDe
 		return none
 	}
 	return CompilerDefaultCloneCallInfo{
-		base_id:       base_id
+		base_id: base_id
 		raw_base_type: raw_base_type
-		base_type:     base_type
-		can_lower:     t.tc.ownership_default_clone_missing_method(parsed_base_type) == none
+		base_type: base_type
+		can_lower: t.tc.ownership_default_clone_missing_method(parsed_base_type) == none
 	}
 }
 
@@ -8981,14 +8903,12 @@ fn (mut t Transformer) make_compiler_default_clone_value(source flat.NodeId, typ
 		inner := t.optional_base_type(t.qualify_optional_type(clean))
 		inner_needs_work := t.compiler_default_clone_type_needs_work(inner)
 		source_is_owned_temporary := !t.expr_can_take_address(source)
-		stable_source := t.stable_transformed_expr_for_reuse(source, clean,
-			'derived_clone_opt_source')
+		stable_source := t.stable_transformed_expr_for_reuse(source, clean, 'derived_clone_opt_source')
 		out_name := t.new_temp('derived_clone_opt')
 		t.pending_stmts << t.make_decl_assign_typed(out_name, t.make_optional_none(clean), clean)
 		pending_start := t.pending_stmts.len
 		cloned_value := if inner_needs_work {
-			t.make_compiler_default_clone_value(t.make_selector(stable_source, 'value', inner),
-				inner, true)
+			t.make_compiler_default_clone_value(t.make_selector(stable_source, 'value', inner), inner, true)
 		} else if inner.len > 0 && inner != 'void' {
 			t.make_selector(stable_source, 'value', inner)
 		} else {
@@ -8996,8 +8916,7 @@ fn (mut t Transformer) make_compiler_default_clone_value(source flat.NodeId, typ
 		}
 		mut body := t.pending_stmts[pending_start..].clone()
 		t.pending_stmts = t.pending_stmts[..pending_start].clone()
-		body << t.make_assign_without_ownership_drop(t.make_ident(out_name), t.make_optional_some(cloned_value,
-			clean))
+		body << t.make_assign_without_ownership_drop(t.make_ident(out_name), t.make_optional_some(cloned_value, clean))
 		source_err := t.make_selector(stable_source, 'err', 'IError')
 		t.mark_fn_used('string__clone')
 		if !isnil(t.tc) {
@@ -9009,11 +8928,9 @@ fn (mut t Transformer) make_compiler_default_clone_value(source flat.NodeId, typ
 		}
 		cloned_err := t.make_call_typed('__v3_clone_owned_ierror', [source_err], 'IError')
 		else_branch := t.make_block_skip_scope_drops([
-			t.make_assign_without_ownership_drop(t.make_ident(out_name), t.make_optional_none_with_err(clean,
-				cloned_err)),
+			t.make_assign_without_ownership_drop(t.make_ident(out_name), t.make_optional_none_with_err(clean, cloned_err)),
 		])
-		t.pending_stmts << t.make_if_with_skip_ownership_drops(t.make_selector(stable_source,
-			'ok', 'bool'), t.make_block_skip_scope_drops(body), else_branch)
+		t.pending_stmts << t.make_if_with_skip_ownership_drops(t.make_selector(stable_source, 'ok', 'bool'), t.make_block_skip_scope_drops(body), else_branch)
 		if source_is_owned_temporary {
 			t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
 				stable_source,
@@ -9026,15 +8943,13 @@ fn (mut t Transformer) make_compiler_default_clone_value(source flat.NodeId, typ
 		return t.make_call_typed('string__clone', [source], 'string')
 	}
 	if clean.starts_with('[]') {
-		return t.make_compiler_default_array_clone_value(source, clean,
-			!t.expr_can_take_address(source))
+		return t.make_compiler_default_array_clone_value(source, clean, !t.expr_can_take_address(source))
 	}
 	if t.is_fixed_array_type(clean) {
 		return t.make_compiler_default_fixed_array_clone_value(source, clean)
 	}
 	if clean.starts_with('map[') {
-		return t.make_compiler_default_map_clone_value(source, clean,
-			!t.expr_can_take_address(source))
+		return t.make_compiler_default_map_clone_value(source, clean, !t.expr_can_take_address(source))
 	}
 	if allow_method && !isnil(t.tc) && t.tc.ownership_type_has_clone_method(t.tc.parse_type(clean)) {
 		if !isnil(t.tc) && clean.contains('[') && clean.ends_with(']') {
@@ -9052,8 +8967,7 @@ fn (mut t Transformer) make_compiler_default_clone_value(source flat.NodeId, typ
 				receiver = t.runtime_addr(source, clean)
 			}
 			t.mark_fn_used_name(method_name)
-			return t.make_call_typed(method_name, [receiver], t.receiver_method_return_type(method_name,
-				clean))
+			return t.make_call_typed(method_name, [receiver], t.receiver_method_return_type(method_name, clean))
 		}
 	}
 	if isnil(t.tc) || (!t.tc.named_type_implements_marker(clean, 'IClone')
@@ -9102,8 +9016,7 @@ fn (mut t Transformer) make_compiler_default_clone_value(source flat.NodeId, typ
 			t.pending_stmts << t.make_expr_stmt(drop_call)
 			cloned_field = t.make_ident(cloned_name)
 		}
-		t.pending_stmts << t.make_assign_after_owned_drop(t.make_selector(t.make_ident(tmp_name),
-			field.name, field_type), cloned_field)
+		t.pending_stmts << t.make_assign_after_owned_drop(t.make_selector(t.make_ident(tmp_name), field.name, field_type), cloned_field)
 	}
 	return t.make_ident(tmp_name)
 }
@@ -9117,8 +9030,7 @@ fn (mut t Transformer) make_compiler_default_sum_clone_value(source flat.NodeId,
 		return source
 	}
 	source_is_owned_temporary := !t.expr_can_take_address(source)
-	stable_source := t.stable_transformed_expr_for_reuse(source, sum_type,
-		'derived_clone_sum_source')
+	stable_source := t.stable_transformed_expr_for_reuse(source, sum_type, 'derived_clone_sum_source')
 	out_name := t.new_temp('derived_clone_sum')
 	t.pending_stmts << t.make_decl_assign_typed(out_name, stable_source, sum_type)
 	for variant in variants {
@@ -9142,8 +9054,7 @@ fn (mut t Transformer) make_compiler_default_sum_clone_value(source flat.NodeId,
 		wrapped := t.make_sum_literal(resolved_sum, qvariant, cloned_payload)
 		body << t.make_assign_without_ownership_drop(t.make_ident(out_name), wrapped)
 		cond := t.make_sum_is_check(stable_source, sum_type, resolved_sum, qvariant)
-		t.pending_stmts << t.make_if_with_skip_ownership_drops(cond,
-			t.make_block_skip_scope_drops(body), t.make_empty())
+		t.pending_stmts << t.make_if_with_skip_ownership_drops(cond, t.make_block_skip_scope_drops(body), t.make_empty())
 	}
 	if source_is_owned_temporary {
 		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
@@ -9164,7 +9075,7 @@ fn (mut t Transformer) request_default_clone_helper(source flat.NodeId, typ stri
 	if typ !in t.default_clone_types {
 		t.default_clone_types[typ] = DefaultCloneRequest{
 			module: t.cur_module
-			file:   t.cur_file
+			file: t.cur_file
 		}
 	}
 	t.mark_fn_used_name(helper)
@@ -9266,9 +9177,9 @@ fn (mut t Transformer) build_default_clone_helper_fn(typ string) {
 	t.cur_fn_ret_type = typ
 	param_name := '__default_clone_source'
 	param := t.a.add_node(flat.Node{
-		kind:  .param
+		kind: .param
 		value: param_name
-		typ:   'voidptr'
+		typ: 'voidptr'
 	})
 	t.set_var_type(param_name, 'voidptr')
 	typed_pointer := t.make_cast('&${typ}', t.make_ident(param_name), '&${typ}')
@@ -9295,9 +9206,9 @@ fn (mut t Transformer) build_default_clone_helper_fn(typ string) {
 	t.a.children << param
 	t.a.children << body
 	fn_decl := t.a.add_node(flat.Node{
-		kind:           .fn_decl
-		value:          helper
-		typ:            typ
+		kind: .fn_decl
+		value: helper
+		typ: typ
 		children_start: i32(start)
 		children_count: flat.child_count(1 + body.len)
 	})
@@ -9322,8 +9233,7 @@ fn (mut t Transformer) make_compiler_default_array_clone_value(source flat.NodeI
 	if !t.compiler_default_clone_type_needs_work(elem_type) {
 		return t.make_array_clone_value(source, array_type)
 	}
-	stable_source := t.stable_transformed_expr_for_reuse(source, array_type,
-		'derived_clone_array_source')
+	stable_source := t.stable_transformed_expr_for_reuse(source, array_type, 'derived_clone_array_source')
 	out_name := t.new_temp('derived_clone_array')
 	idx_name := t.new_temp('derived_clone_array_idx')
 	t.mark_fn_used('array__clone')
@@ -9332,16 +9242,14 @@ fn (mut t Transformer) make_compiler_default_array_clone_value(source flat.NodeI
 	], array_type)
 	t.pending_stmts << t.make_decl_assign_typed(out_name, storage_clone, array_type)
 	init := t.make_decl_assign_typed(idx_name, t.make_int_literal(0), 'int')
-	cond := t.make_infix(.lt, t.make_ident(idx_name), t.make_selector(t.make_ident(out_name),
-		'len', 'int'))
+	cond := t.make_infix(.lt, t.make_ident(idx_name), t.make_selector(t.make_ident(out_name), 'len', 'int'))
 	post := t.make_expr_stmt(t.make_postfix(t.make_ident(idx_name), .inc))
 	source_elem := t.array_get_value(stable_source, t.make_ident(idx_name), elem_type)
 	pending_start := t.pending_stmts.len
 	cloned_elem := t.make_compiler_default_clone_value(source_elem, elem_type, true)
 	mut body := t.pending_stmts[pending_start..].clone()
 	t.pending_stmts = t.pending_stmts[..pending_start].clone()
-	body << t.make_assign_without_ownership_drop(t.make_index(t.make_ident(out_name),
-		t.make_ident(idx_name), elem_type), cloned_elem)
+	body << t.make_assign_without_ownership_drop(t.make_index(t.make_ident(out_name), t.make_ident(idx_name), elem_type), cloned_elem)
 	t.pending_stmts << t.make_for_stmt(init, cond, post, body, flat.Node{
 		skip_ownership_drops: true
 	})
@@ -9366,8 +9274,7 @@ fn (mut t Transformer) make_compiler_default_fixed_array_clone_value(source flat
 		return source
 	}
 	source_is_owned_temporary := !t.expr_can_take_address(source)
-	stable_source := t.stable_transformed_expr_for_reuse(source, fixed_type,
-		'derived_clone_fixed_array_source')
+	stable_source := t.stable_transformed_expr_for_reuse(source, fixed_type, 'derived_clone_fixed_array_source')
 	out_name := t.new_temp('derived_clone_fixed_array')
 	idx_name := t.new_temp('derived_clone_fixed_array_idx')
 	t.pending_stmts << t.make_decl_assign_typed(out_name, stable_source, fixed_type)
@@ -9379,8 +9286,7 @@ fn (mut t Transformer) make_compiler_default_fixed_array_clone_value(source flat
 	cloned_elem := t.make_compiler_default_clone_value(source_elem, elem_type, true)
 	mut body := t.pending_stmts[pending_start..].clone()
 	t.pending_stmts = t.pending_stmts[..pending_start].clone()
-	body << t.make_assign_without_ownership_drop(t.make_index(t.make_ident(out_name),
-		t.make_ident(idx_name), elem_type), cloned_elem)
+	body << t.make_assign_without_ownership_drop(t.make_index(t.make_ident(out_name), t.make_ident(idx_name), elem_type), cloned_elem)
 	t.pending_stmts << t.make_for_stmt(init, cond, post, body, flat.Node{
 		skip_ownership_drops: true
 	})
@@ -9404,8 +9310,7 @@ fn (mut t Transformer) make_compiler_default_map_clone_value(source flat.NodeId,
 	key_needs_clone := clean_key_type != 'string'
 		&& t.compiler_default_clone_type_needs_work(key_type)
 	value_needs_clone := t.compiler_default_clone_type_needs_work(value_type)
-	stable_source := t.stable_transformed_expr_for_reuse(source, map_type,
-		'derived_clone_map_source')
+	stable_source := t.stable_transformed_expr_for_reuse(source, map_type, 'derived_clone_map_source')
 	if key_type.len == 0 || value_type.len == 0 || (!key_needs_clone && !value_needs_clone) {
 		t.mark_fn_used('map__clone')
 		storage_clone := t.make_call_typed('map__clone', [
@@ -9464,10 +9369,10 @@ fn (mut t Transformer) make_compiler_default_map_clone_value(source flat.NodeId,
 		t.a.children << stmt
 	}
 	t.pending_stmts << t.a.add_node(flat.Node{
-		kind:                 .for_in_stmt
-		children_start:       start
-		children_count:       flat.child_count(3 + body.len)
-		value:                '3'
+		kind: .for_in_stmt
+		children_start: start
+		children_count: flat.child_count(3 + body.len)
+		value: '3'
 		skip_ownership_drops: true
 	})
 	if source_is_owned_temporary {
@@ -9542,8 +9447,8 @@ fn (mut t Transformer) try_lower_array_method_call(call_id flat.NodeId, node fla
 		}
 		if !decoded_value_is_concrete {
 			mut raw_base_types := []string{}
-			for candidate in [t.raw_var_type_for_expr(base_id) or { '' },
-				t.node_type(base_id), t.lvalue_type(base_id)] {
+			for candidate in [t.raw_var_type_for_expr(base_id) or { '' }, t.node_type(base_id),
+				t.lvalue_type(base_id)] {
 				clean := candidate.trim_left('&')
 				if clean.len > 0 && clean !in raw_base_types {
 					raw_base_types << clean
@@ -9578,8 +9483,8 @@ fn (mut t Transformer) try_lower_array_method_call(call_id flat.NodeId, node fla
 	array_builtin_method := t.array_builtin_method_name(fn_node.value) or { '' }
 	if fn_node.value !in ['clone', 'reverse', 'contains', 'index', 'last_index', 'join', 'any',
 		'all', 'count', 'equals', 'prepend', 'insert', 'push_many', 'str', 'to_fixed_size', 'wait'] {
-		if fn_node.value !in ['filter', 'map', 'sort', 'sorted', 'sort_with_compare', 'sorted_with_compare']
-			&& array_builtin_method.len == 0 {
+		if fn_node.value !in ['filter', 'map', 'sort', 'sorted', 'sort_with_compare',
+			'sorted_with_compare'] && array_builtin_method.len == 0 {
 			mut early_base_type := t.node_type(base_id)
 			if early_base_type.len == 0 {
 				early_base_type = t.lvalue_type(base_id)
@@ -9590,9 +9495,7 @@ fn (mut t Transformer) try_lower_array_method_call(call_id flat.NodeId, node fla
 				early_base_type
 			})
 			if early_clean_type.starts_with('[]') || t.is_fixed_array_type(early_clean_type) {
-				if smartcast_method := t.resolve_smartcast_target_receiver_method(base_id,
-					fn_node.value)
-				{
+				if smartcast_method := t.resolve_smartcast_target_receiver_method(base_id, fn_node.value) {
 					if !t.receiver_method_name_is_open_generic(smartcast_method) {
 						args := t.transform_receiver_method_args(node, base_id, smartcast_method)
 						ret_type := t.receiver_method_return_type(smartcast_method, node.typ)
@@ -9600,9 +9503,7 @@ fn (mut t Transformer) try_lower_array_method_call(call_id flat.NodeId, node fla
 						return t.make_call_typed(smartcast_method, args, ret_type)
 					}
 				}
-				if exact_call := t.lower_checker_selected_receiver_method(call_id, node, base_id,
-					'')
-				{
+				if exact_call := t.lower_checker_selected_receiver_method(call_id, node, base_id, '') {
 					return exact_call
 				}
 			}
@@ -9655,11 +9556,11 @@ fn (mut t Transformer) try_lower_array_method_call(call_id flat.NodeId, node fla
 					t.a.children << child
 				}
 				new_node := flat.Node{
-					kind:           .call
+					kind: .call
 					children_start: start
 					children_count: node.children_count
-					pos:            node.pos
-					typ:            node.typ
+					pos: node.pos
+					typ: node.typ
 				}
 				return t.try_lower_array_method_call(call_id, new_node)
 			}
@@ -9710,12 +9611,9 @@ fn (mut t Transformer) try_lower_array_method_call(call_id flat.NodeId, node fla
 			t.mark_fn_used(method_name)
 			return t.make_call_typed(method_name, args, ret_type)
 		}
-		if dynamic_method := t.resolve_fixed_array_dynamic_receiver_method(clean_base_type,
-			fn_node.value)
-		{
+		if dynamic_method := t.resolve_fixed_array_dynamic_receiver_method(clean_base_type, fn_node.value) {
 			if dynamic_method != array_builtin_method {
-				return t.lower_fixed_array_dynamic_receiver_method_call(node, base_id,
-					clean_base_type, dynamic_method)
+				return t.lower_fixed_array_dynamic_receiver_method_call(node, base_id, clean_base_type, dynamic_method)
 			}
 		}
 		// Keep the fixed receiver as a fixed-array expression. Adapting it through
@@ -9741,9 +9639,7 @@ fn (mut t Transformer) try_lower_array_method_call(call_id flat.NodeId, node fla
 		// A fixed-array alias may declare a method with the same name as an array
 		// builtin. Honor the checker-selected alias method before adapting the
 		// fixed array to a dynamic array for builtin lowering.
-		if exact_call := t.lower_checker_selected_receiver_method(call_id, node, base_id,
-			array_builtin_method)
-		{
+		if exact_call := t.lower_checker_selected_receiver_method(call_id, node, base_id, array_builtin_method) {
 			return exact_call
 		}
 		elem_type := fixed_array_elem_type(clean_base_type)
@@ -9772,11 +9668,11 @@ fn (mut t Transformer) try_lower_array_method_call(call_id flat.NodeId, node fla
 			t.a.children << child
 		}
 		new_node := flat.Node{
-			kind:           .call
+			kind: .call
 			children_start: start
 			children_count: node.children_count
-			pos:            node.pos
-			typ:            node.typ
+			pos: node.pos
+			typ: node.typ
 		}
 		return t.try_lower_array_method_call(call_id, new_node)
 	}
@@ -9784,9 +9680,7 @@ fn (mut t Transformer) try_lower_array_method_call(call_id flat.NodeId, node fla
 		return none
 	}
 	if !(smartcast_container && fn_node.value == 'str') {
-		if exact_call := t.lower_checker_selected_receiver_method(call_id, node, base_id,
-			array_builtin_method)
-		{
+		if exact_call := t.lower_checker_selected_receiver_method(call_id, node, base_id, array_builtin_method) {
 			return exact_call
 		}
 	}
@@ -9874,8 +9768,7 @@ fn (mut t Transformer) try_lower_array_method_call(call_id flat.NodeId, node fla
 			receiver := t.transform_expr(base_id)
 			arg := t.transform_expr(t.a.children[node.children_start + 1])
 			if t.array_elem_needs_element_eq(elem_type) {
-				return t.make_array_elementwise_eq_call(receiver, arg, elem_type, clean_base_type,
-					clean_base_type, node)
+				return t.make_array_elementwise_eq_call(receiver, arg, elem_type, clean_base_type, clean_base_type, node)
 			}
 			if elem_type.starts_with('[]') {
 				return t.make_call_typed('array_eq_array', [receiver, arg,
@@ -9884,16 +9777,14 @@ fn (mut t Transformer) try_lower_array_method_call(call_id flat.NodeId, node fla
 			if elem_type == 'string' {
 				return t.make_call_typed('array_eq_string', [receiver, arg], 'bool')
 			}
-			return t.make_call_typed('array_eq_raw',
-				[receiver, arg, t.make_sizeof_type(elem_type)], 'bool')
+			return t.make_call_typed('array_eq_raw', [receiver, arg, t.make_sizeof_type(elem_type)], 'bool')
 		}
 		else {}
 	}
 
 	match fn_node.value {
 		'clone' {
-			method_name := t.resolve_collection_receiver_method_name(base_id, fn_node.value,
-				clean_base_type)
+			method_name := t.resolve_collection_receiver_method_name(base_id, fn_node.value, clean_base_type)
 			if method_name.len > 0 && method_name != array_builtin_method
 				&& t.call_resolved_to_method(call_id, method_name)
 				&& !t.receiver_method_name_is_open_generic(method_name) {
@@ -9905,8 +9796,7 @@ fn (mut t Transformer) try_lower_array_method_call(call_id flat.NodeId, node fla
 			return t.make_array_clone_call(base_id, base_type)
 		}
 		'reverse' {
-			method_name := t.resolve_collection_receiver_method_name(base_id, fn_node.value,
-				clean_base_type)
+			method_name := t.resolve_collection_receiver_method_name(base_id, fn_node.value, clean_base_type)
 			if method_name.len > 0 && method_name != array_builtin_method
 				&& t.call_resolved_to_method(call_id, method_name)
 				&& !t.receiver_method_name_is_open_generic(method_name) {
@@ -9967,8 +9857,7 @@ fn (mut t Transformer) try_lower_array_method_call(call_id flat.NodeId, node fla
 		}
 		else {
 			if array_method_stays_in_cgen(fn_node.value) {
-				method_name := t.resolve_collection_receiver_method_name(base_id, fn_node.value,
-					clean_base_type)
+				method_name := t.resolve_collection_receiver_method_name(base_id, fn_node.value, clean_base_type)
 				if method_name.len > 0 && method_name != array_builtin_method
 					&& t.call_resolved_to_method(call_id, method_name)
 					&& !t.receiver_method_name_is_open_generic(method_name) {
@@ -9981,14 +9870,10 @@ fn (mut t Transformer) try_lower_array_method_call(call_id flat.NodeId, node fla
 					&& !t.validate_cgen_array_method_args(node, base_id, clean_base_type, fn_node.value) {
 					return t.make_empty()
 				}
-				if lowered := t.lower_owned_array_accessor_call(base_id, base_type, elem_type,
-					fn_node.value)
-				{
+				if lowered := t.lower_owned_array_accessor_call(base_id, base_type, elem_type, fn_node.value) {
 					return lowered
 				}
-				if lowered := t.lower_owned_array_removal_call(node, base_id, base_type, elem_type,
-					fn_node.value)
-				{
+				if lowered := t.lower_owned_array_removal_call(node, base_id, base_type, elem_type, fn_node.value) {
 					return lowered
 				}
 				if array_method_stays_in_cgen_needs_runtime_mark(fn_node.value) {
@@ -9997,8 +9882,7 @@ fn (mut t Transformer) try_lower_array_method_call(call_id flat.NodeId, node fla
 				return none
 			}
 			if array_builtin_method.len > 0 {
-				method_name := t.resolve_collection_receiver_method_name(base_id, fn_node.value,
-					clean_base_type)
+				method_name := t.resolve_collection_receiver_method_name(base_id, fn_node.value, clean_base_type)
 				if method_name.len > 0 && method_name != array_builtin_method
 					&& !t.receiver_method_name_is_open_generic(method_name) {
 					args := t.transform_receiver_method_args(node, base_id, method_name)
@@ -10006,14 +9890,10 @@ fn (mut t Transformer) try_lower_array_method_call(call_id flat.NodeId, node fla
 					t.mark_fn_used(method_name)
 					return t.make_call_typed(method_name, args, ret_type)
 				}
-				if lowered := t.lower_owned_array_accessor_call(base_id, base_type, elem_type,
-					fn_node.value)
-				{
+				if lowered := t.lower_owned_array_accessor_call(base_id, base_type, elem_type, fn_node.value) {
 					return lowered
 				}
-				if lowered := t.lower_owned_array_removal_call(node, base_id, base_type, elem_type,
-					fn_node.value)
-				{
+				if lowered := t.lower_owned_array_removal_call(node, base_id, base_type, elem_type, fn_node.value) {
 					return lowered
 				}
 				args := t.transform_receiver_method_args(node, base_id, array_builtin_method)
@@ -10071,8 +9951,7 @@ fn (mut t Transformer) lower_owned_array_accessor_call(base_id flat.NodeId, base
 // lower_owned_array_removal_call drops ownership-bearing elements before a raw array
 // operation removes them from the range visited by the scope-exit destructor.
 fn (mut t Transformer) lower_owned_array_removal_call(node flat.Node, base_id flat.NodeId, base_type string, elem_type string, method string) ?flat.NodeId {
-	if method !in ['delete', 'delete_many', 'clear', 'free', 'trim', 'drop', 'delete_last']
-		|| isnil(t.tc) || !t.tc.ownership_type_requires_destruction(t.tc.parse_type(elem_type)) {
+	if method !in ['delete', 'delete_many', 'clear', 'free', 'trim', 'drop', 'delete_last'] || isnil(t.tc) || !t.tc.ownership_type_requires_destruction(t.tc.parse_type(elem_type)) {
 		return none
 	}
 	// V1 autofree treats clear() after a bulk append as an ownership transfer:
@@ -10096,65 +9975,50 @@ fn (mut t Transformer) lower_owned_array_removal_call(node flat.Node, base_id fl
 			if node.children_count < 2 {
 				return none
 			}
-			index := t.stable_transformed_expr_for_reuse(t.transform_expr_for_type(t.a.child(&node, 1),
-				'int'), 'int', 'array_delete_index')
+			index := t.stable_transformed_expr_for_reuse(t.transform_expr_for_type(t.a.child(&node, 1), 'int'), 'int', 'array_delete_index')
 			args << index
 			drop_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
 				t.make_index(array_value, index, elem_type),
 			], 'void'))
-			valid_drop_range = t.make_infix(.logical_and, t.make_infix(.ge, index,
-				t.make_int_literal(0)), t.make_infix(.lt, index, t.make_selector(array_value,
-				'len', 'int')))
+			valid_drop_range = t.make_infix(.logical_and, t.make_infix(.ge, index, t.make_int_literal(0)), t.make_infix(.lt, index, t.make_selector(array_value, 'len', 'int')))
 		}
 		'delete_many' {
 			if node.children_count < 3 {
 				return none
 			}
-			index := t.stable_transformed_expr_for_reuse(t.transform_expr_for_type(t.a.child(&node, 1),
-				'int'), 'int', 'array_delete_index')
-			size := t.stable_transformed_expr_for_reuse(t.transform_expr_for_type(t.a.child(&node, 2),
-				'int'), 'int', 'array_delete_size')
+			index := t.stable_transformed_expr_for_reuse(t.transform_expr_for_type(t.a.child(&node, 1), 'int'), 'int', 'array_delete_index')
+			size := t.stable_transformed_expr_for_reuse(t.transform_expr_for_type(t.a.child(&node, 2), 'int'), 'int', 'array_delete_size')
 			args << index
 			args << size
-			t.append_owned_array_drop_range(array_value, elem_type, index, t.make_infix(.plus,
-				index, size), mut drop_stmts)
-			end := t.make_infix(.plus, t.make_cast('i64', index, 'i64'), t.make_cast('i64', size,
-				'i64'))
-			valid_drop_range = t.make_infix(.logical_and, t.make_infix(.ge, index,
-				t.make_int_literal(0)), t.make_infix(.le, end, t.make_cast('i64', t.make_selector(array_value,
-				'len', 'int'), 'i64')))
+			t.append_owned_array_drop_range(array_value, elem_type, index, t.make_infix(.plus, index, size), mut drop_stmts)
+			end := t.make_infix(.plus, t.make_cast('i64', index, 'i64'), t.make_cast('i64', size, 'i64'))
+			valid_drop_range = t.make_infix(.logical_and, t.make_infix(.ge, index, t.make_int_literal(0)), t.make_infix(.le, end, t.make_cast('i64', t.make_selector(array_value, 'len', 'int'), 'i64')))
 		}
 		'clear', 'free' {
-			t.append_owned_array_drop_range(array_value, elem_type, t.make_int_literal(0), t.make_selector(array_value,
-				'len', 'int'), mut drop_stmts)
+			t.append_owned_array_drop_range(array_value, elem_type, t.make_int_literal(0), t.make_selector(array_value, 'len', 'int'), mut drop_stmts)
 		}
 		'trim' {
 			if node.children_count < 2 {
 				return none
 			}
-			index := t.stable_transformed_expr_for_reuse(t.transform_expr_for_type(t.a.child(&node, 1),
-				'int'), 'int', 'array_trim_index')
+			index := t.stable_transformed_expr_for_reuse(t.transform_expr_for_type(t.a.child(&node, 1), 'int'), 'int', 'array_trim_index')
 			args << index
-			t.append_owned_array_drop_range(array_value, elem_type, index, t.make_selector(array_value,
-				'len', 'int'), mut drop_stmts)
+			t.append_owned_array_drop_range(array_value, elem_type, index, t.make_selector(array_value, 'len', 'int'), mut drop_stmts)
 		}
 		'drop' {
 			if node.children_count < 2 {
 				return none
 			}
-			count := t.stable_transformed_expr_for_reuse(t.transform_expr_for_type(t.a.child(&node, 1),
-				'int'), 'int', 'array_drop_count')
+			count := t.stable_transformed_expr_for_reuse(t.transform_expr_for_type(t.a.child(&node, 1), 'int'), 'int', 'array_drop_count')
 			args << count
 			t.append_owned_array_drop_prefix(array_value, elem_type, count, mut drop_stmts)
 		}
 		'delete_last' {
-			last := t.make_infix(.minus, t.make_selector(array_value, 'len', 'int'),
-				t.make_int_literal(1))
+			last := t.make_infix(.minus, t.make_selector(array_value, 'len', 'int'), t.make_int_literal(1))
 			drop_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
 				t.make_index(array_value, last, elem_type),
 			], 'void'))
-			valid_drop_range = t.make_infix(.gt, t.make_selector(array_value, 'len', 'int'),
-				t.make_int_literal(0))
+			valid_drop_range = t.make_infix(.gt, t.make_selector(array_value, 'len', 'int'), t.make_int_literal(0))
 		}
 		else {
 			return none
@@ -10162,8 +10026,7 @@ fn (mut t Transformer) lower_owned_array_removal_call(node flat.Node, base_id fl
 	}
 
 	if drop_stmts.len > 0 {
-		needs_unique_shrink := t.make_method_call(array_value, 'needs_unique_shrink',
-			[]flat.NodeId{})
+		needs_unique_shrink := t.make_method_call(array_value, 'needs_unique_shrink', []flat.NodeId{})
 		t.set_node_typ(int(needs_unique_shrink), 'bool')
 		t.mark_fn_used('array.needs_unique_shrink')
 		mut should_drop := t.make_prefix(.not, needs_unique_shrink)
@@ -10175,9 +10038,9 @@ fn (mut t Transformer) lower_owned_array_removal_call(node flat.Node, base_id fl
 		t.a.children << should_drop
 		t.a.children << drop_block
 		t.pending_stmts << t.a.add_node(flat.Node{
-			kind:                 .if_expr
-			children_start:       start
-			children_count:       2
+			kind: .if_expr
+			children_start: start
+			children_count: 2
 			skip_ownership_drops: true
 		})
 	}
@@ -10201,8 +10064,7 @@ fn (mut t Transformer) append_owned_array_drop_prefix(array_value flat.NodeId, e
 	idx_name := t.new_temp('array_drop_index')
 	init := t.make_decl_assign_typed(idx_name, t.make_int_literal(0), 'int')
 	below_count := t.make_infix(.lt, t.make_ident(idx_name), count)
-	below_len := t.make_infix(.lt, t.make_ident(idx_name), t.make_selector(array_value, 'len',
-		'int'))
+	below_len := t.make_infix(.lt, t.make_ident(idx_name), t.make_selector(array_value, 'len', 'int'))
 	cond := t.make_infix(.logical_and, below_count, below_len)
 	post := t.make_expr_stmt(t.make_postfix(t.make_ident(idx_name), .inc))
 	elem := t.make_index(array_value, t.make_ident(idx_name), elem_type)
@@ -10233,8 +10095,7 @@ fn (mut t Transformer) try_lower_ignored_owned_array_pop_stmt(call_id flat.NodeI
 		return none
 	}
 	fn_node := t.a.child_node(&node, 0)
-	if fn_node.kind != .selector || fn_node.value !in ['first', 'last', 'pop', 'pop_left']
-		|| fn_node.children_count == 0 {
+	if fn_node.kind != .selector || fn_node.value !in ['first', 'last', 'pop', 'pop_left'] || fn_node.children_count == 0 {
 		return none
 	}
 	base_id := t.a.child(fn_node, 0)
@@ -10251,8 +10112,7 @@ fn (mut t Transformer) try_lower_ignored_owned_array_pop_stmt(call_id flat.NodeI
 		return none
 	}
 	array_builtin_method := t.array_builtin_method_name(fn_node.value) or { '' }
-	method_name := t.resolve_collection_receiver_method_name(base_id, fn_node.value,
-		clean_base_type)
+	method_name := t.resolve_collection_receiver_method_name(base_id, fn_node.value, clean_base_type)
 	if method_name.len > 0 && method_name != array_builtin_method
 		&& t.call_resolved_to_method(call_id, method_name)
 		&& !t.receiver_method_name_is_open_generic(method_name) {
@@ -10270,13 +10130,11 @@ fn (mut t Transformer) try_lower_ignored_owned_array_pop_stmt(call_id flat.NodeI
 			array_value = t.make_prefix(.mul, base)
 			t.set_node_typ(int(array_value), clean_base_type)
 		}
-		needs_unique_shrink := t.make_method_call(array_value, 'needs_unique_shrink',
-			[]flat.NodeId{})
+		needs_unique_shrink := t.make_method_call(array_value, 'needs_unique_shrink', []flat.NodeId{})
 		t.set_node_typ(int(needs_unique_shrink), 'bool')
 		t.mark_fn_used('array.needs_unique_shrink')
 		drop_result_guard_name = t.new_temp('ignored_array_pop_can_drop')
-		result << t.make_decl_assign_typed(drop_result_guard_name, t.make_prefix(.not,
-			needs_unique_shrink), 'bool')
+		result << t.make_decl_assign_typed(drop_result_guard_name, t.make_prefix(.not, needs_unique_shrink), 'bool')
 		popped = t.make_method_call(array_value, fn_node.value, []flat.NodeId{})
 		t.set_node_typ(int(popped), elem_type)
 		if fn_node.value == 'pop' {
@@ -10297,9 +10155,9 @@ fn (mut t Transformer) try_lower_ignored_owned_array_pop_stmt(call_id flat.NodeI
 		t.a.children << t.make_ident(drop_result_guard_name)
 		t.a.children << drop_block
 		result << t.a.add_node(flat.Node{
-			kind:                 .if_expr
-			children_start:       start
-			children_count:       2
+			kind: .if_expr
+			children_start: start
+			children_count: 2
 			skip_ownership_drops: true
 		})
 	} else {
@@ -10494,8 +10352,7 @@ fn (mut t Transformer) try_lower_map_method_call(call_id flat.NodeId, node flat.
 		if _ := t.tc.ownership_default_clone_missing_method(t.tc.parse_type(value_type)) {
 			return source
 		}
-		return t.make_compiler_default_map_clone_value(source, clean_type,
-			source_is_owned_temporary)
+		return t.make_compiler_default_map_clone_value(source, clean_type, source_is_owned_temporary)
 	}
 	if fn_node.value == 'delete' {
 		if nested_delete := t.try_lower_nested_map_delete_call(node, base_id, clean_type) {
@@ -10507,8 +10364,7 @@ fn (mut t Transformer) try_lower_map_method_call(call_id flat.NodeId, node flat.
 	if map_method_needs_runtime_addr_only(fn_node.value) {
 		key_type, value_type := t.map_type_parts(clean_type)
 		if key_type.len > 0 && value_type.len > 0 {
-			t.append_owned_map_entries_drop_before_reset(base, base_type, key_type, value_type,
-				fn_node.value)
+			t.append_owned_map_entries_drop_before_reset(base, base_type, key_type, value_type, fn_node.value)
 		}
 		t.mark_fn_used('map__${fn_node.value}')
 		call := t.make_call_typed('map__${fn_node.value}', [
@@ -10539,8 +10395,7 @@ fn (mut t Transformer) try_lower_map_method_call(call_id flat.NodeId, node flat.
 		}
 		t.mark_fn_used('map__reserve')
 		capacity := t.transform_expr_for_type(t.a.child(&node, 1), 'u32')
-		return t.make_call_typed('map__reserve', [t.runtime_addr(base, base_type), capacity],
-			'void')
+		return t.make_call_typed('map__reserve', [t.runtime_addr(base, base_type), capacity], 'void')
 	}
 	if fn_node.value == 'delete' {
 		if node.children_count < 2 {
@@ -10556,10 +10411,8 @@ fn (mut t Transformer) try_lower_map_method_call(call_id flat.NodeId, node flat.
 			&& t.tc.ownership_type_requires_destruction(t.tc.parse_type(key_type))
 		key_name := t.new_temp('map_key')
 		key_storage_type := t.map_key_storage_type(key_type)
-		t.pending_stmts << t.make_decl_assign_typed(key_name, t.transform_expr_for_type(key_id,
-			key_type), key_storage_type)
-		handled_delete := t.append_owned_map_entry_delete_with_drops(base, base_type, key_name,
-			key_type, value_type)
+		t.pending_stmts << t.make_decl_assign_typed(key_name, t.transform_expr_for_type(key_id, key_type), key_storage_type)
+		handled_delete := t.append_owned_map_entry_delete_with_drops(base, base_type, key_name, key_type, value_type)
 		if handled_delete {
 			if cleanup_key {
 				t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
@@ -10595,8 +10448,7 @@ fn (mut t Transformer) try_lower_map_method_call(call_id flat.NodeId, node flat.
 	if !isnil(t.tc) && t.tc.ownership_type_requires_destruction(t.tc.parse_type(elem_type))
 		&& t.compiler_default_clone_type_needs_work(elem_type)
 		&& (fn_node.value == 'values' || t.normalize_type_alias(elem_type).trim_space() != 'string') {
-		return t.make_owned_map_items_value(base, clean_type, elem_type, fn_node.value == 'keys',
-			source_is_owned_temporary)
+		return t.make_owned_map_items_value(base, clean_type, elem_type, fn_node.value == 'keys', source_is_owned_temporary)
 	}
 	t.mark_fn_used('map__${fn_node.value}')
 	items := t.make_call_typed('map__${fn_node.value}', [
@@ -10626,8 +10478,7 @@ fn (mut t Transformer) make_owned_map_items_value(source flat.NodeId, map_type s
 	key_name := t.new_temp('map_items_key')
 	value_name := t.new_temp('map_items_value')
 	item_name := t.new_temp('map_items_item')
-	t.pending_stmts << t.make_decl_assign_typed(out_name, t.make_array_new_call(item_type,
-		t.make_int_literal(0), t.make_selector(stable_source, 'len', 'int')), '[]${item_type}')
+	t.pending_stmts << t.make_decl_assign_typed(out_name, t.make_array_new_call(item_type, t.make_int_literal(0), t.make_selector(stable_source, 'len', 'int')), '[]${item_type}')
 	t.set_var_type(key_name, t.map_key_storage_type(key_type))
 	t.set_var_type(value_name, value_type)
 	source_item := if take_keys { t.make_ident(key_name) } else { t.make_ident(value_name) }
@@ -10654,10 +10505,10 @@ fn (mut t Transformer) make_owned_map_items_value(source flat.NodeId, map_type s
 		t.a.children << stmt
 	}
 	t.pending_stmts << t.a.add_node(flat.Node{
-		kind:                 .for_in_stmt
-		children_start:       start
-		children_count:       flat.child_count(3 + body.len)
-		value:                '3'
+		kind: .for_in_stmt
+		children_start: start
+		children_count: flat.child_count(3 + body.len)
+		value: '3'
 		skip_ownership_drops: true
 	})
 	if source_is_owned_temporary {
@@ -10692,10 +10543,8 @@ fn (mut t Transformer) append_owned_map_entries_drop_before_reset(map_expr flat.
 	if key_requires_drop {
 		t.mark_fn_used('map__get_key_check')
 		key_ptr_name := t.new_temp('map_reset_key_ptr')
-		body << t.make_decl_assign_typed(key_ptr_name, t.make_map_get_key_check_expr(map_expr,
-			map_type, key_name), 'voidptr')
-		stored_key_ptr := t.make_cast('&${key_type_name}', t.make_ident(key_ptr_name),
-			'&${key_type_name}')
+		body << t.make_decl_assign_typed(key_ptr_name, t.make_map_get_key_check_expr(map_expr, map_type, key_name), 'voidptr')
+		stored_key_ptr := t.make_cast('&${key_type_name}', t.make_ident(key_ptr_name), '&${key_type_name}')
 		stored_key := t.make_prefix(.mul, stored_key_ptr)
 		t.set_node_typ(int(stored_key), key_type_name)
 		body << t.make_expr_stmt(t.make_call_typed('drop_owned', [stored_key], 'void'))
@@ -10723,10 +10572,10 @@ fn (mut t Transformer) append_owned_map_entries_drop_before_reset(map_expr flat.
 		t.a.children << stmt
 	}
 	t.pending_stmts << t.a.add_node(flat.Node{
-		kind:                 .for_in_stmt
-		children_start:       start
-		children_count:       flat.child_count(3 + body.len)
-		value:                '3'
+		kind: .for_in_stmt
+		children_start: start
+		children_count: flat.child_count(3 + body.len)
+		value: '3'
 		skip_ownership_drops: true
 	})
 }
@@ -10754,8 +10603,7 @@ fn (mut t Transformer) append_owned_map_entry_delete_with_drops(map_expr flat.No
 	if key_requires_drop {
 		t.mark_fn_used('map__get_key_check')
 		key_ptr_name := t.new_temp('map_delete_key')
-		body << t.make_decl_assign_typed(key_ptr_name, t.make_map_get_key_check_expr(map_expr,
-			map_type, key_name), 'voidptr')
+		body << t.make_decl_assign_typed(key_ptr_name, t.make_map_get_key_check_expr(map_expr, map_type, key_name), 'voidptr')
 		key_ptr := t.make_cast('&${key_type_name}', t.make_ident(key_ptr_name), '&${key_type_name}')
 		stored_key := t.make_prefix(.mul, key_ptr)
 		t.set_node_typ(int(stored_key), key_type_name)
@@ -10764,8 +10612,7 @@ fn (mut t Transformer) append_owned_map_entry_delete_with_drops(map_expr flat.No
 	}
 	mut saved_value_name := ''
 	if value_requires_drop {
-		stored_value_ptr := t.make_cast('&${value_type_name}', t.make_ident(value_ptr_name),
-			'&${value_type_name}')
+		stored_value_ptr := t.make_cast('&${value_type_name}', t.make_ident(value_ptr_name), '&${value_type_name}')
 		stored_value := t.make_prefix(.mul, stored_value_ptr)
 		t.set_node_typ(int(stored_value), value_type_name)
 		saved_value_name = t.new_temp('map_deleted_value')
@@ -10791,9 +10638,9 @@ fn (mut t Transformer) append_owned_map_entry_delete_with_drops(map_expr flat.No
 	t.a.children << found
 	t.a.children << body_block
 	t.pending_stmts << t.a.add_node(flat.Node{
-		kind:                 .if_expr
-		children_start:       start
-		children_count:       2
+		kind: .if_expr
+		children_start: start
+		children_count: 2
 		skip_ownership_drops: true
 	})
 	return true
@@ -10847,9 +10694,7 @@ fn (mut t Transformer) try_lower_channel_method_call(call_id flat.NodeId, node f
 			if resolved_method != channel_method && resolved_method != runtime_method
 				&& !is_typed_channel_method {
 				if fn_node.value == 'close' {
-					if exact_call := t.lower_checker_selected_receiver_method(call_id, node,
-						base_id, 'chan.close')
-					{
+					if exact_call := t.lower_checker_selected_receiver_method(call_id, node, base_id, 'chan.close') {
 						return exact_call
 					}
 				}
@@ -10864,9 +10709,7 @@ fn (mut t Transformer) try_lower_channel_method_call(call_id flat.NodeId, node f
 		clean_type = clean_type[1..].trim_space()
 	}
 	if clean_type != 'chan' && !clean_type.starts_with('chan ') {
-		if exact_call := t.lower_checker_selected_receiver_method(call_id, node, base_id,
-			'chan.close')
-		{
+		if exact_call := t.lower_checker_selected_receiver_method(call_id, node, base_id, 'chan.close') {
 			return exact_call
 		}
 		return none
@@ -11024,8 +10867,7 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 					capture_from_heap[child.value] = true
 				}
 				if t.active_specialization_args.len > 0 {
-					specialized_capture_type := t.subst_type(capture_type,
-						t.active_specialization_args)
+					specialized_capture_type := t.subst_type(capture_type, t.active_specialization_args)
 					if specialized_capture_type.len > 0
 						&& !t.generic_arg_is_unresolved(specialized_capture_type) {
 						capture_type = specialized_capture_type
@@ -11087,8 +10929,7 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 	context_type := '${name}_Ctx'
 	context_local := '${name}_ctx'
 	if capture_names.len > 0 {
-		t.add_fn_literal_capture_context(context_type, generated_module, capture_names,
-			context_field_types)
+		t.add_fn_literal_capture_context(context_type, generated_module, capture_names, context_field_types)
 	}
 	saved_fn_name := t.cur_fn_name
 	saved_ret_type := t.cur_fn_ret_type
@@ -11237,9 +11078,9 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 		t.a.children << child_id
 	}
 	fn_decl := t.a.add_node(flat.Node{
-		kind:           .fn_decl
-		value:          name
-		typ:            ret_type
+		kind: .fn_decl
+		value: name
+		typ: ret_type
 		children_start: start
 		children_count: flat.child_count(all_ids.len)
 	})
@@ -11307,9 +11148,9 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 		t.a.children << field
 	}
 	context_init := t.a.add_node(flat.Node{
-		kind:           .struct_init
-		value:          context_type
-		typ:            context_type
+		kind: .struct_init
+		value: context_type
+		typ: context_type
 		children_start: context_start
 		children_count: flat.child_count(context_fields.len)
 	})
@@ -11391,9 +11232,9 @@ fn (mut t Transformer) add_fn_literal_capture_context(name string, module_name s
 	for capture_name in capture_names {
 		capture_type := capture_types[capture_name] or { continue }
 		field_ids << t.a.add_node(flat.Node{
-			kind:  .field_decl
+			kind: .field_decl
 			value: capture_name
-			typ:   capture_type
+			typ: capture_type
 		})
 		parsed_type := if isnil(t.tc) {
 			types.Type(types.Unknown{
@@ -11404,12 +11245,12 @@ fn (mut t Transformer) add_fn_literal_capture_context(name string, module_name s
 		}
 		semantic_fields << types.StructField{
 			name: capture_name
-			typ:  parsed_type
+			typ: parsed_type
 		}
 		transform_fields << FieldInfo{
-			name:         capture_name
-			typ:          capture_type
-			raw_typ:      capture_type
+			name: capture_name
+			typ: capture_type
+			raw_typ: capture_type
 			default_expr: flat.empty_node
 		}
 	}
@@ -11418,15 +11259,15 @@ fn (mut t Transformer) add_fn_literal_capture_context(name string, module_name s
 		t.a.children << field_id
 	}
 	struct_id := t.a.add_node(flat.Node{
-		kind:           .struct_decl
-		value:          name
+		kind: .struct_decl
+		value: name
 		children_start: start
 		children_count: flat.child_count(field_ids.len)
 	})
 	t.ensure_node_context_map_capacity()
 	t.mark_node_context(struct_id, module_name, t.cur_file)
 	info := StructInfo{
-		name:   name
+		name: name
 		module: module_name
 		fields: transform_fields
 	}
@@ -11454,13 +11295,13 @@ fn (mut t Transformer) add_fn_literal_capture_context(name string, module_name s
 fn (mut t Transformer) add_generated_fn_decl_context(module_name string) {
 	if t.cur_file.len > 0 {
 		t.a.add_node(flat.Node{
-			kind:  .file
+			kind: .file
 			value: t.cur_file
 		})
 	}
 	if module_name.len > 0 {
 		t.a.add_node(flat.Node{
-			kind:  .module_decl
+			kind: .module_decl
 			value: module_name
 		})
 	}
@@ -11702,8 +11543,7 @@ fn (mut t Transformer) try_lower_smartcast_target_receiver_method_call(_call_id 
 					value_ptr := t.make_prefix(.amp, args[0])
 					t.set_node_typ(int(value_ptr), '&${aggregate}')
 					interface_expr := t.make_plain_expr_for_smartcast(base_id)
-					return t.lower_interface_smartcast_ref_str(value_ptr, interface_expr,
-						aggregate, method_name)
+					return t.lower_interface_smartcast_ref_str(value_ptr, interface_expr, aggregate, method_name)
 				}
 			}
 		}
@@ -11747,7 +11587,9 @@ fn (mut t Transformer) try_lower_minmaxof_call(name string, raw_type string) ?fl
 			'u64' { '18446744073709551615' }
 			'f32' { '3.40282346638528859811704183484516925440e+38' }
 			'f64' { '1.797693134862315708145274237317043567981e+308' }
-			else { return none }
+			else {
+				return none
+			}
 		}
 	} else {
 		match typ {
@@ -11758,7 +11600,9 @@ fn (mut t Transformer) try_lower_minmaxof_call(name string, raw_type string) ?fl
 			'u8', 'u16', 'u32', 'u64' { '0' }
 			'f32' { '-3.40282346638528859811704183484516925440e+38' }
 			'f64' { '-1.797693134862315708145274237317043567981e+308' }
-			else { return none }
+			else {
+				return none
+			}
 		}
 	}
 	if typ in ['f32', 'f64'] {
@@ -11810,8 +11654,7 @@ fn (mut t Transformer) try_lower_pointer_str_method_call(call_id flat.NodeId, no
 				return none
 			}
 			t.mark_fn_used_name(method_name)
-			return t.lower_ref_str_guarded(t.transform_expr(base_id), aggregate,
-				!t.str_method_has_pointer_receiver(method_name), method_name, '&nil')
+			return t.lower_ref_str_guarded(t.transform_expr(base_id), aggregate, !t.str_method_has_pointer_receiver(method_name), method_name, '&nil')
 		}
 		return t.lower_ref_str_prefixed(t.transform_expr(base_id), aggregate)
 	}
@@ -11884,8 +11727,7 @@ fn (mut t Transformer) try_lower_copy_call(node flat.Node) ?flat.NodeId {
 		slice := t.transform_expr(dst_id)
 		tmp_name := t.new_temp('copy_dst')
 		t.pending_stmts << t.make_decl_assign_typed(tmp_name, slice, '[]u8')
-		return t.make_call_typed('copy', [t.make_prefix(.amp, t.make_ident(tmp_name)),
-			src], 'int')
+		return t.make_call_typed('copy', [t.make_prefix(.amp, t.make_ident(tmp_name)), src], 'int')
 	}
 	dst_expr := t.transform_expr(dst_id)
 	// a `mut` param destination is already a pointer; taking its address again
@@ -11956,11 +11798,11 @@ fn (mut t Transformer) try_lower_generic_sum_constructor_call(node flat.Node) ?f
 	start := t.a.children.len
 	t.a.children << arg
 	return t.a.add_node(flat.Node{
-		kind:           .cast_expr
-		value:          target
+		kind: .cast_expr
+		value: target
 		children_start: start
 		children_count: 1
-		typ:            target
+		typ: target
 	})
 }
 
@@ -11984,11 +11826,11 @@ fn (mut t Transformer) try_lower_generic_named_type_cast_call(node flat.Node) ?f
 	start := t.a.children.len
 	t.a.children << arg
 	return t.a.add_node(flat.Node{
-		kind:           .cast_expr
-		value:          target
+		kind: .cast_expr
+		value: target
 		children_start: start
 		children_count: 1
-		typ:            target
+		typ: target
 	})
 }
 
@@ -12051,8 +11893,7 @@ fn (mut t Transformer) try_lower_flag_default_value_call(node flat.Node) ?flat.N
 	}
 	if t.normalize_type_alias(arg_type) == 'string' {
 		escaped := t.make_call_typed('escape_default_string', [arg], 'string')
-		return t.string_plus(t.string_plus(t.make_string_literal('"'), escaped),
-			t.make_string_literal('"'))
+		return t.string_plus(t.string_plus(t.make_string_literal('"'), escaped), t.make_string_literal('"'))
 	}
 	return t.wrap_string_conversion(arg, arg_type)
 }
@@ -12064,8 +11905,7 @@ fn (mut t Transformer) try_lower_sum_type_name_method_call(node flat.Node) ?flat
 	}
 	fn_id := t.a.child(&node, 0)
 	fn_node := t.a.nodes[int(fn_id)]
-	if fn_node.kind != .selector || fn_node.value !in ['type_name', 'type_idx']
-		|| fn_node.children_count == 0 {
+	if fn_node.kind != .selector || fn_node.value !in ['type_name', 'type_idx'] || fn_node.children_count == 0 {
 		return none
 	}
 	base_id := t.a.child(&fn_node, 0)
@@ -12096,8 +11936,7 @@ fn (mut t Transformer) try_lower_interface_runtime_method_call(node flat.Node) ?
 	}
 	fn_id := t.a.child(&node, 0)
 	fn_node := t.a.nodes[int(fn_id)]
-	if fn_node.kind != .selector || fn_node.value !in ['type_name', 'type_idx']
-		|| fn_node.children_count == 0 {
+	if fn_node.kind != .selector || fn_node.value !in ['type_name', 'type_idx'] || fn_node.children_count == 0 {
 		return none
 	}
 	base_id := t.a.child(&fn_node, 0)
@@ -12151,10 +11990,10 @@ fn (mut t Transformer) build_interface_type_idx_chain(tag flat.NodeId, iface_nam
 		t.a.children << then_block
 		t.a.children << else_block
 		return t.a.add_node(flat.Node{
-			kind:           .if_expr
+			kind: .if_expr
 			children_start: start
 			children_count: 3
-			typ:            'int'
+			typ: 'int'
 		})
 	}
 	impl := impls[idx]
@@ -12172,10 +12011,10 @@ fn (mut t Transformer) build_interface_type_idx_chain(tag flat.NodeId, iface_nam
 	t.a.children << then_block
 	t.a.children << else_block
 	return t.a.add_node(flat.Node{
-		kind:           .if_expr
+		kind: .if_expr
 		children_start: start
 		children_count: 3
-		typ:            'int'
+		typ: 'int'
 	})
 }
 
@@ -12197,10 +12036,10 @@ fn (mut t Transformer) build_interface_type_name_chain(tag flat.NodeId, iface_na
 	t.a.children << then_block
 	t.a.children << else_block
 	return t.a.add_node(flat.Node{
-		kind:           .if_expr
+		kind: .if_expr
 		children_start: start
 		children_count: 3
-		typ:            'string'
+		typ: 'string'
 	})
 }
 
@@ -12220,10 +12059,10 @@ fn (mut t Transformer) build_sum_type_name_chain(tag flat.NodeId, sum_name strin
 	t.a.children << then_block
 	t.a.children << else_block
 	return t.a.add_node(flat.Node{
-		kind:           .if_expr
+		kind: .if_expr
 		children_start: start
 		children_count: 3
-		typ:            'string'
+		typ: 'string'
 	})
 }
 
@@ -12243,10 +12082,10 @@ fn (mut t Transformer) build_sum_type_idx_chain(tag flat.NodeId, sum_name string
 	t.a.children << then_block
 	t.a.children << else_block
 	return t.a.add_node(flat.Node{
-		kind:           .if_expr
+		kind: .if_expr
 		children_start: start
 		children_count: 3
-		typ:            'int'
+		typ: 'int'
 	})
 }
 
@@ -12297,8 +12136,7 @@ fn (mut t Transformer) try_lower_pool_generic_method_call(node flat.Node) ?flat.
 	is_ref_results := method == 'get_results_ref'
 	out_elem_type := if is_ref_results { '&${elem_type}' } else { elem_type }
 	out_type := '[]${out_elem_type}'
-	prefix << t.make_decl_assign_typed(result_name, t.make_array_new_call(out_elem_type,
-		t.make_int_literal(0), results_len), out_type)
+	prefix << t.make_decl_assign_typed(result_name, t.make_array_new_call(out_elem_type, t.make_int_literal(0), results_len), out_type)
 	init := t.make_decl_assign_typed(idx_name, t.make_int_literal(0), 'int')
 	cond_results := t.pool_processor_field(base, base_type, 'results', '[]voidptr')
 	cond := t.make_infix(.lt, t.make_ident(idx_name), t.make_selector(cond_results, 'len', 'int'))
@@ -12434,9 +12272,7 @@ fn (mut t Transformer) try_lower_receiver_method_call(id flat.NodeId, node flat.
 	if method == 'close' && !isnil(t.tc) {
 		if resolved_method := t.tc.resolved_call_name(id) {
 			if resolved_method != 'chan.close' && resolved_method != 'sync__Channel__close' {
-				if exact_call := t.lower_checker_selected_receiver_method(id, node, base_id,
-					'chan.close')
-				{
+				if exact_call := t.lower_checker_selected_receiver_method(id, node, base_id, 'chan.close') {
 					return exact_call
 				}
 			}
@@ -12500,8 +12336,7 @@ fn (mut t Transformer) try_lower_receiver_method_call(id flat.NodeId, node flat.
 			}
 		}
 		if base_type.starts_with('[]') || base_type.starts_with('map[') {
-			collection_method = t.resolve_collection_receiver_method_name(base_id, method,
-				base_type)
+			collection_method = t.resolve_collection_receiver_method_name(base_id, method, base_type)
 			if collection_method.len > 0 && collection_method !in method_names {
 				method_names << collection_method
 			}
@@ -12509,7 +12344,7 @@ fn (mut t Transformer) try_lower_receiver_method_call(id flat.NodeId, node flat.
 		for method_name in method_names {
 			if t.is_known_fn_name(method_name)
 				&& (t.receiver_method_matches_base_type(method_name, base_id)
-				|| (collection_method.len > 0 && method_name == collection_method)) {
+					|| (collection_method.len > 0 && method_name == collection_method)) {
 				args := t.transform_receiver_method_args(node, base_id, method_name)
 				ret_type := t.receiver_method_return_type(method_name, node.typ)
 				t.mark_fn_used_name(method_name)
@@ -12571,8 +12406,7 @@ fn (mut t Transformer) try_lower_receiver_method_call(id flat.NodeId, node flat.
 			return t.make_call_typed('Array_u8__hex', [t.transform_expr(base_id)], 'string')
 		}
 	}
-	mut pointer_method := t.pointer_builtin_vbytes_method(base_is_pointer, builtin_base_type,
-		method) or { '' }
+	mut pointer_method := t.pointer_builtin_vbytes_method(base_is_pointer, builtin_base_type, method) or { '' }
 	if method == 'vbytes' && !isnil(t.tc) {
 		if resolved := t.tc.resolved_call_name(id) {
 			if resolved in ['byteptr.vbytes', 'byteptr__vbytes', 'u8.vbytes', 'u8__vbytes'] {
@@ -12617,8 +12451,7 @@ fn (mut t Transformer) try_lower_receiver_method_call(id flat.NodeId, node flat.
 					if !t.validate_cgen_array_method_args(node, base_id, base_type, method) {
 						return t.make_empty()
 					}
-				} else if
-					t.resolve_collection_receiver_method_name(base_id, method, base_type).len == 0
+				} else if t.resolve_collection_receiver_method_name(base_id, method, base_type).len == 0
 					&& !t.receiver_selector_is_fn_field(base_type, method) {
 					base_name := if base_node.kind == .ident && base_node.value.len > 0 {
 						base_node.value
@@ -12650,8 +12483,7 @@ fn (mut t Transformer) try_lower_receiver_method_call(id flat.NodeId, node flat.
 					if !t.validate_resolved_receiver_method_args(node, base_id, resolved_method) {
 						return t.make_empty()
 					}
-					args := t.transform_receiver_method_args_with_base(node, t.receiver_base_for_resolved_method(base_id,
-						resolved_method), resolved_method)
+					args := t.transform_receiver_method_args_with_base(node, t.receiver_base_for_resolved_method(base_id, resolved_method), resolved_method)
 					ret_type := t.receiver_method_return_type(resolved_method, node.typ)
 					if !t.validate_specialized_call_result(id, ret_type) {
 						return t.make_empty()
@@ -12692,8 +12524,7 @@ fn (mut t Transformer) try_lower_receiver_method_call(id flat.NodeId, node flat.
 				if !t.validate_resolved_receiver_method_args(node, base_id, resolved_method) {
 					return t.make_empty()
 				}
-				args := t.transform_receiver_method_args_with_base(node, t.receiver_base_for_resolved_method(base_id,
-					resolved_method), resolved_method)
+				args := t.transform_receiver_method_args_with_base(node, t.receiver_base_for_resolved_method(base_id, resolved_method), resolved_method)
 				ret_type := t.receiver_method_return_type(resolved_method, node.typ)
 				if !t.validate_specialized_call_result(id, ret_type) {
 					return t.make_empty()
@@ -12706,8 +12537,7 @@ fn (mut t Transformer) try_lower_receiver_method_call(id flat.NodeId, node flat.
 		if !t.validate_resolved_receiver_method_args(node, base_id, sum_method) {
 			return t.make_empty()
 		}
-		args := t.transform_receiver_method_args_with_base(node, t.receiver_base_for_resolved_method(base_id,
-			sum_method), sum_method)
+		args := t.transform_receiver_method_args_with_base(node, t.receiver_base_for_resolved_method(base_id, sum_method), sum_method)
 		ret_type := t.receiver_method_return_type(sum_method, node.typ)
 		if !t.validate_specialized_call_result(id, ret_type) {
 			return t.make_empty()
@@ -12757,8 +12587,7 @@ fn (mut t Transformer) smartcast_sum_str_call(base_id flat.NodeId) ?flat.NodeId 
 	if target_type.len == 0 || t.is_sum_type_name(target_type) {
 		return none
 	}
-	receiver := t.apply_smartcast_contexts(t.make_plain_expr_for_smartcast(base_id),
-		t.original_expr_type(base_id), t.smartcasts_for(key))
+	receiver := t.apply_smartcast_contexts(t.make_plain_expr_for_smartcast(base_id), t.original_expr_type(base_id), t.smartcasts_for(key))
 	return t.wrap_string_conversion(receiver, target_type)
 }
 
@@ -12854,10 +12683,8 @@ fn (mut t Transformer) validate_resolved_receiver_method_args(node flat.Node, ba
 						spread_id := t.a.child(&arg_node, 0)
 						actual_name := t.specialized_expr_type_name(spread_id)
 						expected_name := t.semantic_type_name(params[params.len - 1])
-						if !t.resolved_receiver_arg_compatible(spread_id, actual_name,
-							expected_name) {
-							t.record_monomorph_error('cannot use `${actual_name}` as argument ${
-								arg_idx + 1} to `${display_name}`; expected `${expected_name}`')
+						if !t.resolved_receiver_arg_compatible(spread_id, actual_name, expected_name) {
+							t.record_monomorph_error('cannot use `${actual_name}` as argument ${arg_idx + 1} to `${display_name}`; expected `${expected_name}`')
 							valid = false
 						}
 					}
@@ -13031,9 +12858,7 @@ fn (mut t Transformer) validate_specialized_comparison_operands(node flat.Node, 
 	}
 	lhs_type := t.specialized_expr_type_name(transformed_lhs)
 	rhs_type := t.specialized_expr_type_name(transformed_rhs)
-	if t.specialized_comparison_types_compatible(transformed_lhs, lhs_type, transformed_rhs,
-		rhs_type)
-	{
+	if t.specialized_comparison_types_compatible(transformed_lhs, lhs_type, transformed_rhs, rhs_type) {
 		return true
 	}
 	if lhs_is_call {
@@ -13230,7 +13055,7 @@ fn (t &Transformer) specialized_int_literal(id flat.NodeId) ?SpecializedIntLiter
 		mut literal := t.specialized_int_literal(t.a.child(&node, 0)) or { return none }
 		if node.op == .minus && literal.magnitude != 0 {
 			literal = SpecializedIntLiteral{
-				negative:  !literal.negative
+				negative: !literal.negative
 				magnitude: literal.magnitude
 			}
 		}
@@ -13532,8 +13357,8 @@ fn (t &Transformer) resolved_call_uses_receiver_type(base_id flat.NodeId, receiv
 fn (mut t Transformer) receiver_base_for_resolved_method(base_id flat.NodeId, method_name string) flat.NodeId {
 	method_receiver := t.trim_pointer_type(owner_name_view(method_name))
 	key := t.expr_key(base_id)
-	for source_type in [t.raw_var_type_for_expr(base_id) or { '' },
-		t.original_expr_type(base_id), t.node_type(base_id)] {
+	for source_type in [t.raw_var_type_for_expr(base_id) or { '' }, t.original_expr_type(base_id),
+		t.node_type(base_id)] {
 		clean_source := t.trim_pointer_type(source_type)
 		if clean_source.len > 0 && method_receiver.len > 0
 			&& t.normalize_type_alias(clean_source) == t.normalize_type_alias(method_receiver) {
@@ -13573,18 +13398,14 @@ fn (mut t Transformer) receiver_base_for_resolved_method(base_id flat.NodeId, me
 	}
 	target_type := t.trim_pointer_type(t.smartcast_target_type(sc))
 	if target_type.len > 0 {
-		smartcast_base := t.apply_smartcast_contexts(t.make_plain_expr_for_smartcast(base_id),
-			t.original_expr_type(base_id), t.smartcasts_for(key))
-		if embedded_base := t.embedded_receiver_base_for_type(smartcast_base, target_type,
-			param_type)
-		{
+		smartcast_base := t.apply_smartcast_contexts(t.make_plain_expr_for_smartcast(base_id), t.original_expr_type(base_id), t.smartcasts_for(key))
+		if embedded_base := t.embedded_receiver_base_for_type(smartcast_base, target_type, param_type) {
 			return embedded_base
 		}
 	}
 	if target_type.len > 0
 		&& t.normalize_type_alias(param_type) == t.normalize_type_alias(target_type) {
-		return t.apply_smartcast_contexts(t.make_plain_expr_for_smartcast(base_id),
-			t.original_expr_type(base_id), t.smartcasts_for(key))
+		return t.apply_smartcast_contexts(t.make_plain_expr_for_smartcast(base_id), t.original_expr_type(base_id), t.smartcasts_for(key))
 	}
 	if method_receiver.len > 0 && t.is_sum_type_name(method_receiver)
 		&& t.normalize_type_alias(param_type) == t.normalize_type_alias(method_receiver) {
@@ -14179,7 +14000,11 @@ fn (t &Transformer) receiver_method_candidates(receiver_type string, method stri
 	}
 	if clean_type.starts_with('[]') {
 		elem_type := clean_type[2..]
-		short_elem := if elem_type.contains('.') { elem_type.all_after_last('.') } else { elem_type }
+		short_elem := if elem_type.contains('.') {
+			elem_type.all_after_last('.')
+		} else {
+			elem_type
+		}
 		candidates << '[]${short_elem}.${method}'
 		if elem_type.contains('.') {
 			candidates << '${elem_type.all_before_last('.')}.[]${short_elem}.${method}'
@@ -14209,8 +14034,7 @@ fn generic_receiver_flat_type_variants(receiver_type string) []string {
 	if base.contains('.') {
 		short_base := base.all_after_last('.')
 		transform_push_receiver_candidate(mut receivers, '${short_base}_${suffix}')
-		transform_push_receiver_candidate(mut receivers,
-			'${base.all_before_last('.')}.${short_base}_${suffix}')
+		transform_push_receiver_candidate(mut receivers, '${base.all_before_last('.')}.${short_base}_${suffix}')
 	}
 	return receivers
 }
@@ -14277,8 +14101,7 @@ fn (mut t Transformer) lower_fixed_array_dynamic_receiver_method_call(node flat.
 	elem_type := fixed_array_outer_elem_type(fixed_type)
 	array_type := '[]${elem_type}'
 	tmp_name := t.new_temp('fixed_arr')
-	t.pending_stmts << t.make_decl_assign_typed(tmp_name, t.fixed_array_value_to_array(base_id,
-		fixed_type, array_type), array_type)
+	t.pending_stmts << t.make_decl_assign_typed(tmp_name, t.fixed_array_value_to_array(base_id, fixed_type, array_type), array_type)
 	args := t.transform_receiver_method_args_with_base(node, t.make_ident(tmp_name), method_name)
 	ret_type := t.receiver_method_return_type(method_name, node.typ)
 	t.mark_fn_used(method_name)
@@ -14391,8 +14214,7 @@ fn receiver_type_text_short_spelling(type_text string) string {
 	if clean.starts_with('[') {
 		bracket_end := generic_matching_bracket(clean, 0)
 		if bracket_end < clean.len {
-			return clean[..bracket_end + 1] + receiver_type_text_short_spelling(clean[bracket_end +
-				1..])
+			return clean[..bracket_end + 1] + receiver_type_text_short_spelling(clean[bracket_end + 1..])
 		}
 	}
 	if clean.starts_with('map[') {
@@ -14482,8 +14304,7 @@ fn (t &Transformer) map_receiver_method_candidates(receiver_type string, method 
 
 // transform_receiver_method_args transforms transform receiver method args data for transform.
 fn (mut t Transformer) transform_receiver_method_args(node flat.Node, base_id flat.NodeId, method_name string) []flat.NodeId {
-	return t.transform_receiver_method_args_with_base(node, t.receiver_base_for_resolved_method(base_id,
-		method_name), method_name)
+	return t.transform_receiver_method_args_with_base(node, t.receiver_base_for_resolved_method(base_id, method_name), method_name)
 }
 
 // expr_root_ident_name walks selector/index/paren chains down to the base identifier and
@@ -14578,13 +14399,10 @@ fn (mut t Transformer) transform_receiver_method_args_with_base(node flat.Node, 
 		} else {
 			''
 		}
-		if spread_args := t.transform_spread_arg_over_fixed_variadic_tail(arg_node, param_idx,
-			variadic_idx, params)
-		{
+		if spread_args := t.transform_spread_arg_over_fixed_variadic_tail(arg_node, param_idx, variadic_idx, params) {
 			variadic_type := params[variadic_idx]
 			if variadic_type is types.Array {
-				args << t.fixed_variadic_spread_args_with_trailing(spread_args, node, i + 1,
-					variadic_type)
+				args << t.fixed_variadic_spread_args_with_trailing(spread_args, node, i + 1, variadic_type)
 			} else {
 				args << spread_args
 			}
@@ -14616,8 +14434,7 @@ fn (mut t Transformer) transform_receiver_method_args_with_base(node flat.Node, 
 				if arg_node.kind == .prefix && arg_node.value == '...'
 					&& arg_node.children_count > 0 {
 					spread_id := t.a.child(&arg_node, 0)
-					args << t.transform_variadic_spread_arg_for_param(spread_id, variadic_type,
-						param_type)
+					args << t.transform_variadic_spread_arg_for_param(spread_id, variadic_type, param_type)
 					i++
 					break
 				}
@@ -14642,8 +14459,7 @@ fn (mut t Transformer) transform_receiver_method_args_with_base(node flat.Node, 
 			spread_count := params.len - param_idx
 			for spread_offset in 0 .. spread_count {
 				expected := t.semantic_type_name(params[param_idx + spread_offset])
-				index_arg := t.make_spread_index_for_expected_param(spread_base, spread_offset,
-					expected)
+				index_arg := t.make_spread_index_for_expected_param(spread_base, spread_offset, expected)
 				args << t.transform_call_arg_for_param(index_arg, expected)
 			}
 			i++
@@ -14654,24 +14470,20 @@ fn (mut t Transformer) transform_receiver_method_args_with_base(node flat.Node, 
 			if arg_type is types.MultiReturn && arg_type.types.len == params.len - param_idx {
 				items := arg_type.types
 				multi_type := t.multi_return_type_name(items)
-				value := t.stable_transformed_expr_for_reuse(t.transform_expr(arg_id), multi_type,
-					'multi_arg')
+				value := t.stable_transformed_expr_for_reuse(t.transform_expr(arg_id), multi_type, 'multi_arg')
 				for multi_idx, item_type in items {
 					expected_idx := param_idx + multi_idx
 					if expected_idx >= params.len {
 						break
 					}
-					field := t.make_selector(value, 'arg${multi_idx}',
-						t.semantic_type_name(item_type))
-					args << t.transform_call_arg_for_param(field,
-						t.semantic_type_name(params[expected_idx]))
+					field := t.make_selector(value, 'arg${multi_idx}', t.semantic_type_name(item_type))
+					args << t.transform_call_arg_for_param(field, t.semantic_type_name(params[expected_idx]))
 				}
 				i++
 				continue
 			}
 		}
-		args << t.clone_receiver_aliased_arg(recv_root, arg_id, t.transform_call_arg_for_param(arg_id,
-			param_type), param_type)
+		args << t.clone_receiver_aliased_arg(recv_root, arg_id, t.transform_call_arg_for_param(arg_id, param_type), param_type)
 		i++
 	}
 	if variadic_idx >= 0 && !variadic_tail_supplied && explicit_args == variadic_idx - param_offset {
@@ -14908,8 +14720,7 @@ fn (t &Transformer) get_call_return_type(id flat.NodeId, node flat.Node) string 
 				receiver_base, _, is_generic_receiver := generic_app_parts(receiver_type)
 				if is_generic_receiver {
 					mut names := ['${receiver_base}.${fn_node.value}']
-					if t.cur_module.len > 0 && t.cur_module !in ['main', 'builtin']
-						&& !receiver_base.contains('.') {
+					if t.cur_module.len > 0 && t.cur_module !in ['main', 'builtin'] && !receiver_base.contains('.') {
 						names << '${t.cur_module}.${receiver_base}.${fn_node.value}'
 					}
 					for name in names {
@@ -14926,8 +14737,7 @@ fn (t &Transformer) get_call_return_type(id flat.NodeId, node flat.Node) string 
 			}
 		}
 		if fn_node.kind == .ident && t.var_type(fn_node.value).len == 0 {
-			qualified_name := if t.cur_module.len > 0 && t.cur_module !in ['main', 'builtin']
-				&& !fn_node.value.contains('.') {
+			qualified_name := if t.cur_module.len > 0 && t.cur_module !in ['main', 'builtin'] && !fn_node.value.contains('.') {
 				'${t.cur_module}.${fn_node.value}'
 			} else {
 				fn_node.value
@@ -15175,8 +14985,7 @@ fn (t &Transformer) checker_resolved_non_builtin_return_type_uncached(id flat.No
 	decl_module := t.tc.fn_type_modules[name] or { '' }
 	if ret := t.tc.fn_ret_types[name] {
 		if ret !is types.Unknown && ret !is types.Void {
-			candidate := t.call_return_type_name_in_module(t.semantic_type_name(ret), node,
-				decl_module)
+			candidate := t.call_return_type_name_in_module(t.semantic_type_name(ret), node, decl_module)
 			if decl_type_is_usable(candidate) {
 				return candidate
 			}
@@ -15259,8 +15068,7 @@ fn (t &Transformer) specialize_generic_type_name(typ string, generic_arg string)
 	}
 	if clean.starts_with('[') {
 		bracket_end := clean.index(']') or { return typ }
-		return clean[..bracket_end + 1] + t.specialize_generic_type_name(clean[bracket_end +
-			1..], generic_arg)
+		return clean[..bracket_end + 1] + t.specialize_generic_type_name(clean[bracket_end + 1..], generic_arg)
 	}
 	return typ
 }

--- a/vlib/v3/transform/for.v
+++ b/vlib/v3/transform/for.v
@@ -1268,6 +1268,16 @@ fn (mut t Transformer) detect_for_in_type(node flat.Node) string {
 				return selector_type
 			}
 		}
+		if iter_node.kind == .call {
+			concrete_call_type := t.normalize_type_alias(t.concrete_generic_call_return_type(iter_id,
+				iter_node))
+			concrete_payload := for_iter_payload_type(concrete_call_type)
+			if concrete_payload.len > 0 && !for_iter_type_has_generic_placeholder(concrete_payload)
+				&& for_iter_type_is_container(concrete_payload) {
+				t.set_node_typ(int(iter_id), concrete_call_type)
+				return concrete_payload
+			}
+		}
 		checker_type := t.raw_checker_node_type(iter_id)
 		if checker_type.len > 0 {
 			checker_payload := for_iter_payload_type(checker_type)

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -5921,9 +5921,14 @@ fn (mut t Transformer) make_non_aliasing_allocation_call(name string, args []fla
 // as a `&T` — a plain value type, not an already-reference / container / optional type (those
 // either carry their own indirection or are not addressable as a single `T`).
 fn (t &Transformer) heapable_value_type(typ string) bool {
-	return typ.len > 0 && !typ.starts_with('&') && !typ.starts_with('[]')
-		&& !typ.starts_with('map[') && !typ.starts_with('?') && !typ.starts_with('!')
-		&& !typ.starts_with('[') && typ != 'unknown' && typ != 'void'
+	if typ.len == 0 || typ.starts_with('&') || typ.starts_with('[]') || typ.starts_with('map[')
+		|| typ.starts_with('?') || typ.starts_with('!') || typ.starts_with('[') || typ == 'unknown'
+		|| typ == 'void' {
+		return false
+	}
+	// Function values are already pointers in C. `&callback` is accepted as the
+	// same callable value and must not move the function-pointer slot to the heap.
+	return isnil(t.tc) || types.unalias_type(t.tc.parse_type(typ)) !is types.FnType
 }
 
 // heap_attr_struct_type reports whether `typ` is a plain (non-pointer) struct type

--- a/vlib/v3/transform/transform_parallel_test.v
+++ b/vlib/v3/transform/transform_parallel_test.v
@@ -35,9 +35,9 @@ fn test_generated_calls_publish_exact_resolution_except_cgen_intrinsics() {
 fn test_forwarded_optional_conversion_propagates_borrowed_clone() {
 	mut a := flat.FlatAst.new()
 	source := a.add_node(flat.Node{
-		kind:  .ident
+		kind: .ident
 		value: 'source'
-		typ:   '?string'
+		typ: '?string'
 	})
 	mut tc := types.TypeChecker.new(&a)
 	mut t := new_transformer(mut a, &tc, map[string]bool{})
@@ -46,8 +46,7 @@ fn test_forwarded_optional_conversion_propagates_borrowed_clone() {
 		base_type: types.Type(types.string_)
 	})
 
-	result := t.convert_forwarded_optional_result(source, optional, payload, optional, optional,
-		payload, true)
+	result := t.convert_forwarded_optional_result(source, optional, payload, optional, optional, payload, true)
 
 	assert result != source
 	mut saw_clone := false

--- a/vlib/v3/types/checker_ownership_d_ownership.v
+++ b/vlib/v3/types/checker_ownership_d_ownership.v
@@ -250,18 +250,18 @@ fn ownership_clone_name_snapshots(names map[string]OwnershipNameSnapshot) map[st
 	mut cloned := map[string]OwnershipNameSnapshot{}
 	for name, snap in names {
 		cloned[name] = OwnershipNameSnapshot{
-			had_owned:         snap.had_owned
-			owned_pos:         snap.owned_pos
-			had_type:          snap.had_type
-			type_name:         snap.type_name
-			had_moved:         snap.had_moved
-			moved:             snap.moved
-			borrows:           snap.borrows.clone()
-			children:          snap.children.clone()
-			had_fn:            snap.had_fn
-			fn_name:           snap.fn_name
+			had_owned: snap.had_owned
+			owned_pos: snap.owned_pos
+			had_type: snap.had_type
+			type_name: snap.type_name
+			had_moved: snap.had_moved
+			moved: snap.moved
+			borrows: snap.borrows.clone()
+			children: snap.children.clone()
+			had_fn: snap.had_fn
+			fn_name: snap.fn_name
 			had_pointer_alias: snap.had_pointer_alias
-			pointer_alias:     snap.pointer_alias
+			pointer_alias: snap.pointer_alias
 		}
 	}
 	return cloned
@@ -271,12 +271,12 @@ fn ownership_clone_scope_frames(frames []OwnershipScopeFrame) []OwnershipScopeFr
 	mut cloned := []OwnershipScopeFrame{cap: frames.len}
 	for frame in frames {
 		cloned << OwnershipScopeFrame{
-			cur_fn:      frame.cur_fn
+			cur_fn: frame.cur_fn
 			is_fn_scope: frame.is_fn_scope
-			names:       ownership_clone_name_snapshots(frame.names)
-			decl_order:  frame.decl_order.clone()
+			names: ownership_clone_name_snapshots(frame.names)
+			decl_order: frame.decl_order.clone()
 			defer_stmts: frame.defer_stmts.clone()
-			scope_id:    frame.scope_id
+			scope_id: frame.scope_id
 		}
 	}
 	return cloned
@@ -284,58 +284,58 @@ fn ownership_clone_scope_frames(frames []OwnershipScopeFrame) []OwnershipScopeFr
 
 fn new_ownership_state() &OwnershipState {
 	return &OwnershipState{
-		owned_vars:                       map[string]flat.NodeId{}
-		owned_var_types:                  map[string]string{}
-		moved_vars:                       map[string]MovedVar{}
-		borrowed_vars:                    map[string][]BorrowInfo{}
-		ownership_fns:                    map[string]bool{}
-		ownership_fn_params:              map[string]bool{}
-		ownership_fn_returns_param:       map[string][]int{}
-		ownership_fn_return_params:       map[string][]OwnershipReturnParamSlot{}
-		ownership_fn_return_slots:        map[string][]int{}
-		ownership_fn_return_descs:        map[string][]OwnershipReturnDescendant{}
-		ownership_fn_return_param_descs:  map[string][]OwnershipReturnParamDescendant{}
-		ownership_fn_return_fn_values:    map[string]string{}
-		ownership_fn_literal_ret_types:   map[string]Type{}
+		owned_vars: map[string]flat.NodeId{}
+		owned_var_types: map[string]string{}
+		moved_vars: map[string]MovedVar{}
+		borrowed_vars: map[string][]BorrowInfo{}
+		ownership_fns: map[string]bool{}
+		ownership_fn_params: map[string]bool{}
+		ownership_fn_returns_param: map[string][]int{}
+		ownership_fn_return_params: map[string][]OwnershipReturnParamSlot{}
+		ownership_fn_return_slots: map[string][]int{}
+		ownership_fn_return_descs: map[string][]OwnershipReturnDescendant{}
+		ownership_fn_return_param_descs: map[string][]OwnershipReturnParamDescendant{}
+		ownership_fn_return_fn_values: map[string]string{}
+		ownership_fn_literal_ret_types: map[string]Type{}
 		ownership_fn_literal_param_types: map[string][]Type{}
-		ownership_fn_param_mut:           map[string][]bool{}
-		ownership_fn_param_descs:         map[string][]OwnershipParamDescendant{}
-		ownership_fn_param_desc_count:    0
-		owned_structs:                    map[string]bool{}
-		copy_structs:                     map[string]bool{}
-		drop_structs:                     map[string]bool{}
-		drop_at_fn_exit:                  map[string][]OwnershipDropEntry{}
-		drop_at_returns:                  map[string][]OwnershipDropEntry{}
-		drop_at_return_nodes:             map[string][]OwnershipDropEntry{}
-		drop_at_propagations:             map[string][]OwnershipDropEntry{}
-		drop_at_loop_controls:            map[string][]OwnershipDropEntry{}
-		drop_at_loop_iterations:          map[string][]OwnershipDropEntry{}
-		drop_at_scope_exit:               map[string][]OwnershipDropEntry{}
-		drop_return_counts:               map[string]int{}
-		drop_propagation_counts:          map[string]int{}
-		drop_loop_control_counts:         map[string]int{}
-		drop_loop_iteration_counts:       map[string]int{}
-		drop_scope_counts:                map[string]int{}
-		drop_type_names:                  map[string]bool{}
-		value_receiver_methods:           map[string]bool{}
-		owned_globals:                    map[string]string{}
-		array_lengths:                    map[string]int{}
-		ownership_fn_value_vars:          map[string]string{}
-		frames:                           []OwnershipFrame{}
-		branch_groups:                    []OwnershipBranchGroup{}
-		pending_value_branch_groups:      []OwnershipBranchGroup{}
-		pending_loop_label:               ''
-		deferred_aggregate_consumption:   map[int]int{}
-		index_move_reads:                 map[int]bool{}
-		receiver_alias_clone_reads:       map[int]bool{}
-		borrowed_projection_actions:      map[int]OwnershipBorrowedProjectionAction{}
-		pointer_index_aliases:            map[string]string{}
-		borrowed_storage_clone_reads:     map[int]bool{}
-		guard_move_reads:                 map[int]bool{}
-		skip_drop_before_assign:          map[int]bool{}
-		scope_frames:                     []OwnershipScopeFrame{}
-		suppressed_checks:                0
-		path_active:                      true
+		ownership_fn_param_mut: map[string][]bool{}
+		ownership_fn_param_descs: map[string][]OwnershipParamDescendant{}
+		ownership_fn_param_desc_count: 0
+		owned_structs: map[string]bool{}
+		copy_structs: map[string]bool{}
+		drop_structs: map[string]bool{}
+		drop_at_fn_exit: map[string][]OwnershipDropEntry{}
+		drop_at_returns: map[string][]OwnershipDropEntry{}
+		drop_at_return_nodes: map[string][]OwnershipDropEntry{}
+		drop_at_propagations: map[string][]OwnershipDropEntry{}
+		drop_at_loop_controls: map[string][]OwnershipDropEntry{}
+		drop_at_loop_iterations: map[string][]OwnershipDropEntry{}
+		drop_at_scope_exit: map[string][]OwnershipDropEntry{}
+		drop_return_counts: map[string]int{}
+		drop_propagation_counts: map[string]int{}
+		drop_loop_control_counts: map[string]int{}
+		drop_loop_iteration_counts: map[string]int{}
+		drop_scope_counts: map[string]int{}
+		drop_type_names: map[string]bool{}
+		value_receiver_methods: map[string]bool{}
+		owned_globals: map[string]string{}
+		array_lengths: map[string]int{}
+		ownership_fn_value_vars: map[string]string{}
+		frames: []OwnershipFrame{}
+		branch_groups: []OwnershipBranchGroup{}
+		pending_value_branch_groups: []OwnershipBranchGroup{}
+		pending_loop_label: ''
+		deferred_aggregate_consumption: map[int]int{}
+		index_move_reads: map[int]bool{}
+		receiver_alias_clone_reads: map[int]bool{}
+		borrowed_projection_actions: map[int]OwnershipBorrowedProjectionAction{}
+		pointer_index_aliases: map[string]string{}
+		borrowed_storage_clone_reads: map[int]bool{}
+		guard_move_reads: map[int]bool{}
+		skip_drop_before_assign: map[int]bool{}
+		scope_frames: []OwnershipScopeFrame{}
+		suppressed_checks: 0
+		path_active: true
 	}
 }
 
@@ -396,58 +396,58 @@ fn ownership_clone_bool_lists(src map[string][]bool) map[string][]bool {
 
 fn ownership_clone_state_for_parallel(src &OwnershipState) &OwnershipState {
 	return &OwnershipState{
-		owned_vars:                       map[string]flat.NodeId{}
-		owned_var_types:                  map[string]string{}
-		moved_vars:                       map[string]MovedVar{}
-		borrowed_vars:                    map[string][]BorrowInfo{}
-		ownership_fns:                    src.ownership_fns.clone()
-		ownership_fn_params:              src.ownership_fn_params.clone()
-		ownership_fn_returns_param:       ownership_clone_int_lists(src.ownership_fn_returns_param)
-		ownership_fn_return_params:       ownership_clone_return_param_slots(src.ownership_fn_return_params)
-		ownership_fn_return_slots:        ownership_clone_int_lists(src.ownership_fn_return_slots)
-		ownership_fn_return_descs:        ownership_clone_return_descs(src.ownership_fn_return_descs)
-		ownership_fn_return_param_descs:  ownership_clone_return_param_descs(src.ownership_fn_return_param_descs)
-		ownership_fn_return_fn_values:    src.ownership_fn_return_fn_values.clone()
-		ownership_fn_literal_ret_types:   map[string]Type{}
+		owned_vars: map[string]flat.NodeId{}
+		owned_var_types: map[string]string{}
+		moved_vars: map[string]MovedVar{}
+		borrowed_vars: map[string][]BorrowInfo{}
+		ownership_fns: src.ownership_fns.clone()
+		ownership_fn_params: src.ownership_fn_params.clone()
+		ownership_fn_returns_param: ownership_clone_int_lists(src.ownership_fn_returns_param)
+		ownership_fn_return_params: ownership_clone_return_param_slots(src.ownership_fn_return_params)
+		ownership_fn_return_slots: ownership_clone_int_lists(src.ownership_fn_return_slots)
+		ownership_fn_return_descs: ownership_clone_return_descs(src.ownership_fn_return_descs)
+		ownership_fn_return_param_descs: ownership_clone_return_param_descs(src.ownership_fn_return_param_descs)
+		ownership_fn_return_fn_values: src.ownership_fn_return_fn_values.clone()
+		ownership_fn_literal_ret_types: map[string]Type{}
 		ownership_fn_literal_param_types: map[string][]Type{}
-		ownership_fn_param_mut:           ownership_clone_bool_lists(src.ownership_fn_param_mut)
-		ownership_fn_param_descs:         ownership_clone_param_descs(src.ownership_fn_param_descs)
-		ownership_fn_param_desc_count:    src.ownership_fn_param_desc_count
-		owned_structs:                    src.owned_structs.clone()
-		copy_structs:                     src.copy_structs.clone()
-		drop_structs:                     src.drop_structs.clone()
-		drop_at_fn_exit:                  map[string][]OwnershipDropEntry{}
-		drop_at_returns:                  map[string][]OwnershipDropEntry{}
-		drop_at_return_nodes:             map[string][]OwnershipDropEntry{}
-		drop_at_propagations:             map[string][]OwnershipDropEntry{}
-		drop_at_loop_controls:            map[string][]OwnershipDropEntry{}
-		drop_at_loop_iterations:          map[string][]OwnershipDropEntry{}
-		drop_at_scope_exit:               map[string][]OwnershipDropEntry{}
-		drop_return_counts:               map[string]int{}
-		drop_propagation_counts:          map[string]int{}
-		drop_loop_control_counts:         map[string]int{}
-		drop_loop_iteration_counts:       map[string]int{}
-		drop_scope_counts:                map[string]int{}
-		drop_type_names:                  map[string]bool{}
-		value_receiver_methods:           src.value_receiver_methods.clone()
-		owned_globals:                    src.owned_globals.clone()
-		array_lengths:                    map[string]int{}
-		ownership_fn_value_vars:          map[string]string{}
-		frames:                           []OwnershipFrame{}
-		branch_groups:                    []OwnershipBranchGroup{}
-		pending_value_branch_groups:      []OwnershipBranchGroup{}
-		pending_loop_label:               ''
-		deferred_aggregate_consumption:   map[int]int{}
-		index_move_reads:                 map[int]bool{}
-		receiver_alias_clone_reads:       map[int]bool{}
-		borrowed_projection_actions:      map[int]OwnershipBorrowedProjectionAction{}
-		pointer_index_aliases:            map[string]string{}
-		borrowed_storage_clone_reads:     map[int]bool{}
-		guard_move_reads:                 map[int]bool{}
-		skip_drop_before_assign:          map[int]bool{}
-		scope_frames:                     []OwnershipScopeFrame{}
-		suppressed_checks:                0
-		path_active:                      true
+		ownership_fn_param_mut: ownership_clone_bool_lists(src.ownership_fn_param_mut)
+		ownership_fn_param_descs: ownership_clone_param_descs(src.ownership_fn_param_descs)
+		ownership_fn_param_desc_count: src.ownership_fn_param_desc_count
+		owned_structs: src.owned_structs.clone()
+		copy_structs: src.copy_structs.clone()
+		drop_structs: src.drop_structs.clone()
+		drop_at_fn_exit: map[string][]OwnershipDropEntry{}
+		drop_at_returns: map[string][]OwnershipDropEntry{}
+		drop_at_return_nodes: map[string][]OwnershipDropEntry{}
+		drop_at_propagations: map[string][]OwnershipDropEntry{}
+		drop_at_loop_controls: map[string][]OwnershipDropEntry{}
+		drop_at_loop_iterations: map[string][]OwnershipDropEntry{}
+		drop_at_scope_exit: map[string][]OwnershipDropEntry{}
+		drop_return_counts: map[string]int{}
+		drop_propagation_counts: map[string]int{}
+		drop_loop_control_counts: map[string]int{}
+		drop_loop_iteration_counts: map[string]int{}
+		drop_scope_counts: map[string]int{}
+		drop_type_names: map[string]bool{}
+		value_receiver_methods: src.value_receiver_methods.clone()
+		owned_globals: src.owned_globals.clone()
+		array_lengths: map[string]int{}
+		ownership_fn_value_vars: map[string]string{}
+		frames: []OwnershipFrame{}
+		branch_groups: []OwnershipBranchGroup{}
+		pending_value_branch_groups: []OwnershipBranchGroup{}
+		pending_loop_label: ''
+		deferred_aggregate_consumption: map[int]int{}
+		index_move_reads: map[int]bool{}
+		receiver_alias_clone_reads: map[int]bool{}
+		borrowed_projection_actions: map[int]OwnershipBorrowedProjectionAction{}
+		pointer_index_aliases: map[string]string{}
+		borrowed_storage_clone_reads: map[int]bool{}
+		guard_move_reads: map[int]bool{}
+		skip_drop_before_assign: map[int]bool{}
+		scope_frames: []OwnershipScopeFrame{}
+		suppressed_checks: 0
+		path_active: true
 	}
 }
 
@@ -659,21 +659,15 @@ fn (mut tc TypeChecker) ownership_merge_parallel_check_worker(w &TypeChecker) {
 	ownership_merge_bool_map(mut dst.ownership_fns, src.ownership_fns)
 	ownership_merge_bool_map(mut dst.ownership_fn_params, src.ownership_fn_params)
 	ownership_merge_int_lists(mut dst.ownership_fn_returns_param, src.ownership_fn_returns_param)
-	ownership_merge_return_param_slots(mut dst.ownership_fn_return_params,
-		src.ownership_fn_return_params)
+	ownership_merge_return_param_slots(mut dst.ownership_fn_return_params, src.ownership_fn_return_params)
 	ownership_merge_int_lists(mut dst.ownership_fn_return_slots, src.ownership_fn_return_slots)
 	ownership_merge_return_descs(mut dst.ownership_fn_return_descs, src.ownership_fn_return_descs)
-	ownership_merge_return_param_descs(mut dst.ownership_fn_return_param_descs,
-		src.ownership_fn_return_param_descs)
-	ownership_merge_fn_value_returns(mut dst.ownership_fn_return_fn_values,
-		src.ownership_fn_return_fn_values)
-	ownership_merge_type_map(mut dst.ownership_fn_literal_ret_types,
-		src.ownership_fn_literal_ret_types)
-	ownership_merge_type_lists(mut dst.ownership_fn_literal_param_types,
-		src.ownership_fn_literal_param_types)
+	ownership_merge_return_param_descs(mut dst.ownership_fn_return_param_descs, src.ownership_fn_return_param_descs)
+	ownership_merge_fn_value_returns(mut dst.ownership_fn_return_fn_values, src.ownership_fn_return_fn_values)
+	ownership_merge_type_map(mut dst.ownership_fn_literal_ret_types, src.ownership_fn_literal_ret_types)
+	ownership_merge_type_lists(mut dst.ownership_fn_literal_param_types, src.ownership_fn_literal_param_types)
 	ownership_merge_bool_lists(mut dst.ownership_fn_param_mut, src.ownership_fn_param_mut)
-	dst.ownership_fn_param_desc_count += ownership_merge_param_descs(mut dst.ownership_fn_param_descs,
-		src.ownership_fn_param_descs)
+	dst.ownership_fn_param_desc_count += ownership_merge_param_descs(mut dst.ownership_fn_param_descs, src.ownership_fn_param_descs)
 	ownership_merge_bool_map(mut dst.owned_structs, src.owned_structs)
 	ownership_merge_bool_map(mut dst.copy_structs, src.copy_structs)
 	ownership_merge_bool_map(mut dst.drop_structs, src.drop_structs)
@@ -843,12 +837,10 @@ fn (tc &TypeChecker) ownership_collect_deferred_aggregate_ids(expr_id flat.NodeI
 		}
 		.if_expr {
 			if node.children_count > 1 {
-				tc.ownership_collect_deferred_aggregate_ids(tc.branch_tail_expr_id(tc.a.child(&node,
-					1)), mut ids)
+				tc.ownership_collect_deferred_aggregate_ids(tc.branch_tail_expr_id(tc.a.child(&node, 1)), mut ids)
 			}
 			if node.children_count > 2 {
-				tc.ownership_collect_deferred_aggregate_ids(tc.branch_tail_expr_id(tc.a.child(&node,
-					2)), mut ids)
+				tc.ownership_collect_deferred_aggregate_ids(tc.branch_tail_expr_id(tc.a.child(&node, 2)), mut ids)
 			}
 		}
 		.match_stmt {
@@ -858,15 +850,13 @@ fn (tc &TypeChecker) ownership_collect_deferred_aggregate_ids(expr_id flat.NodeI
 					continue
 				}
 				if tc.a.nodes[int(branch_id)].kind == .match_branch {
-					tc.ownership_collect_deferred_aggregate_ids(tc.branch_tail_expr_id(branch_id), mut
-						ids)
+					tc.ownership_collect_deferred_aggregate_ids(tc.branch_tail_expr_id(branch_id), mut ids)
 				}
 			}
 		}
 		.or_expr {
 			if node.children_count >= 2 && node.value !in ['!', '?'] {
-				tc.ownership_collect_deferred_aggregate_ids(tc.branch_tail_expr_id(tc.a.child(&node,
-					1)), mut ids)
+				tc.ownership_collect_deferred_aggregate_ids(tc.branch_tail_expr_id(tc.a.child(&node, 1)), mut ids)
 			}
 		}
 		else {}
@@ -912,10 +902,10 @@ fn (mut tc TypeChecker) ownership_push_scope() {
 		}
 	}
 	st.scope_frames << OwnershipScopeFrame{
-		cur_fn:      st.cur_fn
+		cur_fn: st.cur_fn
 		is_fn_scope: is_fn_scope
-		names:       map[string]OwnershipNameSnapshot{}
-		decl_order:  []string{}
+		names: map[string]OwnershipNameSnapshot{}
+		decl_order: []string{}
 		defer_stmts: []flat.NodeId{}
 	}
 }
@@ -1158,8 +1148,8 @@ fn (mut tc TypeChecker) ownership_live_drop_entry(name string) ?OwnershipDropEnt
 	type_name := st.owned_var_types[name] or { return none }
 	target := tc.ownership_drop_target_for_type_name(type_name) or { return none }
 	return OwnershipDropEntry{
-		name:             name
-		type_name:        target.type_name
+		name: name
+		type_name: target.type_name
 		optional_wrapper: target.optional_wrapper
 	}
 }
@@ -1197,7 +1187,7 @@ fn (tc &TypeChecker) ownership_drop_target_for_type_name(type_name string) ?Owne
 fn (tc &TypeChecker) ownership_drop_target_for_direct_type_name(type_name string, optional_wrapper bool) ?OwnershipDropTarget {
 	if tc.ownership_type_name_has_direct_drop(type_name) {
 		return OwnershipDropTarget{
-			type_name:        type_name
+			type_name: type_name
 			optional_wrapper: optional_wrapper
 		}
 	}
@@ -1210,20 +1200,20 @@ fn (tc &TypeChecker) ownership_drop_target_for_resolved_type(typ Type, optional_
 	}
 	if typ is OptionType {
 		return OwnershipDropTarget{
-			type_name:        Type(typ).name()
+			type_name: Type(typ).name()
 			optional_wrapper: optional_wrapper
 		}
 	}
 	if typ is ResultType {
 		return OwnershipDropTarget{
-			type_name:        Type(typ).name()
+			type_name: Type(typ).name()
 			optional_wrapper: optional_wrapper
 		}
 	}
 	type_name := typ.name()
 	if tc.ownership_type_name_has_direct_drop(type_name) {
 		return OwnershipDropTarget{
-			type_name:        type_name
+			type_name: type_name
 			optional_wrapper: optional_wrapper
 		}
 	}
@@ -1292,9 +1282,7 @@ fn (mut tc TypeChecker) check_ownership_map_assignment_key(lhs_id flat.NodeId, o
 		return
 	}
 	if bad_type := tc.ownership_default_clone_missing_method(map_type.key_type) {
-		tc.record_error(.assignment_mismatch,
-			'cannot clone borrowed map key: `${bad_type}` requires ownership destruction but has no `clone()` method',
-			key_id)
+		tc.record_error(.assignment_mismatch, 'cannot clone borrowed map key: `${bad_type}` requires ownership destruction but has no `clone()` method', key_id)
 	}
 }
 
@@ -1307,9 +1295,7 @@ fn (mut tc TypeChecker) check_ownership_uncloneable_overlapping_map_assignment(l
 	}
 	if op == .left_shift_assign && unalias_type(lhs_type) is Array {
 		if bad_type := tc.ownership_default_clone_missing_method(lhs_type) {
-			tc.record_error(.assignment_mismatch,
-				'cannot update owned map array value: `${bad_type}` requires ownership destruction but has no `clone()` method',
-				pos)
+			tc.record_error(.assignment_mismatch, 'cannot update owned map array value: `${bad_type}` requires ownership destruction but has no `clone()` method', pos)
 		}
 		return
 	}
@@ -1318,9 +1304,7 @@ fn (mut tc TypeChecker) check_ownership_uncloneable_overlapping_map_assignment(l
 		return
 	}
 	if bad_type := tc.ownership_default_clone_missing_method(lhs_type) {
-		tc.record_error(.assignment_mismatch,
-			'cannot move overlapping map storage: `${bad_type}` requires ownership destruction but has no `clone()` method',
-			pos)
+		tc.record_error(.assignment_mismatch, 'cannot move overlapping map storage: `${bad_type}` requires ownership destruction but has no `clone()` method', pos)
 	}
 }
 
@@ -1570,8 +1554,7 @@ fn (tc &TypeChecker) ownership_collect_drop_type_names(typ Type, mut names []str
 				base, args, is_generic := generic_type_application_parts(name)
 				if is_generic && base.all_after_last('.') == 'Arc' {
 					for arg in args {
-						tc.ownership_collect_drop_type_names(tc.parse_type(arg), mut names, mut
-							seen)
+						tc.ownership_collect_drop_type_names(tc.parse_type(arg), mut names, mut seen)
 					}
 				}
 				return
@@ -1604,7 +1587,7 @@ fn (mut tc TypeChecker) ownership_live_drop_entries() []OwnershipDropEntry {
 		if !name.contains('.') && !name.contains('[') {
 			candidates << OwnershipDropCandidate{
 				name: name
-				pos:  int(pos)
+				pos: int(pos)
 			}
 		}
 	}
@@ -1646,18 +1629,18 @@ fn (mut tc TypeChecker) ownership_note_decl(name string) {
 	}
 	children := tc.ownership_child_snapshots(name)
 	st.scope_frames[scope_idx].names[name] = OwnershipNameSnapshot{
-		had_owned:         name in st.owned_vars
-		owned_pos:         st.owned_vars[name] or { flat.NodeId(-1) }
-		had_type:          name in st.owned_var_types
-		type_name:         st.owned_var_types[name] or { '' }
-		had_moved:         name in st.moved_vars
-		moved:             st.moved_vars[name] or { MovedVar{} }
-		borrows:           borrows
-		children:          children
-		had_fn:            name in st.ownership_fn_value_vars
-		fn_name:           st.ownership_fn_value_vars[name] or { '' }
+		had_owned: name in st.owned_vars
+		owned_pos: st.owned_vars[name] or { flat.NodeId(-1) }
+		had_type: name in st.owned_var_types
+		type_name: st.owned_var_types[name] or { '' }
+		had_moved: name in st.moved_vars
+		moved: st.moved_vars[name] or { MovedVar{} }
+		borrows: borrows
+		children: children
+		had_fn: name in st.ownership_fn_value_vars
+		fn_name: st.ownership_fn_value_vars[name] or { '' }
 		had_pointer_alias: name in st.pointer_index_aliases
-		pointer_alias:     st.pointer_index_aliases[name] or { '' }
+		pointer_alias: st.pointer_index_aliases[name] or { '' }
 	}
 	st.scope_frames[scope_idx].decl_order << name
 }
@@ -1673,18 +1656,18 @@ fn (mut tc TypeChecker) ownership_refresh_scope_snapshot(name string) {
 	scope_idx := st.scope_frames.len - 1
 	snap := st.scope_frames[scope_idx].names[name] or { return }
 	st.scope_frames[scope_idx].names[name] = OwnershipNameSnapshot{
-		had_owned:         name in st.owned_vars
-		owned_pos:         st.owned_vars[name] or { flat.NodeId(-1) }
-		had_type:          name in st.owned_var_types
-		type_name:         st.owned_var_types[name] or { '' }
-		had_moved:         name in st.moved_vars
-		moved:             st.moved_vars[name] or { MovedVar{} }
-		borrows:           snap.borrows
-		children:          tc.ownership_child_snapshots(name)
-		had_fn:            name in st.ownership_fn_value_vars
-		fn_name:           st.ownership_fn_value_vars[name] or { '' }
+		had_owned: name in st.owned_vars
+		owned_pos: st.owned_vars[name] or { flat.NodeId(-1) }
+		had_type: name in st.owned_var_types
+		type_name: st.owned_var_types[name] or { '' }
+		had_moved: name in st.moved_vars
+		moved: st.moved_vars[name] or { MovedVar{} }
+		borrows: snap.borrows
+		children: tc.ownership_child_snapshots(name)
+		had_fn: name in st.ownership_fn_value_vars
+		fn_name: st.ownership_fn_value_vars[name] or { '' }
 		had_pointer_alias: name in st.pointer_index_aliases
-		pointer_alias:     st.pointer_index_aliases[name] or { '' }
+		pointer_alias: st.pointer_index_aliases[name] or { '' }
 	}
 }
 
@@ -1696,13 +1679,13 @@ fn (mut tc TypeChecker) ownership_child_snapshots(name string) []OwnershipKeySna
 	mut out := []OwnershipKeySnapshot{}
 	for key in tc.ownership_child_state_keys(name) {
 		out << OwnershipKeySnapshot{
-			name:      key
+			name: key
 			had_owned: key in st.owned_vars
 			owned_pos: st.owned_vars[key] or { flat.NodeId(-1) }
-			had_type:  key in st.owned_var_types
+			had_type: key in st.owned_var_types
 			type_name: st.owned_var_types[key] or { '' }
 			had_moved: key in st.moved_vars
-			moved:     st.moved_vars[key] or { MovedVar{} }
+			moved: st.moved_vars[key] or { MovedVar{} }
 		}
 	}
 	return out
@@ -1773,8 +1756,7 @@ fn (mut tc TypeChecker) ownership_note_binding(name string, typ Type, pos flat.N
 			if source_name in st.owned_vars {
 				moved_source = tc.ownership_move_var_result(source_name, name, pos, false, '', true)
 			} else {
-				moved_source = tc.ownership_move_overlapping_dynamic_storage(source_name, name,
-					pos, false, '', true).len > 0
+				moved_source = tc.ownership_move_overlapping_dynamic_storage(source_name, name, pos, false, '', true).len > 0
 			}
 		}
 		if !source_participates && mutable_owned_source {
@@ -1924,8 +1906,7 @@ fn (mut tc TypeChecker) ownership_collect_global_decl(cur_module string, node fl
 				}
 			}
 			if field.children_count > 0 {
-				tc.ownership_collect_global_init_descendants(field.value, qname, tc.a.child(field,
-					0))
+				tc.ownership_collect_global_init_descendants(field.value, qname, tc.a.child(field, 0))
 			}
 		}
 	}
@@ -1950,9 +1931,7 @@ fn (mut tc TypeChecker) ownership_collect_global_init_descendant(name string, qn
 		.array_literal {
 			mut marked := false
 			for i in 0 .. node.children_count {
-				if tc.ownership_collect_global_init_descendant(name, qname, '${suffix}[${i}]', tc.a.child(&node,
-					i))
-				{
+				if tc.ownership_collect_global_init_descendant(name, qname, '${suffix}[${i}]', tc.a.child(&node, i)) {
 					marked = true
 				}
 			}
@@ -1966,17 +1945,13 @@ fn (mut tc TypeChecker) ownership_collect_global_init_descendant(name string, qn
 				child := tc.a.nodes[int(child_id)]
 				if child.kind == .field_init {
 					if child.value == 'init' && child.children_count > 0 {
-						if tc.ownership_collect_global_init_descendant(name, qname, '${suffix}[*]', tc.a.child(&child,
-							0))
-						{
+						if tc.ownership_collect_global_init_descendant(name, qname, '${suffix}[*]', tc.a.child(&child, 0)) {
 							marked = true
 						}
 					}
 					continue
 				}
-				if tc.ownership_collect_global_init_descendant(name, qname,
-					'${suffix}[${elem_idx}]', child_id)
-				{
+				if tc.ownership_collect_global_init_descendant(name, qname, '${suffix}[${elem_idx}]', child_id) {
 					marked = true
 				}
 				elem_idx++
@@ -1987,9 +1962,7 @@ fn (mut tc TypeChecker) ownership_collect_global_init_descendant(name string, qn
 			mut marked := false
 			for i := 0; i < node.children_count; i += 2 {
 				key_id := tc.a.child(&node, i)
-				if tc.ownership_collect_global_init_descendant(name, qname,
-					ownership_map_key_storage_suffix(suffix), key_id)
-				{
+				if tc.ownership_collect_global_init_descendant(name, qname, ownership_map_key_storage_suffix(suffix), key_id) {
 					marked = true
 				}
 				if i + 1 >= node.children_count {
@@ -1999,9 +1972,7 @@ fn (mut tc TypeChecker) ownership_collect_global_init_descendant(name string, qn
 				if key_part.len == 0 {
 					continue
 				}
-				if tc.ownership_collect_global_init_descendant(name, qname,
-					'${suffix}[${key_part}]', tc.a.child(&node, i + 1))
-				{
+				if tc.ownership_collect_global_init_descendant(name, qname, '${suffix}[${key_part}]', tc.a.child(&node, i + 1)) {
 					marked = true
 				}
 			}
@@ -2009,18 +1980,15 @@ fn (mut tc TypeChecker) ownership_collect_global_init_descendant(name string, qn
 		}
 		.struct_init {
 			init_type := tc.parse_type(node.value)
-			return tc.ownership_collect_global_struct_init_descendants(name, qname, suffix, node,
-				init_type, map[string]bool{})
+			return tc.ownership_collect_global_struct_init_descendants(name, qname, suffix, node, init_type, map[string]bool{})
 		}
 		.assoc {
-			return tc.ownership_collect_global_assoc_init_descendants(name, qname, suffix, id,
-				map[string]bool{})
+			return tc.ownership_collect_global_assoc_init_descendants(name, qname, suffix, id, map[string]bool{})
 		}
 		else {}
 	}
 
-	marked_call_descendants := tc.ownership_collect_global_call_return_descendants(name, qname,
-		suffix, id)
+	marked_call_descendants := tc.ownership_collect_global_call_return_descendants(name, qname, suffix, id)
 	if !tc.ownership_global_init_expr_is_owned(id, ownership_global_module_name(name, qname)) {
 		return marked_call_descendants
 	}
@@ -2058,9 +2026,7 @@ fn (mut tc TypeChecker) ownership_collect_global_struct_init_descendants(name st
 			continue
 		}
 		explicit_fields[field_name] = true
-		if tc.ownership_collect_global_init_descendant(name, qname, '${suffix}.${field_name}', tc.a.child(field,
-			0))
-		{
+		if tc.ownership_collect_global_init_descendant(name, qname, '${suffix}.${field_name}', tc.a.child(field, 0)) {
 			marked = true
 		}
 	}
@@ -2072,9 +2038,7 @@ fn (mut tc TypeChecker) ownership_collect_global_struct_init_descendants(name st
 					|| field.value in explicit_fields || field.value in skip_fields {
 					continue
 				}
-				if tc.ownership_collect_global_init_descendant(name, qname,
-					'${suffix}.${field.value}', tc.a.child(field, 0))
-				{
+				if tc.ownership_collect_global_init_descendant(name, qname, '${suffix}.${field.value}', tc.a.child(field, 0)) {
 					marked = true
 				}
 			}
@@ -2117,9 +2081,7 @@ fn (mut tc TypeChecker) ownership_collect_global_assoc_init_descendants(name str
 	}
 	mut marked := false
 	base_id := tc.a.child(&node, 0)
-	if tc.ownership_collect_global_assoc_base_descendants(name, qname, suffix, base_id,
-		base_skip_fields)
-	{
+	if tc.ownership_collect_global_assoc_base_descendants(name, qname, suffix, base_id, base_skip_fields) {
 		marked = true
 	}
 	for i in 1 .. node.children_count {
@@ -2135,9 +2097,7 @@ fn (mut tc TypeChecker) ownership_collect_global_assoc_init_descendants(name str
 		if field_name.len == 0 || field_name in skip_fields {
 			continue
 		}
-		if tc.ownership_collect_global_init_descendant(name, qname, '${suffix}.${field_name}', tc.a.child(field,
-			0))
-		{
+		if tc.ownership_collect_global_init_descendant(name, qname, '${suffix}.${field_name}', tc.a.child(field, 0)) {
 			marked = true
 		}
 	}
@@ -2147,8 +2107,7 @@ fn (mut tc TypeChecker) ownership_collect_global_assoc_init_descendants(name str
 fn (mut tc TypeChecker) ownership_collect_global_assoc_base_descendants(name string, qname string, suffix string, base_id flat.NodeId, skip_fields map[string]bool) bool {
 	base_name := tc.ownership_expr_ident_name(base_id)
 	if base_name.len > 0 {
-		return tc.ownership_collect_global_assoc_named_base_descendants(name, qname, suffix,
-			base_name, skip_fields)
+		return tc.ownership_collect_global_assoc_named_base_descendants(name, qname, suffix, base_name, skip_fields)
 	}
 	id := tc.ownership_unwrap_expr(base_id)
 	if !tc.valid_node_id(id) {
@@ -2158,12 +2117,10 @@ fn (mut tc TypeChecker) ownership_collect_global_assoc_base_descendants(name str
 	match node.kind {
 		.struct_init {
 			init_type := tc.parse_type(node.value)
-			return tc.ownership_collect_global_struct_init_descendants(name, qname, suffix, node,
-				init_type, skip_fields)
+			return tc.ownership_collect_global_struct_init_descendants(name, qname, suffix, node, init_type, skip_fields)
 		}
 		.assoc {
-			return tc.ownership_collect_global_assoc_init_descendants(name, qname, suffix, id,
-				skip_fields)
+			return tc.ownership_collect_global_assoc_init_descendants(name, qname, suffix, id, skip_fields)
 		}
 		else {
 			return tc.ownership_collect_global_init_descendant(name, qname, suffix, base_id)
@@ -2307,10 +2264,10 @@ fn (tc &TypeChecker) ownership_fn_scan_items() []OwnershipFnScanItem {
 			}
 			.fn_decl {
 				items << OwnershipFnScanItem{
-					idx:    i
-					file:   cur_file
+					idx: i
+					file: cur_file
 					module: cur_module
-					name:   ownership_qualify_fn_decl_name(cur_module, node.value)
+					name: ownership_qualify_fn_decl_name(cur_module, node.value)
 				}
 			}
 			else {}
@@ -2547,8 +2504,7 @@ fn (mut tc TypeChecker) ownership_prescan_fn_return_node(fn_name string, fn_node
 		if child.kind == .param {
 			continue
 		}
-		tc.ownership_prescan_returns_in(fn_name, child_id, param_names, mut owned_locals, mut
-			local_types)
+		tc.ownership_prescan_returns_in(fn_name, child_id, param_names, mut owned_locals, mut local_types)
 		if tc.ownership_stmt_definitely_exits_statement_sequence(child_id) {
 			break
 		}
@@ -2607,10 +2563,8 @@ fn (mut tc TypeChecker) ownership_prescan_returns_in(fn_name string, id flat.Nod
 				tc.ownership_note_fn_return_fn_value(fn_name, fn_value)
 			}
 			tc.ownership_prescan_return_param_sources(fn_name, expr_id, i, param_names, local_types)
-			tc.ownership_prescan_return_aggregate_literal_descendants(fn_name, i, '', expr_id,
-				param_names, mut owned_locals, mut local_types)
-			tc.ownership_prescan_add_return_owned_descendants_from_expr(fn_name, i, expr_id, mut
-				owned_locals, local_types)
+			tc.ownership_prescan_return_aggregate_literal_descendants(fn_name, i, '', expr_id, param_names, mut owned_locals, mut local_types)
+			tc.ownership_prescan_add_return_owned_descendants_from_expr(fn_name, i, expr_id, mut owned_locals, local_types)
 			mut return_owned_locals := owned_locals.clone()
 			for pname in param_names {
 				return_owned_locals.delete(pname)
@@ -2619,8 +2573,7 @@ fn (mut tc TypeChecker) ownership_prescan_returns_in(fn_name string, id flat.Nod
 			expr_owned := if is_returned_fn_literal {
 				false
 			} else {
-				tc.ownership_prescan_expr_for_owned_calls(expr_id, mut return_owned_locals, mut
-					return_local_types)
+				tc.ownership_prescan_expr_for_owned_calls(expr_id, mut return_owned_locals, mut return_local_types)
 			}
 			if tc.ownership_expr_is_to_owned_call(expr_id)
 				|| tc.ownership_expr_is_ownership_call(expr_id) || expr_owned
@@ -2639,8 +2592,7 @@ fn (mut tc TypeChecker) ownership_prescan_returns_in(fn_name string, id flat.Nod
 		if node.children_count > 0 {
 			inner_id := tc.a.child(&node, 0)
 			if tc.valid_node_id(inner_id) && tc.a.nodes[int(inner_id)].kind == .select_stmt {
-				tc.ownership_prescan_returns_in(fn_name, inner_id, param_names, mut owned_locals, mut
-					local_types)
+				tc.ownership_prescan_returns_in(fn_name, inner_id, param_names, mut owned_locals, mut local_types)
 				return
 			}
 		}
@@ -2648,45 +2600,36 @@ fn (mut tc TypeChecker) ownership_prescan_returns_in(fn_name string, id flat.Nod
 		return
 	}
 	if node.kind == .block {
-		tc.ownership_prescan_returns_in_sequence(fn_name, node, 0, param_names, mut owned_locals, mut
-			local_types)
+		tc.ownership_prescan_returns_in_sequence(fn_name, node, 0, param_names, mut owned_locals, mut local_types)
 		return
 	}
 	if node.kind == .match_branch {
 		body_start := if node.value == 'else' { 0 } else { node.value.int() }
-		tc.ownership_prescan_returns_in_sequence(fn_name, node, body_start, param_names, mut
-			owned_locals, mut local_types)
+		tc.ownership_prescan_returns_in_sequence(fn_name, node, body_start, param_names, mut owned_locals, mut local_types)
 		return
 	}
 	if node.kind == .select_branch {
-		tc.ownership_prescan_returns_in_sequence(fn_name, node,
-			tc.ownership_select_branch_body_start(node), param_names, mut owned_locals, mut
-			local_types)
+		tc.ownership_prescan_returns_in_sequence(fn_name, node, tc.ownership_select_branch_body_start(node), param_names, mut owned_locals, mut local_types)
 		return
 	}
 	if node.kind == .if_expr {
-		tc.ownership_prescan_if_returns_in(fn_name, node, param_names, mut owned_locals, mut
-			local_types)
+		tc.ownership_prescan_if_returns_in(fn_name, node, param_names, mut owned_locals, mut local_types)
 		return
 	}
 	if node.kind == .match_stmt {
-		tc.ownership_prescan_match_returns_in(fn_name, node, param_names, mut owned_locals, mut
-			local_types)
+		tc.ownership_prescan_match_returns_in(fn_name, node, param_names, mut owned_locals, mut local_types)
 		return
 	}
 	if node.kind == .select_stmt {
-		tc.ownership_prescan_select_returns_in(fn_name, node, param_names, mut owned_locals, mut
-			local_types)
+		tc.ownership_prescan_select_returns_in(fn_name, node, param_names, mut owned_locals, mut local_types)
 		return
 	}
 	if node.kind == .for_stmt {
-		tc.ownership_prescan_for_returns_in(fn_name, node, param_names, mut owned_locals, mut
-			local_types)
+		tc.ownership_prescan_for_returns_in(fn_name, node, param_names, mut owned_locals, mut local_types)
 		return
 	}
 	if node.kind == .for_in_stmt {
-		tc.ownership_prescan_for_in_returns_in(fn_name, node, param_names, mut owned_locals, mut
-			local_types)
+		tc.ownership_prescan_for_in_returns_in(fn_name, node, param_names, mut owned_locals, mut local_types)
 		return
 	}
 	if node.kind in [.decl_assign, .assign, .selector_assign, .index_assign] {
@@ -2694,8 +2637,7 @@ fn (mut tc TypeChecker) ownership_prescan_returns_in(fn_name string, id flat.Nod
 		return
 	}
 	for i in 0 .. node.children_count {
-		tc.ownership_prescan_returns_in(fn_name, tc.a.child(&node, i), param_names, mut
-			owned_locals, mut local_types)
+		tc.ownership_prescan_returns_in(fn_name, tc.a.child(&node, i), param_names, mut owned_locals, mut local_types)
 	}
 }
 
@@ -2703,8 +2645,7 @@ fn (mut tc TypeChecker) ownership_prescan_returns_in_sequence(fn_name string, no
 	start := if body_start < 0 { 0 } else { body_start }
 	for i in start .. node.children_count {
 		stmt_id := tc.a.child(&node, i)
-		tc.ownership_prescan_returns_in(fn_name, stmt_id, param_names, mut owned_locals, mut
-			local_types)
+		tc.ownership_prescan_returns_in(fn_name, stmt_id, param_names, mut owned_locals, mut local_types)
 		if tc.ownership_stmt_definitely_exits_statement_sequence(stmt_id) {
 			return
 		}
@@ -2715,8 +2656,7 @@ fn (mut tc TypeChecker) ownership_prescan_if_returns_in(fn_name string, node fla
 	if node.children_count == 0 {
 		return
 	}
-	_ := tc.ownership_prescan_expr_for_owned_calls(tc.a.child(&node, 0), mut owned_locals, mut
-		local_types)
+	_ := tc.ownership_prescan_expr_for_owned_calls(tc.a.child(&node, 0), mut owned_locals, mut local_types)
 	base_owned := owned_locals.clone()
 	base_types := local_types.clone()
 	mut branch_owned := []map[string]bool{}
@@ -2725,8 +2665,7 @@ fn (mut tc TypeChecker) ownership_prescan_if_returns_in(fn_name string, node fla
 		then_id := tc.a.child(&node, 1)
 		mut then_owned := base_owned.clone()
 		mut then_types := base_types.clone()
-		tc.ownership_prescan_returns_in(fn_name, then_id, param_names, mut then_owned, mut
-			then_types)
+		tc.ownership_prescan_returns_in(fn_name, then_id, param_names, mut then_owned, mut then_types)
 		if !tc.stmt_definitely_returns(then_id) {
 			branch_owned << then_owned
 			branch_types << then_types
@@ -2736,8 +2675,7 @@ fn (mut tc TypeChecker) ownership_prescan_if_returns_in(fn_name string, node fla
 		else_id := tc.a.child(&node, 2)
 		mut else_owned := base_owned.clone()
 		mut else_types := base_types.clone()
-		tc.ownership_prescan_returns_in(fn_name, else_id, param_names, mut else_owned, mut
-			else_types)
+		tc.ownership_prescan_returns_in(fn_name, else_id, param_names, mut else_owned, mut else_types)
 		if !tc.stmt_definitely_returns(else_id) {
 			branch_owned << else_owned
 			branch_types << else_types
@@ -2746,16 +2684,14 @@ fn (mut tc TypeChecker) ownership_prescan_if_returns_in(fn_name string, node fla
 		branch_owned << base_owned
 		branch_types << base_types
 	}
-	tc.ownership_prescan_merge_branch_states(base_owned, base_types, branch_owned, branch_types, mut
-		owned_locals, mut local_types)
+	tc.ownership_prescan_merge_branch_states(base_owned, base_types, branch_owned, branch_types, mut owned_locals, mut local_types)
 }
 
 fn (mut tc TypeChecker) ownership_prescan_match_returns_in(fn_name string, node flat.Node, param_names []string, mut owned_locals map[string]bool, mut local_types map[string]Type) {
 	if node.children_count == 0 {
 		return
 	}
-	_ := tc.ownership_prescan_expr_for_owned_calls(tc.a.child(&node, 0), mut owned_locals, mut
-		local_types)
+	_ := tc.ownership_prescan_expr_for_owned_calls(tc.a.child(&node, 0), mut owned_locals, mut local_types)
 	base_owned := owned_locals.clone()
 	base_types := local_types.clone()
 	mut branch_owned := []map[string]bool{}
@@ -2775,8 +2711,7 @@ fn (mut tc TypeChecker) ownership_prescan_match_returns_in(fn_name string, node 
 		}
 		mut cur_owned := base_owned.clone()
 		mut cur_types := base_types.clone()
-		tc.ownership_prescan_returns_in(fn_name, branch_id, param_names, mut cur_owned, mut
-			cur_types)
+		tc.ownership_prescan_returns_in(fn_name, branch_id, param_names, mut cur_owned, mut cur_types)
 		if !tc.match_branch_definitely_returns(branch) {
 			branch_owned << cur_owned
 			branch_types << cur_types
@@ -2786,8 +2721,7 @@ fn (mut tc TypeChecker) ownership_prescan_match_returns_in(fn_name string, node 
 		branch_owned << base_owned
 		branch_types << base_types
 	}
-	tc.ownership_prescan_merge_branch_states(base_owned, base_types, branch_owned, branch_types, mut
-		owned_locals, mut local_types)
+	tc.ownership_prescan_merge_branch_states(base_owned, base_types, branch_owned, branch_types, mut owned_locals, mut local_types)
 }
 
 fn (mut tc TypeChecker) ownership_prescan_select_returns_in(fn_name string, node flat.Node, param_names []string, mut owned_locals map[string]bool, mut local_types map[string]Type) {
@@ -2804,8 +2738,7 @@ fn (mut tc TypeChecker) ownership_prescan_select_returns_in(fn_name string, node
 		if branch.kind != .select_branch {
 			mut cur_owned := base_owned.clone()
 			mut cur_types := base_types.clone()
-			tc.ownership_prescan_returns_in(fn_name, branch_id, param_names, mut cur_owned, mut
-				cur_types)
+			tc.ownership_prescan_returns_in(fn_name, branch_id, param_names, mut cur_owned, mut cur_types)
 			if !tc.ownership_stmt_definitely_exits_statement_sequence(branch_id) {
 				branch_owned << cur_owned
 				branch_types << cur_types
@@ -2814,30 +2747,26 @@ fn (mut tc TypeChecker) ownership_prescan_select_returns_in(fn_name string, node
 		}
 		mut cur_owned := base_owned.clone()
 		mut cur_types := base_types.clone()
-		tc.ownership_prescan_returns_in(fn_name, branch_id, param_names, mut cur_owned, mut
-			cur_types)
+		tc.ownership_prescan_returns_in(fn_name, branch_id, param_names, mut cur_owned, mut cur_types)
 		if !tc.ownership_select_branch_definitely_exits_statement_sequence(branch) {
 			branch_owned << cur_owned
 			branch_types << cur_types
 		}
 	}
-	tc.ownership_prescan_merge_branch_states(base_owned, base_types, branch_owned, branch_types, mut
-		owned_locals, mut local_types)
+	tc.ownership_prescan_merge_branch_states(base_owned, base_types, branch_owned, branch_types, mut owned_locals, mut local_types)
 }
 
 fn (mut tc TypeChecker) ownership_prescan_for_returns_in(fn_name string, node flat.Node, param_names []string, mut owned_locals map[string]bool, mut local_types map[string]Type) {
 	if node.children_count > 0 {
 		init_id := tc.a.child(&node, 0)
 		if tc.valid_node_id(init_id) && tc.a.nodes[int(init_id)].kind != .empty {
-			tc.ownership_prescan_returns_in(fn_name, init_id, param_names, mut owned_locals, mut
-				local_types)
+			tc.ownership_prescan_returns_in(fn_name, init_id, param_names, mut owned_locals, mut local_types)
 		}
 	}
 	if node.children_count > 1 {
 		cond_id := tc.a.child(&node, 1)
 		if tc.valid_node_id(cond_id) && tc.a.nodes[int(cond_id)].kind != .empty {
-			_ := tc.ownership_prescan_expr_for_owned_calls(cond_id, mut owned_locals, mut
-				local_types)
+			_ := tc.ownership_prescan_expr_for_owned_calls(cond_id, mut owned_locals, mut local_types)
 		}
 	}
 	base_owned := owned_locals.clone()
@@ -2846,13 +2775,11 @@ fn (mut tc TypeChecker) ownership_prescan_for_returns_in(fn_name string, node fl
 	mut branch_types := []map[string]Type{}
 	mut body_owned := base_owned.clone()
 	mut body_types := base_types.clone()
-	tc.ownership_prescan_returns_in_sequence(fn_name, node, 3, param_names, mut body_owned, mut
-		body_types)
+	tc.ownership_prescan_returns_in_sequence(fn_name, node, 3, param_names, mut body_owned, mut body_types)
 	if node.children_count > 2 && tc.ownership_statement_sequence_can_reach_loop_post(node, 3) {
 		post_id := tc.a.child(&node, 2)
 		if tc.valid_node_id(post_id) && tc.a.nodes[int(post_id)].kind != .empty {
-			tc.ownership_prescan_returns_in(fn_name, post_id, param_names, mut body_owned, mut
-				body_types)
+			tc.ownership_prescan_returns_in(fn_name, post_id, param_names, mut body_owned, mut body_types)
 		}
 	}
 	if !tc.ownership_statement_sequence_definitely_returns(node, 3) {
@@ -2864,8 +2791,7 @@ fn (mut tc TypeChecker) ownership_prescan_for_returns_in(fn_name string, node fl
 		branch_owned << base_owned
 		branch_types << base_types
 	}
-	tc.ownership_prescan_merge_branch_states(base_owned, base_types, branch_owned, branch_types, mut
-		owned_locals, mut local_types)
+	tc.ownership_prescan_merge_branch_states(base_owned, base_types, branch_owned, branch_types, mut owned_locals, mut local_types)
 }
 
 fn (mut tc TypeChecker) ownership_prescan_for_in_returns_in(fn_name string, node flat.Node, param_names []string, mut owned_locals map[string]bool, mut local_types map[string]Type) {
@@ -2877,8 +2803,7 @@ fn (mut tc TypeChecker) ownership_prescan_for_in_returns_in(fn_name string, node
 	_ := tc.ownership_prescan_expr_for_owned_calls(container_id, mut owned_locals, mut local_types)
 	if header == 4 && node.children_count > 3 {
 		range_end_id := tc.a.child(&node, 3)
-		_ := tc.ownership_prescan_expr_for_owned_calls(range_end_id, mut owned_locals, mut
-			local_types)
+		_ := tc.ownership_prescan_expr_for_owned_calls(range_end_id, mut owned_locals, mut local_types)
 	}
 	base_owned := owned_locals.clone()
 	base_types := local_types.clone()
@@ -2886,16 +2811,14 @@ fn (mut tc TypeChecker) ownership_prescan_for_in_returns_in(fn_name string, node
 	mut branch_types := []map[string]Type{}
 	mut body_owned := base_owned.clone()
 	mut body_types := base_types.clone()
-	tc.ownership_prescan_returns_in_sequence(fn_name, node, header, param_names, mut body_owned, mut
-		body_types)
+	tc.ownership_prescan_returns_in_sequence(fn_name, node, header, param_names, mut body_owned, mut body_types)
 	if !tc.ownership_statement_sequence_definitely_returns(node, header) {
 		branch_owned << body_owned
 		branch_types << body_types
 	}
 	branch_owned << base_owned
 	branch_types << base_types
-	tc.ownership_prescan_merge_branch_states(base_owned, base_types, branch_owned, branch_types, mut
-		owned_locals, mut local_types)
+	tc.ownership_prescan_merge_branch_states(base_owned, base_types, branch_owned, branch_types, mut owned_locals, mut local_types)
 }
 
 fn (mut tc TypeChecker) ownership_prescan_merge_branch_states(base_owned map[string]bool, base_types map[string]Type, branch_owned []map[string]bool, branch_types []map[string]Type, mut owned_locals map[string]bool, mut local_types map[string]Type) {
@@ -3008,8 +2931,7 @@ fn (mut tc TypeChecker) ownership_prescan_return_aggregate_literal_descendants(f
 					|| tc.ownership_prescan_add_return_descendant_from_expr(fn_name, slot_idx, key_suffix, key_id, mut owned_locals, mut local_types) {
 					marked = true
 				} else {
-					key_owned := tc.ownership_prescan_expr_for_owned_calls(key_id, mut
-						owned_locals, mut local_types)
+					key_owned := tc.ownership_prescan_expr_for_owned_calls(key_id, mut owned_locals, mut local_types)
 					if key_owned {
 						tc.ownership_prescan_consume_local(key_id, mut owned_locals)
 					}
@@ -3020,8 +2942,7 @@ fn (mut tc TypeChecker) ownership_prescan_return_aggregate_literal_descendants(f
 				key_part := tc.ownership_index_key_part(key_id)
 				if key_part.len == 0 {
 					value_id := tc.a.child(&node, i + 1)
-					value_owned := tc.ownership_prescan_expr_for_owned_calls(value_id, mut
-						owned_locals, mut local_types)
+					value_owned := tc.ownership_prescan_expr_for_owned_calls(value_id, mut owned_locals, mut local_types)
 					if value_owned {
 						tc.ownership_prescan_consume_local(value_id, mut owned_locals)
 					}
@@ -3126,8 +3047,7 @@ fn (mut tc TypeChecker) ownership_prescan_add_return_param_descendant_from_expr(
 			return true
 		}
 		if ownership_storage_key_is_descendant(source_name, pname) {
-			tc.ownership_add_fn_return_param_descendant(fn_name, pi, slot_idx,
-				source_name[pname.len..], target_suffix)
+			tc.ownership_add_fn_return_param_descendant(fn_name, pi, slot_idx, source_name[pname.len..], target_suffix)
 			return true
 		}
 	}
@@ -3138,16 +3058,14 @@ fn (mut tc TypeChecker) ownership_prescan_add_return_descendant_from_expr(fn_nam
 	if fn_name.len == 0 || slot_idx < 0 || suffix.len == 0 || !tc.valid_node_id(expr_id) {
 		return false
 	}
-	expr_owned := tc.ownership_prescan_expr_for_owned_calls(expr_id, mut owned_locals, mut
-		local_types)
+	expr_owned := tc.ownership_prescan_expr_for_owned_calls(expr_id, mut owned_locals, mut local_types)
 	source_name := tc.ownership_expr_ident_name(expr_id)
 	mut marked := false
 	if source_name.len > 0 {
 		for source in ownership_prescan_owned_descendant_names(source_name, owned_locals) {
 			source_suffix := source[source_name.len..]
 			type_name := (local_types[source] or { tc.resolve_type(expr_id) }).name()
-			tc.ownership_add_fn_return_descendant(fn_name, slot_idx, suffix + source_suffix,
-				type_name)
+			tc.ownership_add_fn_return_descendant(fn_name, slot_idx, suffix + source_suffix, type_name)
 			owned_locals.delete(source)
 			marked = true
 		}
@@ -3222,8 +3140,7 @@ fn (mut tc TypeChecker) ownership_prescan_param_aggregate_literal_descendants(fn
 					|| tc.ownership_prescan_add_param_descendant_from_expr(fn_name, param_idx, key_suffix, key_id, mut owned_locals, mut local_types) {
 					marked = true
 				} else {
-					key_owned := tc.ownership_prescan_expr_for_owned_calls(key_id, mut
-						owned_locals, mut local_types)
+					key_owned := tc.ownership_prescan_expr_for_owned_calls(key_id, mut owned_locals, mut local_types)
 					if key_owned {
 						tc.ownership_prescan_consume_local(key_id, mut owned_locals)
 					}
@@ -3234,8 +3151,7 @@ fn (mut tc TypeChecker) ownership_prescan_param_aggregate_literal_descendants(fn
 				key_part := tc.ownership_index_key_part(key_id)
 				value_id := tc.a.child(&node, i + 1)
 				if key_part.len == 0 {
-					value_owned := tc.ownership_prescan_expr_for_owned_calls(value_id, mut
-						owned_locals, mut local_types)
+					value_owned := tc.ownership_prescan_expr_for_owned_calls(value_id, mut owned_locals, mut local_types)
 					if value_owned {
 						tc.ownership_prescan_consume_local(value_id, mut owned_locals)
 					}
@@ -3307,16 +3223,14 @@ fn (mut tc TypeChecker) ownership_prescan_add_param_descendant_from_expr(fn_name
 	if fn_name.len == 0 || param_idx < 0 || suffix.len == 0 || !tc.valid_node_id(expr_id) {
 		return false
 	}
-	expr_owned := tc.ownership_prescan_expr_for_owned_calls(expr_id, mut owned_locals, mut
-		local_types)
+	expr_owned := tc.ownership_prescan_expr_for_owned_calls(expr_id, mut owned_locals, mut local_types)
 	source_name := tc.ownership_expr_ident_name(expr_id)
 	mut marked := false
 	if source_name.len > 0 {
 		for source in ownership_prescan_owned_descendant_names(source_name, owned_locals) {
 			source_suffix := source[source_name.len..]
 			type_name := (local_types[source] or { tc.resolve_type(expr_id) }).name()
-			tc.ownership_add_fn_param_descendant(fn_name, param_idx, suffix + source_suffix,
-				type_name)
+			tc.ownership_add_fn_param_descendant(fn_name, param_idx, suffix + source_suffix, type_name)
 			owned_locals.delete(source)
 			marked = true
 		}
@@ -3344,8 +3258,7 @@ fn (mut tc TypeChecker) ownership_prescan_return_param_sources(fn_name string, e
 				continue
 			}
 			if ownership_storage_key_is_descendant(name, pname) {
-				tc.ownership_add_fn_return_param_descendant(fn_name, pi, slot_idx,
-					name[pname.len..], '')
+				tc.ownership_add_fn_return_param_descendant(fn_name, pi, slot_idx, name[pname.len..], '')
 			}
 		}
 		return
@@ -3356,8 +3269,7 @@ fn (mut tc TypeChecker) ownership_prescan_return_param_sources(fn_name string, e
 	}
 	node := tc.a.nodes[int(call_id)]
 	if node.kind in [.if_expr, .match_stmt, .or_expr] {
-		tc.ownership_prescan_conditional_return_param_sources(fn_name, call_id, slot_idx,
-			param_names, local_types)
+		tc.ownership_prescan_conditional_return_param_sources(fn_name, call_id, slot_idx, param_names, local_types)
 		return
 	}
 	if node.kind != .call {
@@ -3376,8 +3288,7 @@ fn (mut tc TypeChecker) ownership_prescan_return_param_sources(fn_name string, e
 		} else {
 			slot_idx
 		}
-		tc.ownership_prescan_add_return_param_descendant_from_call_arg(fn_name, node, info,
-			param_desc, target_slot_idx, param_names)
+		tc.ownership_prescan_add_return_param_descendant_from_call_arg(fn_name, node, info, param_desc, target_slot_idx, param_names)
 	}
 	if param_slots.len > 0 {
 		for param_slot in param_slots {
@@ -3386,15 +3297,13 @@ fn (mut tc TypeChecker) ownership_prescan_return_param_sources(fn_name string, e
 			} else {
 				slot_idx
 			}
-			tc.ownership_prescan_add_return_param_from_call_arg(fn_name, node, info,
-				param_slot.param_idx, target_slot_idx, param_names)
+			tc.ownership_prescan_add_return_param_from_call_arg(fn_name, node, info, param_slot.param_idx, target_slot_idx, param_names)
 		}
 		return
 	}
 	return_param_idxs := tc.ownership_state().ownership_fn_returns_param[info.name] or { []int{} }
 	for callee_param_idx in return_param_idxs {
-		tc.ownership_prescan_add_return_param_from_call_arg(fn_name, node, info, callee_param_idx,
-			slot_idx, param_names)
+		tc.ownership_prescan_add_return_param_from_call_arg(fn_name, node, info, callee_param_idx, slot_idx, param_names)
 	}
 }
 
@@ -3407,18 +3316,15 @@ fn (mut tc TypeChecker) ownership_prescan_conditional_return_param_sources(fn_na
 		.if_expr {
 			if node.children_count > 1 {
 				then_tail := tc.branch_tail_expr_id(tc.a.child(&node, 1))
-				tc.ownership_prescan_return_param_sources(fn_name, then_tail, slot_idx,
-					param_names, local_types)
+				tc.ownership_prescan_return_param_sources(fn_name, then_tail, slot_idx, param_names, local_types)
 			}
 			if node.children_count > 2 {
 				else_id := tc.a.child(&node, 2)
 				if tc.valid_node_id(else_id) && tc.a.nodes[int(else_id)].kind == .if_expr {
-					tc.ownership_prescan_conditional_return_param_sources(fn_name, else_id,
-						slot_idx, param_names, local_types)
+					tc.ownership_prescan_conditional_return_param_sources(fn_name, else_id, slot_idx, param_names, local_types)
 				} else {
 					else_tail := tc.branch_tail_expr_id(else_id)
-					tc.ownership_prescan_return_param_sources(fn_name, else_tail, slot_idx,
-						param_names, local_types)
+					tc.ownership_prescan_return_param_sources(fn_name, else_tail, slot_idx, param_names, local_types)
 				}
 			}
 		}
@@ -3432,19 +3338,16 @@ fn (mut tc TypeChecker) ownership_prescan_conditional_return_param_sources(fn_na
 					continue
 				}
 				tail := tc.branch_tail_expr_id(branch_id)
-				tc.ownership_prescan_return_param_sources(fn_name, tail, slot_idx, param_names,
-					local_types)
+				tc.ownership_prescan_return_param_sources(fn_name, tail, slot_idx, param_names, local_types)
 			}
 		}
 		.or_expr {
 			if node.children_count > 0 {
-				tc.ownership_prescan_return_param_sources(fn_name, tc.a.child(&node, 0), slot_idx,
-					param_names, local_types)
+				tc.ownership_prescan_return_param_sources(fn_name, tc.a.child(&node, 0), slot_idx, param_names, local_types)
 			}
 			if node.children_count > 1 && node.value !in ['!', '?'] {
 				fallback_tail := tc.branch_tail_expr_id(tc.a.child(&node, 1))
-				tc.ownership_prescan_return_param_sources(fn_name, fallback_tail, slot_idx,
-					param_names, local_types)
+				tc.ownership_prescan_return_param_sources(fn_name, fallback_tail, slot_idx, param_names, local_types)
 			}
 		}
 		else {}
@@ -3468,22 +3371,19 @@ fn (mut tc TypeChecker) ownership_prescan_add_return_param_from_call_arg(fn_name
 }
 
 fn (mut tc TypeChecker) ownership_prescan_add_return_param_descendant_from_call_arg(fn_name string, node flat.Node, info CallInfo, callee_desc OwnershipReturnParamDescendant, slot_idx int, param_names []string) {
-	source := tc.ownership_call_arg_for_return_param_source_info(node, info, callee_desc.param_idx,
-		callee_desc.source_suffix) or { return }
+	source := tc.ownership_call_arg_for_return_param_source_info(node, info, callee_desc.param_idx, callee_desc.source_suffix) or { return }
 	arg_name := tc.ownership_expr_ident_name(source.arg_id)
 	if arg_name.len == 0 {
 		return
 	}
 	for pi, pname in param_names {
 		if arg_name == pname {
-			tc.ownership_add_fn_return_param_descendant(fn_name, pi, slot_idx,
-				source.source_suffix, callee_desc.target_suffix)
+			tc.ownership_add_fn_return_param_descendant(fn_name, pi, slot_idx, source.source_suffix, callee_desc.target_suffix)
 			return
 		}
 		if ownership_storage_key_is_descendant(arg_name, pname) {
 			source_suffix := arg_name[pname.len..] + source.source_suffix
-			tc.ownership_add_fn_return_param_descendant(fn_name, pi, slot_idx, source_suffix,
-				callee_desc.target_suffix)
+			tc.ownership_add_fn_return_param_descendant(fn_name, pi, slot_idx, source_suffix, callee_desc.target_suffix)
 			return
 		}
 	}
@@ -3536,7 +3436,7 @@ fn (mut tc TypeChecker) ownership_add_fn_return_param_slot(fn_name string, param
 	}
 	slots << OwnershipReturnParamSlot{
 		param_idx: param_idx
-		slot_idx:  slot_idx
+		slot_idx: slot_idx
 	}
 	st.ownership_fn_return_params[fn_name] = slots
 }
@@ -3562,8 +3462,8 @@ fn (mut tc TypeChecker) ownership_add_fn_return_descendant(fn_name string, slot_
 		}
 	}
 	descs << OwnershipReturnDescendant{
-		slot_idx:  slot_idx
-		suffix:    suffix
+		slot_idx: slot_idx
+		suffix: suffix
 		type_name: if type_name.len > 0 { type_name } else { 'string' }
 	}
 	st.ownership_fn_return_descs[fn_name] = descs
@@ -3579,8 +3479,8 @@ fn (mut tc TypeChecker) ownership_add_fn_return_param_descendant(fn_name string,
 		[]OwnershipReturnParamDescendant{}
 	}
 	candidate := OwnershipReturnParamDescendant{
-		param_idx:     param_idx
-		slot_idx:      slot_idx
+		param_idx: param_idx
+		slot_idx: slot_idx
 		source_suffix: source_suffix
 		target_suffix: target_suffix
 	}
@@ -3606,7 +3506,7 @@ fn (mut tc TypeChecker) ownership_add_fn_param_descendant(fn_name string, param_
 	}
 	descs << OwnershipParamDescendant{
 		param_idx: param_idx
-		suffix:    suffix
+		suffix: suffix
 		type_name: if type_name.len > 0 { type_name } else { 'string' }
 	}
 	st.ownership_fn_param_descs[fn_name] = descs
@@ -3840,9 +3740,7 @@ fn (mut tc TypeChecker) ownership_prescan_node_for_owned_calls(id flat.NodeId, m
 }
 
 fn (mut tc TypeChecker) ownership_prescan_assign_for_owned_calls(node flat.Node, mut owned_locals map[string]bool, mut local_types map[string]Type) {
-	if tc.ownership_prescan_multi_return_assign_for_owned_calls(node, mut owned_locals, mut
-		local_types)
-	{
+	if tc.ownership_prescan_multi_return_assign_for_owned_calls(node, mut owned_locals, mut local_types) {
 		return
 	}
 	mut i := 0
@@ -3856,8 +3754,7 @@ fn (mut tc TypeChecker) ownership_prescan_assign_for_owned_calls(node flat.Node,
 			i += 2
 			continue
 		}
-		rhs_owned := tc.ownership_prescan_expr_for_owned_calls(rhs_id, mut owned_locals, mut
-			local_types)
+		rhs_owned := tc.ownership_prescan_expr_for_owned_calls(rhs_id, mut owned_locals, mut local_types)
 		rhs_name := tc.ownership_expr_ident_name(rhs_id)
 		if rhs_owned && rhs_name.len > 0 {
 			owned_locals.delete(rhs_name)
@@ -3866,8 +3763,7 @@ fn (mut tc TypeChecker) ownership_prescan_assign_for_owned_calls(node flat.Node,
 			local_types[lhs_name] = tc.resolve_type(rhs_id)
 			tc.ownership_track_fn_value_binding(lhs_name, rhs_id)
 			if rhs_name.len > 0 {
-				tc.ownership_prescan_transfer_owned_descendants(rhs_name, lhs_name, mut
-					owned_locals, mut local_types)
+				tc.ownership_prescan_transfer_owned_descendants(rhs_name, lhs_name, mut owned_locals, mut local_types)
 			}
 			if rhs_owned {
 				owned_locals[lhs_name] = true
@@ -3937,9 +3833,7 @@ fn (mut tc TypeChecker) ownership_prescan_mark_storage_from_expr(target_name str
 	if !tc.valid_node_id(id) {
 		return false
 	}
-	if tc.ownership_prescan_assign_literal_to_name(target_name, id, mut owned_locals, mut
-		local_types)
-	{
+	if tc.ownership_prescan_assign_literal_to_name(target_name, id, mut owned_locals, mut local_types) {
 		return true
 	}
 	expr_owned := tc.ownership_prescan_expr_for_owned_calls(id, mut owned_locals, mut local_types)
@@ -3990,8 +3884,7 @@ fn (mut tc TypeChecker) ownership_prescan_assign_literal_to_name(lhs_name string
 			explicit_fields[field_name] = true
 			value_id := tc.a.child(field, 0)
 			target_name := '${lhs_name}.${field_name}'
-			tc.ownership_prescan_mark_storage_from_expr(target_name, value_id, mut owned_locals, mut
-				local_types)
+			tc.ownership_prescan_mark_storage_from_expr(target_name, value_id, mut owned_locals, mut local_types)
 		}
 		if init_type is Struct {
 			if decl := tc.ownership_struct_decl_node(init_type.name) {
@@ -4003,8 +3896,7 @@ fn (mut tc TypeChecker) ownership_prescan_assign_literal_to_name(lhs_name string
 					}
 					target_name := '${lhs_name}.${field.value}'
 					default_id := tc.a.child(field, 0)
-					tc.ownership_prescan_mark_storage_from_expr(target_name, default_id, mut
-						owned_locals, mut local_types)
+					tc.ownership_prescan_mark_storage_from_expr(target_name, default_id, mut owned_locals, mut local_types)
 				}
 			}
 		}
@@ -4020,8 +3912,7 @@ fn (mut tc TypeChecker) ownership_prescan_assign_literal_to_name(lhs_name string
 		for i in 0 .. node.children_count {
 			elem_id := tc.a.child(&node, i)
 			target_name := '${lhs_name}[${i}]'
-			tc.ownership_prescan_mark_storage_from_expr(target_name, elem_id, mut owned_locals, mut
-				local_types)
+			tc.ownership_prescan_mark_storage_from_expr(target_name, elem_id, mut owned_locals, mut local_types)
 		}
 		local_types[lhs_name] = tc.resolve_type(id)
 		owned_locals.delete(lhs_name)
@@ -4036,14 +3927,12 @@ fn (mut tc TypeChecker) ownership_prescan_assign_literal_to_name(lhs_name string
 				if child.value == 'init' && child.children_count > 0 {
 					init_id := tc.a.child(&child, 0)
 					target_name := '${lhs_name}[*]'
-					tc.ownership_prescan_mark_storage_from_expr(target_name, init_id, mut
-						owned_locals, mut local_types)
+					tc.ownership_prescan_mark_storage_from_expr(target_name, init_id, mut owned_locals, mut local_types)
 				}
 				continue
 			}
 			target_name := '${lhs_name}[${elem_idx}]'
-			tc.ownership_prescan_mark_storage_from_expr(target_name, child_id, mut owned_locals, mut
-				local_types)
+			tc.ownership_prescan_mark_storage_from_expr(target_name, child_id, mut owned_locals, mut local_types)
 			elem_idx++
 		}
 		local_types[lhs_name] = tc.resolve_type(id)
@@ -4054,24 +3943,21 @@ fn (mut tc TypeChecker) ownership_prescan_assign_literal_to_name(lhs_name string
 		for i := 0; i < node.children_count; i += 2 {
 			key_id := tc.a.child(&node, i)
 			key_target := ownership_map_key_storage_name(lhs_name)
-			tc.ownership_prescan_mark_storage_from_expr(key_target, key_id, mut owned_locals, mut
-				local_types)
+			tc.ownership_prescan_mark_storage_from_expr(key_target, key_id, mut owned_locals, mut local_types)
 			if i + 1 >= node.children_count {
 				break
 			}
 			value_id := tc.a.child(&node, i + 1)
 			key_part := tc.ownership_index_key_part(key_id)
 			if key_part.len == 0 {
-				value_owned := tc.ownership_prescan_expr_for_owned_calls(value_id, mut
-					owned_locals, mut local_types)
+				value_owned := tc.ownership_prescan_expr_for_owned_calls(value_id, mut owned_locals, mut local_types)
 				if value_owned {
 					tc.ownership_prescan_consume_local(value_id, mut owned_locals)
 				}
 				continue
 			}
 			target_name := '${lhs_name}[${key_part}]'
-			tc.ownership_prescan_mark_storage_from_expr(target_name, value_id, mut owned_locals, mut
-				local_types)
+			tc.ownership_prescan_mark_storage_from_expr(target_name, value_id, mut owned_locals, mut local_types)
 		}
 		local_types[lhs_name] = tc.resolve_type(id)
 		owned_locals.delete(lhs_name)
@@ -4101,8 +3987,7 @@ fn (mut tc TypeChecker) ownership_prescan_assign_literal_to_name(lhs_name string
 				explicit_fields[field_name] = true
 			}
 		}
-		tc.ownership_prescan_transfer_assoc_base_to_name(lhs_name, tc.a.child(&node, 0),
-			explicit_fields, mut owned_locals, mut local_types)
+		tc.ownership_prescan_transfer_assoc_base_to_name(lhs_name, tc.a.child(&node, 0), explicit_fields, mut owned_locals, mut local_types)
 		for i in 1 .. node.children_count {
 			field := tc.a.child_node(&node, i)
 			if field.kind != .field_init || field.children_count == 0 {
@@ -4117,8 +4002,7 @@ fn (mut tc TypeChecker) ownership_prescan_assign_literal_to_name(lhs_name string
 				continue
 			}
 			target_name := '${lhs_name}.${field_name}'
-			tc.ownership_prescan_mark_storage_from_expr(target_name, tc.a.child(field, 0), mut
-				owned_locals, mut local_types)
+			tc.ownership_prescan_mark_storage_from_expr(target_name, tc.a.child(field, 0), mut owned_locals, mut local_types)
 		}
 		local_types[lhs_name] = tc.resolve_type(id)
 		if tc.ownership_type_is_owned(tc.resolve_type(id)) {
@@ -4134,8 +4018,7 @@ fn (mut tc TypeChecker) ownership_prescan_assign_literal_to_name(lhs_name string
 fn (mut tc TypeChecker) ownership_prescan_transfer_assoc_base_to_name(lhs_name string, base_id flat.NodeId, explicit_fields map[string]bool, mut owned_locals map[string]bool, mut local_types map[string]Type) bool {
 	base_name := tc.ownership_expr_ident_name(base_id)
 	if base_name.len == 0 {
-		return tc.ownership_prescan_mark_storage_from_expr(lhs_name, base_id, mut owned_locals, mut
-			local_types)
+		return tc.ownership_prescan_mark_storage_from_expr(lhs_name, base_id, mut owned_locals, mut local_types)
 	}
 	mut marked := false
 	if base_name in owned_locals {
@@ -4175,26 +4058,21 @@ fn (mut tc TypeChecker) ownership_prescan_expr_for_owned_calls(id flat.NodeId, m
 		}
 		.paren, .expr_stmt, .cast_expr {
 			if node.children_count > 0 {
-				return tc.ownership_prescan_expr_for_owned_calls(tc.a.child(&node, 0), mut
-					owned_locals, mut local_types)
+				return tc.ownership_prescan_expr_for_owned_calls(tc.a.child(&node, 0), mut owned_locals, mut local_types)
 			}
 			return false
 		}
 		.call {
-			return tc.ownership_prescan_call_for_owned_calls(id, node, mut owned_locals, mut
-				local_types)
+			return tc.ownership_prescan_call_for_owned_calls(id, node, mut owned_locals, mut local_types)
 		}
 		.if_expr {
-			return tc.ownership_prescan_if_expr_for_owned_calls(node, mut owned_locals, mut
-				local_types)
+			return tc.ownership_prescan_if_expr_for_owned_calls(node, mut owned_locals, mut local_types)
 		}
 		.match_stmt {
-			return tc.ownership_prescan_match_expr_for_owned_calls(node, mut owned_locals, mut
-				local_types)
+			return tc.ownership_prescan_match_expr_for_owned_calls(node, mut owned_locals, mut local_types)
 		}
 		.or_expr {
-			return tc.ownership_prescan_or_expr_for_owned_calls(node, mut owned_locals, mut
-				local_types)
+			return tc.ownership_prescan_or_expr_for_owned_calls(node, mut owned_locals, mut local_types)
 		}
 		.fn_literal {
 			_ := tc.ownership_prescan_fn_literal_owned_call_params(id, node)
@@ -4205,8 +4083,7 @@ fn (mut tc TypeChecker) ownership_prescan_expr_for_owned_calls(id flat.NodeId, m
 				field := tc.a.child_node(&node, i)
 				if field.children_count > 0 {
 					value_id := tc.a.child(field, 0)
-					value_owned := tc.ownership_prescan_expr_for_owned_calls(value_id, mut
-						owned_locals, mut local_types)
+					value_owned := tc.ownership_prescan_expr_for_owned_calls(value_id, mut owned_locals, mut local_types)
 					if value_owned {
 						tc.ownership_prescan_consume_local(value_id, mut owned_locals)
 					}
@@ -4217,8 +4094,7 @@ fn (mut tc TypeChecker) ownership_prescan_expr_for_owned_calls(id flat.NodeId, m
 		.array_literal {
 			for i in 0 .. node.children_count {
 				elem_id := tc.a.child(&node, i)
-				elem_owned := tc.ownership_prescan_expr_for_owned_calls(elem_id, mut owned_locals, mut
-					local_types)
+				elem_owned := tc.ownership_prescan_expr_for_owned_calls(elem_id, mut owned_locals, mut local_types)
 				if elem_owned {
 					tc.ownership_prescan_consume_local(elem_id, mut owned_locals)
 				}
@@ -4228,8 +4104,7 @@ fn (mut tc TypeChecker) ownership_prescan_expr_for_owned_calls(id flat.NodeId, m
 		.map_init {
 			for i in 0 .. node.children_count {
 				elem_id := tc.a.child(&node, i)
-				elem_owned := tc.ownership_prescan_expr_for_owned_calls(elem_id, mut owned_locals, mut
-					local_types)
+				elem_owned := tc.ownership_prescan_expr_for_owned_calls(elem_id, mut owned_locals, mut local_types)
 				if elem_owned {
 					tc.ownership_prescan_consume_local(elem_id, mut owned_locals)
 				}
@@ -4240,8 +4115,7 @@ fn (mut tc TypeChecker) ownership_prescan_expr_for_owned_calls(id flat.NodeId, m
 	}
 
 	for i in 0 .. node.children_count {
-		tc.ownership_prescan_node_for_owned_calls(tc.a.child(&node, i), mut owned_locals, mut
-			local_types)
+		tc.ownership_prescan_node_for_owned_calls(tc.a.child(&node, i), mut owned_locals, mut local_types)
 	}
 	return false
 }
@@ -4250,8 +4124,7 @@ fn (mut tc TypeChecker) ownership_prescan_if_expr_for_owned_calls(node flat.Node
 	if node.children_count == 0 {
 		return false
 	}
-	_ := tc.ownership_prescan_expr_for_owned_calls(tc.a.child(&node, 0), mut owned_locals, mut
-		local_types)
+	_ := tc.ownership_prescan_expr_for_owned_calls(tc.a.child(&node, 0), mut owned_locals, mut local_types)
 	base_owned := owned_locals.clone()
 	base_types := local_types.clone()
 	mut branch_owned := []map[string]bool{}
@@ -4284,8 +4157,7 @@ fn (mut tc TypeChecker) ownership_prescan_if_expr_for_owned_calls(node flat.Node
 		branch_owned << base_owned
 		branch_types << base_types
 	}
-	tc.ownership_prescan_merge_branch_states(base_owned, base_types, branch_owned, branch_types, mut
-		owned_locals, mut local_types)
+	tc.ownership_prescan_merge_branch_states(base_owned, base_types, branch_owned, branch_types, mut owned_locals, mut local_types)
 	return result_owned
 }
 
@@ -4293,8 +4165,7 @@ fn (mut tc TypeChecker) ownership_prescan_match_expr_for_owned_calls(node flat.N
 	if node.children_count == 0 {
 		return false
 	}
-	_ := tc.ownership_prescan_expr_for_owned_calls(tc.a.child(&node, 0), mut owned_locals, mut
-		local_types)
+	_ := tc.ownership_prescan_expr_for_owned_calls(tc.a.child(&node, 0), mut owned_locals, mut local_types)
 	base_owned := owned_locals.clone()
 	base_types := local_types.clone()
 	mut branch_owned := []map[string]bool{}
@@ -4327,8 +4198,7 @@ fn (mut tc TypeChecker) ownership_prescan_match_expr_for_owned_calls(node flat.N
 		branch_owned << base_owned
 		branch_types << base_types
 	}
-	tc.ownership_prescan_merge_branch_states(base_owned, base_types, branch_owned, branch_types, mut
-		owned_locals, mut local_types)
+	tc.ownership_prescan_merge_branch_states(base_owned, base_types, branch_owned, branch_types, mut owned_locals, mut local_types)
 	return result_owned
 }
 
@@ -4336,8 +4206,7 @@ fn (mut tc TypeChecker) ownership_prescan_or_expr_for_owned_calls(node flat.Node
 	if node.children_count == 0 {
 		return false
 	}
-	_ := tc.ownership_prescan_expr_for_owned_calls(tc.a.child(&node, 0), mut owned_locals, mut
-		local_types)
+	_ := tc.ownership_prescan_expr_for_owned_calls(tc.a.child(&node, 0), mut owned_locals, mut local_types)
 	if node.children_count < 2 || node.value in ['!', '?'] {
 		return false
 	}
@@ -4345,12 +4214,10 @@ fn (mut tc TypeChecker) ownership_prescan_or_expr_for_owned_calls(node flat.Node
 	base_types := local_types.clone()
 	mut fallback_owned := base_owned.clone()
 	mut fallback_types := base_types.clone()
-	result_owned := tc.ownership_prescan_branch_tail_for_owned_calls(tc.a.child(&node, 1), mut
-		fallback_owned, mut fallback_types)
+	result_owned := tc.ownership_prescan_branch_tail_for_owned_calls(tc.a.child(&node, 1), mut fallback_owned, mut fallback_types)
 	branch_owned := [base_owned, fallback_owned]
 	branch_types := [base_types, fallback_types]
-	tc.ownership_prescan_merge_branch_states(base_owned, base_types, branch_owned, branch_types, mut
-		owned_locals, mut local_types)
+	tc.ownership_prescan_merge_branch_states(base_owned, base_types, branch_owned, branch_types, mut owned_locals, mut local_types)
 	return result_owned
 }
 
@@ -4365,11 +4232,9 @@ fn (mut tc TypeChecker) ownership_prescan_branch_tail_for_owned_calls(branch_id 
 		}
 		last_idx := node.children_count - 1
 		for i in 0 .. last_idx {
-			tc.ownership_prescan_node_for_owned_calls(tc.a.child(&node, i), mut
-				branch_owned_locals, mut branch_local_types)
+			tc.ownership_prescan_node_for_owned_calls(tc.a.child(&node, i), mut branch_owned_locals, mut branch_local_types)
 		}
-		return tc.ownership_prescan_expr_for_owned_calls(tc.branch_tail_expr_id(branch_id), mut
-			branch_owned_locals, mut branch_local_types)
+		return tc.ownership_prescan_expr_for_owned_calls(tc.branch_tail_expr_id(branch_id), mut branch_owned_locals, mut branch_local_types)
 	}
 	if node.kind == .match_branch {
 		body_start := if node.value == 'else' { 0 } else { node.value.int() }
@@ -4378,20 +4243,16 @@ fn (mut tc TypeChecker) ownership_prescan_branch_tail_for_owned_calls(branch_id 
 		}
 		last_idx := node.children_count - 1
 		for i in body_start .. last_idx {
-			tc.ownership_prescan_node_for_owned_calls(tc.a.child(&node, i), mut
-				branch_owned_locals, mut branch_local_types)
+			tc.ownership_prescan_node_for_owned_calls(tc.a.child(&node, i), mut branch_owned_locals, mut branch_local_types)
 		}
-		return tc.ownership_prescan_expr_for_owned_calls(tc.branch_tail_expr_id(branch_id), mut
-			branch_owned_locals, mut branch_local_types)
+		return tc.ownership_prescan_expr_for_owned_calls(tc.branch_tail_expr_id(branch_id), mut branch_owned_locals, mut branch_local_types)
 	}
-	return tc.ownership_prescan_expr_for_owned_calls(branch_id, mut branch_owned_locals, mut
-		branch_local_types)
+	return tc.ownership_prescan_expr_for_owned_calls(branch_id, mut branch_owned_locals, mut branch_local_types)
 }
 
 fn (mut tc TypeChecker) ownership_prescan_params_field_arg(node flat.Node, info CallInfo, arg_node flat.Node, arg_id flat.NodeId, mut owned_locals map[string]bool, mut local_types map[string]Type) {
 	field_name := arg_node.value
-	arg_owned := tc.ownership_prescan_expr_for_owned_calls(arg_id, mut owned_locals, mut
-		local_types)
+	arg_owned := tc.ownership_prescan_expr_for_owned_calls(arg_id, mut owned_locals, mut local_types)
 	if field_name.len == 0 || info.name.len == 0 {
 		if arg_owned {
 			tc.ownership_prescan_consume_local(arg_id, mut owned_locals)
@@ -4418,8 +4279,7 @@ fn (mut tc TypeChecker) ownership_prescan_params_field_arg(node flat.Node, info 
 	}
 	arg_name := tc.ownership_expr_ident_name(arg_id)
 	if arg_name.len > 0 {
-		tc.ownership_prescan_transfer_owned_descendants_to_param_with_suffix(arg_name, info.name,
-			param_idx, suffix, mut owned_locals, local_types)
+		tc.ownership_prescan_transfer_owned_descendants_to_param_with_suffix(arg_name, info.name, param_idx, suffix, mut owned_locals, local_types)
 	}
 }
 
@@ -4444,20 +4304,16 @@ fn (mut tc TypeChecker) ownership_prescan_call_for_owned_calls(id flat.NodeId, n
 	if tc.ownership_prescan_expr_is_owned_clone_call(id, mut owned_locals, mut local_types) {
 		return true
 	}
-	if tc.ownership_prescan_array_element_method_for_owned_calls(id, mut owned_locals, mut
-		local_types)
-	{
+	if tc.ownership_prescan_array_element_method_for_owned_calls(id, mut owned_locals, mut local_types) {
 		return true
 	}
 	info := tc.ownership_prescan_call_info(node, local_types) or {
 		fn_node := tc.a.child_node(&node, 0)
 		if fn_node.kind == .selector && fn_node.children_count > 0 {
-			_ := tc.ownership_prescan_expr_for_owned_calls(tc.a.child(fn_node, 0), mut
-				owned_locals, mut local_types)
+			_ := tc.ownership_prescan_expr_for_owned_calls(tc.a.child(fn_node, 0), mut owned_locals, mut local_types)
 		}
 		for i in 1 .. node.children_count {
-			_ := tc.ownership_prescan_expr_for_owned_calls(tc.call_arg_value(tc.a.child(&node, i)), mut
-				owned_locals, mut local_types)
+			_ := tc.ownership_prescan_expr_for_owned_calls(tc.call_arg_value(tc.a.child(&node, i)), mut owned_locals, mut local_types)
 		}
 		return false
 	}
@@ -4468,8 +4324,7 @@ fn (mut tc TypeChecker) ownership_prescan_call_for_owned_calls(id flat.NodeId, n
 		fn_node := tc.a.child_node(&node, 0)
 		if fn_node.kind == .selector && fn_node.children_count > 0 {
 			recv_id := tc.a.child(fn_node, 0)
-			recv_owned := tc.ownership_prescan_expr_for_owned_calls(recv_id, mut owned_locals, mut
-				local_types)
+			recv_owned := tc.ownership_prescan_expr_for_owned_calls(recv_id, mut owned_locals, mut local_types)
 			if 0 in return_param_idxs && recv_owned {
 				returns_owned = true
 			}
@@ -4487,8 +4342,7 @@ fn (mut tc TypeChecker) ownership_prescan_call_for_owned_calls(id flat.NodeId, n
 				&& !tc.ownership_array_builtin_keeps_receiver(recv_id, fn_node.value)
 				&& !tc.ownership_map_builtin_keeps_receiver(recv_id, fn_node.value)
 				&& !tc.ownership_string_builtin_keeps_receiver(recv_id, fn_node.value) {
-				tc.ownership_prescan_transfer_owned_descendants_to_param(recv_name, info.name, 0, mut
-					owned_locals, local_types)
+				tc.ownership_prescan_transfer_owned_descendants_to_param(recv_name, info.name, 0, mut owned_locals, local_types)
 			}
 		}
 	}
@@ -4496,15 +4350,13 @@ fn (mut tc TypeChecker) ownership_prescan_call_for_owned_calls(id flat.NodeId, n
 		arg_node := tc.a.child_node(&node, i)
 		arg_id := tc.call_arg_value(tc.a.child(&node, i))
 		if arg_node.kind == .field_init {
-			tc.ownership_prescan_params_field_arg(node, info, arg_node, arg_id, mut owned_locals, mut
-				local_types)
+			tc.ownership_prescan_params_field_arg(node, info, arg_node, arg_id, mut owned_locals, mut local_types)
 			continue
 		}
 		param_idx := tc.ownership_call_arg_decl_param_idx(info, i)
 		type_param_idx := param_idx + arg_shift
 		variadic_elem_idx := tc.ownership_call_arg_variadic_elem_idx(info, type_param_idx)
-		target_param_idx := tc.ownership_call_arg_variadic_decl_param_idx(param_idx,
-			variadic_elem_idx)
+		target_param_idx := tc.ownership_call_arg_variadic_decl_param_idx(param_idx, variadic_elem_idx)
 		target_suffix := ownership_call_arg_variadic_suffix(variadic_elem_idx)
 		expected := tc.ownership_call_arg_expected_type(info, type_param_idx, variadic_elem_idx)
 		if expected !is Void && expected !is Pointer
@@ -4518,8 +4370,7 @@ fn (mut tc TypeChecker) ownership_prescan_call_for_owned_calls(id flat.NodeId, n
 			&& tc.ownership_prescan_param_aggregate_literal_descendants(info.name, target_param_idx, target_suffix, arg_id, mut owned_locals, mut local_types) {
 			continue
 		}
-		arg_owned := tc.ownership_prescan_expr_for_owned_calls(arg_id, mut owned_locals, mut
-			local_types)
+		arg_owned := tc.ownership_prescan_expr_for_owned_calls(arg_id, mut owned_locals, mut local_types)
 		if param_idx in return_param_idxs && arg_owned {
 			returns_owned = true
 		}
@@ -4527,8 +4378,7 @@ fn (mut tc TypeChecker) ownership_prescan_call_for_owned_calls(id flat.NodeId, n
 			if expected !is Void && expected !is Pointer && !tc.ownership_expr_is_borrow(arg_id) {
 				arg_name := tc.ownership_expr_ident_name(arg_id)
 				if arg_name.len > 0 {
-					tc.ownership_prescan_transfer_owned_descendants_to_param_with_suffix(arg_name,
-						info.name, target_param_idx, target_suffix, mut owned_locals, local_types)
+					tc.ownership_prescan_transfer_owned_descendants_to_param_with_suffix(arg_name, info.name, target_param_idx, target_suffix, mut owned_locals, local_types)
 				}
 			}
 			continue
@@ -4544,8 +4394,7 @@ fn (mut tc TypeChecker) ownership_prescan_call_for_owned_calls(id flat.NodeId, n
 				} else {
 					tc.resolve_type(arg_id)
 				}
-				tc.ownership_add_fn_param_descendant(info.name, target_param_idx, target_suffix,
-					arg_type.name())
+				tc.ownership_add_fn_param_descendant(info.name, target_param_idx, target_suffix, arg_type.name())
 			} else {
 				tc.ownership_mark_fn_param_owned(info.name, param_idx)
 			}
@@ -4553,8 +4402,7 @@ fn (mut tc TypeChecker) ownership_prescan_call_for_owned_calls(id flat.NodeId, n
 		tc.ownership_prescan_consume_local(arg_id, mut owned_locals)
 		arg_name := tc.ownership_expr_ident_name(arg_id)
 		if arg_name.len > 0 {
-			tc.ownership_prescan_transfer_owned_descendants_to_param_with_suffix(arg_name,
-				info.name, target_param_idx, target_suffix, mut owned_locals, local_types)
+			tc.ownership_prescan_transfer_owned_descendants_to_param_with_suffix(arg_name, info.name, target_param_idx, target_suffix, mut owned_locals, local_types)
 		}
 	}
 	return returns_owned || tc.ownership_type_is_owned(tc.resolve_type(id))
@@ -4586,8 +4434,7 @@ fn (mut tc TypeChecker) ownership_prescan_array_element_method_for_owned_calls(i
 		return false
 	}
 	mut owned := false
-	for source_key in ownership_prescan_array_element_method_source_keys(array_name, method,
-		owned_locals) {
+	for source_key in ownership_prescan_array_element_method_source_keys(array_name, method, owned_locals) {
 		if source_key in owned_locals {
 			owned_locals.delete(source_key)
 			owned = true
@@ -4708,8 +4555,7 @@ fn (mut tc TypeChecker) ownership_prescan_call_info(node flat.Node, local_types 
 				return info
 			}
 			if recv_type := local_types[base_node.value] {
-				for mname in receiver_method_name_candidates(unwrap_pointer(recv_type),
-					fn_node.value, tc.cur_module) {
+				for mname in receiver_method_name_candidates(unwrap_pointer(recv_type), fn_node.value, tc.cur_module) {
 					if mname !in tc.fn_ret_types {
 						continue
 					}
@@ -4843,8 +4689,7 @@ fn (tc &TypeChecker) ownership_prescan_transfer_owned_descendants(source_prefix 
 }
 
 fn (mut tc TypeChecker) ownership_prescan_transfer_owned_descendants_to_param(source_prefix string, fn_name string, param_idx int, mut owned_locals map[string]bool, local_types map[string]Type) bool {
-	return tc.ownership_prescan_transfer_owned_descendants_to_param_with_suffix(source_prefix,
-		fn_name, param_idx, '', mut owned_locals, local_types)
+	return tc.ownership_prescan_transfer_owned_descendants_to_param_with_suffix(source_prefix, fn_name, param_idx, '', mut owned_locals, local_types)
 }
 
 fn (mut tc TypeChecker) ownership_prescan_transfer_owned_descendants_to_param_with_suffix(source_prefix string, fn_name string, param_idx int, target_suffix string, mut owned_locals map[string]bool, local_types map[string]Type) bool {
@@ -4896,16 +4741,16 @@ fn (mut tc TypeChecker) ownership_begin_fn(node flat.Node) {
 	mut st := tc.ownership_state()
 	fn_name := tc.ownership_fn_name(node)
 	st.frames << OwnershipFrame{
-		cur_fn:          st.cur_fn
-		owned_vars:      st.owned_vars.clone()
+		cur_fn: st.cur_fn
+		owned_vars: st.owned_vars.clone()
 		owned_var_types: st.owned_var_types.clone()
-		moved_vars:      st.moved_vars.clone()
-		borrowed_vars:   st.borrowed_vars.clone()
-		array_lengths:   st.array_lengths.clone()
-		fn_value_vars:   st.ownership_fn_value_vars.clone()
+		moved_vars: st.moved_vars.clone()
+		borrowed_vars: st.borrowed_vars.clone()
+		array_lengths: st.array_lengths.clone()
+		fn_value_vars: st.ownership_fn_value_vars.clone()
 		pointer_aliases: st.pointer_index_aliases.clone()
-		scope_frames:    ownership_clone_scope_frames(st.scope_frames)
-		path_active:     st.path_active
+		scope_frames: ownership_clone_scope_frames(st.scope_frames)
+		path_active: st.path_active
 	}
 	st.cur_fn = fn_name
 	st.drop_return_counts[fn_name] = 0
@@ -4959,16 +4804,16 @@ fn (mut tc TypeChecker) ownership_begin_fn_literal(id flat.NodeId, node flat.Nod
 	fn_name := ownership_fn_literal_name(st.cur_fn, id)
 	captures, captured_pointer_aliases := tc.ownership_consume_fn_literal_captures(node, fn_name)
 	st.frames << OwnershipFrame{
-		cur_fn:          st.cur_fn
-		owned_vars:      st.owned_vars.clone()
+		cur_fn: st.cur_fn
+		owned_vars: st.owned_vars.clone()
 		owned_var_types: st.owned_var_types.clone()
-		moved_vars:      st.moved_vars.clone()
-		borrowed_vars:   st.borrowed_vars.clone()
-		array_lengths:   st.array_lengths.clone()
-		fn_value_vars:   st.ownership_fn_value_vars.clone()
+		moved_vars: st.moved_vars.clone()
+		borrowed_vars: st.borrowed_vars.clone()
+		array_lengths: st.array_lengths.clone()
+		fn_value_vars: st.ownership_fn_value_vars.clone()
 		pointer_aliases: st.pointer_index_aliases.clone()
-		scope_frames:    ownership_clone_scope_frames(st.scope_frames)
-		path_active:     st.path_active
+		scope_frames: ownership_clone_scope_frames(st.scope_frames)
+		path_active: st.path_active
 	}
 	st.cur_fn = fn_name
 	st.drop_return_counts[fn_name] = 0
@@ -5029,9 +4874,9 @@ fn (mut tc TypeChecker) ownership_consume_fn_literal_capture(name string, fn_nam
 		type_name := tc.ownership_type_name_for_var(name)
 		if tc.ownership_move_var_result(name, fn_name, pos, false, '', true) {
 			captures << OwnershipCaptureBinding{
-				name:      name
+				name: name
 				type_name: type_name
-				pos:       pos
+				pos: pos
 			}
 		}
 	}
@@ -5039,9 +4884,9 @@ fn (mut tc TypeChecker) ownership_consume_fn_literal_capture(name string, fn_nam
 		type_name := tc.ownership_type_name_for_var(source_name)
 		if tc.ownership_move_var_result(source_name, fn_name, pos, false, '', true) {
 			captures << OwnershipCaptureBinding{
-				name:      source_name
+				name: source_name
 				type_name: type_name
-				pos:       pos
+				pos: pos
 			}
 		}
 	}
@@ -5072,16 +4917,16 @@ fn (mut tc TypeChecker) ownership_begin_lambda_expr(id flat.NodeId, node flat.No
 	fn_name := ownership_lambda_name(st.cur_fn, id)
 	captures, captured_pointer_aliases := tc.ownership_consume_lambda_captures(node, fn_name)
 	st.frames << OwnershipFrame{
-		cur_fn:          st.cur_fn
-		owned_vars:      st.owned_vars.clone()
+		cur_fn: st.cur_fn
+		owned_vars: st.owned_vars.clone()
 		owned_var_types: st.owned_var_types.clone()
-		moved_vars:      st.moved_vars.clone()
-		borrowed_vars:   st.borrowed_vars.clone()
-		array_lengths:   st.array_lengths.clone()
-		fn_value_vars:   st.ownership_fn_value_vars.clone()
+		moved_vars: st.moved_vars.clone()
+		borrowed_vars: st.borrowed_vars.clone()
+		array_lengths: st.array_lengths.clone()
+		fn_value_vars: st.ownership_fn_value_vars.clone()
 		pointer_aliases: st.pointer_index_aliases.clone()
-		scope_frames:    ownership_clone_scope_frames(st.scope_frames)
-		path_active:     st.path_active
+		scope_frames: ownership_clone_scope_frames(st.scope_frames)
+		path_active: st.path_active
 	}
 	st.cur_fn = fn_name
 	st.owned_vars = map[string]flat.NodeId{}
@@ -5173,8 +5018,7 @@ fn (mut tc TypeChecker) ownership_collect_lambda_capture_names(id flat.NodeId, l
 					flat.Node{}
 				}
 				if callee.kind == .selector && callee.children_count > 0 {
-					tc.ownership_collect_lambda_capture_names(tc.a.child(callee, 0), locals, mut
-						names)
+					tc.ownership_collect_lambda_capture_names(tc.a.child(callee, 0), locals, mut names)
 				}
 			}
 			for i in 1 .. node.children_count {
@@ -5245,8 +5089,7 @@ fn (mut tc TypeChecker) ownership_collect_lambda_match_captures(node flat.Node, 
 		}
 		mut branch_scope := locals.clone()
 		for j in body_start .. branch.children_count {
-			tc.ownership_collect_lambda_capture_stmt(tc.a.child(&branch, j), mut branch_scope, mut
-				names)
+			tc.ownership_collect_lambda_capture_stmt(tc.a.child(&branch, j), mut branch_scope, mut names)
 		}
 	}
 }
@@ -5283,15 +5126,13 @@ fn (mut tc TypeChecker) ownership_collect_lambda_condition_captures(id flat.Node
 	}
 	if node.kind == .infix && node.op == .logical_and && node.children_count >= 2 {
 		mut lhs_scope := locals.clone()
-		tc.ownership_collect_lambda_condition_captures(tc.a.child(&node, 0), locals, mut lhs_scope, mut
-			names)
+		tc.ownership_collect_lambda_condition_captures(tc.a.child(&node, 0), locals, mut lhs_scope, mut names)
 		for name, _ in lhs_scope {
 			if name !in locals {
 				then_scope[name] = true
 			}
 		}
-		tc.ownership_collect_lambda_condition_captures(tc.a.child(&node, 1), lhs_scope, mut
-			then_scope, mut names)
+		tc.ownership_collect_lambda_condition_captures(tc.a.child(&node, 1), lhs_scope, mut then_scope, mut names)
 		return
 	}
 	tc.ownership_collect_lambda_capture_names(id, locals, mut names)
@@ -5414,16 +5255,16 @@ fn (mut tc TypeChecker) ownership_end_fn() {
 fn (mut tc TypeChecker) ownership_snapshot_frame() OwnershipFrame {
 	st := tc.ownership_state()
 	return OwnershipFrame{
-		cur_fn:          st.cur_fn
-		owned_vars:      st.owned_vars.clone()
+		cur_fn: st.cur_fn
+		owned_vars: st.owned_vars.clone()
 		owned_var_types: st.owned_var_types.clone()
-		moved_vars:      st.moved_vars.clone()
-		borrowed_vars:   st.borrowed_vars.clone()
-		array_lengths:   st.array_lengths.clone()
-		fn_value_vars:   st.ownership_fn_value_vars.clone()
+		moved_vars: st.moved_vars.clone()
+		borrowed_vars: st.borrowed_vars.clone()
+		array_lengths: st.array_lengths.clone()
+		fn_value_vars: st.ownership_fn_value_vars.clone()
 		pointer_aliases: st.pointer_index_aliases.clone()
-		scope_frames:    ownership_clone_scope_frames(st.scope_frames)
-		path_active:     st.path_active
+		scope_frames: ownership_clone_scope_frames(st.scope_frames)
+		path_active: st.path_active
 	}
 }
 
@@ -5478,13 +5319,13 @@ fn (mut tc TypeChecker) ownership_begin_branch_group_with_label(is_loop bool, va
 	}
 	base := tc.ownership_snapshot_frame()
 	tc.ownership_state().branch_groups << OwnershipBranchGroup{
-		base:          base
-		branches:      []OwnershipFrame{}
-		continues:     []OwnershipFrame{}
-		saw_else:      false
-		is_loop:       is_loop
+		base: base
+		branches: []OwnershipFrame{}
+		continues: []OwnershipFrame{}
+		saw_else: false
+		is_loop: is_loop
 		value_context: value_context
-		label:         label
+		label: label
 	}
 }
 
@@ -5588,8 +5429,7 @@ fn (mut tc TypeChecker) ownership_after_stmt_node(id flat.NodeId) {
 			if node.children_count > 0 {
 				expr_id := tc.a.child(&node, 0)
 				if tc.ownership_expr_may_consume_array_element_method(expr_id) {
-					tc.ownership_consume_array_element_method_result(expr_id,
-						'discarded expression', id)
+					tc.ownership_consume_array_element_method_result(expr_id, 'discarded expression', id)
 				}
 				call_id := tc.ownership_unwrap_expr(expr_id)
 				if tc.autofree_mode && tc.valid_node_id(call_id)
@@ -5654,8 +5494,7 @@ fn (mut tc TypeChecker) ownership_add_loop_continue_snapshot(label string) {
 		if ownership_loop_group_matches(st.branch_groups[group_idx], label) {
 			base := st.branch_groups[group_idx].base
 			tc.ownership_record_loop_control_drops(base, snapshot)
-			st.branch_groups[group_idx].continues << ownership_frame_without_loop_locals(base,
-				snapshot)
+			st.branch_groups[group_idx].continues << ownership_frame_without_loop_locals(base, snapshot)
 			return
 		}
 	}
@@ -5760,8 +5599,8 @@ fn (mut tc TypeChecker) ownership_drop_entries_for_loop_base_scope(base Ownershi
 		type_name := snapshot.owned_var_types[name] or { continue }
 		if target := tc.ownership_drop_target_for_type_name(type_name) {
 			entries << OwnershipDropEntry{
-				name:             name
-				type_name:        target.type_name
+				name: name
+				type_name: target.type_name
 				optional_wrapper: target.optional_wrapper
 			}
 		}
@@ -5777,7 +5616,7 @@ fn (mut tc TypeChecker) ownership_drop_entries_since_frame(base OwnershipFrame, 
 			&& !name.contains('[') {
 			candidates << OwnershipDropCandidate{
 				name: name
-				pos:  int(pos)
+				pos: int(pos)
 			}
 		}
 	}
@@ -5787,8 +5626,8 @@ fn (mut tc TypeChecker) ownership_drop_entries_since_frame(base OwnershipFrame, 
 		type_name := snapshot.owned_var_types[candidate.name] or { continue }
 		if target := tc.ownership_drop_target_for_type_name(type_name) {
 			entries << OwnershipDropEntry{
-				name:             candidate.name
-				type_name:        target.type_name
+				name: candidate.name
+				type_name: target.type_name
 				optional_wrapper: target.optional_wrapper
 			}
 		}
@@ -5831,16 +5670,16 @@ fn ownership_frame_without_loop_locals(base OwnershipFrame, snapshot OwnershipFr
 		}
 	}
 	return OwnershipFrame{
-		cur_fn:          snapshot.cur_fn
-		owned_vars:      owned_vars
+		cur_fn: snapshot.cur_fn
+		owned_vars: owned_vars
 		owned_var_types: owned_var_types
-		moved_vars:      moved_vars
-		borrowed_vars:   borrowed_vars
-		array_lengths:   array_lengths
-		fn_value_vars:   fn_value_vars
+		moved_vars: moved_vars
+		borrowed_vars: borrowed_vars
+		array_lengths: array_lengths
+		fn_value_vars: fn_value_vars
 		pointer_aliases: pointer_aliases
-		scope_frames:    ownership_clone_scope_frames(base.scope_frames)
-		path_active:     snapshot.path_active
+		scope_frames: ownership_clone_scope_frames(base.scope_frames)
+		path_active: snapshot.path_active
 	}
 }
 
@@ -6238,8 +6077,7 @@ fn (mut tc TypeChecker) ownership_bind_for_in_vars(key_id flat.NodeId, val_id fl
 	} else {
 		''
 	}
-	tc.ownership_bind_for_in_var_from_storage(target_name, source_name, target_id,
-		clones_storage_binding)
+	tc.ownership_bind_for_in_var_from_storage(target_name, source_name, target_id, clones_storage_binding)
 }
 
 fn (mut tc TypeChecker) ownership_bind_mut_for_in_var(key_id flat.NodeId, val_id flat.NodeId, container_id flat.NodeId, has_val bool) {
@@ -6310,9 +6148,7 @@ fn (mut tc TypeChecker) check_array_dsl_fn_borrows_element(node flat.Node, elem_
 	if mapper.params.len == 0 || fn_param_unalias_type(fn_param_type(mapper, 0)) is Pointer {
 		return
 	}
-	tc.record_error(.call_arg_mismatch,
-		'${label} cannot consume borrowed `${elem_type.name()}` elements; use a pointer parameter or clone the element',
-		pos)
+	tc.record_error(.call_arg_mismatch, '${label} cannot consume borrowed `${elem_type.name()}` elements; use a pointer parameter or clone the element', pos)
 }
 
 fn (mut tc TypeChecker) ownership_bind_for_in_var_from_storage(target_name string, source_name string, target_id flat.NodeId, clones_storage_binding bool) bool {
@@ -6333,8 +6169,7 @@ fn (mut tc TypeChecker) ownership_bind_for_in_var_from_storage(target_name strin
 			}
 		}
 	} else if source_name.len > 0 {
-		moved_types = tc.ownership_move_overlapping_dynamic_storage(source_name, target_name,
-			target_id, false, '', true)
+		moved_types = tc.ownership_move_overlapping_dynamic_storage(source_name, target_name, target_id, false, '', true)
 	}
 	tc.ownership_clear_descendant_state(target_name)
 	{
@@ -6384,13 +6219,11 @@ fn (tc &TypeChecker) ownership_select_branch_body_start(branch flat.Node) int {
 }
 
 fn (tc &TypeChecker) ownership_select_branch_definitely_exits_statement_sequence(branch flat.Node) bool {
-	return !tc.ownership_statement_sequence_can_continue(branch,
-		tc.ownership_select_branch_body_start(branch))
+	return !tc.ownership_statement_sequence_can_continue(branch, tc.ownership_select_branch_body_start(branch))
 }
 
 fn (tc &TypeChecker) ownership_select_branch_definitely_breaks_statement_sequence(branch flat.Node) bool {
-	return tc.ownership_statement_sequence_definitely_breaks(branch,
-		tc.ownership_select_branch_body_start(branch))
+	return tc.ownership_statement_sequence_definitely_breaks(branch, tc.ownership_select_branch_body_start(branch))
 }
 
 fn (mut tc TypeChecker) ownership_end_branch_group() {
@@ -6494,8 +6327,7 @@ fn (mut tc TypeChecker) ownership_merge_branch_borrows(group OwnershipBranchGrou
 	mut st := tc.ownership_state()
 	for branch in group.branches {
 		for name, borrows in branch.borrowed_vars {
-			if name !in group.base.owned_vars && name !in group.base.borrowed_vars
-				&& !tc.ownership_storage_participates(name) {
+			if name !in group.base.owned_vars && name !in group.base.borrowed_vars && !tc.ownership_storage_participates(name) {
 				continue
 			}
 			mut merged := st.borrowed_vars[name] or { []BorrowInfo{} }
@@ -6851,8 +6683,7 @@ fn (mut tc TypeChecker) ownership_after_multi_return_assign_impl(lhs_ids []flat.
 			tc.ownership_mark_owned(lhs_name, rhs_type.types[i], assign_id)
 			continue
 		}
-		marked_return_desc := tc.ownership_mark_return_descendants_from_call(lhs_name, fn_name, i,
-			assign_id)
+		marked_return_desc := tc.ownership_mark_return_descendants_from_call(lhs_name, fn_name, i, assign_id)
 		mut marked_from_param := false
 		mut marked_param_desc := false
 		if !tc.valid_node_id(call_id) {
@@ -6860,8 +6691,7 @@ fn (mut tc TypeChecker) ownership_after_multi_return_assign_impl(lhs_ids []flat.
 		} else {
 			call_node := tc.a.nodes[int(call_id)]
 			if call_node.kind == .call {
-				marked_param_desc = tc.ownership_mark_return_param_descendants_from_call(lhs_name,
-					call_id, call_node, fn_name, i, assign_id)
+				marked_param_desc = tc.ownership_mark_return_param_descendants_from_call(lhs_name, call_id, call_node, fn_name, i, assign_id)
 				for slot in return_param_slots {
 					if slot.slot_idx == i
 						&& tc.ownership_mark_from_return_param(lhs_name, call_id, call_node, fn_name, slot.param_idx, assign_id) {
@@ -7039,8 +6869,7 @@ fn (mut tc TypeChecker) ownership_commit_multi_assign_temp(temp_name string, lhs
 	}
 	for owned_name in tc.ownership_owned_descendant_names(temp_name) {
 		suffix := owned_name[temp_name.len..]
-		tc.ownership_mark_owned_name(lhs_name + suffix, tc.ownership_type_name_for_var(owned_name),
-			assign_id)
+		tc.ownership_mark_owned_name(lhs_name + suffix, tc.ownership_type_name_for_var(owned_name), assign_id)
 		marked = true
 	}
 	if !marked {
@@ -7122,7 +6951,7 @@ fn (mut tc TypeChecker) ownership_assign_to_name(lhs_name string, rhs_id flat.No
 	rhs_node := tc.a.nodes[int(tc.ownership_unwrap_expr(rhs_id))]
 	aggregate_literal_owned :=
 		rhs_node.kind in [.array_literal, .array_init, .map_init, .struct_init, .assoc]
-		&& tc.ownership_type_requires_destruction(lhs_type)
+			&& tc.ownership_type_requires_destruction(lhs_type)
 	if array_literal_owned || array_init_owned || map_literal_owned || aggregate_literal_owned {
 		tc.ownership_mark_owned(lhs_name, tc.resolve_type(rhs_id), assign_id)
 		return
@@ -7148,8 +6977,7 @@ fn (mut tc TypeChecker) ownership_assign_to_name(lhs_name string, rhs_id flat.No
 				tc.ownership_mark_owned(lhs_name, source_type, assign_id)
 				for source_name in descendants {
 					suffix := source_name[rhs_name.len..]
-					tc.ownership_mark_owned_name(lhs_name + suffix,
-						tc.ownership_type_name_for_var(source_name), assign_id)
+					tc.ownership_mark_owned_name(lhs_name + suffix, tc.ownership_type_name_for_var(source_name), assign_id)
 					st.owned_vars.delete(source_name)
 					st.owned_var_types.delete(source_name)
 					st.moved_vars.delete(source_name)
@@ -7158,8 +6986,7 @@ fn (mut tc TypeChecker) ownership_assign_to_name(lhs_name string, rhs_id flat.No
 			return
 		}
 		tc.ownership_transfer_owned_descendants(rhs_name, lhs_name, assign_id)
-		moved_types := tc.ownership_move_overlapping_dynamic_storage(rhs_name, lhs_name, assign_id,
-			false, '', true)
+		moved_types := tc.ownership_move_overlapping_dynamic_storage(rhs_name, lhs_name, assign_id, false, '', true)
 		if moved_types.len > 0 {
 			tc.ownership_mark_owned_name(lhs_name, moved_types[0], assign_id)
 			return
@@ -7175,8 +7002,7 @@ fn (mut tc TypeChecker) ownership_assign_to_name(lhs_name string, rhs_id flat.No
 			source_type := if rhs_owned { rhs_type } else { lhs_type }
 			tc.ownership_mark_owned(rhs_name, source_type, assign_id)
 			tc.ownership_move_var(rhs_name, lhs_name, assign_id, false, '', true)
-			tc.ownership_mark_owned(lhs_name, tc.ownership_type_for_var(rhs_name, source_type),
-				assign_id)
+			tc.ownership_mark_owned(lhs_name, tc.ownership_type_for_var(rhs_name, source_type), assign_id)
 			return
 		}
 	}
@@ -7344,9 +7170,9 @@ fn (mut tc TypeChecker) ownership_fn_literal_call_info(fn_name string) ?CallInfo
 	ret_type := tc.ownership.ownership_fn_literal_ret_types[fn_name] or { return none }
 	params := tc.ownership.ownership_fn_literal_param_types[fn_name] or { []Type{} }
 	return CallInfo{
-		name:         fn_name
-		params:       params.clone()
-		return_type:  ret_type
+		name: fn_name
+		params: params.clone()
+		return_type: ret_type
 		params_known: true
 	}
 }
@@ -7479,9 +7305,7 @@ fn (mut tc TypeChecker) ownership_move_owned_descendants(source_prefix string, t
 	}
 	mut moved_any := false
 	for source_name in tc.ownership_owned_descendant_names(source_prefix) {
-		if tc.ownership_move_var_result(source_name, target, pos, is_fn_call, fn_name,
-			suggest_clone)
-		{
+		if tc.ownership_move_var_result(source_name, target, pos, is_fn_call, fn_name, suggest_clone) {
 			moved_any = true
 		}
 	}
@@ -7489,8 +7313,7 @@ fn (mut tc TypeChecker) ownership_move_owned_descendants(source_prefix string, t
 }
 
 fn (mut tc TypeChecker) ownership_transfer_owned_descendants_to_param(source_prefix string, fn_name string, param_idx int, pos flat.NodeId) bool {
-	return tc.ownership_transfer_owned_descendants_to_param_with_suffix(source_prefix, fn_name,
-		param_idx, '', pos)
+	return tc.ownership_transfer_owned_descendants_to_param_with_suffix(source_prefix, fn_name, param_idx, '', pos)
 }
 
 fn (mut tc TypeChecker) ownership_transfer_owned_descendants_to_param_with_suffix(source_prefix string, fn_name string, param_idx int, target_suffix string, pos flat.NodeId) bool {
@@ -7502,8 +7325,7 @@ fn (mut tc TypeChecker) ownership_transfer_owned_descendants_to_param_with_suffi
 		suffix := source_name[source_prefix.len..]
 		type_name := tc.ownership_type_name_for_var(source_name)
 		if tc.ownership_move_var_result(source_name, fn_name, pos, true, fn_name, true) {
-			tc.ownership_add_fn_param_descendant(fn_name, param_idx, target_suffix + suffix,
-				type_name)
+			tc.ownership_add_fn_param_descendant(fn_name, param_idx, target_suffix + suffix, type_name)
 			moved_any = true
 		}
 	}
@@ -7574,9 +7396,7 @@ fn (mut tc TypeChecker) ownership_mark_array_literal_elements_with_mode(lhs_name
 		}
 		elem_key := '${lhs_name}[${i}]'
 		elem_type := tc.resolve_type(elem_id)
-		if tc.ownership_mark_storage_from_expr_with_mode(elem_key, elem_id, elem_type, pos,
-			clear_unowned)
-		{
+		if tc.ownership_mark_storage_from_expr_with_mode(elem_key, elem_id, elem_type, pos, clear_unowned) {
 			marked = true
 			continue
 		}
@@ -7619,9 +7439,7 @@ fn (mut tc TypeChecker) ownership_mark_array_init_elements_with_mode(lhs_name st
 				init_id := tc.a.child(&child, 0)
 				elem_key := '${lhs_name}[*]'
 				elem_type := tc.resolve_type(init_id)
-				if tc.ownership_mark_storage_from_expr_with_mode(elem_key, init_id, elem_type, pos,
-					clear_unowned)
-				{
+				if tc.ownership_mark_storage_from_expr_with_mode(elem_key, init_id, elem_type, pos, clear_unowned) {
 					marked = true
 					continue
 				}
@@ -7637,9 +7455,7 @@ fn (mut tc TypeChecker) ownership_mark_array_init_elements_with_mode(lhs_name st
 		elem_key := '${lhs_name}[${elem_idx}]'
 		elem_idx++
 		elem_type := tc.resolve_type(child_id)
-		if tc.ownership_mark_storage_from_expr_with_mode(elem_key, child_id, elem_type, pos,
-			clear_unowned)
-		{
+		if tc.ownership_mark_storage_from_expr_with_mode(elem_key, child_id, elem_type, pos, clear_unowned) {
 			marked = true
 			continue
 		}
@@ -7768,14 +7584,14 @@ fn (mut tc TypeChecker) ownership_shift_array_elements_for_insert(array_name str
 			continue
 		}
 		entries << OwnershipArrayShiftEntry{
-			old_name:  name
-			new_name:  new_name
+			old_name: name
+			new_name: new_name
 			had_owned: name in st.owned_vars
 			owned_pos: st.owned_vars[name] or { flat.empty_node }
-			had_type:  name in st.owned_var_types
+			had_type: name in st.owned_var_types
 			type_name: st.owned_var_types[name] or { '' }
 			had_moved: name in st.moved_vars
-			moved:     st.moved_vars[name] or { MovedVar{} }
+			moved: st.moved_vars[name] or { MovedVar{} }
 		}
 	}
 	for entry in entries {
@@ -7835,14 +7651,14 @@ fn (mut tc TypeChecker) ownership_shift_array_elements_after_pop_left(array_name
 	for name, _ in names {
 		new_name := ownership_pop_left_shifted_array_storage_key(name, array_name) or { continue }
 		entries << OwnershipArrayShiftEntry{
-			old_name:  name
-			new_name:  new_name
+			old_name: name
+			new_name: new_name
 			had_owned: name in st.owned_vars
 			owned_pos: st.owned_vars[name] or { flat.empty_node }
-			had_type:  name in st.owned_var_types
+			had_type: name in st.owned_var_types
 			type_name: st.owned_var_types[name] or { '' }
 			had_moved: name in st.moved_vars
-			moved:     st.moved_vars[name] or { MovedVar{} }
+			moved: st.moved_vars[name] or { MovedVar{} }
 		}
 	}
 	for entry in entries {
@@ -8032,9 +7848,7 @@ fn (mut tc TypeChecker) ownership_mark_map_literal_entries_with_mode(lhs_name st
 		key_id := tc.a.child(&node, i)
 		key_entry := ownership_map_key_storage_name(lhs_name)
 		key_type := tc.resolve_type(key_id)
-		if tc.ownership_mark_storage_from_expr_with_mode(key_entry, key_id, key_type, pos,
-			clear_unowned)
-		{
+		if tc.ownership_mark_storage_from_expr_with_mode(key_entry, key_id, key_type, pos, clear_unowned) {
 			marked = true
 		}
 		key_part := tc.ownership_index_key_part(key_id)
@@ -8044,9 +7858,7 @@ fn (mut tc TypeChecker) ownership_mark_map_literal_entries_with_mode(lhs_name st
 		value_id := tc.a.child(&node, i + 1)
 		entry_key := '${lhs_name}[${key_part}]'
 		value_type := tc.resolve_type(value_id)
-		if tc.ownership_mark_storage_from_expr_with_mode(entry_key, value_id, value_type, pos,
-			clear_unowned)
-		{
+		if tc.ownership_mark_storage_from_expr_with_mode(entry_key, value_id, value_type, pos, clear_unowned) {
 			marked = true
 			continue
 		}
@@ -8110,9 +7922,7 @@ fn (mut tc TypeChecker) ownership_mark_struct_literal_fields_with_mode(lhs_name 
 		} else {
 			tc.resolve_type(value_id)
 		}
-		if tc.ownership_mark_storage_from_expr_with_mode(field_key, value_id, field_type, pos,
-			clear_unowned)
-		{
+		if tc.ownership_mark_storage_from_expr_with_mode(field_key, value_id, field_type, pos, clear_unowned) {
 			marked = true
 			continue
 		}
@@ -8138,9 +7948,7 @@ fn (mut tc TypeChecker) ownership_mark_struct_literal_fields_with_mode(lhs_name 
 			field_type := tc.struct_field_type((init_type as Struct).name, field.value) or {
 				tc.parse_type(field.typ)
 			}
-			if tc.ownership_mark_storage_from_expr_with_mode(field_key, default_id, field_type,
-				pos, clear_unowned)
-			{
+			if tc.ownership_mark_storage_from_expr_with_mode(field_key, default_id, field_type, pos, clear_unowned) {
 				marked = true
 				continue
 			}
@@ -8205,9 +8013,7 @@ fn (mut tc TypeChecker) ownership_mark_assoc_literal_fields_with_mode(lhs_name s
 		if tc.ownership_transfer_assoc_base_descendants(base_name, lhs_name, explicit_fields, pos) {
 			marked = true
 		}
-	} else if tc.ownership_mark_storage_from_expr_with_mode(lhs_name, base_id, init_type, pos,
-		clear_unowned)
-	{
+	} else if tc.ownership_mark_storage_from_expr_with_mode(lhs_name, base_id, init_type, pos, clear_unowned) {
 		marked = true
 	}
 	for i in 1 .. node.children_count {
@@ -8232,9 +8038,7 @@ fn (mut tc TypeChecker) ownership_mark_assoc_literal_fields_with_mode(lhs_name s
 		field_type := tc.struct_field_type((init_type as Struct).name, field_name) or {
 			tc.resolve_type(value_id)
 		}
-		if tc.ownership_mark_storage_from_expr_with_mode(field_key, value_id, field_type, pos,
-			clear_unowned)
-		{
+		if tc.ownership_mark_storage_from_expr_with_mode(field_key, value_id, field_type, pos, clear_unowned) {
 			marked = true
 			continue
 		}
@@ -8313,24 +8117,19 @@ fn (mut tc TypeChecker) ownership_mark_aggregate_literal_storage(target_name str
 	node := tc.a.nodes[int(expr_id)]
 	match node.kind {
 		.array_literal {
-			return tc.ownership_mark_array_literal_elements_with_mode(target_name, expr_id, pos,
-				clear_unowned)
+			return tc.ownership_mark_array_literal_elements_with_mode(target_name, expr_id, pos, clear_unowned)
 		}
 		.array_init {
-			return tc.ownership_mark_array_init_elements_with_mode(target_name, expr_id, pos,
-				clear_unowned)
+			return tc.ownership_mark_array_init_elements_with_mode(target_name, expr_id, pos, clear_unowned)
 		}
 		.map_init {
-			return tc.ownership_mark_map_literal_entries_with_mode(target_name, expr_id, pos,
-				clear_unowned)
+			return tc.ownership_mark_map_literal_entries_with_mode(target_name, expr_id, pos, clear_unowned)
 		}
 		.struct_init {
-			return tc.ownership_mark_struct_literal_fields_with_mode(target_name, expr_id, pos,
-				clear_unowned)
+			return tc.ownership_mark_struct_literal_fields_with_mode(target_name, expr_id, pos, clear_unowned)
 		}
 		.assoc {
-			return tc.ownership_mark_assoc_literal_fields_with_mode(target_name, expr_id, pos,
-				clear_unowned)
+			return tc.ownership_mark_assoc_literal_fields_with_mode(target_name, expr_id, pos, clear_unowned)
 		}
 		else {}
 	}
@@ -8339,8 +8138,7 @@ fn (mut tc TypeChecker) ownership_mark_aggregate_literal_storage(target_name str
 }
 
 fn (mut tc TypeChecker) ownership_mark_storage_from_expr(target_name string, expr_id flat.NodeId, target_type Type, pos flat.NodeId) bool {
-	return tc.ownership_mark_storage_from_expr_with_mode(target_name, expr_id, target_type, pos,
-		true)
+	return tc.ownership_mark_storage_from_expr_with_mode(target_name, expr_id, target_type, pos, true)
 }
 
 fn (mut tc TypeChecker) ownership_mark_storage_from_expr_with_mode(target_name string, expr_id flat.NodeId, target_type Type, pos flat.NodeId, clear_unowned bool) bool {
@@ -8405,8 +8203,7 @@ fn (mut tc TypeChecker) ownership_mark_storage_from_expr_with_mode(target_name s
 		return true
 	}
 	if source_name.len > 0 {
-		moved_types := tc.ownership_move_overlapping_dynamic_storage(source_name, target_name, pos,
-			false, '', true)
+		moved_types := tc.ownership_move_overlapping_dynamic_storage(source_name, target_name, pos, false, '', true)
 		if moved_types.len > 0 {
 			tc.ownership_mark_owned_name(target_name, moved_types[0], pos)
 			return true
@@ -8438,7 +8235,7 @@ fn (mut tc TypeChecker) ownership_alias_borrower(lhs_name string, rhs_name strin
 			if borrow.borrower == rhs_name {
 				aliases << OwnershipBorrowerSnapshot{
 					var_name: var_name
-					borrow:   borrow
+					borrow: borrow
 				}
 			}
 		}
@@ -8467,8 +8264,7 @@ fn (mut tc TypeChecker) ownership_mark_from_conditional_expr(lhs_name string, rh
 		return false
 	}
 	mut moved_sources := []OwnershipConditionalMoveSource{}
-	mut marked := tc.ownership_collect_conditional_result(lhs_name, cond_id, lhs_type, pos, mut
-		moved_sources)
+	mut marked := tc.ownership_collect_conditional_result(lhs_name, cond_id, lhs_type, pos, mut moved_sources)
 	for move in moved_sources {
 		target_name := lhs_name + move.target_suffix
 		tc.ownership_reject_global_move(move.source, pos, target_name, false)
@@ -8500,25 +8296,19 @@ fn (mut tc TypeChecker) ownership_collect_conditional_result(lhs_name string, if
 			mut marked := false
 			if node.children_count > 1 {
 				then_tail := tc.branch_tail_expr_id(tc.a.child(&node, 1))
-				if tc.ownership_collect_expr_result(lhs_name, then_tail, lhs_type, pos, mut
-					moved_sources)
-				{
+				if tc.ownership_collect_expr_result(lhs_name, then_tail, lhs_type, pos, mut moved_sources) {
 					marked = true
 				}
 			}
 			if node.children_count > 2 {
 				else_id := tc.a.child(&node, 2)
 				if tc.valid_node_id(else_id) && tc.a.nodes[int(else_id)].kind == .if_expr {
-					if tc.ownership_collect_conditional_result(lhs_name, else_id, lhs_type, pos, mut
-						moved_sources)
-					{
+					if tc.ownership_collect_conditional_result(lhs_name, else_id, lhs_type, pos, mut moved_sources) {
 						marked = true
 					}
 				} else {
 					else_tail := tc.branch_tail_expr_id(else_id)
-					if tc.ownership_collect_expr_result(lhs_name, else_tail, lhs_type, pos, mut
-						moved_sources)
-					{
+					if tc.ownership_collect_expr_result(lhs_name, else_tail, lhs_type, pos, mut moved_sources) {
 						marked = true
 					}
 				}
@@ -8536,9 +8326,7 @@ fn (mut tc TypeChecker) ownership_collect_conditional_result(lhs_name string, if
 					continue
 				}
 				tail := tc.branch_tail_expr_id(branch_id)
-				if tc.ownership_collect_expr_result(lhs_name, tail, lhs_type, pos, mut
-					moved_sources)
-				{
+				if tc.ownership_collect_expr_result(lhs_name, tail, lhs_type, pos, mut moved_sources) {
 					marked = true
 				}
 			}
@@ -8548,8 +8336,7 @@ fn (mut tc TypeChecker) ownership_collect_conditional_result(lhs_name string, if
 			if node.children_count < 2 || node.value in ['!', '?'] {
 				return false
 			}
-			mut marked := tc.ownership_collect_expr_result(lhs_name, tc.a.child(&node, 0),
-				lhs_type, pos, mut moved_sources)
+			mut marked := tc.ownership_collect_expr_result(lhs_name, tc.a.child(&node, 0), lhs_type, pos, mut moved_sources)
 			tail := tc.branch_tail_expr_id(tc.a.child(&node, 1))
 			if tc.ownership_collect_expr_result(lhs_name, tail, lhs_type, pos, mut moved_sources) {
 				marked = true
@@ -8589,8 +8376,7 @@ fn (mut tc TypeChecker) ownership_collect_expr_result(lhs_name string, expr_id f
 	}
 	node := tc.a.nodes[int(id)]
 	if node.kind in [.if_expr, .match_stmt, .or_expr] {
-		return tc.ownership_collect_conditional_result(lhs_name, id, lhs_type, pos, mut
-			moved_sources)
+		return tc.ownership_collect_conditional_result(lhs_name, id, lhs_type, pos, mut moved_sources)
 	}
 	if tc.ownership_mark_aggregate_literal_storage(lhs_name, id, pos, false) {
 		return true
@@ -8645,7 +8431,7 @@ fn ownership_add_conditional_move_source(mut moved_sources []OwnershipConditiona
 		}
 	}
 	moved_sources << OwnershipConditionalMoveSource{
-		source:        source
+		source: source
 		target_suffix: target_suffix
 	}
 }
@@ -8675,8 +8461,7 @@ fn (mut tc TypeChecker) ownership_after_params_field_arg(node flat.Node, info Ca
 	tc.ownership_mark_fn_param_descendant_from_expr(info.name, param_idx, suffix, arg_id, pos)
 	arg_name := tc.ownership_expr_ident_name(arg_id)
 	if arg_name.len > 0 {
-		tc.ownership_transfer_owned_descendants_to_param_with_suffix(arg_name, info.name,
-			param_idx, suffix, pos)
+		tc.ownership_transfer_owned_descendants_to_param_with_suffix(arg_name, info.name, param_idx, suffix, pos)
 	}
 }
 
@@ -8694,25 +8479,21 @@ fn (mut tc TypeChecker) ownership_consume_conditional_call_arg(fn_name string, p
 	}
 	tmp_name := '${fn_name}__conditional_arg_${param_idx}_${int(pos)}'
 	mut moved_sources := []OwnershipConditionalMoveSource{}
-	mut marked := tc.ownership_collect_conditional_result(tmp_name, id, target_type, pos, mut
-		moved_sources)
+	mut marked := tc.ownership_collect_conditional_result(tmp_name, id, target_type, pos, mut moved_sources)
 	for move in moved_sources {
 		tc.ownership_reject_global_move(move.source, pos, fn_name, true)
 		if tc.ownership_move_var_result(move.source, fn_name, pos, true, fn_name, true) {
-			tc.ownership_mark_call_param_owned(fn_name, param_idx, suffix + move.target_suffix,
-				tc.ownership_type_name_for_var(move.source))
+			tc.ownership_mark_call_param_owned(fn_name, param_idx, suffix + move.target_suffix, tc.ownership_type_name_for_var(move.source))
 			marked = true
 		}
 	}
 	if tmp_name in tc.ownership_state().owned_vars {
-		tc.ownership_mark_call_param_owned(fn_name, param_idx, suffix,
-			tc.ownership_type_name_for_var(tmp_name))
+		tc.ownership_mark_call_param_owned(fn_name, param_idx, suffix, tc.ownership_type_name_for_var(tmp_name))
 		marked = true
 	}
 	for owned_name in tc.ownership_owned_descendant_names(tmp_name) {
 		source_suffix := owned_name[tmp_name.len..]
-		tc.ownership_mark_call_param_owned(fn_name, param_idx, suffix + source_suffix,
-			tc.ownership_type_name_for_var(owned_name))
+		tc.ownership_mark_call_param_owned(fn_name, param_idx, suffix + source_suffix, tc.ownership_type_name_for_var(owned_name))
 		marked = true
 	}
 	tc.ownership_clear_temp_storage(tmp_name)
@@ -8864,9 +8645,7 @@ fn (mut tc TypeChecker) ownership_mark_fn_param_aggregate_literal_descendants(fn
 				}
 			}
 			base_id := tc.a.child(&node, 0)
-			if tc.ownership_mark_fn_param_assoc_base_descendants(fn_name, param_idx, base_suffix,
-				base_id, explicit_fields, pos)
-			{
+			if tc.ownership_mark_fn_param_assoc_base_descendants(fn_name, param_idx, base_suffix, base_id, explicit_fields, pos) {
 				marked = true
 			}
 			for i in 1 .. node.children_count {
@@ -8901,13 +8680,10 @@ fn (mut tc TypeChecker) ownership_mark_fn_param_aggregate_literal_descendants(fn
 fn (mut tc TypeChecker) ownership_mark_fn_param_assoc_base_descendants(fn_name string, param_idx int, base_suffix string, base_id flat.NodeId, explicit_fields map[string]bool, pos flat.NodeId) bool {
 	base_name := tc.ownership_expr_ident_name(base_id)
 	if base_name.len == 0 {
-		if tc.ownership_mark_fn_param_aggregate_literal_descendants(fn_name, param_idx,
-			base_suffix, base_id, pos)
-		{
+		if tc.ownership_mark_fn_param_aggregate_literal_descendants(fn_name, param_idx, base_suffix, base_id, pos) {
 			return true
 		}
-		return tc.ownership_mark_fn_param_descendant_from_expr(fn_name, param_idx, base_suffix,
-			base_id, pos)
+		return tc.ownership_mark_fn_param_descendant_from_expr(fn_name, param_idx, base_suffix, base_id, pos)
 	}
 	mut marked := false
 	mut st := tc.ownership_state()
@@ -8949,8 +8725,7 @@ fn (mut tc TypeChecker) ownership_mark_fn_param_descendant_from_expr(fn_name str
 			return false
 		}
 		tc.ownership_move_var(source_name, fn_name, pos, true, fn_name, true)
-		tc.ownership_add_fn_param_descendant(fn_name, param_idx, suffix,
-			tc.ownership_type_name_for_var(source_name))
+		tc.ownership_add_fn_param_descendant(fn_name, param_idx, suffix, tc.ownership_type_name_for_var(source_name))
 		return true
 	}
 	if source_name.len > 0
@@ -9109,9 +8884,7 @@ fn (mut tc TypeChecker) ownership_mark_return_aggregate_literal_descendants(fn_n
 				}
 			}
 			base_id := tc.a.child(&node, 0)
-			if tc.ownership_mark_return_assoc_base_descendants(fn_name, slot_idx, base_suffix,
-				base_id, explicit_fields, pos)
-			{
+			if tc.ownership_mark_return_assoc_base_descendants(fn_name, slot_idx, base_suffix, base_id, explicit_fields, pos) {
 				marked = true
 			}
 			for i in 1 .. node.children_count {
@@ -9146,13 +8919,10 @@ fn (mut tc TypeChecker) ownership_mark_return_aggregate_literal_descendants(fn_n
 fn (mut tc TypeChecker) ownership_mark_return_assoc_base_descendants(fn_name string, slot_idx int, base_suffix string, base_id flat.NodeId, explicit_fields map[string]bool, pos flat.NodeId) bool {
 	base_name := tc.ownership_expr_ident_name(base_id)
 	if base_name.len == 0 {
-		if tc.ownership_mark_return_aggregate_literal_descendants(fn_name, slot_idx, base_suffix,
-			base_id, pos)
-		{
+		if tc.ownership_mark_return_aggregate_literal_descendants(fn_name, slot_idx, base_suffix, base_id, pos) {
 			return true
 		}
-		return tc.ownership_add_return_descendant_from_expr(fn_name, slot_idx, base_suffix,
-			base_id, pos)
+		return tc.ownership_add_return_descendant_from_expr(fn_name, slot_idx, base_suffix, base_id, pos)
 	}
 	mut marked := false
 	mut st := tc.ownership_state()
@@ -9236,8 +9006,7 @@ fn (mut tc TypeChecker) ownership_after_call(id flat.NodeId, node flat.Node, inf
 				&& !tc.ownership_string_builtin_keeps_receiver(recv_id, fn_node.value) {
 				if info.params[0] is Pointer {
 					if recv_name.len > 0 && tc.ownership_storage_participates(recv_name) {
-						tc.ownership_add_borrow(recv_name, call_name, id, tc.ownership_call_param_is_mut(call_name,
-							0))
+						tc.ownership_add_borrow(recv_name, call_name, id, tc.ownership_call_param_is_mut(call_name, 0))
 						call_borrows << recv_name
 					}
 				} else if recv_requires_move {
@@ -9245,26 +9014,21 @@ fn (mut tc TypeChecker) ownership_after_call(id flat.NodeId, node flat.Node, inf
 						tc.ownership_reject_global_move(recv_name, id, call_name, true)
 						if recv_name in st.owned_vars {
 							descendants := tc.ownership_owned_descendant_names(recv_name)
-							if tc.ownership_move_var_result(recv_name, call_name, id, true,
-								call_name, true)
-							{
+							if tc.ownership_move_var_result(recv_name, call_name, id, true, call_name, true) {
 								st.ownership_fn_params['${call_name}__param_0'] = true
 								for source_name in descendants {
 									suffix := source_name[recv_name.len..]
-									tc.ownership_add_fn_param_descendant(call_name, 0, suffix,
-										tc.ownership_type_name_for_var(source_name))
+									tc.ownership_add_fn_param_descendant(call_name, 0, suffix, tc.ownership_type_name_for_var(source_name))
 									st.owned_vars.delete(source_name)
 									st.owned_var_types.delete(source_name)
 									st.moved_vars.delete(source_name)
 								}
 							}
 						} else {
-							tc.ownership_transfer_owned_descendants_to_param(recv_name, call_name,
-								0, id)
+							tc.ownership_transfer_owned_descendants_to_param(recv_name, call_name, 0, id)
 						}
 					} else {
-						_ := tc.ownership_consume_conditional_call_arg(call_name, 0, '', recv_id,
-							recv_type, id)
+						_ := tc.ownership_consume_conditional_call_arg(call_name, 0, '', recv_id, recv_type, id)
 					}
 				}
 			}
@@ -9274,15 +9038,13 @@ fn (mut tc TypeChecker) ownership_after_call(id flat.NodeId, node flat.Node, inf
 		arg_node := tc.a.child_node(&node, i)
 		arg_id := tc.call_arg_value(tc.a.child(&node, i))
 		if arg_node.kind == .field_init {
-			tc.ownership_after_params_field_arg(node, info, arg_node, arg_id, id, call_name, mut
-				call_borrows)
+			tc.ownership_after_params_field_arg(node, info, arg_node, arg_id, id, call_name, mut call_borrows)
 			continue
 		}
 		param_idx := tc.ownership_call_arg_decl_param_idx(info, i)
 		type_param_idx := param_idx + tc.ownership_call_arg_shift(node, info)
 		variadic_elem_idx := tc.ownership_call_arg_variadic_elem_idx(info, type_param_idx)
-		target_param_idx := tc.ownership_call_arg_variadic_decl_param_idx(param_idx,
-			variadic_elem_idx)
+		target_param_idx := tc.ownership_call_arg_variadic_decl_param_idx(param_idx, variadic_elem_idx)
 		target_suffix := ownership_call_arg_variadic_suffix(variadic_elem_idx)
 		expected := tc.ownership_call_arg_expected_type(info, type_param_idx, variadic_elem_idx)
 		if tc.ownership_mark_array_insert_prepend_arg(node, call_name, param_idx, arg_id, id) {
@@ -9296,7 +9058,11 @@ fn (mut tc TypeChecker) ownership_after_call(id flat.NodeId, node flat.Node, inf
 		if tc.ownership_prepare_receiver_alias_arg_clone(node, info, arg_id, expected) {
 			continue
 		}
-		borrow_param_idx := if variadic_elem_idx >= 0 { info.params.len - 1 } else { type_param_idx }
+		borrow_param_idx := if variadic_elem_idx >= 0 {
+			info.params.len - 1
+		} else {
+			type_param_idx
+		}
 		borrow_name := if expected is Pointer {
 			explicit := tc.ownership_borrowed_name(arg_id)
 			if explicit.len > 0 {
@@ -9318,8 +9084,7 @@ fn (mut tc TypeChecker) ownership_after_call(id flat.NodeId, node flat.Node, inf
 			}
 		}
 		if borrow_name.len > 0 && tc.ownership_storage_participates(borrow_name) {
-			tc.ownership_add_borrow(borrow_name, call_name, id, tc.ownership_call_param_is_mut(call_name,
-				borrow_param_idx))
+			tc.ownership_add_borrow(borrow_name, call_name, id, tc.ownership_call_param_is_mut(call_name, borrow_param_idx))
 			call_borrows << borrow_name
 			continue
 		}
@@ -9336,13 +9101,10 @@ fn (mut tc TypeChecker) ownership_after_call(id flat.NodeId, node flat.Node, inf
 				if tc.ownership_consume_array_element_method_result(arg_id, call_name, arg_id) {
 					continue
 				}
-				if tc.ownership_consume_conditional_call_arg(call_name, target_param_idx,
-					target_suffix, arg_id, expected, arg_id)
-				{
+				if tc.ownership_consume_conditional_call_arg(call_name, target_param_idx, target_suffix, arg_id, expected, arg_id) {
 					continue
 				}
-				tc.ownership_mark_fn_param_aggregate_literal_descendants(call_name,
-					target_param_idx, target_suffix, arg_id, arg_id)
+				tc.ownership_mark_fn_param_aggregate_literal_descendants(call_name, target_param_idx, target_suffix, arg_id, arg_id)
 			}
 			continue
 		}
@@ -9377,8 +9139,7 @@ fn (mut tc TypeChecker) ownership_after_call(id flat.NodeId, node flat.Node, inf
 			if tc.ownership_move_var_result(arg_name, call_name, arg_id, true, call_name, true) {
 				moved_base = true
 				if variadic_elem_idx >= 0 {
-					tc.ownership_add_fn_param_descendant(call_name, target_param_idx,
-						target_suffix, type_name)
+					tc.ownership_add_fn_param_descendant(call_name, target_param_idx, target_suffix, type_name)
 				} else {
 					key := '${call_name}__param_${param_idx}'
 					st.ownership_fn_params[key] = true
@@ -9387,20 +9148,17 @@ fn (mut tc TypeChecker) ownership_after_call(id flat.NodeId, node flat.Node, inf
 					suffix := source_name[arg_name.len..]
 					target_name := target_suffix + suffix
 					descendant_type_name := tc.ownership_type_name_for_var(source_name)
-					tc.ownership_add_fn_param_descendant(call_name, target_param_idx, target_name,
-						descendant_type_name)
+					tc.ownership_add_fn_param_descendant(call_name, target_param_idx, target_name, descendant_type_name)
 					st.owned_vars.delete(source_name)
 					st.owned_var_types.delete(source_name)
 					st.moved_vars.delete(source_name)
 				}
 			}
 		} else {
-			moved_types := tc.ownership_move_overlapping_dynamic_storage(arg_name, call_name,
-				arg_id, true, call_name, true)
+			moved_types := tc.ownership_move_overlapping_dynamic_storage(arg_name, call_name, arg_id, true, call_name, true)
 			if moved_types.len > 0 {
 				if variadic_elem_idx >= 0 {
-					tc.ownership_add_fn_param_descendant(call_name, target_param_idx,
-						target_suffix, moved_types[0])
+					tc.ownership_add_fn_param_descendant(call_name, target_param_idx, target_suffix, moved_types[0])
 				} else {
 					key := '${call_name}__param_${param_idx}'
 					st.ownership_fn_params[key] = true
@@ -9408,8 +9166,7 @@ fn (mut tc TypeChecker) ownership_after_call(id flat.NodeId, node flat.Node, inf
 			}
 		}
 		if expected !is Void && expected !is Pointer && !moved_base {
-			tc.ownership_transfer_owned_descendants_to_param_with_suffix(arg_name, call_name,
-				target_param_idx, target_suffix, arg_id)
+			tc.ownership_transfer_owned_descendants_to_param_with_suffix(arg_name, call_name, target_param_idx, target_suffix, arg_id)
 		}
 	}
 	for name in call_borrows {
@@ -9454,9 +9211,7 @@ fn (mut tc TypeChecker) ownership_prepare_receiver_alias_arg_clone(node flat.Nod
 	}
 	arg_type := tc.resolve_type(arg_id)
 	if bad_type := tc.ownership_default_clone_missing_method(arg_type) {
-		tc.record_error(.call_arg_mismatch,
-			'cannot copy receiver-aliased `${arg_type.name()}` value: `${bad_type}` requires ownership destruction but has no compatible `clone()` method; implement `IClone` or use a pointer',
-			arg_id)
+		tc.record_error(.call_arg_mismatch, 'cannot copy receiver-aliased `${arg_type.name()}` value: `${bad_type}` requires ownership destruction but has no compatible `clone()` method; implement `IClone` or use a pointer', arg_id)
 		return true
 	}
 	tc.ownership_state().receiver_alias_clone_reads[int(arg_id)] = true
@@ -9508,10 +9263,9 @@ fn (mut tc TypeChecker) ownership_consume_method_value_receiver(arg_id flat.Node
 	}
 	if info.params[0] is Pointer {
 		if tc.ownership_storage_participates(recv_name) {
-			tc.ownership_add_borrow(recv_name, call_name, pos, tc.ownership_call_param_is_mut(info.name,
-				0))
+			tc.ownership_add_borrow(recv_name, call_name, pos, tc.ownership_call_param_is_mut(info.name, 0))
 			return OwnershipMethodValueReceiverResult{
-				consumed:    true
+				consumed: true
 				borrow_name: recv_name
 			}
 		}
@@ -9524,8 +9278,7 @@ fn (mut tc TypeChecker) ownership_consume_method_value_receiver(arg_id flat.Node
 	if recv_name in st.owned_vars {
 		tc.ownership_move_var(recv_name, call_name, pos, true, call_name, true)
 	} else {
-		_ := tc.ownership_move_overlapping_dynamic_storage(recv_name, call_name, pos, true,
-			call_name, true)
+		_ := tc.ownership_move_overlapping_dynamic_storage(recv_name, call_name, pos, true, call_name, true)
 	}
 	return OwnershipMethodValueReceiverResult{
 		consumed: true
@@ -9537,8 +9290,7 @@ fn (mut tc TypeChecker) ownership_method_value_call_info(node flat.Node, recv_id
 		return none
 	}
 	recv_type := tc.resolve_type(recv_id)
-	for method_name in receiver_method_name_candidates(unwrap_pointer(recv_type), node.value,
-		tc.cur_module) {
+	for method_name in receiver_method_name_candidates(unwrap_pointer(recv_type), node.value, tc.cur_module) {
 		if method_name !in tc.fn_param_types {
 			continue
 		}
@@ -9647,8 +9399,7 @@ fn (mut tc TypeChecker) ownership_after_return(id flat.NodeId, node flat.Node) {
 						suffix := source_name[name.len..]
 						type_name := tc.ownership_type_name_for_var(source_name)
 						for slot_idx in return_slots {
-							tc.ownership_add_fn_return_descendant(st.cur_fn, slot_idx, suffix,
-								type_name)
+							tc.ownership_add_fn_return_descendant(st.cur_fn, slot_idx, suffix, type_name)
 						}
 						st.owned_vars.delete(source_name)
 						st.owned_var_types.delete(source_name)
@@ -9662,8 +9413,7 @@ fn (mut tc TypeChecker) ownership_after_return(id flat.NodeId, node flat.Node) {
 			}
 		}
 		if name.len > 0 && name !in st.owned_vars {
-			moved_types := tc.ownership_move_overlapping_dynamic_storage(name, st.cur_fn, id, true,
-				st.cur_fn, false)
+			moved_types := tc.ownership_move_overlapping_dynamic_storage(name, st.cur_fn, id, true, st.cur_fn, false)
 			if moved_types.len > 0 {
 				st.mark_fn_return_owned(st.cur_fn)
 				for slot_idx in tc.ownership_return_slot_indices(expr_id, i, '') {
@@ -9771,8 +9521,7 @@ fn (mut tc TypeChecker) ownership_mark_return_from_array_element_method(fn_name 
 				marked = true
 			}
 		} else {
-			moved_types := tc.ownership_move_overlapping_dynamic_storage(source_key, fn_name, pos,
-				true, fn_name, false)
+			moved_types := tc.ownership_move_overlapping_dynamic_storage(source_key, fn_name, pos, true, fn_name, false)
 			if moved_types.len > 0 {
 				tc.ownership_add_fn_return_slot(fn_name, return_slot)
 				st.mark_fn_return_owned(fn_name)
@@ -9802,8 +9551,7 @@ fn (mut tc TypeChecker) ownership_move_conditional_return_sources(fn_name string
 	}
 	tmp_name := '${fn_name}__return_conditional_${slot_idx}_${int(pos)}'
 	mut moved_sources := []OwnershipConditionalMoveSource{}
-	mut marked := tc.ownership_collect_conditional_result(tmp_name, cond_id,
-		tc.resolve_type(cond_id), pos, mut moved_sources)
+	mut marked := tc.ownership_collect_conditional_result(tmp_name, cond_id, tc.resolve_type(cond_id), pos, mut moved_sources)
 	mut st := tc.ownership_state()
 	for move in moved_sources {
 		tc.ownership_reject_global_move(move.source, pos, fn_name, true)
@@ -9814,8 +9562,7 @@ fn (mut tc TypeChecker) ownership_move_conditional_return_sources(fn_name string
 				if move.target_suffix.len == 0 {
 					tc.ownership_add_fn_return_slot(fn_name, return_slot)
 				} else {
-					tc.ownership_add_fn_return_descendant(fn_name, return_slot, move.target_suffix,
-						type_name)
+					tc.ownership_add_fn_return_descendant(fn_name, return_slot, move.target_suffix, type_name)
 				}
 			}
 			marked = true
@@ -9915,8 +9662,7 @@ fn (mut tc TypeChecker) ownership_consume_conditional_expr(expr_id flat.NodeId, 
 	}
 	tmp_name := '${tc.ownership_state().cur_fn}__conditional_sink_${int(at)}'
 	mut moved_sources := []OwnershipConditionalMoveSource{}
-	mut consumed := tc.ownership_collect_conditional_result(tmp_name, id, tc.resolve_type(id), at, mut
-		moved_sources)
+	mut consumed := tc.ownership_collect_conditional_result(tmp_name, id, tc.resolve_type(id), at, mut moved_sources)
 	for move in moved_sources {
 		tc.ownership_reject_global_move(move.source, at, target, false)
 		if tc.ownership_move_var_result(move.source, target, at, false, '', false) {
@@ -9967,8 +9713,7 @@ fn (mut tc TypeChecker) ownership_consume_array_element_method_result(expr_id fl
 		tc.ownership_reject_global_move(source_key, pos, target, false)
 		tc.ownership_move_var(source_key, target, pos, false, '', false)
 	} else {
-		_ := tc.ownership_move_overlapping_dynamic_storage(source_key, target, pos, false, '',
-			false)
+		_ := tc.ownership_move_overlapping_dynamic_storage(source_key, target, pos, false, '', false)
 	}
 	tc.ownership_update_array_length_after_element_method(array_name, method)
 	tc.ownership_clear_removed_array_element_after_method(array_name, source_key, method)
@@ -10005,9 +9750,7 @@ fn (mut tc TypeChecker) ownership_mark_return_param_descendants_from_call(lhs_na
 		if desc.slot_idx != slot_idx {
 			continue
 		}
-		if tc.ownership_mark_from_return_param_descendant(lhs_name + desc.target_suffix, call_id,
-			node, fn_name, desc, pos)
-		{
+		if tc.ownership_mark_from_return_param_descendant(lhs_name + desc.target_suffix, call_id, node, fn_name, desc, pos) {
 			marked = true
 		}
 	}
@@ -10018,19 +9761,16 @@ fn (mut tc TypeChecker) ownership_mark_from_return_param_descendant(target_name 
 	if target_name.len == 0 || desc.param_idx < 0 {
 		return false
 	}
-	source := tc.ownership_call_arg_for_return_param_source(call_id, node, desc.param_idx,
-		desc.source_suffix) or { return false }
+	source := tc.ownership_call_arg_for_return_param_source(call_id, node, desc.param_idx, desc.source_suffix) or { return false }
 	arg_id := source.arg_id
 	source_suffix := source.source_suffix
 	arg_name := tc.ownership_expr_ident_name(arg_id)
 	if source_suffix.len == 0 {
 		if arg_name.len == 0 {
-			return tc.ownership_mark_storage_from_expr(target_name, arg_id,
-				tc.resolve_type(arg_id), pos)
+			return tc.ownership_mark_storage_from_expr(target_name, arg_id, tc.resolve_type(arg_id), pos)
 		}
 		if arg_name in tc.ownership_state().owned_vars {
-			tc.ownership_mark_owned(target_name, tc.ownership_type_for_name(arg_name,
-				tc.resolve_type(arg_id)), pos)
+			tc.ownership_mark_owned(target_name, tc.ownership_type_for_name(arg_name, tc.resolve_type(arg_id)), pos)
 			return true
 		}
 		if info := tc.ownership_state().moved_vars[arg_name] {
@@ -10042,8 +9782,7 @@ fn (mut tc TypeChecker) ownership_mark_from_return_param_descendant(target_name 
 		return false
 	}
 	if arg_name.len == 0 {
-		return tc.ownership_mark_from_return_param_arg_projection(target_name, arg_id,
-			source_suffix, fn_name, pos)
+		return tc.ownership_mark_from_return_param_arg_projection(target_name, arg_id, source_suffix, fn_name, pos)
 	}
 	source_name := arg_name + source_suffix
 	if source_name in tc.ownership_state().owned_vars {
@@ -10079,22 +9818,18 @@ fn (mut tc TypeChecker) ownership_mark_from_return_param_arg_projection(target_n
 		}
 		if field_id := tc.ownership_aggregate_field_expr(id, field_name) {
 			if rest.len == 0 {
-				return tc.ownership_mark_from_return_param_source_expr(target_name, field_id,
-					fn_name, pos)
+				return tc.ownership_mark_from_return_param_source_expr(target_name, field_id, fn_name, pos)
 			}
-			return tc.ownership_mark_from_return_param_arg_projection(target_name, field_id, rest,
-				fn_name, pos)
+			return tc.ownership_mark_from_return_param_arg_projection(target_name, field_id, rest, fn_name, pos)
 		}
 	}
 	index_part, rest := ownership_split_first_index_suffix(source_suffix)
 	if index_part.len > 0 {
 		if elem_id := tc.ownership_aggregate_index_expr(id, index_part) {
 			if rest.len == 0 {
-				return tc.ownership_mark_from_return_param_source_expr(target_name, elem_id,
-					fn_name, pos)
+				return tc.ownership_mark_from_return_param_source_expr(target_name, elem_id, fn_name, pos)
 			}
-			return tc.ownership_mark_from_return_param_arg_projection(target_name, elem_id, rest,
-				fn_name, pos)
+			return tc.ownership_mark_from_return_param_arg_projection(target_name, elem_id, rest, fn_name, pos)
 		}
 	}
 	return false
@@ -10126,8 +9861,7 @@ fn (mut tc TypeChecker) ownership_mark_from_return_param_source_expr(target_name
 				return true
 			}
 		}
-		moved_types := tc.ownership_move_overlapping_dynamic_storage(source_name, target_name, pos,
-			false, '', true)
+		moved_types := tc.ownership_move_overlapping_dynamic_storage(source_name, target_name, pos, false, '', true)
 		if moved_types.len > 0 {
 			tc.ownership_mark_owned_name(target_name, moved_types[0], pos)
 			return true
@@ -10305,8 +10039,7 @@ fn (mut tc TypeChecker) ownership_mark_return_projection_from_call(lhs_name stri
 	if projection.suffix.len == 0 {
 		return false
 	}
-	return tc.ownership_mark_return_projection_from_call_suffix(lhs_name, projection.call_id,
-		projection.suffix, pos)
+	return tc.ownership_mark_return_projection_from_call_suffix(lhs_name, projection.call_id, projection.suffix, pos)
 }
 
 fn (mut tc TypeChecker) ownership_mark_return_projection_from_call_suffix(lhs_name string, call_id flat.NodeId, projection_suffix string, pos flat.NodeId) bool {
@@ -10336,8 +10069,7 @@ fn (mut tc TypeChecker) ownership_mark_return_projection_from_call_suffix(lhs_na
 			continue
 		}
 		if ownership_storage_key_is_descendant(desc.suffix, projection_suffix) {
-			tc.ownership_mark_owned_name(lhs_name + desc.suffix[projection_suffix.len..],
-				desc.type_name, pos)
+			tc.ownership_mark_owned_name(lhs_name + desc.suffix[projection_suffix.len..], desc.type_name, pos)
 			marked = true
 		}
 	}
@@ -10351,18 +10083,14 @@ fn (mut tc TypeChecker) ownership_mark_return_projection_from_call_suffix(lhs_na
 		if desc.target_suffix == projection_suffix
 			|| ownership_storage_keys_dynamic_overlap(desc.target_suffix, projection_suffix)
 			|| ownership_storage_keys_dynamic_overlap(projection_suffix, desc.target_suffix) {
-			if tc.ownership_mark_from_return_param_descendant(lhs_name, call_id, call_node,
-				fn_name, desc, pos)
-			{
+			if tc.ownership_mark_from_return_param_descendant(lhs_name, call_id, call_node, fn_name, desc, pos) {
 				marked = true
 			}
 			continue
 		}
 		if ownership_storage_key_is_descendant(desc.target_suffix, projection_suffix) {
 			target_name := lhs_name + desc.target_suffix[projection_suffix.len..]
-			if tc.ownership_mark_from_return_param_descendant(target_name, call_id, call_node,
-				fn_name, desc, pos)
-			{
+			if tc.ownership_mark_from_return_param_descendant(target_name, call_id, call_node, fn_name, desc, pos) {
 				marked = true
 			}
 		}
@@ -10380,7 +10108,7 @@ fn (tc &TypeChecker) ownership_call_projection(id flat.NodeId) ?OwnershipCallPro
 		.call {
 			return OwnershipCallProjection{
 				call_id: clean_id
-				suffix:  ''
+				suffix: ''
 			}
 		}
 		.selector {
@@ -10390,7 +10118,7 @@ fn (tc &TypeChecker) ownership_call_projection(id flat.NodeId) ?OwnershipCallPro
 			base := tc.ownership_call_projection(tc.a.child(&node, 0)) or { return none }
 			return OwnershipCallProjection{
 				call_id: base.call_id
-				suffix:  base.suffix + '.${node.value}'
+				suffix: base.suffix + '.${node.value}'
 			}
 		}
 		.index {
@@ -10404,7 +10132,7 @@ fn (tc &TypeChecker) ownership_call_projection(id flat.NodeId) ?OwnershipCallPro
 			base := tc.ownership_call_projection(tc.a.child(&node, 0)) or { return none }
 			return OwnershipCallProjection{
 				call_id: base.call_id
-				suffix:  base.suffix + '[${key_part}]'
+				suffix: base.suffix + '[${key_part}]'
 			}
 		}
 		else {}
@@ -10440,9 +10168,7 @@ fn (mut tc TypeChecker) ownership_mark_from_call(lhs_name string, rhs_id flat.No
 		return true
 	}
 	fn_name := tc.ownership_call_name(call_id)
-	if tc.ownership_mark_return_param_descendants_from_call(lhs_name, call_id, node, fn_name, 0,
-		pos)
-	{
+	if tc.ownership_mark_return_param_descendants_from_call(lhs_name, call_id, node, fn_name, 0, pos) {
 		return true
 	}
 	if tc.ownership_mark_return_descendants_from_call(lhs_name, fn_name, 0, pos) {
@@ -10498,8 +10224,7 @@ fn (mut tc TypeChecker) ownership_mark_from_array_element_method(lhs_name string
 			marked = true
 		}
 	} else {
-		moved_types := tc.ownership_move_overlapping_dynamic_storage(source_key, lhs_name, pos,
-			false, '', true)
+		moved_types := tc.ownership_move_overlapping_dynamic_storage(source_key, lhs_name, pos, false, '', true)
 		if moved_types.len > 0 {
 			tc.ownership_mark_owned_name(lhs_name, moved_types[0], pos)
 			marked = true
@@ -10601,8 +10326,7 @@ fn (mut tc TypeChecker) ownership_mark_borrow_from_call_return(lhs_name string, 
 		mut st := tc.ownership_state()
 		st.owned_vars.delete(lhs_name)
 		st.owned_var_types.delete(lhs_name)
-		tc.ownership_add_borrow(borrow_name, lhs_name, pos, tc.ownership_call_param_is_mut(call_name,
-			param_idx))
+		tc.ownership_add_borrow(borrow_name, lhs_name, pos, tc.ownership_call_param_is_mut(call_name, param_idx))
 		return true
 	}
 	return false
@@ -10618,8 +10342,7 @@ fn (mut tc TypeChecker) ownership_mark_from_return_param(lhs_name string, call_i
 		return tc.ownership_mark_storage_from_expr(lhs_name, arg_id, tc.resolve_type(arg_id), pos)
 	}
 	if arg_name in tc.ownership_state().owned_vars {
-		tc.ownership_mark_owned(lhs_name, tc.ownership_type_for_name(arg_name,
-			tc.resolve_type(arg_id)), pos)
+		tc.ownership_mark_owned(lhs_name, tc.ownership_type_for_name(arg_name, tc.resolve_type(arg_id)), pos)
 		return true
 	}
 	if info := tc.ownership_state().moved_vars[arg_name] {
@@ -10647,7 +10370,7 @@ fn (mut tc TypeChecker) ownership_call_arg_for_return_param_source(call_id flat.
 		arg_child_idx := param_idx + 1
 		if arg_child_idx < node.children_count {
 			return OwnershipReturnParamArg{
-				arg_id:        tc.call_arg_value(tc.a.child(&node, arg_child_idx))
+				arg_id: tc.call_arg_value(tc.a.child(&node, arg_child_idx))
 				source_suffix: source_suffix
 			}
 		}
@@ -10669,7 +10392,7 @@ fn (tc &TypeChecker) ownership_call_arg_for_return_param_source_info(node flat.N
 			fn_node := tc.a.child_node(&node, 0)
 			if fn_node.kind == .selector && fn_node.children_count > 0 {
 				return OwnershipReturnParamArg{
-					arg_id:        tc.a.child(fn_node, 0)
+					arg_id: tc.a.child(fn_node, 0)
 					source_suffix: source_suffix
 				}
 			}
@@ -10686,7 +10409,7 @@ fn (tc &TypeChecker) ownership_call_arg_for_return_param_source_info(node flat.N
 					if arg_node.kind == .field_init && arg_node.value == field_name
 						&& arg_node.children_count > 0 {
 						return OwnershipReturnParamArg{
-							arg_id:        tc.call_arg_value(tc.a.child(&node, i))
+							arg_id: tc.call_arg_value(tc.a.child(&node, i))
 							source_suffix: rest
 						}
 					}
@@ -10703,8 +10426,7 @@ fn (tc &TypeChecker) ownership_call_arg_for_return_param_source_info(node flat.N
 		raw_param_idx := tc.ownership_call_arg_decl_param_idx(info, i)
 		type_param_idx := raw_param_idx + arg_shift
 		variadic_elem_idx := tc.ownership_call_arg_variadic_elem_idx(info, type_param_idx)
-		target_param_idx := tc.ownership_call_arg_variadic_decl_param_idx(raw_param_idx,
-			variadic_elem_idx)
+		target_param_idx := tc.ownership_call_arg_variadic_decl_param_idx(raw_param_idx, variadic_elem_idx)
 		if target_param_idx != param_idx {
 			continue
 		}
@@ -10712,20 +10434,20 @@ fn (tc &TypeChecker) ownership_call_arg_for_return_param_source_info(node flat.N
 		if target_suffix.len > 0 {
 			if source_suffix == target_suffix {
 				return OwnershipReturnParamArg{
-					arg_id:        tc.call_arg_value(tc.a.child(&node, i))
+					arg_id: tc.call_arg_value(tc.a.child(&node, i))
 					source_suffix: ''
 				}
 			}
 			if ownership_storage_key_is_descendant(source_suffix, target_suffix) {
 				return OwnershipReturnParamArg{
-					arg_id:        tc.call_arg_value(tc.a.child(&node, i))
+					arg_id: tc.call_arg_value(tc.a.child(&node, i))
 					source_suffix: source_suffix[target_suffix.len..]
 				}
 			}
 			continue
 		}
 		return OwnershipReturnParamArg{
-			arg_id:        tc.call_arg_value(tc.a.child(&node, i))
+			arg_id: tc.call_arg_value(tc.a.child(&node, i))
 			source_suffix: source_suffix
 		}
 	}
@@ -10915,7 +10637,7 @@ pub fn (mut tc TypeChecker) ownership_call_result_source_args(id flat.NodeId) []
 	for desc in tc.ownership_state().ownership_fn_return_param_descs[call_name] {
 		if projection.suffix.len > 0 && (desc.slot_idx != 0
 			|| (desc.target_suffix.len > 0
-			&& !ownership_storage_keys_overlap(desc.target_suffix, projection.suffix))) {
+				&& !ownership_storage_keys_overlap(desc.target_suffix, projection.suffix))) {
 			continue
 		}
 		if desc.param_idx !in param_indices {
@@ -10969,7 +10691,7 @@ pub fn (mut tc TypeChecker) ownership_call_result_sources(id flat.NodeId) []Owne
 	for slot in tc.ownership_state().ownership_fn_return_params[call_name] {
 		if arg_id := tc.ownership_call_arg_for_return_param_info(node, info, slot.param_idx) {
 			candidate := OwnershipCallResultSource{
-				arg_id:        arg_id
+				arg_id: arg_id
 				target_suffix: if is_multi_return { '[${slot.slot_idx}]' } else { '' }
 			}
 			if candidate !in result {
@@ -10978,11 +10700,10 @@ pub fn (mut tc TypeChecker) ownership_call_result_sources(id flat.NodeId) []Owne
 		}
 	}
 	for desc in tc.ownership_state().ownership_fn_return_param_descs[call_name] {
-		source := tc.ownership_call_arg_for_return_param_source_info(node, info, desc.param_idx,
-			desc.source_suffix) or { continue }
+		source := tc.ownership_call_arg_for_return_param_source_info(node, info, desc.param_idx, desc.source_suffix) or { continue }
 		slot_prefix := if is_multi_return { '[${desc.slot_idx}]' } else { '' }
 		candidate := OwnershipCallResultSource{
-			arg_id:        source.arg_id
+			arg_id: source.arg_id
 			source_suffix: source.source_suffix
 			target_suffix: slot_prefix + desc.target_suffix
 		}
@@ -11109,8 +10830,7 @@ fn (tc &TypeChecker) ownership_rhs_borrows_indexed_storage(rhs_id flat.NodeId) b
 	if rhs_name.len == 0 {
 		return false
 	}
-	return ownership_alias_chain_borrows_indexed_storage(tc.ownership.pointer_index_aliases,
-		rhs_name)
+	return ownership_alias_chain_borrows_indexed_storage(tc.ownership.pointer_index_aliases, rhs_name)
 }
 
 fn ownership_alias_chain_borrows_indexed_storage(aliases map[string]string, rhs_name string) bool {
@@ -11411,11 +11131,11 @@ fn (mut tc TypeChecker) ownership_move_var_result(name string, target string, po
 	st.owned_vars.delete(name)
 	st.owned_var_types.delete(name)
 	st.moved_vars[name] = MovedVar{
-		moved_to:      target
-		move_pos:      pos
-		is_fn_call:    is_fn_call
-		fn_name:       if fn_name.len > 0 { fn_name } else { target }
-		type_name:     tname
+		moved_to: target
+		move_pos: pos
+		is_fn_call: is_fn_call
+		fn_name: if fn_name.len > 0 { fn_name } else { target }
+		type_name: tname
 		suggest_clone: suggest_clone
 	}
 	return true
@@ -11534,9 +11254,7 @@ fn (mut tc TypeChecker) ownership_borrowed_projection_action(id flat.NodeId, pos
 	typ := tc.resolve_type(clean_id)
 	mut action := OwnershipBorrowedProjectionAction.clone_value
 	if bad_type := tc.ownership_default_clone_missing_method(typ) {
-		tc.record_error(.assignment_mismatch,
-			'cannot copy borrowed `${typ.name()}` value: `${bad_type}` requires ownership destruction but has no compatible `clone()` method; implement `IClone` or use a pointer',
-			pos)
+		tc.record_error(.assignment_mismatch, 'cannot copy borrowed `${typ.name()}` value: `${bad_type}` requires ownership destruction but has no compatible `clone()` method; implement `IClone` or use a pointer', pos)
 		action = .reject_copy
 	}
 	st.borrowed_projection_actions[int(id)] = action
@@ -11741,7 +11459,7 @@ fn (mut tc TypeChecker) ownership_borrow_conflict(name string) ?OwnershipBorrowC
 	if borrows := st.borrowed_vars[name] {
 		if borrows.len > 0 {
 			return OwnershipBorrowConflict{
-				name:   name
+				name: name
 				borrow: borrows[0]
 			}
 		}
@@ -11752,7 +11470,7 @@ fn (mut tc TypeChecker) ownership_borrow_conflict(name string) ?OwnershipBorrowC
 		}
 		if ownership_storage_keys_overlap(name, borrowed_name) {
 			return OwnershipBorrowConflict{
-				name:   borrowed_name
+				name: borrowed_name
 				borrow: borrows[0]
 			}
 		}
@@ -11819,13 +11537,10 @@ fn (mut tc TypeChecker) ownership_add_borrow(var_name string, borrower string, p
 			} else {
 				'cannot borrow `${var_name}` as mutable because `${conflict.name}` is borrowed as immutable'
 			}
-			tc.record_error(.assignment_mismatch,
-				'${msg}; previous borrow by `${conflict.borrow.borrower}`', pos)
+			tc.record_error(.assignment_mismatch, '${msg}; previous borrow by `${conflict.borrow.borrower}`', pos)
 			return
 		}
-		tc.record_error(.assignment_mismatch,
-			'cannot borrow `${var_name}` as immutable because `${conflict.name}` is borrowed as mutable by `${conflict.borrow.borrower}`',
-			pos)
+		tc.record_error(.assignment_mismatch, 'cannot borrow `${var_name}` as immutable because `${conflict.name}` is borrowed as mutable by `${conflict.borrow.borrower}`', pos)
 		return
 	}
 	mut st := tc.ownership_state()
@@ -11837,16 +11552,13 @@ fn (mut tc TypeChecker) ownership_add_borrow(var_name string, borrower string, p
 			} else {
 				'cannot borrow `${var_name}` as mutable because it is also borrowed as immutable'
 			}
-			tc.record_error(.assignment_mismatch,
-				'${msg}; previous borrow by `${borrow.borrower}`', pos)
+			tc.record_error(.assignment_mismatch, '${msg}; previous borrow by `${borrow.borrower}`', pos)
 			return
 		}
 		if !is_mut {
 			for borrow in existing {
 				if borrow.is_mut {
-					tc.record_error(.assignment_mismatch,
-						'cannot borrow `${var_name}` as immutable because it is borrowed as mutable by `${borrow.borrower}`',
-						pos)
+					tc.record_error(.assignment_mismatch, 'cannot borrow `${var_name}` as immutable because it is borrowed as mutable by `${borrow.borrower}`', pos)
 					return
 				}
 			}
@@ -11854,8 +11566,8 @@ fn (mut tc TypeChecker) ownership_add_borrow(var_name string, borrower string, p
 		mut updated := existing.clone()
 		updated << BorrowInfo{
 			borrower: borrower
-			pos:      pos
-			is_mut:   is_mut
+			pos: pos
+			is_mut: is_mut
 		}
 		st.borrowed_vars[var_name] = updated
 		return
@@ -11863,8 +11575,8 @@ fn (mut tc TypeChecker) ownership_add_borrow(var_name string, borrower string, p
 	st.borrowed_vars[var_name] = [
 		BorrowInfo{
 			borrower: borrower
-			pos:      pos
-			is_mut:   is_mut
+			pos: pos
+			is_mut: is_mut
 		},
 	]
 }
@@ -11881,7 +11593,7 @@ fn (mut tc TypeChecker) ownership_overlapping_borrow_conflict(var_name string, i
 		for borrow in borrows {
 			if is_mut || borrow.is_mut {
 				return OwnershipBorrowConflict{
-					name:   borrowed_name
+					name: borrowed_name
 					borrow: borrow
 				}
 			}
@@ -11921,7 +11633,7 @@ fn (mut tc TypeChecker) ownership_borrower_snapshot(borrower string) []Ownership
 				|| ownership_storage_key_is_descendant(borrow.borrower, borrower) {
 				out << OwnershipBorrowerSnapshot{
 					var_name: var_name
-					borrow:   borrow
+					borrow: borrow
 				}
 			}
 		}
@@ -11957,15 +11669,11 @@ fn (mut tc TypeChecker) ownership_release_borrower(borrower string) {
 fn (mut tc TypeChecker) ownership_reject_global_move(name string, pos flat.NodeId, target string, is_call bool) {
 	if source := tc.ownership_borrowed_alias_source(name, false) {
 		action := if is_call { 'move into function' } else { 'move to' }
-		tc.record_error(.assignment_mismatch,
-			'cannot move `${name}` because it borrows `${source}`; attempted ${action} `${target}`',
-			pos)
+		tc.record_error(.assignment_mismatch, 'cannot move `${name}` because it borrows `${source}`; attempted ${action} `${target}`', pos)
 	}
 	if tname := tc.ownership_owned_global_type_name(name) {
 		action := if is_call { 'move into function' } else { 'move to' }
-		tc.record_error(.assignment_mismatch,
-			'cannot move owned global `${name}` of type `${tname}`; attempted ${action} `${target}`',
-			pos)
+		tc.record_error(.assignment_mismatch, 'cannot move owned global `${name}` of type `${tname}`; attempted ${action} `${target}`', pos)
 	}
 }
 
@@ -12314,5 +12022,5 @@ fn (tc &TypeChecker) ownership_fn_declared_in_builtin(fn_name string) bool {
 	return normalized.starts_with('vlib/builtin/')
 		|| normalized.contains('/vlib/builtin/')
 		|| (normalized.contains('/v3_module_cache_') && normalized.ends_with('.vh')
-		&& normalized.all_after_last('/').starts_with('builtin_'))
+			&& normalized.all_after_last('/').starts_with('builtin_'))
 }


### PR DESCRIPTION
Fix the remaining actionable master CI failures outside FastC.

- preserve callable values for address-of local function assignments in V3 Cgen/transform
- retain concrete nested element types when lowering for-in over generic calls
- align the vfmt compatibility test and repair files rejected by the current formatter
- allow the intentional legacy-json benchmark warning and migrate the CI restart helper to json2

Validation (all with VJOBS=1):
- rebuilt vnew
- vlib/v/compiler_errors_test.v
- vlib/v3/tests/fn_value_decl_type_test.v
- focused for-in generic call regression
- vlib/v3/parser/ (5 tests)
- vlib/v/builder/cc_test.v
- cmd/tools/vfmt_test.v
- vlib/v3/gen/v/gen_test.v
- vlib/v3/gen/c/names_test.v
- vlib/v3/migrations/migrations_test.v
- benchmark JSON compile/run
- formatter verification for all touched V files
- reproduced and fixed the two failing adventofcode cases

FastC-only issues are intentionally excluded.