### PR TITLE
vself: restore TCC builds on Apple Silicon

### DIFF
--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -24,8 +24,7 @@ fn main() {
 	vexe_name := os.file_name(vexe)
 	short_v_name := vexe_name.all_before('.')
 
-	recompilation.must_be_enabled(vroot,
-		'Please install V from source, to use `${vexe_name} self` .')
+	recompilation.must_be_enabled(vroot, 'Please install V from source, to use `${vexe_name} self` .')
 	os.chdir(vroot)!
 	os.setenv('VCOLORS', 'always', true)
 	command_index := os.getenv('VSELF_COMMAND_INDEX').int()
@@ -46,10 +45,11 @@ fn main() {
 		uos := os.user_os()
 		uname := os.uname()
 		if uos == 'macos' {
-			// V3 relies on native thread-local preallocation scopes to keep
-			// compiler self-builds below the memory limit. TCC does not support
-			// that implementation on macOS, so use the system compiler.
-			args << ['-cc', os.getenv_opt('CC') or { 'cc' }]
+			// Apple Silicon's bundled TCC is much faster for compiler rebuilds. The
+			// generated compiler uses pthread-backed allocator state because native
+			// TinyCC TLS is not reliable on macOS.
+			default_cc := if uname.machine in ['arm64', 'aarch64'] { 'tcc' } else { 'cc' }
+			args << ['-cc', os.getenv_opt('CC') or { default_cc }]
 		} else if uos == 'linux' && uname.machine in ['arm64', 'aarch64'] {
 			// Bundled TCC can hang while bootstrapping V on Linux ARM64, so
 			// prefer the system compiler for self-builds there.
@@ -327,13 +327,14 @@ fn self_build_supports_prealloc(args []string) bool {
 		i++
 	}
 	return target_os in ['linux', 'macos'] && gc == 'none'
-		&& self_ccompiler_supports_prealloc(ccompiler)
+		&& self_ccompiler_supports_prealloc(ccompiler, target_os)
 }
 
-fn self_ccompiler_supports_prealloc(ccompiler string) bool {
+fn self_ccompiler_supports_prealloc(ccompiler string, target_os string) bool {
 	cc := os.file_name(ccompiler.trim_space()).to_lower_ascii()
-	return !cc.contains('tcc') && !cc.contains('tinyc') && !cc.contains('tinygcc')
-		&& !cc.contains('tiny_gcc') && !cc.contains('tiny-gcc')
+	is_tinyc := cc.contains('tcc') || cc.contains('tinyc') || cc.contains('tinygcc')
+		|| cc.contains('tiny_gcc') || cc.contains('tiny-gcc')
+	return !is_tinyc || target_os == 'macos'
 }
 
 fn has_profile_cflag(args []string) bool {
@@ -551,8 +552,7 @@ fn bootstrap_self_build(vroot string, args []string, final_binary string) ! {
 		os.rm(bootstrap_v1) or {}
 		os.rm(bootstrap_v2) or {}
 	}
-	vc_source := os.join_path(vroot, 'vc',
-		if os.user_os() == 'windows' { 'v_win.c' } else { 'v.c' })
+	vc_source := os.join_path(vroot, 'vc', if os.user_os() == 'windows' { 'v_win.c' } else { 'v.c' })
 	if !os.exists(vc_source) {
 		return error('bootstrap fallback failed: `${vc_source}` is missing')
 	}
@@ -585,8 +585,8 @@ fn bootstrap_c_cmd(cc string, out_binary string, vc_source string) string {
 		parts << ['-std=c99', '-municode', '-w', '-o', os.quoted_path(out_binary),
 			os.quoted_path(vc_source), '-lws2_32']
 	} else {
-		parts << ['-std=c99', '-w', '-o', os.quoted_path(out_binary),
-			os.quoted_path(vc_source), '-lm', '-lpthread']
+		parts << ['-std=c99', '-w', '-o', os.quoted_path(out_binary), os.quoted_path(vc_source),
+			'-lm', '-lpthread']
 	}
 	return parts.join(' ')
 }
@@ -608,7 +608,11 @@ fn list_folder(short_v_name string, bmessage string, message string) {
 
 fn backup_old_version_and_rename_newer(short_v_name string) !bool {
 	mut errors := []string{}
-	short_v_file := if os.user_os() == 'windows' { '${short_v_name}.exe' } else { '${short_v_name}' }
+	short_v_file := if os.user_os() == 'windows' {
+		'${short_v_name}.exe'
+	} else {
+		'${short_v_name}'
+	}
 	short_v2_file := if os.user_os() == 'windows' { 'v2.exe' } else { 'v2' }
 	short_bak_file := if os.user_os() == 'windows' { 'v_old.exe' } else { 'v_old' }
 	v_file := os.real_path(short_v_file)

--- a/cmd/tools/vself_test.v
+++ b/cmd/tools/vself_test.v
@@ -12,8 +12,7 @@ fn test_linux_tinyc_self_build_does_not_enable_prealloc() {
 	defer {
 		os.rm(tool) or {}
 	}
-	build := os.execute('${os.quoted_path(vexe)} -o ${os.quoted_path(tool)} ${os.quoted_path(os.join_path(vroot,
-		'cmd', 'tools', 'vself.v'))}')
+	build := os.execute('${os.quoted_path(vexe)} -o ${os.quoted_path(tool)} ${os.quoted_path(os.join_path(vroot, 'cmd', 'tools', 'vself.v'))}')
 	assert build.exit_code == 0, build.output
 	for compiler in ['tcc', 'tinyc'] {
 		result :=
@@ -38,7 +37,7 @@ fn test_linux_tinyc_self_build_does_not_enable_prealloc() {
 	assert clang_override_result.output.contains('-prealloc'), clang_override_result.output
 }
 
-fn test_macos_default_self_build_uses_prealloc_capable_compiler() {
+fn test_macos_default_self_build_compiler_selection() {
 	$if !macos {
 		return
 	}
@@ -47,12 +46,17 @@ fn test_macos_default_self_build_uses_prealloc_capable_compiler() {
 	defer {
 		os.rm(tool) or {}
 	}
-	build := os.execute('${os.quoted_path(vexe)} -o ${os.quoted_path(tool)} ${os.quoted_path(os.join_path(vroot,
-		'cmd', 'tools', 'vself.v'))}')
+	build := os.execute('${os.quoted_path(vexe)} -o ${os.quoted_path(tool)} ${os.quoted_path(os.join_path(vroot, 'cmd', 'tools', 'vself.v'))}')
 	assert build.exit_code == 0, build.output
-	result :=
+	default_result :=
+		os.execute('env -u CC VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -o /tmp/vself_macos_prealloc_test')
+	assert default_result.exit_code == 0, default_result.output
+	default_cc := if os.uname().machine in ['arm64', 'aarch64'] { 'tcc' } else { 'cc' }
+	assert default_result.output.contains('-cc ${default_cc}'), default_result.output
+	assert default_result.output.contains('-prealloc'), default_result.output
+	override_result :=
 		os.execute('CC=cc VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -o /tmp/vself_macos_prealloc_test')
-	assert result.exit_code == 0, result.output
-	assert result.output.contains('-cc cc'), result.output
-	assert result.output.contains('-prealloc'), result.output
+	assert override_result.exit_code == 0, override_result.output
+	assert override_result.output.contains('-cc cc'), override_result.output
+	assert override_result.output.contains('-prealloc'), override_result.output
 }

--- a/vlib/v/help/installation/self.txt
+++ b/vlib/v/help/installation/self.txt
@@ -8,6 +8,7 @@ Usage:
 Options:
   All other options are passed to the build command. (e.g. -prod)
   With -prod and clang/gcc, `v self` may use PGO automatically when tools are available.
+  On Apple Silicon, regular self-builds use bundled TCC by default; `CC` or `-cc` overrides it.
   On macOS and Linux, `-b fastc` builds the standalone experimental V3 FastC compiler.
   `-prod` cannot be combined with `-b fastc`.
   FastC replacement builds (`xN` without `-o`) reject options that the standalone compiler

--- a/vlib/v3/gen/fastc/link.v
+++ b/vlib/v3/gen/fastc/link.v
@@ -12,10 +12,11 @@ mut:
 	base_args   []string
 }
 
-// fastc_prepare_link initializes the in-process TinyCC linker on macOS. Other
-// platforms retain the executable-based linker and only record its arguments.
+// fastc_prepare_link initializes the in-process TinyCC linker on macOS. A compiler
+// built by TinyCC uses the executable-based linker too, since Darwin TinyCC cannot
+// link the libtcc archive that implements the in-process path.
 pub fn fastc_prepare_link(program string, tcc_lib string, base_args []string) FastcPreparedLink {
-	$if macos && !fastc_selfhost ? {
+	$if macos && !tinyc && !fastc_selfhost ? {
 		return fastc_prepare_libtcc_link(program, tcc_lib, base_args)
 	} $else {
 		return FastcPreparedLink{
@@ -28,7 +29,7 @@ pub fn fastc_prepare_link(program string, tcc_lib string, base_args []string) Fa
 // fastc_prepared_link_skips_codesign reports whether the prepared linker
 // suppresses TinyCC's codesign subprocess and needs in-process signing.
 pub fn fastc_prepared_link_skips_codesign(link &FastcPreparedLink) bool {
-	$if macos && !fastc_selfhost ? {
+	$if macos && !tinyc && !fastc_selfhost ? {
 		return !isnil(link.state)
 	} $else {
 		return false
@@ -38,7 +39,7 @@ pub fn fastc_prepared_link_skips_codesign(link &FastcPreparedLink) bool {
 // fastc_finish_link adds the compiled inputs to a prepared linker and writes
 // the executable. `final_args` contains libraries and other link-only flags.
 pub fn fastc_finish_link(mut link FastcPreparedLink, input_paths []string, final_args []string, output string) os.Result {
-	$if macos && !fastc_selfhost ? {
+	$if macos && !tinyc && !fastc_selfhost ? {
 		return fastc_finish_libtcc_link(mut link, input_paths, final_args, output)
 	} $else {
 		mut args := link.base_args.clone()
@@ -51,7 +52,7 @@ pub fn fastc_finish_link(mut link FastcPreparedLink, input_paths []string, final
 
 // fastc_discard_link releases a prepared linker after unit compilation fails.
 pub fn fastc_discard_link(mut link FastcPreparedLink) {
-	$if macos && !fastc_selfhost ? {
+	$if macos && !tinyc && !fastc_selfhost ? {
 		fastc_discard_libtcc_link(mut link)
 	}
 }

--- a/vlib/v3/gen/fastc/link_darwin.c.v
+++ b/vlib/v3/gen/fastc/link_darwin.c.v
@@ -5,11 +5,13 @@ import strings
 
 #flag darwin -I @VEXEROOT/thirdparty/tcc/include
 
-#flag darwin @VEXEROOT/thirdparty/tcc/lib/libtcc.a
+$if !tinyc {
+	#flag darwin @VEXEROOT/thirdparty/tcc/lib/libtcc.a
+}
 
 #include "libtcc.h"
 
-$if !fastc_selfhost ? {
+$if !tinyc && !fastc_selfhost ? {
 	#insert "@VEXEROOT/vlib/v3/gen/fastc/libtcc_system_darwin.h"
 }
 

--- a/vlib/v3/gen/fastc/macho_sign_test.v
+++ b/vlib/v3/gen/fastc/macho_sign_test.v
@@ -17,7 +17,7 @@ fn test_fastc_codesign_shim_restores_path() {
 	assert !os.exists(shim.dir)
 }
 
-fn test_fastc_prepared_libtcc_link() {
+fn test_fastc_prepared_link() {
 	if os.user_os() != 'macos' {
 		return
 	}
@@ -43,10 +43,16 @@ fn test_fastc_prepared_libtcc_link() {
 	compile := os.execute('${tcc} ${base_args.join(' ')} -c -o ${object_path} ${source_path}')
 	assert compile.exit_code == 0, compile.output
 	mut prepared := fastc_prepare_link(tcc, tcc_lib, base_args)
-	skipped_codesigns := C.v_fastc_tcc_skipped_codesign_count()
-	link_result := fastc_finish_link(mut prepared, [object_path], [], exe_path)
-	assert link_result.exit_code == 0, link_result.output
-	assert C.v_fastc_tcc_skipped_codesign_count() == skipped_codesigns + 1
+	$if tinyc {
+		link_result := fastc_finish_link(mut prepared, [object_path], [], exe_path)
+		assert link_result.exit_code == 0, link_result.output
+		assert !fastc_prepared_link_skips_codesign(&prepared)
+	} $else {
+		skipped_codesigns := C.v_fastc_tcc_skipped_codesign_count()
+		link_result := fastc_finish_link(mut prepared, [object_path], [], exe_path)
+		assert link_result.exit_code == 0, link_result.output
+		assert C.v_fastc_tcc_skipped_codesign_count() == skipped_codesigns + 1
+	}
 	fastc_sign_macho_adhoc(exe_path) or { panic(err) }
 	assert os.execute(exe_path).output.trim_space() == 'linked'
 	assert os.system('/usr/bin/true') == 0


### PR DESCRIPTION
## Summary

- use bundled TCC by default for regular `v self` builds on Apple Silicon
- keep allocator preallocation enabled through the pthread-backed macOS path
- use the executable TCC linker when the compiler itself was built by TinyCC, avoiding the unsupported Darwin `libtcc.a` and `system()` interposer paths
- preserve `CC` and explicit `-cc` overrides
- document the Apple Silicon default and add coverage for both linker paths

## Testing

- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew cmd/tools/vself_test.v`
- `./vnew vlib/v3/gen/fastc/macho_sign_test.v`
- `./vnew -cc tcc -gc none -no-retry-compilation -silent vlib/v3/gen/fastc/macho_sign_test.v`
- `env -u CC ./vnew self -no-retry-compilation -o /tmp/vself_pr_tcc`
- TCC-built compiler successfully ran `examples/hello_world.v` with the default backend and `-b fastc`
- `./vnew -silent vlib/v/compiler_errors_test.v` (1696 passed, 1 skipped)