### PR TITLE
net.http: accept HTTP status line without a reason phrase

### DIFF
--- a/vlib/net/http/response.v
+++ b/vlib/net/http/response.v
@@ -153,8 +153,8 @@ fn parse_status_line(line string) !(string, int, string) {
 		return error('response does not start with HTTP/, line: `${line}`')
 	}
 	data := line.split_nth(' ', 3)
-	if data.len != 3 {
-		return error('expected at least 3 tokens, but found: ${data.len}')
+	if data.len < 2 {
+		return error('expected at least 2 tokens, but found: ${data.len}')
 	}
 	version := data[0].substr(5, data[0].len)
 	// validate version is 1*DIGIT "." 1*DIGIT
@@ -167,7 +167,10 @@ fn parse_status_line(line string) !(string, int, string) {
 			return error('HTTP version must contain only integers, found: `${digit}`')
 		}
 	}
-	return version, strconv.atoi(data[1])!, data[2]
+	// RFC 9112 §4: the reason-phrase is optional, and servers that omit it
+	// sometimes omit the SP before it too.
+	reason := if data.len == 3 { data[2] } else { '' }
+	return version, strconv.atoi(data[1])!, reason
 }
 
 // cookies parses the Set-Cookie headers into Cookie objects

--- a/vlib/net/http/response_test.v
+++ b/vlib/net/http/response_test.v
@@ -49,6 +49,31 @@ fn test_parse_response() {
 	assert x.body == 'Foo'
 }
 
+fn test_parse_response_without_reason_phrase() {
+	// RFC 9112 §4: the reason-phrase is optional, and some servers omit the
+	// trailing SP before it as well (`HTTP/1.1 200`).
+	content := 'HTTP/1.1 200\r\nContent-Length: 3\r\n\r\nFoo'
+	x := parse_response(content)!
+	assert x.http_version == '1.1'
+	assert x.status_code == 200
+	assert x.status_msg == ''
+	assert x.header.contains(.content_length)
+	assert x.header.get(.content_length)? == '3'
+	assert x.body == 'Foo'
+}
+
+fn test_parse_response_with_empty_reason_phrase() {
+	// trailing SP present, but the reason phrase itself is empty
+	content := 'HTTP/1.1 200 \r\nContent-Length: 3\r\n\r\nFoo'
+	x := parse_response(content)!
+	assert x.http_version == '1.1'
+	assert x.status_code == 200
+	assert x.status_msg == ''
+	assert x.header.contains(.content_length)
+	assert x.header.get(.content_length)? == '3'
+	assert x.body == 'Foo'
+}
+
 fn test_parse_response_with_cookies() {
 	cookie_id := 'v_is_best'
 	content := 'HTTP/1.1 200 OK\r\nSet-Cookie: id=${cookie_id}\r\nContent-Length: 3\r\n\r\nFoo'


### PR DESCRIPTION
Fixes #28182

## Problem

`parse_status_line` in `vlib/net/http/response.v` required exactly three
space-separated tokens, so a status line that omits the reason phrase —
`HTTP/1.1 200` — failed with `expected at least 3 tokens, but found: 2`.

Per RFC 9112 §4, the grammar is:

```
status-line = HTTP-version SP status-code SP [ reason-phrase ]
```

The reason-phrase is optional, and carries no semantics. Every mainstream
HTTP client accepts a bare `HTTP/1.1 200`; V was the only one that rejected it,
which made `net.http` unable to talk to servers that browsers, curl, Go and
Python all reach without comment.

## Fix

Relax `parse_status_line` to accept a two-token status line, defaulting the
reason phrase to `''`. The existing `http/` prefix guard still rejects
garbage, so a 0- or 1-token line remains an error.

## Verification

Added regression tests for both `HTTP/1.1 200` (no trailing SP) and
`HTTP/1.1 200 ` (empty reason phrase). The issue's reproduction now prints
`200 after 1 request(s)` for all three status-line forms:

```
$ ./vnew run repro.v
"HTTP/1.1 200 OK" -> 200 after 1 request(s)
"HTTP/1.1 200 "   -> 200 after 1 request(s)
"HTTP/1.1 200"    -> 200 after 1 request(s)
```

Tests run: `./vnew -silent test vlib/net/http/` — 30 passed, 4 skipped (Windows-only).

## Not addressed

The issue also notes that a *parse* failure is classified as retryable, so a
malformed response is re-sent up to `max_retries` (5) times. That is a
separate, broader concern about `is_no_need_retry_error`'s exclusion-list
shape and is out of scope for this PR (the author of the issue offered to
split it out too).