### PR TITLE
builder: rewrite gcc windows paths to short 8.3 names, like tcc (fixes #28126)

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -1551,6 +1551,16 @@ fn rewrite_windows_path_arg(arg string, resolver WindowsPathResolver) string {
 	return arg
 }
 
+// cc_uses_short_windows_paths reports whether the given C compiler needs the
+// Windows paths passed to it to be rewritten to their ASCII 8.3 short forms
+// first. Both tcc and the MinGW gcc toolchain read response file contents
+// with the ANSI C runtime: non-ASCII characters in paths get mangled on
+// Windows setups, whose active code page can not represent them (or whose
+// compiler expects UTF-8), so V passes them only as pure ASCII short paths.
+fn cc_uses_short_windows_paths(cc CC) bool {
+	return cc in [.gcc, .tcc]
+}
+
 fn short_windows_path(path string) string {
 	$if windows {
 		return os.short_path(path)
@@ -1560,7 +1570,7 @@ fn short_windows_path(path string) string {
 
 fn (v &Builder) tcc_windows_path(p string) string {
 	$if windows {
-		if v.ccoptions.cc == .tcc {
+		if cc_uses_short_windows_paths(v.ccoptions.cc) {
 			return short_windows_path(p)
 		}
 	}
@@ -1569,7 +1579,7 @@ fn (v &Builder) tcc_windows_path(p string) string {
 
 fn (v &Builder) tcc_windows_path_arg(arg string) string {
 	$if windows {
-		if v.ccoptions.cc == .tcc {
+		if cc_uses_short_windows_paths(v.ccoptions.cc) {
 			return rewrite_windows_path_arg(arg, short_windows_path)
 		}
 	}

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -1523,18 +1523,15 @@ fn looks_like_windows_path(value string) bool {
 	return value.contains('\\') || value.contains('/') || (value.len > 1 && value[1] == `:`)
 }
 
-fn rewrite_windows_path_arg(arg string, resolver WindowsPathResolver) string {
+// rewrite_windows_path_operand_arg rewrites only the path value of compiler
+// arguments that take a filesystem operand: the path bearing options `-I`,
+// `-L`, `-B`, `-o ` and `-c `, and bare source/object/archive file paths.
+// Option values that merely contain a path looking substring are left
+// untouched, so that e.g. `-DROOT="C:\Program Files\SDK"` keeps its exact
+// macro value after the rewrite.
+fn rewrite_windows_path_operand_arg(arg string, resolver WindowsPathResolver) string {
 	if arg == '' {
 		return ''
-	}
-	if start := arg.index('"') {
-		end := arg.last_index('"') or { -1 }
-		if end > start {
-			path := arg[start + 1..end]
-			if looks_like_windows_path(path) {
-				return arg[..start] + '"${resolver(path)}"' + arg[end + 1..]
-			}
-		}
 	}
 	for prefix in ['-I', '-L', '-B', '-o ', '-c '] {
 		if arg.starts_with(prefix) {
@@ -1549,6 +1546,27 @@ fn rewrite_windows_path_arg(arg string, resolver WindowsPathResolver) string {
 		return '"${resolver(trimmed)}"'
 	}
 	return arg
+}
+
+// rewrite_windows_path_arg rewrites any quoted path substring of a compiler
+// argument, in addition to the whole path operands handled by
+// rewrite_windows_path_operand_arg. tcc keeps this broader, pre-existing
+// rewrite, so its whole argument vector stays ASCII on Windows; the narrower
+// operand only rewrite is used for gcc, see tcc_windows_path_arg.
+fn rewrite_windows_path_arg(arg string, resolver WindowsPathResolver) string {
+	if arg == '' {
+		return ''
+	}
+	if start := arg.index('"') {
+		end := arg.last_index('"') or { -1 }
+		if end > start {
+			path := arg[start + 1..end]
+			if looks_like_windows_path(path) {
+				return arg[..start] + '"${resolver(path)}"' + arg[end + 1..]
+			}
+		}
+	}
+	return rewrite_windows_path_operand_arg(arg, resolver)
 }
 
 // cc_uses_short_windows_paths reports whether the given C compiler needs the
@@ -1577,10 +1595,20 @@ fn (v &Builder) tcc_windows_path(p string) string {
 	return p
 }
 
+// tcc_windows_path_arg rewrites the Windows path arguments of tcc and the
+// MinGW gcc toolchain to ASCII 8.3 short paths, so that non-ASCII project
+// paths survive the ANSI response file encoding (see issue #28126). tcc keeps
+// the broader rewrite_windows_path_arg, while gcc gets only its real
+// filesystem operands rewritten: gcc argument vectors can contain user
+// `CFLAGS` with path looking values (e.g. `-DROOT="C:\Program Files\SDK"`),
+// which must not be altered.
 fn (v &Builder) tcc_windows_path_arg(arg string) string {
 	$if windows {
-		if cc_uses_short_windows_paths(v.ccoptions.cc) {
+		if v.ccoptions.cc == .tcc {
 			return rewrite_windows_path_arg(arg, short_windows_path)
+		}
+		if v.ccoptions.cc == .gcc {
+			return rewrite_windows_path_operand_arg(arg, short_windows_path)
 		}
 	}
 	return arg

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -1874,8 +1874,32 @@ fn resolved_windows_ccompiler_path(ccompiler string) string {
 	return name
 }
 
+fn execute_windows_batch_ccompiler(cmd string) os.Result {
+	$if windows {
+		// `os.execute` expands percent-delimited environment variables before starting
+		// cmd.exe. Expand this indirection once inside cmd.exe instead, so percent signs
+		// carried by compiler arguments are not scanned again.
+		command_env_name := 'V_CCOMPILER_BATCH_COMMAND_${os.getpid()}'
+		old_command := os.getenv_opt(command_env_name)
+		os.setenv(command_env_name, cmd, true)
+		defer {
+			if previous := old_command {
+				os.setenv(command_env_name, previous, true)
+			} else {
+				os.unsetenv(command_env_name)
+			}
+		}
+		command_interpreter := os.getenv_opt('COMSPEC') or { 'cmd.exe' }
+		return os.exec([command_interpreter, '/d', '/v:off', '/s', '/c', '%${command_env_name}%'])
+	}
+	return os.execute(cmd)
+}
+
 fn (v &Builder) execute_ccompiler(ccompiler string, cmd string, exec_args []string) os.Result {
-	if exec_args.len > 0 && !ccompiler_is_windows_batch_file(ccompiler) {
+	if exec_args.len > 0 {
+		if ccompiler_is_windows_batch_file(ccompiler) {
+			return execute_windows_batch_ccompiler(cmd)
+		}
 		return os.exec(exec_args)
 	}
 	return os.execute(cmd)

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -1529,21 +1529,37 @@ fn looks_like_windows_path(value string) bool {
 // Option values that merely contain a path looking substring are left
 // untouched, so that e.g. `-DROOT="C:\Program Files\SDK"` keeps its exact
 // macro value after the rewrite.
+fn single_windows_path_operand(value string) ?string {
+	trimmed := value.trim_space()
+	if trimmed.len >= 2 && trimmed[0] == `"` {
+		if trimmed[trimmed.len - 1] != `"` {
+			return none
+		}
+		return trimmed[1..trimmed.len - 1]
+	}
+	if trimmed.bytes().any(it.is_space()) {
+		return none
+	}
+	return trimmed
+}
+
 fn rewrite_windows_path_operand_arg(arg string, resolver WindowsPathResolver) string {
 	if arg == '' {
 		return ''
 	}
 	for prefix in ['-I', '-L', '-B', '-o ', '-c '] {
 		if arg.starts_with(prefix) {
-			path := arg[prefix.len..].trim_space().trim('"')
+			path := single_windows_path_operand(arg[prefix.len..]) or { return arg }
 			if looks_like_windows_path(path) {
 				return prefix + '"${resolver(path)}"'
 			}
 		}
 	}
-	trimmed := arg.trim_space().trim('"')
-	if !arg.starts_with('-') && looks_like_windows_path(trimmed) {
-		return '"${resolver(trimmed)}"'
+	if !arg.starts_with('-') {
+		path := single_windows_path_operand(arg) or { return arg }
+		if looks_like_windows_path(path) {
+			return '"${resolver(path)}"'
+		}
 	}
 	return arg
 }

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -1776,9 +1776,18 @@ fn windows_quote_exec_arg(arg string) string {
 
 struct GccUnicodeResponsePlan {
 mut:
-	args              []string
-	response_files    []string
-	response_contents []string
+	args                   []string
+	response_files         []string
+	response_contents      []string
+	response_encoding      GccResponseFileEncoding
+	requires_full_response bool
+	full_response_content  string
+}
+
+enum GccResponseFileEncoding {
+	ascii
+	ansi
+	utf8
 }
 
 fn (mut plan GccUnicodeResponsePlan) add_ascii_run(response_file string, args []string) {
@@ -1788,9 +1797,11 @@ fn (mut plan GccUnicodeResponsePlan) add_ascii_run(response_file string, args []
 	plan.response_contents << gcc_response_file_content_for_exact_args(args)
 }
 
-fn gcc_unicode_response_plan(response_file string, args []string, max_command_bytes int, ansi_preserves_args bool) !GccUnicodeResponsePlan {
+fn gcc_unicode_response_plan(response_file string, args []string, max_command_bytes int) GccUnicodeResponsePlan {
 	exact_args := ccompiler_exec_args('', args)[1..]
-	mut plan := GccUnicodeResponsePlan{}
+	mut plan := GccUnicodeResponsePlan{
+		response_encoding: .ascii
+	}
 	mut ascii_run := []string{}
 	for arg in exact_args {
 		if arg.is_ascii() {
@@ -1811,19 +1822,20 @@ fn gcc_unicode_response_plan(response_file string, args []string, max_command_by
 		// Account for the exact backslash+quote expansion used by CreateProcessW.
 		quoted_command_bytes += windows_quote_exec_arg(arg).len + 1
 	}
-	// Preserve the compiler's active-code-page response-file encoding when it is
-	// lossless. Otherwise no response-file encoding can safely carry these args.
 	if quoted_command_bytes > max_command_bytes {
-		if !ansi_preserves_args {
-			return error('the Windows GCC command has too many non-ASCII arguments for the command line and they cannot be represented in the active ANSI code page; enable 8.3 short paths or use a Unicode-capable GCC or Clang toolchain')
-		}
-		return GccUnicodeResponsePlan{
-			args: ['@${response_file}']
-			response_files: [response_file]
-			response_contents: [gcc_response_file_content_for_exact_args(exact_args)]
-		}
+		plan.requires_full_response = true
+		plan.full_response_content = gcc_response_file_content_for_exact_args(exact_args)
 	}
 	return plan
+}
+
+fn gcc_unicode_full_response_plan(response_file string, content string, encoding GccResponseFileEncoding) GccUnicodeResponsePlan {
+	return GccUnicodeResponsePlan{
+		args: ['@${response_file}']
+		response_files: [response_file]
+		response_contents: [content]
+		response_encoding: encoding
+	}
 }
 
 fn response_file_content_is_ansi_lossless(content string) bool {
@@ -1834,6 +1846,79 @@ fn response_file_content_is_ansi_lossless(content string) bool {
 		return decoded == content
 	}
 	return true
+}
+
+fn gcc_response_file_encoding_from_probes(utf8_supported bool, ansi_supported bool, ansi_preserves_content bool) !GccResponseFileEncoding {
+	if utf8_supported {
+		return .utf8
+	}
+	if ansi_supported && ansi_preserves_content {
+		return .ansi
+	}
+	return error('the Windows GCC command has too many non-ASCII arguments for the command line, and the selected driver accepts neither a compatible UTF-8 response file nor a lossless active-code-page response file; enable 8.3 short paths or use a Unicode-capable GCC or Clang toolchain')
+}
+
+fn first_non_ascii_response_rune(content string) string {
+	for character in content.runes() {
+		if character > 127 {
+			return character.str()
+		}
+	}
+	return ''
+}
+
+fn (mut v Builder) windows_gcc_response_file_probe(ccompiler string, response_file string, marker string, encoding GccResponseFileEncoding) bool {
+	$if windows {
+		probe_id := '${os.getpid()}_${time.sys_mono_now()}'
+		probe_source := '${response_file}.${probe_id}_${marker}.c'
+		probe_response := '${response_file}.${probe_id}.encoding_probe'
+		defer {
+			os.rm(probe_source) or {}
+			os.rm(probe_response) or {}
+		}
+		transport_source := v.tcc_windows_path(probe_source)
+		// Resolve the production path transport before creating the leaf so the
+		// non-ASCII marker remains available to distinguish the driver's decoder.
+		os.write_file(probe_source, '') or { return false }
+		probe_content := gcc_response_file_content_for_exact_args(['-fsyntax-only', '-x', 'c',
+			transport_source])
+		if encoding == .utf8 {
+			os.write_file(probe_response, probe_content) or { return false }
+		} else {
+			os.write_file_array(probe_response, string_to_ansi_not_null_terminated(probe_content)) or {
+				return false
+			}
+		}
+		probe_arg := '@${v.tcc_windows_path(probe_response)}'
+		probe_cmd := '${v.quote_compiler_name(ccompiler)} ${windows_quote_exec_arg(probe_arg)}'
+		probe_result := v.execute_ccompiler(ccompiler, probe_cmd, [ccompiler, probe_arg])
+		return probe_result.exit_code == 0
+	}
+	return false
+}
+
+fn (mut v Builder) windows_gcc_response_file_encoding(ccompiler string, response_file string, content string) !GccResponseFileEncoding {
+	marker := first_non_ascii_response_rune(content)
+	if marker == '' {
+		return .ascii
+	}
+	utf8_supported := v.windows_gcc_response_file_probe(ccompiler, response_file, marker, .utf8)
+	ansi_preserves_content := response_file_content_is_ansi_lossless(content)
+	mut ansi_supported := false
+	if !utf8_supported && ansi_preserves_content {
+		ansi_supported = v.windows_gcc_response_file_probe(ccompiler, response_file, marker, .ansi)
+	}
+	return gcc_response_file_encoding_from_probes(utf8_supported, ansi_supported, ansi_preserves_content)
+}
+
+fn write_gcc_response_file(response_file string, response_file_content string, encoding GccResponseFileEncoding) {
+	if encoding == .utf8 {
+		os.write_file(response_file, response_file_content) or {
+			write_response_file_error(response_file, err)
+		}
+		return
+	}
+	write_response_file(response_file, response_file_content)
 }
 
 fn (v &Builder) ccompiler_response_file_content(args []string, formatted string) string {
@@ -2318,8 +2403,11 @@ pub fn (mut v Builder) cc() {
 			} else {
 				30000
 			}
-			ansi_preserves_args := response_file_content_is_ansi_lossless(gcc_response_file_content(rsp_args))
-			plan := gcc_unicode_response_plan(response_file, rsp_args, max_command_bytes, ansi_preserves_args) or { verror(err.msg()) }
+			mut plan := gcc_unicode_response_plan(response_file, rsp_args, max_command_bytes)
+			if plan.requires_full_response {
+				response_encoding := v.windows_gcc_response_file_encoding(ccompiler, response_file, plan.full_response_content) or { verror(err.msg()) }
+				plan = gcc_unicode_full_response_plan(response_file, plan.full_response_content, response_encoding)
+			}
 			mut transport_args := plan.args.clone()
 			for i, arg in transport_args {
 				if arg.starts_with('@') {
@@ -2327,7 +2415,7 @@ pub fn (mut v Builder) cc() {
 				}
 			}
 			for i, file in plan.response_files {
-				write_response_file(file, plan.response_contents[i])
+				write_gcc_response_file(file, plan.response_contents[i], plan.response_encoding)
 			}
 			response_file_content = plan.response_contents.join('\n')
 			compiler_exec_args = [ccompiler]

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -1731,7 +1731,46 @@ fn ccompiler_exec_args(ccompiler string, args []string) []string {
 
 fn gcc_response_file_content(args []string) string {
 	exact_args := ccompiler_exec_args('', args)[1..]
-	return exact_args.map('"' + it.replace('\\', '\\\\').replace('"', '\\"') + '"').join(' ')
+	return gcc_response_file_content_for_exact_args(exact_args)
+}
+
+fn gcc_response_file_content_for_exact_args(args []string) string {
+	return args.map('"' + it.replace('\\', '\\\\').replace('"', '\\"') + '"').join(' ')
+}
+
+struct GccUnicodeResponsePlan {
+mut:
+	args              []string
+	response_files    []string
+	response_contents []string
+}
+
+fn (mut plan GccUnicodeResponsePlan) add_ascii_run(response_file string, args []string) {
+	file := '${response_file}.${plan.response_files.len}'
+	plan.args << '@${file}'
+	plan.response_files << file
+	plan.response_contents << gcc_response_file_content_for_exact_args(args)
+}
+
+fn gcc_unicode_response_plan(response_file string, args []string) GccUnicodeResponsePlan {
+	exact_args := ccompiler_exec_args('', args)[1..]
+	mut plan := GccUnicodeResponsePlan{}
+	mut ascii_run := []string{}
+	for arg in exact_args {
+		if arg.is_ascii() {
+			ascii_run << arg
+			continue
+		}
+		if ascii_run.len > 0 {
+			plan.add_ascii_run(response_file, ascii_run)
+			ascii_run = []string{}
+		}
+		plan.args << arg
+	}
+	if ascii_run.len > 0 {
+		plan.add_ascii_run(response_file, ascii_run)
+	}
+	return plan
 }
 
 fn (v &Builder) ccompiler_response_file_content(args []string, formatted string) string {
@@ -1756,14 +1795,14 @@ fn ccompiler_is_windows_batch_file(ccompiler string) bool {
 	return name.ends_with('.bat') || name.ends_with('.cmd')
 }
 
-fn (v &Builder) execute_ccompiler(ccompiler string, args []string, cmd string) os.Result {
-	if v.windows_gcc_needs_direct_exec(args) && !ccompiler_is_windows_batch_file(ccompiler) {
-		return os.exec(ccompiler_exec_args(ccompiler, args))
+fn (v &Builder) execute_ccompiler(ccompiler string, cmd string, exec_args []string) os.Result {
+	if exec_args.len > 0 && !ccompiler_is_windows_batch_file(ccompiler) {
+		return os.exec(exec_args)
 	}
 	return os.execute(cmd)
 }
 
-fn (v &Builder) should_use_rsp(rsp_args []string) bool {
+fn (v &Builder) response_files_are_allowed(rsp_args []string) bool {
 	if v.pref.no_rsp || v.pref.os == .termux {
 		return false
 	}
@@ -1771,6 +1810,13 @@ fn (v &Builder) should_use_rsp(rsp_args []string) bool {
 		if arg.contains("'\\''") || arg.contains('\n') || arg.contains('\r') {
 			return false
 		}
+	}
+	return true
+}
+
+fn (v &Builder) should_use_rsp(rsp_args []string) bool {
+	if !v.response_files_are_allowed(rsp_args) {
+		return false
 	}
 	// os.short_path returns its input when a Windows volume has 8.3 aliases disabled.
 	// An ANSI response file would replace those remaining Unicode characters with `?`.
@@ -2144,6 +2190,8 @@ pub fn (mut v Builder) cc() {
 		v.dump_c_options(all_args)
 		mut rsp_args := all_args.map(v.rsp_safe_arg(it))
 		rsp_args = rsp_args.map(v.tcc_windows_path_arg(it))
+		use_unicode_rsp := v.response_files_are_allowed(rsp_args)
+			&& v.windows_gcc_needs_direct_exec(rsp_args)
 		mut should_use_rsp := v.should_use_rsp(rsp_args)
 		mut str_args := if !should_use_rsp {
 			rsp_args.map(shell_safe_cc_arg(it)).join(' ').replace('\n', ' ')
@@ -2159,7 +2207,27 @@ pub fn (mut v Builder) cc() {
 		}
 		mut response_file := ''
 		mut response_file_content := str_args
-		if should_use_rsp {
+		mut compiler_exec_args := []string{}
+		if use_unicode_rsp {
+			response_file = '${v.out_name_c}.rsp'
+			plan := gcc_unicode_response_plan(response_file, rsp_args)
+			mut transport_args := plan.args.clone()
+			for i, arg in transport_args {
+				if arg.starts_with('@') {
+					transport_args[i] = '@${v.tcc_windows_path(arg[1..])}'
+				}
+			}
+			for i, file in plan.response_files {
+				write_response_file(file, plan.response_contents[i])
+			}
+			response_file_content = plan.response_contents.join('\n')
+			compiler_exec_args = [ccompiler]
+			compiler_exec_args << transport_args
+			cmd = '${v.quote_compiler_name(ccompiler)} ${transport_args.map(os.quoted_path(it)).join(' ')}'
+			if !v.ccoptions.debug_mode {
+				v.pref.cleanup_files << plan.response_files
+			}
+		} else if should_use_rsp {
 			response_file = '${v.out_name_c}.rsp'
 			response_file_content = v.ccompiler_response_file_content(rsp_args, str_args)
 			write_response_file(response_file, response_file_content)
@@ -2186,7 +2254,10 @@ pub fn (mut v Builder) cc() {
 		// Run
 		ccompiler_label := 'C ${os.file_name(ccompiler):3}'
 		util.timing_start(ccompiler_label)
-		res := v.execute_ccompiler(ccompiler, rsp_args, cmd)
+		if compiler_exec_args.len == 0 && v.windows_gcc_needs_direct_exec(rsp_args) {
+			compiler_exec_args = ccompiler_exec_args(ccompiler, rsp_args)
+		}
+		res := v.execute_ccompiler(ccompiler, cmd, compiler_exec_args)
 		util.timing_measure(ccompiler_label)
 		if v.pref.show_c_output {
 			v.show_c_compiler_output(ccompiler, res)
@@ -2343,7 +2414,7 @@ fn (mut v Builder) prepare_reproducible_macos_debug_compiler_object(ccompiler st
 			return ''
 		}
 		util.timing_start('C object')
-		res := v.execute_ccompiler(ccompiler, rsp_args, cmd)
+		res := v.execute_ccompiler(ccompiler, cmd, []string{})
 		util.timing_measure('C object')
 		os.chdir(original_pwd) or {}
 		if v.pref.show_c_output {

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -1531,8 +1531,8 @@ fn looks_like_windows_path(value string) bool {
 // macro value after the rewrite.
 fn single_windows_path_operand(value string) ?string {
 	trimmed := value.trim_space()
-	if trimmed.len >= 2 && trimmed[0] == `"` {
-		if trimmed[trimmed.len - 1] != `"` {
+	if trimmed.len >= 2 && trimmed[0] in [`"`, `'`] {
+		if trimmed[trimmed.len - 1] != trimmed[0] {
 			return none
 		}
 		return trimmed[1..trimmed.len - 1]

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -1743,6 +1743,7 @@ mut:
 	args              []string
 	response_files    []string
 	response_contents []string
+	response_utf8     []bool
 }
 
 fn (mut plan GccUnicodeResponsePlan) add_ascii_run(response_file string, args []string) {
@@ -1750,9 +1751,10 @@ fn (mut plan GccUnicodeResponsePlan) add_ascii_run(response_file string, args []
 	plan.args << '@${file}'
 	plan.response_files << file
 	plan.response_contents << gcc_response_file_content_for_exact_args(args)
+	plan.response_utf8 << false
 }
 
-fn gcc_unicode_response_plan(response_file string, args []string) GccUnicodeResponsePlan {
+fn gcc_unicode_response_plan(response_file string, args []string, max_command_bytes int) GccUnicodeResponsePlan {
 	exact_args := ccompiler_exec_args('', args)[1..]
 	mut plan := GccUnicodeResponsePlan{}
 	mut ascii_run := []string{}
@@ -1769,6 +1771,21 @@ fn gcc_unicode_response_plan(response_file string, args []string) GccUnicodeResp
 	}
 	if ascii_run.len > 0 {
 		plan.add_ascii_run(response_file, ascii_run)
+	}
+	mut quoted_command_bytes := 0
+	for arg in plan.args {
+		// Reserve a separator and the quotes added around every Windows argument.
+		quoted_command_bytes += arg.len + 3
+	}
+	// A Unicode-capable MinGW driver accepts UTF-8 response-file bytes. Use one
+	// only when the wide command line itself would exceed the Windows limit.
+	if quoted_command_bytes > max_command_bytes {
+		return GccUnicodeResponsePlan{
+			args: ['@${response_file}']
+			response_files: [response_file]
+			response_contents: [gcc_response_file_content_for_exact_args(exact_args)]
+			response_utf8: [true]
+		}
 	}
 	return plan
 }
@@ -2210,7 +2227,12 @@ pub fn (mut v Builder) cc() {
 		mut compiler_exec_args := []string{}
 		if use_unicode_rsp {
 			response_file = '${v.out_name_c}.rsp'
-			plan := gcc_unicode_response_plan(response_file, rsp_args)
+			max_command_bytes := if ccompiler_is_windows_batch_file(ccompiler) {
+				7000
+			} else {
+				30000
+			}
+			plan := gcc_unicode_response_plan(response_file, rsp_args, max_command_bytes)
 			mut transport_args := plan.args.clone()
 			for i, arg in transport_args {
 				if arg.starts_with('@') {
@@ -2218,7 +2240,11 @@ pub fn (mut v Builder) cc() {
 				}
 			}
 			for i, file in plan.response_files {
-				write_response_file(file, plan.response_contents[i])
+				if plan.response_utf8[i] {
+					write_utf8_response_file(file, plan.response_contents[i])
+				} else {
+					write_response_file(file, plan.response_contents[i])
+				}
 			}
 			response_file_content = plan.response_contents.join('\n')
 			compiler_exec_args = [ccompiler]
@@ -3625,6 +3651,12 @@ fn write_response_file(response_file string, response_file_content string) {
 		os.write_file(response_file, response_file_content) or {
 			write_response_file_error(response_file_content, err)
 		}
+	}
+}
+
+fn write_utf8_response_file(response_file string, response_file_content string) {
+	os.write_file(response_file, response_file_content) or {
+		write_response_file_error(response_file, err)
 	}
 }
 

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -1543,6 +1543,14 @@ fn single_windows_path_operand(value string) ?string {
 	return trimmed
 }
 
+fn quote_windows_gcc_path_operand(path string) string {
+	mut trailing_separators := 0
+	for i := path.len - 1; i >= 0 && path[i] == `\\`; i-- {
+		trailing_separators++
+	}
+	return '"${path}${'\\'.repeat(trailing_separators)}"'
+}
+
 fn rewrite_windows_path_operand_arg(arg string, resolver WindowsPathResolver) string {
 	if arg == '' {
 		return ''
@@ -1551,14 +1559,14 @@ fn rewrite_windows_path_operand_arg(arg string, resolver WindowsPathResolver) st
 		if arg.starts_with(prefix) {
 			path := single_windows_path_operand(arg[prefix.len..]) or { return arg }
 			if looks_like_windows_path(path) {
-				return prefix + '"${resolver(path)}"'
+				return prefix + quote_windows_gcc_path_operand(resolver(path))
 			}
 		}
 	}
 	if !arg.starts_with('-') {
 		path := single_windows_path_operand(arg) or { return arg }
 		if looks_like_windows_path(path) {
-			return '"${resolver(path)}"'
+			return quote_windows_gcc_path_operand(resolver(path))
 		}
 	}
 	return arg
@@ -1660,33 +1668,79 @@ fn ccompiler_exec_args(ccompiler string, args []string) []string {
 	mut current := []u8{}
 	mut quote := u8(0)
 	mut has_arg := false
-	for ch in args.join(' ').bytes() {
+	input := args.join(' ')
+	mut i := 0
+	for i < input.len {
+		ch := input[i]
 		if quote == 0 && ch.is_space() {
 			if has_arg {
 				exact_args << current.bytestr()
 				current = []u8{}
 				has_arg = false
 			}
+			i++
+			continue
+		}
+		if ch == `\\` {
+			start := i
+			for i < input.len && input[i] == `\\` {
+				i++
+			}
+			count := i - start
+			if i < input.len && input[i] == `"` {
+				for _ in 0 .. count / 2 {
+					current << `\\`
+				}
+				if count % 2 == 1 {
+					current << `"`
+				} else {
+					quote = if quote == `"` { u8(0) } else { u8(`"`) }
+				}
+				has_arg = true
+				i++
+				continue
+			}
+			for _ in 0 .. count {
+				current << `\\`
+			}
+			has_arg = true
 			continue
 		}
 		if ch in [`"`, `'`] {
 			if quote == 0 {
 				quote = ch
 				has_arg = true
+				i++
 				continue
 			}
 			if quote == ch {
 				quote = 0
+				i++
 				continue
 			}
 		}
 		current << ch
 		has_arg = true
+		i++
 	}
 	if has_arg {
 		exact_args << current.bytestr()
 	}
 	return exact_args
+}
+
+fn gcc_response_file_content(args []string) string {
+	exact_args := ccompiler_exec_args('', args)[1..]
+	return exact_args.map('"' + it.replace('\\', '\\\\').replace('"', '\\"') + '"').join(' ')
+}
+
+fn (v &Builder) ccompiler_response_file_content(args []string, formatted string) string {
+	$if windows {
+		if v.ccoptions.cc == .gcc || v.pref.ccompiler_type == .cplusplus {
+			return gcc_response_file_content(args)
+		}
+	}
+	return formatted.replace('\\', '\\\\')
 }
 
 fn (v &Builder) windows_gcc_needs_direct_exec(args []string) bool {
@@ -2102,7 +2156,7 @@ pub fn (mut v Builder) cc() {
 		mut response_file_content := str_args
 		if should_use_rsp {
 			response_file = '${v.out_name_c}.rsp'
-			response_file_content = str_args.replace('\\', '\\\\')
+			response_file_content = v.ccompiler_response_file_content(rsp_args, str_args)
 			write_response_file(response_file, response_file_content)
 			rspexpr := '@${v.tcc_windows_path(response_file)}'
 			cmd = '${v.quote_compiler_name(ccompiler)} ${os.quoted_path(rspexpr)}'
@@ -2272,7 +2326,7 @@ fn (mut v Builder) prepare_reproducible_macos_debug_compiler_object(ccompiler st
 		mut response_file_content := str_args
 		if should_use_rsp {
 			response_file = '${temporary_object}.rsp'
-			response_file_content = str_args.replace('\\', '\\\\')
+			response_file_content = v.ccompiler_response_file_content(rsp_args, str_args)
 			write_response_file(response_file, response_file_content)
 			rspexpr := '@${v.tcc_windows_path(response_file)}'
 			cmd = '${v.quote_compiler_name(ccompiler)} ${os.quoted_path(rspexpr)}'

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -1587,13 +1587,13 @@ fn rewrite_windows_path_arg(arg string, resolver WindowsPathResolver) string {
 
 // cc_uses_short_windows_paths reports whether the given C compiler needs the
 // Windows paths passed to it to be rewritten to their ASCII 8.3 short forms
-// first. Both tcc and the MinGW gcc toolchain read response file contents
+// first. Both tcc and the MinGW GCC toolchain, including its C++ drivers, read response file contents
 // with the ANSI C runtime: non-ASCII characters in paths get mangled on
 // Windows setups, whose active code page can not represent them (or whose
 // compiler expects UTF-8). V therefore prefers pure ASCII short paths and,
 // for gcc, falls back to the Unicode command line when no short name exists.
-fn cc_uses_short_windows_paths(cc CC) bool {
-	return cc in [.gcc, .tcc]
+fn cc_uses_short_windows_paths(cc CC, compiler_type pref.CompilerType) bool {
+	return cc in [.gcc, .tcc] || compiler_type == .cplusplus
 }
 
 fn short_windows_path(path string) string {
@@ -1605,7 +1605,7 @@ fn short_windows_path(path string) string {
 
 fn (v &Builder) tcc_windows_path(p string) string {
 	$if windows {
-		if cc_uses_short_windows_paths(v.ccoptions.cc) {
+		if cc_uses_short_windows_paths(v.ccoptions.cc, v.pref.ccompiler_type) {
 			return short_windows_path(p)
 		}
 	}
@@ -1613,9 +1613,9 @@ fn (v &Builder) tcc_windows_path(p string) string {
 }
 
 // tcc_windows_path_arg rewrites the Windows path arguments of tcc and the
-// MinGW gcc toolchain to ASCII 8.3 short paths, so that non-ASCII project
+// MinGW GCC toolchain to ASCII 8.3 short paths, so that non-ASCII project
 // paths survive the ANSI response file encoding (see issue #28126). tcc keeps
-// the broader rewrite_windows_path_arg, while gcc gets only its real
+// the broader rewrite_windows_path_arg, while GCC and its C++ drivers get only their real
 // filesystem operands rewritten: gcc argument vectors can contain user
 // `CFLAGS` with path looking values (e.g. `-DROOT="C:\Program Files\SDK"`),
 // which must not be altered. If an 8.3 alias is unavailable, should_use_rsp
@@ -1625,7 +1625,7 @@ fn (v &Builder) tcc_windows_path_arg(arg string) string {
 		if v.ccoptions.cc == .tcc {
 			return rewrite_windows_path_arg(arg, short_windows_path)
 		}
-		if v.ccoptions.cc == .gcc {
+		if v.ccoptions.cc == .gcc || v.pref.ccompiler_type == .cplusplus {
 			return rewrite_windows_path_operand_arg(arg, short_windows_path)
 		}
 	}
@@ -1666,7 +1666,8 @@ fn (v &Builder) should_use_rsp(rsp_args []string) bool {
 		// os.short_path returns its input when the volume has 8.3 aliases disabled.
 		// An ANSI response file would replace those remaining Unicode characters
 		// with `?`, while the direct command line is passed through CreateProcessW.
-		if v.ccoptions.cc == .gcc && !gcc_rsp_args_are_ascii(rsp_args) {
+		if (v.ccoptions.cc == .gcc || v.pref.ccompiler_type == .cplusplus)
+			&& !gcc_rsp_args_are_ascii(rsp_args) {
 			return false
 		}
 	}

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -1751,8 +1751,13 @@ fn (v &Builder) windows_gcc_needs_direct_exec(args []string) bool {
 	return false
 }
 
+fn ccompiler_is_windows_batch_file(ccompiler string) bool {
+	name := ccompiler.trim_space().trim('"').trim("'").to_lower_ascii()
+	return name.ends_with('.bat') || name.ends_with('.cmd')
+}
+
 fn (v &Builder) execute_ccompiler(ccompiler string, args []string, cmd string) os.Result {
-	if v.windows_gcc_needs_direct_exec(args) {
+	if v.windows_gcc_needs_direct_exec(args) && !ccompiler_is_windows_batch_file(ccompiler) {
 		return os.exec(ccompiler_exec_args(ccompiler, args))
 	}
 	return os.execute(cmd)

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -1653,6 +1653,57 @@ fn gcc_rsp_args_are_ascii(args []string) bool {
 	return args.all(it.is_ascii())
 }
 
+// ccompiler_exec_args turns the builder's shell-formatted option fragments into the
+// exact argument vector expected by os.exec, without corrupting non-ASCII bytes.
+fn ccompiler_exec_args(ccompiler string, args []string) []string {
+	mut exact_args := [ccompiler]
+	mut current := []u8{}
+	mut quote := u8(0)
+	mut has_arg := false
+	for ch in args.join(' ').bytes() {
+		if quote == 0 && ch.is_space() {
+			if has_arg {
+				exact_args << current.bytestr()
+				current = []u8{}
+				has_arg = false
+			}
+			continue
+		}
+		if ch in [`"`, `'`] {
+			if quote == 0 {
+				quote = ch
+				has_arg = true
+				continue
+			}
+			if quote == ch {
+				quote = 0
+				continue
+			}
+		}
+		current << ch
+		has_arg = true
+	}
+	if has_arg {
+		exact_args << current.bytestr()
+	}
+	return exact_args
+}
+
+fn (v &Builder) windows_gcc_needs_direct_exec(args []string) bool {
+	$if windows {
+		return (v.ccoptions.cc == .gcc || v.pref.ccompiler_type == .cplusplus)
+			&& !gcc_rsp_args_are_ascii(args)
+	}
+	return false
+}
+
+fn (v &Builder) execute_ccompiler(ccompiler string, args []string, cmd string) os.Result {
+	if v.windows_gcc_needs_direct_exec(args) {
+		return os.exec(ccompiler_exec_args(ccompiler, args))
+	}
+	return os.execute(cmd)
+}
+
 fn (v &Builder) should_use_rsp(rsp_args []string) bool {
 	if v.pref.no_rsp || v.pref.os == .termux {
 		return false
@@ -1662,14 +1713,10 @@ fn (v &Builder) should_use_rsp(rsp_args []string) bool {
 			return false
 		}
 	}
-	$if windows {
-		// os.short_path returns its input when the volume has 8.3 aliases disabled.
-		// An ANSI response file would replace those remaining Unicode characters
-		// with `?`, while the direct command line is passed through CreateProcessW.
-		if (v.ccoptions.cc == .gcc || v.pref.ccompiler_type == .cplusplus)
-			&& !gcc_rsp_args_are_ascii(rsp_args) {
-			return false
-		}
+	// os.short_path returns its input when a Windows volume has 8.3 aliases disabled.
+	// An ANSI response file would replace those remaining Unicode characters with `?`.
+	if v.windows_gcc_needs_direct_exec(rsp_args) {
+		return false
 	}
 	return true
 }
@@ -2080,7 +2127,7 @@ pub fn (mut v Builder) cc() {
 		// Run
 		ccompiler_label := 'C ${os.file_name(ccompiler):3}'
 		util.timing_start(ccompiler_label)
-		res := os.execute(cmd)
+		res := v.execute_ccompiler(ccompiler, rsp_args, cmd)
 		util.timing_measure(ccompiler_label)
 		if v.pref.show_c_output {
 			v.show_c_compiler_output(ccompiler, res)
@@ -2237,7 +2284,7 @@ fn (mut v Builder) prepare_reproducible_macos_debug_compiler_object(ccompiler st
 			return ''
 		}
 		util.timing_start('C object')
-		res := os.execute(cmd)
+		res := v.execute_ccompiler(ccompiler, rsp_args, cmd)
 		util.timing_measure('C object')
 		os.chdir(original_pwd) or {}
 		if v.pref.show_c_output {

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -1574,7 +1574,8 @@ fn rewrite_windows_path_arg(arg string, resolver WindowsPathResolver) string {
 // first. Both tcc and the MinGW gcc toolchain read response file contents
 // with the ANSI C runtime: non-ASCII characters in paths get mangled on
 // Windows setups, whose active code page can not represent them (or whose
-// compiler expects UTF-8), so V passes them only as pure ASCII short paths.
+// compiler expects UTF-8). V therefore prefers pure ASCII short paths and,
+// for gcc, falls back to the Unicode command line when no short name exists.
 fn cc_uses_short_windows_paths(cc CC) bool {
 	return cc in [.gcc, .tcc]
 }
@@ -1601,7 +1602,8 @@ fn (v &Builder) tcc_windows_path(p string) string {
 // the broader rewrite_windows_path_arg, while gcc gets only its real
 // filesystem operands rewritten: gcc argument vectors can contain user
 // `CFLAGS` with path looking values (e.g. `-DROOT="C:\Program Files\SDK"`),
-// which must not be altered.
+// which must not be altered. If an 8.3 alias is unavailable, should_use_rsp
+// sends gcc's remaining Unicode arguments through CreateProcessW instead.
 fn (v &Builder) tcc_windows_path_arg(arg string) string {
 	$if windows {
 		if v.ccoptions.cc == .tcc {
@@ -1631,12 +1633,24 @@ fn shell_safe_cc_arg(arg string) string {
 	return arg
 }
 
+fn gcc_rsp_args_are_ascii(args []string) bool {
+	return args.all(it.is_ascii())
+}
+
 fn (v &Builder) should_use_rsp(rsp_args []string) bool {
 	if v.pref.no_rsp || v.pref.os == .termux {
 		return false
 	}
 	for arg in rsp_args {
 		if arg.contains("'\\''") || arg.contains('\n') || arg.contains('\r') {
+			return false
+		}
+	}
+	$if windows {
+		// os.short_path returns its input when the volume has 8.3 aliases disabled.
+		// An ANSI response file would replace those remaining Unicode characters
+		// with `?`, while the direct command line is passed through CreateProcessW.
+		if v.ccoptions.cc == .gcc && !gcc_rsp_args_are_ascii(rsp_args) {
 			return false
 		}
 	}

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -1743,7 +1743,6 @@ mut:
 	args              []string
 	response_files    []string
 	response_contents []string
-	response_utf8     []bool
 }
 
 fn (mut plan GccUnicodeResponsePlan) add_ascii_run(response_file string, args []string) {
@@ -1751,10 +1750,9 @@ fn (mut plan GccUnicodeResponsePlan) add_ascii_run(response_file string, args []
 	plan.args << '@${file}'
 	plan.response_files << file
 	plan.response_contents << gcc_response_file_content_for_exact_args(args)
-	plan.response_utf8 << false
 }
 
-fn gcc_unicode_response_plan(response_file string, args []string, max_command_bytes int) GccUnicodeResponsePlan {
+fn gcc_unicode_response_plan(response_file string, args []string, max_command_bytes int, ansi_preserves_args bool) !GccUnicodeResponsePlan {
 	exact_args := ccompiler_exec_args('', args)[1..]
 	mut plan := GccUnicodeResponsePlan{}
 	mut ascii_run := []string{}
@@ -1777,17 +1775,29 @@ fn gcc_unicode_response_plan(response_file string, args []string, max_command_by
 		// Reserve a separator and the quotes added around every Windows argument.
 		quoted_command_bytes += arg.len + 3
 	}
-	// A Unicode-capable MinGW driver accepts UTF-8 response-file bytes. Use one
-	// only when the wide command line itself would exceed the Windows limit.
+	// Preserve the compiler's active-code-page response-file encoding when it is
+	// lossless. Otherwise no response-file encoding can safely carry these args.
 	if quoted_command_bytes > max_command_bytes {
+		if !ansi_preserves_args {
+			return error('the Windows GCC command has too many non-ASCII arguments for the command line and they cannot be represented in the active ANSI code page; enable 8.3 short paths or use a Unicode-capable GCC or Clang toolchain')
+		}
 		return GccUnicodeResponsePlan{
 			args: ['@${response_file}']
 			response_files: [response_file]
 			response_contents: [gcc_response_file_content_for_exact_args(exact_args)]
-			response_utf8: [true]
 		}
 	}
 	return plan
+}
+
+fn response_file_content_is_ansi_lossless(content string) bool {
+	$if windows {
+		ansi := string_to_ansi_not_null_terminated(content)
+		ansi_text := ansi.bytestr()
+		decoded := unsafe { string_from_wide(ansi_text.to_wide(from_ansi: true)) }
+		return decoded == content
+	}
+	return true
 }
 
 fn (v &Builder) ccompiler_response_file_content(args []string, formatted string) string {
@@ -1808,8 +1818,24 @@ fn (v &Builder) windows_gcc_needs_direct_exec(args []string) bool {
 }
 
 fn ccompiler_is_windows_batch_file(ccompiler string) bool {
-	name := ccompiler.trim_space().trim('"').trim("'").to_lower_ascii()
+	name := resolved_windows_ccompiler_path(ccompiler).to_lower_ascii()
 	return name.ends_with('.bat') || name.ends_with('.cmd')
+}
+
+fn resolved_windows_ccompiler_path(ccompiler string) string {
+	name := ccompiler.trim_space().trim('"').trim("'")
+	$if windows {
+		if os.file_ext(name) == '' && (name.contains('/') || name.contains('\\')) {
+			for suffix in ['.exe', '.bat', '.cmd', ''] {
+				candidate := name + suffix
+				if os.is_file(candidate) {
+					return os.abs_path(candidate)
+				}
+			}
+		}
+		return os.find_abs_path_of_executable(name) or { name }
+	}
+	return name
 }
 
 fn (v &Builder) execute_ccompiler(ccompiler string, cmd string, exec_args []string) os.Result {
@@ -2232,7 +2258,8 @@ pub fn (mut v Builder) cc() {
 			} else {
 				30000
 			}
-			plan := gcc_unicode_response_plan(response_file, rsp_args, max_command_bytes)
+			ansi_preserves_args := response_file_content_is_ansi_lossless(gcc_response_file_content(rsp_args))
+			plan := gcc_unicode_response_plan(response_file, rsp_args, max_command_bytes, ansi_preserves_args) or { verror(err.msg()) }
 			mut transport_args := plan.args.clone()
 			for i, arg in transport_args {
 				if arg.starts_with('@') {
@@ -2240,11 +2267,7 @@ pub fn (mut v Builder) cc() {
 				}
 			}
 			for i, file in plan.response_files {
-				if plan.response_utf8[i] {
-					write_utf8_response_file(file, plan.response_contents[i])
-				} else {
-					write_response_file(file, plan.response_contents[i])
-				}
+				write_response_file(file, plan.response_contents[i])
 			}
 			response_file_content = plan.response_contents.join('\n')
 			compiler_exec_args = [ccompiler]
@@ -3651,12 +3674,6 @@ fn write_response_file(response_file string, response_file_content string) {
 		os.write_file(response_file, response_file_content) or {
 			write_response_file_error(response_file_content, err)
 		}
-	}
-}
-
-fn write_utf8_response_file(response_file string, response_file_content string) {
-	os.write_file(response_file, response_file_content) or {
-		write_response_file_error(response_file, err)
 	}
 }
 

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -14,6 +14,7 @@ import v.pref
 import v.util
 import v.vcache
 import term
+import strings
 
 const c_std = 'c99'
 const cpp_std = 'c++17'
@@ -1738,6 +1739,41 @@ fn gcc_response_file_content_for_exact_args(args []string) string {
 	return args.map('"' + it.replace('\\', '\\\\').replace('"', '\\"') + '"').join(' ')
 }
 
+fn windows_quote_exec_arg(arg string) string {
+	if arg.len == 0 {
+		return '""'
+	}
+	quote_char := `"`
+	backslash := `\\`
+	mut quoted := strings.new_builder(arg.len + 8)
+	quoted.write_u8(quote_char)
+	mut pending_backslashes := 0
+	for ch in arg.bytes() {
+		if ch == backslash {
+			pending_backslashes++
+			continue
+		}
+		if ch == quote_char {
+			for _ in 0 .. pending_backslashes * 2 + 1 {
+				quoted.write_u8(backslash)
+			}
+			quoted.write_u8(quote_char)
+			pending_backslashes = 0
+			continue
+		}
+		for _ in 0 .. pending_backslashes {
+			quoted.write_u8(backslash)
+		}
+		pending_backslashes = 0
+		quoted.write_u8(ch)
+	}
+	for _ in 0 .. pending_backslashes * 2 {
+		quoted.write_u8(backslash)
+	}
+	quoted.write_u8(quote_char)
+	return quoted.str()
+}
+
 struct GccUnicodeResponsePlan {
 mut:
 	args              []string
@@ -1772,8 +1808,8 @@ fn gcc_unicode_response_plan(response_file string, args []string, max_command_by
 	}
 	mut quoted_command_bytes := 0
 	for arg in plan.args {
-		// Reserve a separator and the quotes added around every Windows argument.
-		quoted_command_bytes += arg.len + 3
+		// Account for the exact backslash+quote expansion used by CreateProcessW.
+		quoted_command_bytes += windows_quote_exec_arg(arg).len + 1
 	}
 	// Preserve the compiler's active-code-page response-file encoding when it is
 	// lossless. Otherwise no response-file encoding can safely carry these args.
@@ -2272,7 +2308,7 @@ pub fn (mut v Builder) cc() {
 			response_file_content = plan.response_contents.join('\n')
 			compiler_exec_args = [ccompiler]
 			compiler_exec_args << transport_args
-			cmd = '${v.quote_compiler_name(ccompiler)} ${transport_args.map(os.quoted_path(it)).join(' ')}'
+			cmd = '${v.quote_compiler_name(ccompiler)} ${transport_args.map(windows_quote_exec_arg(it)).join(' ')}'
 			if !v.ccoptions.debug_mode {
 				v.pref.cleanup_files << plan.response_files
 			}

--- a/vlib/v/builder/cc_tcc_retry_test.v
+++ b/vlib/v/builder/cc_tcc_retry_test.v
@@ -258,3 +258,18 @@ fn test_rewrite_windows_path_arg_leaves_non_paths_alone() {
 		assert rewrite_windows_path_arg(arg, fake_windows_short_path) == arg
 	}
 }
+
+fn test_cc_uses_short_windows_paths() {
+	// tcc and the MinGW gcc toolchain both read response files with the ANSI
+	// C runtime, so both need ASCII 8.3 short paths on Windows (see issue #28126).
+	assert cc_uses_short_windows_paths(.tcc)
+	assert cc_uses_short_windows_paths(.gcc)
+	// clang, msvc, icc, emcc and unknown compilers are excluded:
+	// msvc uses the wide CreateProcessW command line directly, while the
+	// clang/LLVM toolchain handles Unicode paths on its own.
+	assert !cc_uses_short_windows_paths(.clang)
+	assert !cc_uses_short_windows_paths(.msvc)
+	assert !cc_uses_short_windows_paths(.icc)
+	assert !cc_uses_short_windows_paths(.emcc)
+	assert !cc_uses_short_windows_paths(.unknown)
+}

--- a/vlib/v/builder/cc_tcc_retry_test.v
+++ b/vlib/v/builder/cc_tcc_retry_test.v
@@ -238,7 +238,7 @@ fn test_tcc_retry_preserves_shared_and_enable_globals_flags() {
 }
 
 fn fake_windows_short_path(path string) string {
-	return path.replace(r'C:\Users\Léo', r'C:\Users\LEO~1')
+	return path.replace(r'C:\Program Files', r'C:\PROGRA~1').replace(r'C:\Users\Léo', r'C:\Users\LEO~1')
 }
 
 fn test_rewrite_windows_path_arg_rewrites_quoted_object_paths() {
@@ -257,6 +257,34 @@ fn test_rewrite_windows_path_arg_leaves_non_paths_alone() {
 	for arg in ['-bt25', '-std=c99', '-D_DEFAULT_SOURCE'] {
 		assert rewrite_windows_path_arg(arg, fake_windows_short_path) == arg
 	}
+}
+
+fn test_rewrite_windows_path_operand_arg_rewrites_path_operands() {
+	assert rewrite_windows_path_operand_arg(r'-I"C:\Users\Léo\include"', fake_windows_short_path) == r'-I"C:\Users\LEO~1\include"'
+	assert rewrite_windows_path_operand_arg(r'-L"C:\Users\Léo\lib"', fake_windows_short_path) == r'-L"C:\Users\LEO~1\lib"'
+	assert rewrite_windows_path_operand_arg(r'-B"C:\Users\Léo\bin"', fake_windows_short_path) == r'-B"C:\Users\LEO~1\bin"'
+	assert rewrite_windows_path_operand_arg(r'-o "C:\Users\Léo\bin\tool.exe"', fake_windows_short_path) == r'-o "C:\Users\LEO~1\bin\tool.exe"'
+	obj := r'"C:\Users\Léo\.vmodules\.cache\bc\artifact.o"'
+	expected := r'"C:\Users\LEO~1\.vmodules\.cache\bc\artifact.o"'
+	assert rewrite_windows_path_operand_arg(obj, fake_windows_short_path) == expected
+}
+
+fn test_rewrite_windows_path_operand_arg_leaves_path_like_values_alone() {
+	// `-DROOT="C:\Program Files\SDK"` is macro data, not a filesystem operand:
+	// rewriting it would silently change the compiled macro value (see the
+	// review of issue #28126), so it must be left byte for byte untouched.
+	for arg in [r'-DROOT="C:\Program Files\SDK"', '-D_DEFAULT_SOURCE', '-std=c99', '-bt25'] {
+		assert rewrite_windows_path_operand_arg(arg, fake_windows_short_path) == arg
+	}
+}
+
+fn test_rewrite_windows_path_arg_rewrites_path_like_values() {
+	// the broader tcc rewrite still rewrites quoted path substrings, even in
+	// data bearing options; only rewrite_windows_path_operand_arg (gcc) leaves
+	// them alone
+	arg := r'-DROOT="C:\Program Files\SDK"'
+	expected := r'-DROOT="C:\PROGRA~1\SDK"'
+	assert rewrite_windows_path_arg(arg, fake_windows_short_path) == expected
 }
 
 fn test_cc_uses_short_windows_paths() {

--- a/vlib/v/builder/cc_tcc_retry_test.v
+++ b/vlib/v/builder/cc_tcc_retry_test.v
@@ -340,6 +340,12 @@ fn test_gcc_response_file_content_quotes_exact_arguments() {
 	assert gcc_response_file_content([r'-B"C:\toolchain\\"', r'-DNAME=\"foo\"']) == r'"-BC:\\toolchain\\" "-DNAME=\"foo\""'
 }
 
+fn test_windows_batch_compilers_keep_the_command_interpreter_path() {
+	assert ccompiler_is_windows_batch_file(r'C:\toolchains\gcc-wrapper.cmd')
+	assert ccompiler_is_windows_batch_file(r'"C:\Program Files\GCC\gcc-wrapper.BAT"')
+	assert !ccompiler_is_windows_batch_file(r'C:\toolchains\gcc.exe')
+}
+
 fn test_windows_gnu_compilers_compile_in_a_non_ascii_directory() {
 	if os.user_os() != 'windows' {
 		return

--- a/vlib/v/builder/cc_tcc_retry_test.v
+++ b/vlib/v/builder/cc_tcc_retry_test.v
@@ -340,6 +340,11 @@ fn test_gcc_response_file_content_quotes_exact_arguments() {
 	assert gcc_response_file_content([r'-B"C:\toolchain\\"', r'-DNAME=\"foo\"']) == r'"-BC:\\toolchain\\" "-DNAME=\"foo\""'
 }
 
+fn test_windows_exec_arg_escaping_preserves_embedded_quotes() {
+	assert windows_quote_exec_arg(r'-DNAME="café"') == r'"-DNAME=\"café\""'
+	assert windows_quote_exec_arg(r'C:\work\') == r'"C:\work\\"'
+}
+
 fn test_windows_batch_compilers_keep_the_command_interpreter_path() {
 	assert ccompiler_is_windows_batch_file(r'C:\toolchains\gcc-wrapper.cmd')
 	assert ccompiler_is_windows_batch_file(r'"C:\Program Files\GCC\gcc-wrapper.BAT"')
@@ -393,6 +398,14 @@ fn test_gcc_unicode_response_plan_uses_ansi_when_it_preserves_oversized_unicode_
 	assert plan.args == [r'@D:\工作目录\main.c.rsp']
 	assert plan.response_files == [r'D:\工作目录\main.c.rsp']
 	assert plan.response_contents[0].contains(r'D:\\工作目录\\cached_1199.o')
+}
+
+fn test_gcc_unicode_response_plan_sizes_windows_escaped_arguments() {
+	arg := r'-DNAME=\"工作\"'
+	exact_arg := ccompiler_exec_args('', [arg])[1]
+	plan := gcc_unicode_response_plan(r'D:\工作目录\main.c.rsp', [arg], exact_arg.len + 3,
+		true)!
+	assert plan.args == [r'@D:\工作目录\main.c.rsp']
 }
 
 fn test_gcc_unicode_response_plan_rejects_an_unrepresentable_oversized_command() {

--- a/vlib/v/builder/cc_tcc_retry_test.v
+++ b/vlib/v/builder/cc_tcc_retry_test.v
@@ -366,6 +366,33 @@ fn test_windows_batch_compilers_keep_the_command_interpreter_path() {
 	}
 }
 
+fn test_windows_batch_execution_preserves_percent_literals() {
+	$if windows {
+		test_root := os.join_path(os.vtmp_dir(), 'v_gcc_batch_percent_${os.getpid()}')
+		wrapper := os.join_path(test_root, 'v-gcc-wrapper.cmd')
+		os.mkdir_all(test_root) or { panic(err) }
+		defer {
+			os.rmdir_all(test_root) or {}
+		}
+		os.write_file(wrapper, '@echo off\r\necho %*\r\n') or { panic(err) }
+		old_keep := os.getenv_opt('KEEP')
+		os.setenv('KEEP', 'expanded', true)
+		defer {
+			if keep := old_keep {
+				os.setenv('KEEP', keep, true)
+			} else {
+				os.unsetenv('KEEP')
+			}
+		}
+		arg := r'-DROOT=D:\工作\%KEEP%\main.c'
+		cmd := '${windows_quote_exec_arg(wrapper)} ${windows_quote_exec_arg(arg)}'
+		res := execute_windows_batch_ccompiler(cmd)
+		assert res.exit_code == 0, res.output
+		assert res.output.contains(r'%KEEP%'), res.output
+		assert !res.output.contains('expanded'), res.output
+	}
+}
+
 fn test_gcc_unicode_response_plan_keeps_large_ascii_runs_out_of_the_command_line() {
 	mut args := []string{}
 	for i in 0 .. 2000 {

--- a/vlib/v/builder/cc_tcc_retry_test.v
+++ b/vlib/v/builder/cc_tcc_retry_test.v
@@ -288,8 +288,8 @@ fn test_rewrite_windows_path_arg_rewrites_path_like_values() {
 }
 
 fn test_cc_uses_short_windows_paths() {
-	// tcc and the MinGW gcc toolchain both read response files with the ANSI
-	// C runtime, so both need ASCII 8.3 short paths on Windows (see issue #28126).
+	// tcc and the MinGW gcc toolchain both read response files with the ANSI C
+	// runtime, so both prefer ASCII 8.3 short paths on Windows (see issue #28126).
 	assert cc_uses_short_windows_paths(.tcc)
 	assert cc_uses_short_windows_paths(.gcc)
 	// clang, msvc, icc, emcc and unknown compilers are excluded:
@@ -300,4 +300,33 @@ fn test_cc_uses_short_windows_paths() {
 	assert !cc_uses_short_windows_paths(.icc)
 	assert !cc_uses_short_windows_paths(.emcc)
 	assert !cc_uses_short_windows_paths(.unknown)
+}
+
+fn test_gcc_rsp_args_require_ascii_paths() {
+	assert gcc_rsp_args_are_ascii([
+		r'-o "C:\PROGRA~1\main.exe"',
+		r'"C:\Users\RUNNER~1\main.c"',
+	])
+	assert !gcc_rsp_args_are_ascii([r'-o "D:\a\_temp\工作目录\main.exe"'])
+}
+
+fn test_windows_gcc_compiles_in_a_non_ascii_directory() {
+	if os.user_os() != 'windows' {
+		return
+	}
+	gcc := os.find_abs_path_of_executable('gcc') or { return }
+	test_root := os.join_path(os.vtmp_dir(), 'v_builder_gcc_工作目录_${os.getpid()}')
+	source_path := os.join_path(test_root, 'main.v')
+	exe_path := os.join_path(test_root, 'main.exe')
+	os.mkdir_all(test_root) or { panic(err) }
+	defer {
+		os.rmdir_all(test_root) or {}
+	}
+	os.write_file(source_path, "fn main() { println('unicode-path-ok') }\n") or { panic(err) }
+	res :=
+		execute_tcc_retry_test_command('${os.quoted_path(@VEXE)} -cc ${os.quoted_path(gcc)} -gc none -no-retry-compilation -o ${os.quoted_path(exe_path)} ${os.quoted_path(source_path)}')
+	assert res.exit_code == 0, res.output
+	run := os.execute(os.quoted_path(exe_path))
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'unicode-path-ok', run.output
 }

--- a/vlib/v/builder/cc_tcc_retry_test.v
+++ b/vlib/v/builder/cc_tcc_retry_test.v
@@ -346,6 +346,28 @@ fn test_windows_batch_compilers_keep_the_command_interpreter_path() {
 	assert !ccompiler_is_windows_batch_file(r'C:\toolchains\gcc.exe')
 }
 
+fn test_gcc_unicode_response_plan_keeps_large_ascii_runs_out_of_the_command_line() {
+	mut args := []string{}
+	for i in 0 .. 2000 {
+		args << '-DV_WINDOWS_UNICODE_PATH_LONG_COMMAND_${i}=1'
+	}
+	assert args.join(' ').len > 32767
+	args << r'-o "D:\工作目录\main.exe"'
+	args << r'"D:\工作目录\main.c"'
+	args << '-lm'
+	plan := gcc_unicode_response_plan(r'D:\工作目录\main.c.rsp', args)
+	assert plan.args == [
+		r'@D:\工作目录\main.c.rsp.0',
+		r'D:\工作目录\main.exe',
+		r'D:\工作目录\main.c',
+		r'@D:\工作目录\main.c.rsp.1',
+	]
+	assert plan.response_files == [r'D:\工作目录\main.c.rsp.0', r'D:\工作目录\main.c.rsp.1']
+	assert plan.response_contents[0].contains('V_WINDOWS_UNICODE_PATH_LONG_COMMAND_1999')
+	assert plan.response_contents[1] == '"-lm"'
+	assert plan.args.join(' ').len < 8191
+}
+
 fn test_windows_gnu_compilers_compile_in_a_non_ascii_directory() {
 	if os.user_os() != 'windows' {
 		return

--- a/vlib/v/builder/cc_tcc_retry_test.v
+++ b/vlib/v/builder/cc_tcc_retry_test.v
@@ -269,6 +269,7 @@ fn test_rewrite_windows_path_operand_arg_rewrites_path_operands() {
 	expected := r'"C:\Users\LEO~1\.vmodules\.cache\bc\artifact.o"'
 	assert rewrite_windows_path_operand_arg(obj, fake_windows_short_path) == expected
 	assert rewrite_windows_path_operand_arg(r"'C:\Users\Léo\input.o'", fake_windows_short_path) == r'"C:\Users\LEO~1\input.o"'
+	assert rewrite_windows_path_operand_arg(r'-B"C:\toolchain\"', fake_windows_short_path) == r'-B"C:\toolchain\\"'
 }
 
 fn test_rewrite_windows_path_operand_arg_leaves_path_like_values_alone() {
@@ -322,7 +323,7 @@ fn test_gcc_rsp_args_require_ascii_paths() {
 
 fn test_ccompiler_exec_args_split_shell_formatted_options() {
 	assert ccompiler_exec_args('gcc', [r'-o "C:\Users\工作\main.exe"', r'"C:\Users\工作\main.c"',
-		r'-I"C:\Program Files\SDK"', '-DFOO=1 -DBAR=2']) == [
+		r'-I"C:\Program Files\SDK"', '-DFOO=1 -DBAR=2', r'-B"C:\toolchain\\"', r'-DNAME=\"foo\"']) == [
 		'gcc',
 		'-o',
 		r'C:\Users\工作\main.exe',
@@ -330,7 +331,13 @@ fn test_ccompiler_exec_args_split_shell_formatted_options() {
 		r'-IC:\Program Files\SDK',
 		'-DFOO=1',
 		'-DBAR=2',
+		r'-BC:\toolchain\',
+		r'-DNAME="foo"',
 	]
+}
+
+fn test_gcc_response_file_content_quotes_exact_arguments() {
+	assert gcc_response_file_content([r'-B"C:\toolchain\\"', r'-DNAME=\"foo\"']) == r'"-BC:\\toolchain\\" "-DNAME=\"foo\""'
 }
 
 fn test_windows_gnu_compilers_compile_in_a_non_ascii_directory() {

--- a/vlib/v/builder/cc_tcc_retry_test.v
+++ b/vlib/v/builder/cc_tcc_retry_test.v
@@ -320,6 +320,19 @@ fn test_gcc_rsp_args_require_ascii_paths() {
 	assert !gcc_rsp_args_are_ascii([r'-o "D:\a\_temp\工作目录\main.exe"'])
 }
 
+fn test_ccompiler_exec_args_split_shell_formatted_options() {
+	assert ccompiler_exec_args('gcc', [r'-o "C:\Users\工作\main.exe"', r'"C:\Users\工作\main.c"',
+		r'-I"C:\Program Files\SDK"', '-DFOO=1 -DBAR=2']) == [
+		'gcc',
+		'-o',
+		r'C:\Users\工作\main.exe',
+		r'C:\Users\工作\main.c',
+		r'-IC:\Program Files\SDK',
+		'-DFOO=1',
+		'-DBAR=2',
+	]
+}
+
 fn test_windows_gnu_compilers_compile_in_a_non_ascii_directory() {
 	if os.user_os() != 'windows' {
 		return
@@ -333,7 +346,13 @@ fn test_windows_gnu_compilers_compile_in_a_non_ascii_directory() {
 		defer {
 			os.rmdir_all(test_root) or {}
 		}
-		os.write_file(source_path, "fn main() { println('unicode-path-ok') }\n") or {
+		mut source := ''
+		for i in 0 .. 400 {
+			source += '#flag -DV_WINDOWS_UNICODE_PATH_LONG_COMMAND_${i}=1\n'
+		}
+		source += "fn main() { println('unicode-path-ok') }\n"
+		assert source.len > 8191
+		os.write_file(source_path, source) or {
 			panic(err)
 		}
 		res :=

--- a/vlib/v/builder/cc_tcc_retry_test.v
+++ b/vlib/v/builder/cc_tcc_retry_test.v
@@ -295,18 +295,19 @@ fn test_rewrite_windows_path_arg_rewrites_path_like_values() {
 }
 
 fn test_cc_uses_short_windows_paths() {
-	// tcc and the MinGW gcc toolchain both read response files with the ANSI C
+	// tcc and the MinGW GCC toolchain both read response files with the ANSI C
 	// runtime, so both prefer ASCII 8.3 short paths on Windows (see issue #28126).
-	assert cc_uses_short_windows_paths(.tcc)
-	assert cc_uses_short_windows_paths(.gcc)
+	assert cc_uses_short_windows_paths(.tcc, .tinyc)
+	assert cc_uses_short_windows_paths(.gcc, .gcc)
+	assert cc_uses_short_windows_paths(.unknown, .cplusplus)
 	// clang, msvc, icc, emcc and unknown compilers are excluded:
 	// msvc uses the wide CreateProcessW command line directly, while the
 	// clang/LLVM toolchain handles Unicode paths on its own.
-	assert !cc_uses_short_windows_paths(.clang)
-	assert !cc_uses_short_windows_paths(.msvc)
-	assert !cc_uses_short_windows_paths(.icc)
-	assert !cc_uses_short_windows_paths(.emcc)
-	assert !cc_uses_short_windows_paths(.unknown)
+	assert !cc_uses_short_windows_paths(.clang, .clang)
+	assert !cc_uses_short_windows_paths(.msvc, .msvc)
+	assert !cc_uses_short_windows_paths(.icc, .gcc)
+	assert !cc_uses_short_windows_paths(.emcc, .emcc)
+	assert !cc_uses_short_windows_paths(.unknown, .gcc)
 }
 
 fn test_gcc_rsp_args_require_ascii_paths() {
@@ -317,23 +318,27 @@ fn test_gcc_rsp_args_require_ascii_paths() {
 	assert !gcc_rsp_args_are_ascii([r'-o "D:\a\_temp\工作目录\main.exe"'])
 }
 
-fn test_windows_gcc_compiles_in_a_non_ascii_directory() {
+fn test_windows_gnu_compilers_compile_in_a_non_ascii_directory() {
 	if os.user_os() != 'windows' {
 		return
 	}
-	gcc := os.find_abs_path_of_executable('gcc') or { return }
-	test_root := os.join_path(os.vtmp_dir(), 'v_builder_gcc_工作目录_${os.getpid()}')
-	source_path := os.join_path(test_root, 'main.v')
-	exe_path := os.join_path(test_root, 'main.exe')
-	os.mkdir_all(test_root) or { panic(err) }
-	defer {
-		os.rmdir_all(test_root) or {}
+	for compiler_name in ['gcc', 'g++', 'c++'] {
+		compiler := os.find_abs_path_of_executable(compiler_name) or { continue }
+		test_root := os.join_path(os.vtmp_dir(), 'v_builder_${compiler_name}_工作目录_${os.getpid()}')
+		source_path := os.join_path(test_root, 'main.v')
+		exe_path := os.join_path(test_root, 'main.exe')
+		os.mkdir_all(test_root) or { panic(err) }
+		defer {
+			os.rmdir_all(test_root) or {}
+		}
+		os.write_file(source_path, "fn main() { println('unicode-path-ok') }\n") or {
+			panic(err)
+		}
+		res :=
+			execute_tcc_retry_test_command('${os.quoted_path(@VEXE)} -cc ${os.quoted_path(compiler)} -gc none -no-retry-compilation -o ${os.quoted_path(exe_path)} ${os.quoted_path(source_path)}')
+		assert res.exit_code == 0, '${compiler_name}: ${res.output}'
+		run := os.execute(os.quoted_path(exe_path))
+		assert run.exit_code == 0, '${compiler_name}: ${run.output}'
+		assert run.output.trim_space() == 'unicode-path-ok', '${compiler_name}: ${run.output}'
 	}
-	os.write_file(source_path, "fn main() { println('unicode-path-ok') }\n") or { panic(err) }
-	res :=
-		execute_tcc_retry_test_command('${os.quoted_path(@VEXE)} -cc ${os.quoted_path(gcc)} -gc none -no-retry-compilation -o ${os.quoted_path(exe_path)} ${os.quoted_path(source_path)}')
-	assert res.exit_code == 0, res.output
-	run := os.execute(os.quoted_path(exe_path))
-	assert run.exit_code == 0, run.output
-	assert run.output.trim_space() == 'unicode-path-ok', run.output
 }

--- a/vlib/v/builder/cc_tcc_retry_test.v
+++ b/vlib/v/builder/cc_tcc_retry_test.v
@@ -278,6 +278,13 @@ fn test_rewrite_windows_path_operand_arg_leaves_path_like_values_alone() {
 	}
 }
 
+fn test_rewrite_windows_path_operand_arg_leaves_compound_environment_flags_alone() {
+	for arg in [r'-IC:\sdk -DFOO=1', r'-I"C:\Program Files\SDK" -DFOO=1', r'-LC:\sdk -lfoo',
+		r'"C:\sdk\input.o" -DFOO=1'] {
+		assert rewrite_windows_path_operand_arg(arg, fake_windows_short_path) == arg
+	}
+}
+
 fn test_rewrite_windows_path_arg_rewrites_path_like_values() {
 	// the broader tcc rewrite still rewrites quoted path substrings, even in
 	// data bearing options; only rewrite_windows_path_operand_arg (gcc) leaves

--- a/vlib/v/builder/cc_tcc_retry_test.v
+++ b/vlib/v/builder/cc_tcc_retry_test.v
@@ -344,6 +344,21 @@ fn test_windows_batch_compilers_keep_the_command_interpreter_path() {
 	assert ccompiler_is_windows_batch_file(r'C:\toolchains\gcc-wrapper.cmd')
 	assert ccompiler_is_windows_batch_file(r'"C:\Program Files\GCC\gcc-wrapper.BAT"')
 	assert !ccompiler_is_windows_batch_file(r'C:\toolchains\gcc.exe')
+	$if windows {
+		test_root := os.join_path(os.vtmp_dir(), 'v_gcc_batch_resolve_${os.getpid()}')
+		wrapper := os.join_path(test_root, 'v-gcc-wrapper.cmd')
+		os.mkdir_all(test_root) or { panic(err) }
+		defer {
+			os.rmdir_all(test_root) or {}
+		}
+		os.write_file(wrapper, '@echo off\r\nexit /b 0\r\n') or { panic(err) }
+		old_path := os.getenv('PATH')
+		defer {
+			os.setenv('PATH', old_path, true)
+		}
+		os.setenv('PATH', test_root + os.path_delimiter + old_path, true)
+		assert ccompiler_is_windows_batch_file('v-gcc-wrapper')
+	}
 }
 
 fn test_gcc_unicode_response_plan_keeps_large_ascii_runs_out_of_the_command_line() {
@@ -355,7 +370,7 @@ fn test_gcc_unicode_response_plan_keeps_large_ascii_runs_out_of_the_command_line
 	args << r'-o "D:\工作目录\main.exe"'
 	args << r'"D:\工作目录\main.c"'
 	args << '-lm'
-	plan := gcc_unicode_response_plan(r'D:\工作目录\main.c.rsp', args, 30000)
+	plan := gcc_unicode_response_plan(r'D:\工作目录\main.c.rsp', args, 30000, false)!
 	assert plan.args == [
 		r'@D:\工作目录\main.c.rsp.0',
 		r'D:\工作目录\main.exe',
@@ -365,21 +380,31 @@ fn test_gcc_unicode_response_plan_keeps_large_ascii_runs_out_of_the_command_line
 	assert plan.response_files == [r'D:\工作目录\main.c.rsp.0', r'D:\工作目录\main.c.rsp.1']
 	assert plan.response_contents[0].contains('V_WINDOWS_UNICODE_PATH_LONG_COMMAND_1999')
 	assert plan.response_contents[1] == '"-lm"'
-	assert plan.response_utf8 == [false, false]
 	assert plan.args.join(' ').len < 8191
 }
 
-fn test_gcc_unicode_response_plan_uses_utf8_for_oversized_unicode_runs() {
+fn test_gcc_unicode_response_plan_uses_ansi_when_it_preserves_oversized_unicode_runs() {
 	mut args := [r'-o "D:\工作目录\main.exe"']
 	for i in 0 .. 1200 {
 		args << '"D:\\工作目录\\cached_${i}.o"'
 	}
 	assert args.join(' ').len > 32767
-	plan := gcc_unicode_response_plan(r'D:\工作目录\main.c.rsp', args, 30000)
+	plan := gcc_unicode_response_plan(r'D:\工作目录\main.c.rsp', args, 30000, true)!
 	assert plan.args == [r'@D:\工作目录\main.c.rsp']
 	assert plan.response_files == [r'D:\工作目录\main.c.rsp']
-	assert plan.response_utf8 == [true]
 	assert plan.response_contents[0].contains(r'D:\\工作目录\\cached_1199.o')
+}
+
+fn test_gcc_unicode_response_plan_rejects_an_unrepresentable_oversized_command() {
+	mut args := []string{}
+	for i in 0 .. 1200 {
+		args << '"D:\\工作目录\\cached_${i}.o"'
+	}
+	if plan := gcc_unicode_response_plan(r'D:\工作目录\main.c.rsp', args, 30000, false) {
+		assert false, '${plan.args}'
+	} else {
+		assert err.msg().contains('cannot be represented in the active ANSI code page')
+	}
 }
 
 fn test_windows_gnu_compilers_compile_in_a_non_ascii_directory() {

--- a/vlib/v/builder/cc_tcc_retry_test.v
+++ b/vlib/v/builder/cc_tcc_retry_test.v
@@ -355,7 +355,7 @@ fn test_gcc_unicode_response_plan_keeps_large_ascii_runs_out_of_the_command_line
 	args << r'-o "D:\工作目录\main.exe"'
 	args << r'"D:\工作目录\main.c"'
 	args << '-lm'
-	plan := gcc_unicode_response_plan(r'D:\工作目录\main.c.rsp', args)
+	plan := gcc_unicode_response_plan(r'D:\工作目录\main.c.rsp', args, 30000)
 	assert plan.args == [
 		r'@D:\工作目录\main.c.rsp.0',
 		r'D:\工作目录\main.exe',
@@ -365,7 +365,21 @@ fn test_gcc_unicode_response_plan_keeps_large_ascii_runs_out_of_the_command_line
 	assert plan.response_files == [r'D:\工作目录\main.c.rsp.0', r'D:\工作目录\main.c.rsp.1']
 	assert plan.response_contents[0].contains('V_WINDOWS_UNICODE_PATH_LONG_COMMAND_1999')
 	assert plan.response_contents[1] == '"-lm"'
+	assert plan.response_utf8 == [false, false]
 	assert plan.args.join(' ').len < 8191
+}
+
+fn test_gcc_unicode_response_plan_uses_utf8_for_oversized_unicode_runs() {
+	mut args := [r'-o "D:\工作目录\main.exe"']
+	for i in 0 .. 1200 {
+		args << '"D:\\工作目录\\cached_${i}.o"'
+	}
+	assert args.join(' ').len > 32767
+	plan := gcc_unicode_response_plan(r'D:\工作目录\main.c.rsp', args, 30000)
+	assert plan.args == [r'@D:\工作目录\main.c.rsp']
+	assert plan.response_files == [r'D:\工作目录\main.c.rsp']
+	assert plan.response_utf8 == [true]
+	assert plan.response_contents[0].contains(r'D:\\工作目录\\cached_1199.o')
 }
 
 fn test_windows_gnu_compilers_compile_in_a_non_ascii_directory() {

--- a/vlib/v/builder/cc_tcc_retry_test.v
+++ b/vlib/v/builder/cc_tcc_retry_test.v
@@ -402,7 +402,7 @@ fn test_gcc_unicode_response_plan_keeps_large_ascii_runs_out_of_the_command_line
 	args << r'-o "D:\工作目录\main.exe"'
 	args << r'"D:\工作目录\main.c"'
 	args << '-lm'
-	plan := gcc_unicode_response_plan(r'D:\工作目录\main.c.rsp', args, 30000, false)!
+	plan := gcc_unicode_response_plan(r'D:\工作目录\main.c.rsp', args, 30000)
 	assert plan.args == [
 		r'@D:\工作目录\main.c.rsp.0',
 		r'D:\工作目录\main.exe',
@@ -413,6 +413,7 @@ fn test_gcc_unicode_response_plan_keeps_large_ascii_runs_out_of_the_command_line
 	assert plan.response_contents[0].contains('V_WINDOWS_UNICODE_PATH_LONG_COMMAND_1999')
 	assert plan.response_contents[1] == '"-lm"'
 	assert plan.args.join(' ').len < 8191
+	assert !plan.requires_full_response
 }
 
 fn test_gcc_unicode_response_plan_uses_ansi_when_it_preserves_oversized_unicode_runs() {
@@ -421,29 +422,70 @@ fn test_gcc_unicode_response_plan_uses_ansi_when_it_preserves_oversized_unicode_
 		args << '"D:\\工作目录\\cached_${i}.o"'
 	}
 	assert args.join(' ').len > 32767
-	plan := gcc_unicode_response_plan(r'D:\工作目录\main.c.rsp', args, 30000, true)!
+	split_plan := gcc_unicode_response_plan(r'D:\工作目录\main.c.rsp', args, 30000)
+	assert split_plan.requires_full_response
+	plan := gcc_unicode_full_response_plan(r'D:\工作目录\main.c.rsp',
+		split_plan.full_response_content, .ansi)
 	assert plan.args == [r'@D:\工作目录\main.c.rsp']
 	assert plan.response_files == [r'D:\工作目录\main.c.rsp']
+	assert plan.response_contents[0].contains(r'D:\\工作目录\\cached_1199.o')
+	assert plan.response_encoding == .ansi
+}
+
+fn test_gcc_unicode_response_plan_uses_utf8_when_the_driver_accepts_it() {
+	mut args := []string{}
+	for i in 0 .. 1200 {
+		args << '"D:\\工作目录\\cached_${i}.o"'
+	}
+	split_plan := gcc_unicode_response_plan(r'D:\工作目录\main.c.rsp', args, 30000)
+	assert split_plan.requires_full_response
+	plan := gcc_unicode_full_response_plan(r'D:\工作目录\main.c.rsp',
+		split_plan.full_response_content, .utf8)
+	assert plan.args == [r'@D:\工作目录\main.c.rsp']
+	assert plan.response_encoding == .utf8
 	assert plan.response_contents[0].contains(r'D:\\工作目录\\cached_1199.o')
 }
 
 fn test_gcc_unicode_response_plan_sizes_windows_escaped_arguments() {
 	arg := r'-DNAME=\"工作\"'
 	exact_arg := ccompiler_exec_args('', [arg])[1]
-	plan := gcc_unicode_response_plan(r'D:\工作目录\main.c.rsp', [arg], exact_arg.len + 3,
-		true)!
+	split_plan := gcc_unicode_response_plan(r'D:\工作目录\main.c.rsp', [arg], exact_arg.len + 3)
+	assert split_plan.requires_full_response
+	plan := gcc_unicode_full_response_plan(r'D:\工作目录\main.c.rsp',
+		split_plan.full_response_content, .ansi)
 	assert plan.args == [r'@D:\工作目录\main.c.rsp']
 }
 
-fn test_gcc_unicode_response_plan_rejects_an_unrepresentable_oversized_command() {
-	mut args := []string{}
-	for i in 0 .. 1200 {
-		args << '"D:\\工作目录\\cached_${i}.o"'
+fn test_gcc_response_file_encoding_prefers_the_selected_drivers_utf8_support() {
+	assert gcc_response_file_encoding_from_probes(true, false, false)! == .utf8
+	assert gcc_response_file_encoding_from_probes(true, true, true)! == .utf8
+}
+
+fn test_gcc_response_file_encoding_uses_only_lossless_supported_ansi() {
+	assert gcc_response_file_encoding_from_probes(false, true, true)! == .ansi
+	for probe in [[true, false], [false, true], [false, false]] {
+		if encoding := gcc_response_file_encoding_from_probes(false, probe[0], probe[1]) {
+			assert false, '${encoding}'
+		} else {
+			assert err.msg().contains('lossless active-code-page response file')
+		}
 	}
-	if plan := gcc_unicode_response_plan(r'D:\工作目录\main.c.rsp', args, 30000, false) {
-		assert false, '${plan.args}'
-	} else {
-		assert err.msg().contains('cannot be represented in the active ANSI code page')
+}
+
+fn test_write_gcc_response_file_honors_the_selected_encoding() {
+	$if windows {
+		test_root := os.join_path(os.vtmp_dir(), 'v_gcc_rsp_encoding_${os.getpid()}')
+		utf8_file := os.join_path(test_root, 'utf8.rsp')
+		ansi_file := os.join_path(test_root, 'ansi.rsp')
+		content := '"café 工作"'
+		os.mkdir_all(test_root) or { panic(err) }
+		defer {
+			os.rmdir_all(test_root) or {}
+		}
+		write_gcc_response_file(utf8_file, content, .utf8)
+		write_gcc_response_file(ansi_file, content, .ansi)
+		assert os.read_bytes(utf8_file)! == content.bytes()
+		assert os.read_bytes(ansi_file)! == string_to_ansi_not_null_terminated(content)
 	}
 }
 

--- a/vlib/v/builder/cc_tcc_retry_test.v
+++ b/vlib/v/builder/cc_tcc_retry_test.v
@@ -261,12 +261,14 @@ fn test_rewrite_windows_path_arg_leaves_non_paths_alone() {
 
 fn test_rewrite_windows_path_operand_arg_rewrites_path_operands() {
 	assert rewrite_windows_path_operand_arg(r'-I"C:\Users\Léo\include"', fake_windows_short_path) == r'-I"C:\Users\LEO~1\include"'
+	assert rewrite_windows_path_operand_arg(r"-I'C:\Users\Léo\include'", fake_windows_short_path) == r'-I"C:\Users\LEO~1\include"'
 	assert rewrite_windows_path_operand_arg(r'-L"C:\Users\Léo\lib"', fake_windows_short_path) == r'-L"C:\Users\LEO~1\lib"'
 	assert rewrite_windows_path_operand_arg(r'-B"C:\Users\Léo\bin"', fake_windows_short_path) == r'-B"C:\Users\LEO~1\bin"'
 	assert rewrite_windows_path_operand_arg(r'-o "C:\Users\Léo\bin\tool.exe"', fake_windows_short_path) == r'-o "C:\Users\LEO~1\bin\tool.exe"'
 	obj := r'"C:\Users\Léo\.vmodules\.cache\bc\artifact.o"'
 	expected := r'"C:\Users\LEO~1\.vmodules\.cache\bc\artifact.o"'
 	assert rewrite_windows_path_operand_arg(obj, fake_windows_short_path) == expected
+	assert rewrite_windows_path_operand_arg(r"'C:\Users\Léo\input.o'", fake_windows_short_path) == r'"C:\Users\LEO~1\input.o"'
 }
 
 fn test_rewrite_windows_path_operand_arg_leaves_path_like_values_alone() {


### PR DESCRIPTION
Fixes https://github.com/vlang/v/issues/28126

## Problem

On Windows, `v -cc gcc run main.v` fails when the project is in a directory whose path contains non-ASCII characters (e.g. `D:\工作目录`), while `v -cc tcc` and a direct `gcc test.c -o test.exe` both work:

```
ld.exe: cannot open output file D:\???????\main.exe: Invalid argument
```

## Root cause

V passes the C compiler arguments through a `.rsp` response file, whose contents are written using the ANSI code page encoding (`write_response_file`). The MinGW gcc toolchain reads response-file contents with the ANSI C runtime. When the code page cannot represent the non-ASCII characters (or the compiler build expects UTF-8), the paths are mangled into `?` before they reach `ld`.

tcc never hits this, because V already rewrites **all** Windows path arguments to pure ASCII 8.3 short names (`os.short_path`) when `cc == .tcc`. ASCII short paths are encoding-agnostic, so they survive the response file intact for both ANSI-CRT and UTF-8-native toolchains.

## Fix

Extend that existing mechanism to gcc: new `cc_uses_short_windows_paths()` helper gates the rewrite for `.gcc` and `.tcc`. Since `tcc_windows_path`/`tcc_windows_path_arg`/`tcc_quoted_path` already feed the `-o` output path, source paths, thirdparty args and the parallel-compile rsp path, no other call site needs changes.

clang, msvc, icc, emcc are intentionally excluded: msvc already keeps Unicode on the direct wide `CreateProcessW` command line (`msvc_should_use_rsp`), and the LLVM toolchain handles Unicode paths itself.

## Tests

- Added `test_cc_uses_short_windows_paths()` (Linux-runnable) in `vlib/v/builder/cc_tcc_retry_test.v`.
- Existing `rewrite_windows_path_arg` unit tests already cover the rewriting mechanics.
- `./vnew -silent test vlib/v/builder/` → 15 passed, 1 skipped (Windows-only).
- `./vnew -silent test vlib/v/builder/cc_tcc_retry_test.v` → 1 passed.
- `compiler_errors_test.v`: 52/53 pass; the 1 failure (`skip_unused/auto_str.vv`) also fails on clean master in this environment (V1/V3 default drift), unrelated to this change.

## Caveat

The fix relies on 8.3 short-name support on the target volume (Windows default). On volumes with 8.3 name creation disabled, gcc on non-ASCII paths will still fail — the same limitation tcc already has.