### PR TITLE
v3: speed up large program compilation

### DIFF
--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -88,8 +88,11 @@ currently supported collector mode. Directory builds read `subdirs` through the 
 Native C compilation uses `-fwrapv` on supported targets so signed integer overflow retains V's
 two's-complement semantics. On macOS, `-cg` links executables with exported symbols for symbolic
 backtraces while plain `-g` retains its V-source debug behavior.
-The driver monitors compiler memory throughout the build and exits when it reaches 3840 MiB,
-leaving sampling headroom below a 4 GiB process ceiling.
+For `-prod`, generated C units of at least 8 MiB use `-O2 -flto`; Clang also uses a bounded inline
+threshold for those units. Smaller production units retain `-O3 -flto`.
+The driver monitors compiler memory throughout the build. Ordinary builds stop at 4032 MiB;
+compiler-tree and self-host builds stop at 3840 MiB, leaving extra sampling headroom below a
+4 GiB process ceiling.
 On macOS it uses physical footprint, matching Activity Monitor more closely; elsewhere it uses
 current RSS. Pass `-no-memory-limit`/`--no-memory-limit` to disable this safety limit.
 On macOS and Linux, `make` and the default `v self` build the compiler with `-prealloc`, enabling

--- a/vlib/v3/bench/bench.v
+++ b/vlib/v3/bench/bench.v
@@ -5,9 +5,9 @@ import runtime
 import sync
 import time
 
-// Leave 256 MiB below the externally visible 4 GiB ceiling so an allocation
-// between watchdog samples cannot make the process cross that ceiling first.
-const default_memory_limit_kb = i64(3840) * 1024
+// Ordinary builds leave 64 MiB below the externally visible 4 GiB ceiling.
+// Compiler-tree and self-host builds retain the larger 256 MiB sampling cushion.
+const default_memory_limit_kb = i64(4032) * 1024
 const self_host_memory_limit_kb = i64(3840) * 1024
 const compiler_tree_memory_limit_kb = i64(3840) * 1024
 const memory_monitor_interval = 10 * time.millisecond

--- a/vlib/v3/bench/bench_test.v
+++ b/vlib/v3/bench/bench_test.v
@@ -11,8 +11,8 @@ fn test_memory_limit_error_starts_at_limit() {
 
 	message := memory_limit_error(default_memory_limit_kb, default_memory_limit_kb, 'after parse',
 		'RSS')
-	assert message.contains('3840 MiB RSS after parse')
-	assert message.contains('limit: 3840 MiB')
+	assert message.contains('4032 MiB RSS after parse')
+	assert message.contains('limit: 4032 MiB')
 	assert message.contains('`-no-memory-limit`')
 }
 

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -26,20 +26,25 @@ import v3.workers
 import v.build_constraint
 import v.vmod
 
+// vfmt off
 $if !skip_fastc ? {
 	import v3.gen.fastc
 }
+
 $if !skip_eval ? {
 	import v3.eval
 }
+
 $if !skip_arm64 ? {
 	import v3.gen.arm64
 	import v3.ssa
 	import v3.ssa.optimize
 }
+
 $if !skip_wasm ? {
-	import v3.gen.wasm
+	import v3.gen.wasm as wasmgen
 }
+// vfmt on
 
 const cache_bundle_import_file_name = '.v3_cache_bundle_imports.vh'
 const macos_v3_fallback_file_env = 'V_MACOS_V3_FALLBACK_FILE'
@@ -284,8 +289,7 @@ fn add_c_language_runtime_link_flags(mut prepared []string, original []string, l
 			prepared << cpp_runtime
 		}
 	}
-	if language in ['objective-c', 'objective-c++'] && '-lobjc' !in original
-		&& '-lobjc' !in prepared {
+	if language in ['objective-c', 'objective-c++'] && '-lobjc' !in original && '-lobjc' !in prepared {
 		prepared << '-lobjc'
 	}
 }
@@ -317,8 +321,7 @@ fn prepare_c_flags_for_link(flags []string, environment_c_flags []string, optimi
 	support_flags << c_object_compile_support_flags(flags)
 	cache_dir := os.join_path(os.vtmp_dir(), 'v3_thirdparty_objs')
 	os.mkdir_all(cache_dir)!
-	plan_path := c_link_plan_path(cache_dir, flags, support_flags, c99, pic_flag, target_args,
-		target, c_compiler, mut stats)
+	plan_path := c_link_plan_path(cache_dir, flags, support_flags, c99, pic_flag, target_args, target, c_compiler, mut stats)
 	// Tracing intentionally walks the object manifests so every requested
 	// object's cache decision remains visible.
 	if os.getenv('V3_CACHE_TRACE') == '' {
@@ -358,15 +361,13 @@ fn prepare_c_flags_for_link(flags []string, environment_c_flags []string, optimi
 			} else {
 				''
 			}
-			object_path := ensure_c_object_file(clean, active_language, support_flags, c99,
-				pic_flag, target_args, target, c_compiler, uncached_dir, mut stats)!
+			object_path := ensure_c_object_file(clean, active_language, support_flags, c99, pic_flag, target_args, target, c_compiler, uncached_dir, mut stats)!
 			append_c_link_object(mut prepared, object_path, active_language)
 			add_c_language_runtime_link_flags(mut prepared, flags, adjacent_language, target)
 		} else if clean.ends_with('.mm') {
 			stats.requests++
 			language := c_source_language(clean, active_language)
-			object_path := ensure_c_source_object(clean, active_language, support_flags, c99,
-				pic_flag, target_args, target, c_compiler, uncached_dir, mut stats)!
+			object_path := ensure_c_source_object(clean, active_language, support_flags, c99, pic_flag, target_args, target, c_compiler, uncached_dir, mut stats)!
 			append_c_link_object(mut prepared, object_path, active_language)
 			if c_generated_native_source_context(clean, uncached_dir) {
 				os.rm(clean) or {}
@@ -395,10 +396,9 @@ fn prepare_c_flags_for_link(flags []string, environment_c_flags []string, optimi
 fn c_link_plan_path(cache_dir string, flags []string, support_flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, compiler string, mut stats CObjectCacheStats) string {
 	compiler_path, compiler_version := c_object_compiler_identity(compiler, mut stats)
 	mut hash := u64(1469598103934665603)
-	for identity in ['v3-c-link-plan-v3', os.getwd(), flags.join('\x00'),
-		support_flags.join('\x00'), c99.str(), pic_flag, target_args.join('\x00'), compiler_path,
-		compiler_version, target.os, target.arch, target.abi, target.endian, target.pointer_bits.str(),
-		target.object_format] {
+	for identity in ['v3-c-link-plan-v3', os.getwd(), flags.join('\x00'), support_flags.join('\x00'),
+		c99.str(), pic_flag, target_args.join('\x00'), compiler_path, compiler_version, target.os,
+		target.arch, target.abi, target.endian, target.pointer_bits.str(), target.object_format] {
 		hash = c_hash_bytes(hash, identity.bytes())
 		hash = c_hash_bytes(hash, [u8(0xff)])
 	}
@@ -687,7 +687,7 @@ fn c_dylib_link_flags(flags []string) []string {
 		if clean == '-pthread' || clean.starts_with('-F')
 			|| c_flag_token_is_link_only(clean) || c_flag_is_object_file(clean)
 			|| (c_flag_is_existing_file(clean) && !c_flag_is_c_source_file(clean)
-			&& language != 'c') {
+				&& language != 'c') {
 			link_flags << flag
 		}
 		i++
@@ -823,7 +823,7 @@ fn tcc_dynamic_link_flags(flags []string) []string {
 			link_flags << flag
 		} else if c_flag_is_existing_file(clean)
 			&& (clean.ends_with('.dylib') || clean.ends_with('.so')
-			|| clean.contains('.so.') || clean.ends_with('.tbd')) {
+				|| clean.contains('.so.') || clean.ends_with('.tbd')) {
 			link_flags << flag
 		}
 		i++
@@ -1002,9 +1002,9 @@ fn compile_v3_dev_dylib(prefix_object string, cached_objects []string, resolved_
 	objects << cached_objects
 	mut hash := u64(1469598103934665603)
 	compiler_path, compiler_version := c_object_compiler_identity(c_compiler, mut stats)
-	for identity in ['v3-cached-dev-dylib-v2', compiler_path, compiler_version, target_args.join('\x00'),
-		link_flags.join('\x00'), target.os, target.arch, target.abi, target.endian, target.pointer_bits.str(),
-		target.object_format] {
+	for identity in ['v3-cached-dev-dylib-v2', compiler_path, compiler_version,
+		target_args.join('\x00'), link_flags.join('\x00'), target.os, target.arch, target.abi,
+		target.endian, target.pointer_bits.str(), target.object_format] {
 		hash = c_hash_bytes(hash, identity.bytes())
 		hash = c_hash_bytes(hash, [u8(0xff)])
 	}
@@ -1087,8 +1087,7 @@ fn v3_cache_file_identity(path string) string {
 fn v3_cached_tcc_executable_path(manager &modulecache.Manager, source_identity string, link_plan_signature string, tcc_path string, tcc_lib_dir string, tcc_args []string) string {
 	mut hash := u64(1469598103934665603)
 	for identity in ['v3-cached-tcc-executable-v1', source_identity, link_plan_signature,
-		os.real_path(tcc_path), v3_cache_file_identity(tcc_path),
-		tcc_args.join('\x00')] {
+		os.real_path(tcc_path), v3_cache_file_identity(tcc_path), tcc_args.join('\x00')] {
 		hash = c_hash_bytes(hash, identity.bytes())
 		hash = c_hash_bytes(hash, [u8(0xff)])
 	}
@@ -1125,7 +1124,8 @@ fn publish_v3_cached_executable(source string, destination string) {
 fn c_flag_token_is_link_only(token string) bool {
 	clean := token.trim(' \t\r\n"\'')
 	if clean.starts_with('-l') || clean.starts_with('-L') || clean.starts_with('-Wl,')
-		|| clean in ['-ObjC', '-all_load', '-bundle', '-dynamiclib', '-shared', '-static', '-rdynamic', '-pie', '-no-pie'] {
+		|| clean in ['-ObjC', '-all_load', '-bundle', '-dynamiclib', '-shared', '-static', '-rdynamic',
+			'-pie', '-no-pie'] {
 		return true
 	}
 	return clean.ends_with('.a') || clean.ends_with('.so') || clean.contains('.so.')
@@ -1153,16 +1153,14 @@ fn ensure_c_object_file(obj_path string, source_language string, support_flags [
 	source_file := c_source_from_object_file(obj_path) or {
 		return error('missing C object ${obj_path}, and no adjacent .c/.cc/.cpp/.m/.mm/.S source was found')
 	}
-	return compile_cached_c_source_object(obj_path, source_file, source_language, support_flags,
-		c99, pic_flag, target_args, target, c_compiler, uncached_dir, mut stats)
+	return compile_cached_c_source_object(obj_path, source_file, source_language, support_flags, c99, pic_flag, target_args, target, c_compiler, uncached_dir, mut stats)
 }
 
 fn ensure_c_source_object(source_file string, source_language string, support_flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, c_compiler string, uncached_dir string, mut stats CObjectCacheStats) !string {
 	if !os.exists(source_file) {
 		return error('missing C source ${source_file}')
 	}
-	return compile_cached_c_source_object('${source_file}.o', source_file, source_language,
-		support_flags, c99, pic_flag, target_args, target, c_compiler, uncached_dir, mut stats)
+	return compile_cached_c_source_object('${source_file}.o', source_file, source_language, support_flags, c99, pic_flag, target_args, target, c_compiler, uncached_dir, mut stats)
 }
 
 fn c_source_language(source_file string, source_language string) string {
@@ -1215,10 +1213,8 @@ fn compile_cached_c_source_object(obj_path string, source_file string, source_la
 	stats.dependency_files += dependencies.files.len
 	if dependencies.used_fallback {
 		stats.dependency_scan_fallbacks++
-		uncached_obj := os.join_path(uncached_dir,
-			'dependency_scan_fallback_${tempname.unique_token()}.o')
-		trace_c_object_cache('bypass', os.base(obj_path),
-			'dependency scan failed; using build-local object', dependencies.files.len)
+		uncached_obj := os.join_path(uncached_dir, 'dependency_scan_fallback_${tempname.unique_token()}.o')
+		trace_c_object_cache('bypass', os.base(obj_path), 'dependency scan failed; using build-local object', dependencies.files.len)
 		args << ['-o', uncached_obj, '-c', source_file]
 		res := cmdexec.run(compiler, args)
 		if res.exit_code != 0 {
@@ -1228,19 +1224,16 @@ fn compile_cached_c_source_object(obj_path string, source_file string, source_la
 		stats.temporary_objects << uncached_obj
 		return uncached_obj
 	}
-	cache_key := c_object_cache_name(obj_path, compiler, args, dependencies.files, target, false, mut
-		stats)
+	cache_key := c_object_cache_name(obj_path, compiler, args, dependencies.files, target, false, mut stats)
 	cached_obj := os.join_path(cache_dir, cache_key)
 	if os.exists(cached_obj) {
 		stats.content_key_hits++
-		trace_c_object_cache('hit', cache_key,
-			'compiler, target, argv, and dependency contents matched', dependencies.files.len)
+		trace_c_object_cache('hit', cache_key, 'compiler, target, argv, and dependency contents matched', dependencies.files.len)
 		write_c_object_manifest(manifest_path, cached_obj, dependencies.files, mut stats) or {}
 		return cached_obj
 	}
 	stats.misses++
-	trace_c_object_cache('miss', cache_key, 'no published content-key entry',
-		dependencies.files.len)
+	trace_c_object_cache('miss', cache_key, 'no published content-key entry', dependencies.files.len)
 	// Snapshot the exact arguments that produced cache_key so the post-compile
 	// digest is computed over the same inputs (temp_obj/-c must not perturb it).
 	key_args := args.clone()
@@ -1255,14 +1248,11 @@ fn compile_cached_c_source_object(obj_path string, source_file string, source_la
 	// the compiler was running, the object no longer corresponds to cache_key;
 	// publishing it would certify content it was not built from. Use it as a
 	// build-local, uncached object instead.
-	post_key := c_object_cache_name(obj_path, compiler, key_args, dependencies.files, target, true, mut
-		stats)
+	post_key := c_object_cache_name(obj_path, compiler, key_args, dependencies.files, target, true, mut stats)
 	if post_key != cache_key {
 		stats.input_snapshot_races++
-		trace_c_object_cache('bypass', cache_key,
-			'inputs changed during compilation; using build-local object', dependencies.files.len)
-		uncached_obj := os.join_path(uncached_dir,
-			'input_snapshot_race_${tempname.unique_token()}.o')
+		trace_c_object_cache('bypass', cache_key, 'inputs changed during compilation; using build-local object', dependencies.files.len)
+		uncached_obj := os.join_path(uncached_dir, 'input_snapshot_race_${tempname.unique_token()}.o')
 		os.mv(temp_obj, uncached_obj) or {
 			os.rm(temp_obj) or {}
 			return error('failed to stage build-local C object ${uncached_obj}: ${err}')
@@ -1285,8 +1275,8 @@ fn c_object_manifest_path(cache_dir string, obj_path string, compiler string, co
 	compiler_path, compiler_version := c_object_compiler_identity(compiler, mut stats)
 	mut hash := u64(1469598103934665603)
 	for identity in ['v3-c-object-manifest-v1', os.real_path(obj_path), compiler_path,
-		compiler_version, target.os, target.arch, target.abi, target.endian, target.pointer_bits.str(),
-		target.object_format, compile_args.join('\x00')] {
+		compiler_version, target.os, target.arch, target.abi, target.endian,
+		target.pointer_bits.str(), target.object_format, compile_args.join('\x00')] {
 		hash = c_hash_bytes(hash, identity.bytes())
 		hash = c_hash_bytes(hash, [u8(0xff)])
 	}
@@ -1328,8 +1318,7 @@ fn valid_c_object_manifest(manifest_path string, mut stats CObjectCacheStats) ?s
 	stats.dependency_manifest_hits++
 	stats.content_key_hits++
 	stats.dependency_files += dependency_count
-	trace_c_object_cache('hit', os.base(object_path),
-		'compiler, target, argv, and dependency contents matched via manifest', dependency_count)
+	trace_c_object_cache('hit', os.base(object_path), 'compiler, target, argv, and dependency contents matched via manifest', dependency_count)
 	return object_path
 }
 
@@ -1395,7 +1384,7 @@ fn c_object_dependencies(compiler string, compile_args []string, source_file str
 	// is silently accepted as a valid, source-only dependency set would let a
 	// later build certify a stale object as current.
 	fallback := CObjectDependencies{
-		files:         [source_file]
+		files: [source_file]
 		used_fallback: true
 	}
 	if result.exit_code != 0 {
@@ -1455,7 +1444,8 @@ fn c_object_cache_name(path string, compiler string, compile_args []string, depe
 	compiler_path, compiler_version := c_object_compiler_identity(compiler, mut stats)
 	mut hash := u64(1469598103934665603)
 	for identity in [os.real_path(path), compiler_path, compiler_version, target.os, target.arch,
-		target.abi, target.endian, target.pointer_bits.str(), target.object_format, compile_args.join('\x00')] {
+		target.abi, target.endian, target.pointer_bits.str(), target.object_format,
+		compile_args.join('\x00')] {
 		hash = c_hash_bytes(hash, identity.bytes())
 	}
 	for dependency in dependencies {
@@ -1915,7 +1905,7 @@ fn v3_tcc_resource_flags(vroot string) V3TccResourceFlags {
 	}
 	return V3TccResourceFlags{
 		install_dir: install_dir
-		base_arg:    '-B${install_dir}'
+		base_arg: '-B${install_dir}'
 		include_arg: '-I${include_dir}'
 		library_arg: '-L${install_dir}'
 	}
@@ -1963,9 +1953,7 @@ fn v3_c_compiler_flag_plan(options V3CCompilerFlagOptions) V3CCompilerFlagPlan {
 	if options.link_c_standard.len > 0 {
 		before_inputs << options.link_c_standard
 	}
-	before_inputs << v3_prod_c_optimization_flags(options.is_prod, options.no_prod_options,
-		options.is_shared, options.parallel_cc, options.large_c_unit, options.limit_inlining,
-		options.explicit_tcc)
+	before_inputs << v3_prod_c_optimization_flags(options.is_prod, options.no_prod_options, options.is_shared, options.parallel_cc, options.large_c_unit, options.limit_inlining, options.explicit_tcc)
 	if options.pic_flag.len > 0 {
 		before_inputs << options.pic_flag
 	}
@@ -1973,7 +1961,8 @@ fn v3_c_compiler_flag_plan(options V3CCompilerFlagOptions) V3CCompilerFlagPlan {
 	if options.explicit_tcc {
 		tcc_resources := v3_tcc_resource_flags(options.vroot)
 		tcc_includes = tcc_resources.include_arg
-		before_inputs << [tcc_resources.base_arg, tcc_resources.include_arg, tcc_resources.library_arg]
+		before_inputs << [tcc_resources.base_arg, tcc_resources.include_arg,
+			tcc_resources.library_arg]
 		before_inputs << v3_tcc_host_system_flags(options.target_os, options.macos_sdk_root)
 		if v3_tcc_backtrace_enabled(options.target_os, options.target_arch, options.is_shared) {
 			before_inputs << '-bt25'
@@ -2006,8 +1995,8 @@ fn v3_c_compiler_flag_plan(options V3CCompilerFlagOptions) V3CCompilerFlagPlan {
 	}
 	return V3CCompilerFlagPlan{
 		before_inputs: before_inputs
-		after_inputs:  after_inputs
-		tcc_includes:  tcc_includes
+		after_inputs: after_inputs
+		tcc_includes: tcc_includes
 	}
 }
 
@@ -2087,18 +2076,16 @@ fn v3_posix_shell_command(program string, args []string) string {
 fn write_v3_c_project(project_dir string, c_source string, c_compiler string, plan V3CCompilerFlagPlan, support_inputs []string, objective_c bool) ! {
 	output_name := os.base(c_source).all_before_last('.c')
 	output_path := os.join_path_single(project_dir, output_name)
-	args := plan.compiler_args(output_path, v3_c_source_inputs(c_source, objective_c),
-		support_inputs)
+	args := plan.compiler_args(output_path, v3_c_source_inputs(c_source, objective_c), support_inputs)
 	display_command := cmdexec.display(c_compiler, args)
 	posix_command := v3_posix_shell_command(c_compiler, args)
-	make_command := posix_command.replace('$', '$$')
+	make_command := posix_command.replace('\$', '\$\$')
 	windows_command := v3_windows_batch_command(c_compiler, args)
 	os.write_file(os.join_path_single(project_dir, 'build_command.txt'), display_command + '\n')!
 	os.write_file(os.join_path_single(project_dir, 'Makefile'), 'all:\n\t${make_command}\n')!
 	build_sh := os.join_path_single(project_dir, 'build.sh')
 	os.write_file(build_sh, '#!/bin/sh\nset -eu\n${posix_command}\n')!
-	os.write_file(os.join_path_single(project_dir, 'build.bat'),
-		'@echo off\r\nsetlocal DisableDelayedExpansion\r\n${windows_command}\r\n')!
+	os.write_file(os.join_path_single(project_dir, 'build.bat'), '@echo off\r\nsetlocal DisableDelayedExpansion\r\n${windows_command}\r\n')!
 	$if !windows {
 		os.chmod(build_sh, 0o755)!
 	}
@@ -2218,8 +2205,7 @@ fn keep_c_output_file(bin_file string) string {
 	if base in ['', '.', '..'] {
 		base = 'vtmp'
 	}
-	return os.real_path(os.join_path_single(os.vtmp_dir(),
-		'${base}.${tempname.unique_token()}.tmp.c'))
+	return os.real_path(os.join_path_single(os.vtmp_dir(), '${base}.${tempname.unique_token()}.tmp.c'))
 }
 
 fn v3_crun_cache_marker_path(bin_file string) string {
@@ -2342,21 +2328,7 @@ fn v3_crun_build_identity(state &V3ModuleCacheState, prefs &pref.Preferences, us
 }
 
 fn cli_usage() string {
-	return 'usage: v3 [run|test] <file.v|directory> [options]\n' +
-		'  -o <output>                 output binary or C file\n' +
-		'  -b <c|fastc|arm64|wasm|eval> backend\n' +
-		'  -os <name> -arch <name>     target platform\n' +
-		'  -cc <compiler>               C compiler executable\n' +
-		'  -thread-stack-size <bytes>   spawned-thread stack size\n' +
-		'  -prod -c99 -shared -strict  C build modes\n' +
-		'  -v                           verbose stage profiling\n' +
-		'  -silent                      suppress benchmark output\n' +
-		'  -showcc                      print C compiler commands\n' +
-		'  -profile [file]              write V1-compatible function profile data\n' +
-		'  -profile-fns <names>         profile only named functions and their callees\n' +
-		'  -profile-no-inline           omit @[inline] functions from the profile\n' +
-		'  -no-memory-limit             disable the 4032 MiB user-build memory safety limit\n' +
-		'  -d <name>                    compile-time define'
+	return 'usage: v3 [run|test] <file.v|directory> [options]\n' + '  -o <output>                 output binary or C file\n' + '  -b <c|fastc|arm64|wasm|eval> backend\n' + '  -os <name> -arch <name>     target platform\n' + '  -cc <compiler>               C compiler executable\n' + '  -thread-stack-size <bytes>   spawned-thread stack size\n' + '  -prod -c99 -shared -strict  C build modes\n' + '  -v                           verbose stage profiling\n' + '  -silent                      suppress benchmark output\n' + '  -showcc                      print C compiler commands\n' + '  -profile [file]              write V1-compatible function profile data\n' + '  -profile-fns <names>         profile only named functions and their callees\n' + '  -profile-no-inline           omit @[inline] functions from the profile\n' + '  -no-memory-limit             disable the 4032 MiB user-build memory safety limit\n' + '  -d <name>                    compile-time define'
 }
 
 fn shared_library_postfix(target_os string) string {
@@ -2448,6 +2420,16 @@ fn prealloc_scope_free_for_v3(scope voidptr) {
 	}
 }
 
+// release_unused_diagnostic_scope discards notice storage before its arena is released.
+fn release_unused_diagnostic_scope(mut notices []types.TypeError, scope voidptr) {
+	prealloc_scope_leave_for_v3(scope)
+	// clear() retains capacity that may have been grown in the disposable scope.
+	// Rebind under the parent allocator before releasing that scoped storage.
+	notices.clear()
+	notices = []types.TypeError{}
+	prealloc_scope_free_for_v3(scope)
+}
+
 // clone_string_list clones a string slice out of a scoped prealloc arena.
 fn clone_string_list(values []string) []string {
 	if values.len == 0 {
@@ -2467,16 +2449,16 @@ fn clone_type_errors(values []types.TypeError) []types.TypeError {
 	mut cloned := []types.TypeError{cap: values.len}
 	for value in values {
 		cloned << types.TypeError{
-			msg:        value.msg.clone()
-			kind:       value.kind
-			node:       value.node
-			file:       value.file.clone()
-			node_kind:  value.node_kind.clone()
+			msg: value.msg.clone()
+			kind: value.kind
+			node: value.node
+			file: value.file.clone()
+			node_kind: value.node_kind.clone()
 			node_value: value.node_value.clone()
-			node_pos:   value.node_pos.clone()
-			pos:        value.pos
-			details:    clone_string_list(value.details)
-			severity:   value.severity.clone()
+			node_pos: value.node_pos.clone()
+			pos: value.pos
+			details: clone_string_list(value.details)
+			severity: value.severity.clone()
 		}
 	}
 	return cloned
@@ -2561,8 +2543,8 @@ fn v3_cgen_cache_input(state &V3ModuleCacheState, user_files []string, user_c_fl
 	mut source_files := source_set.keys()
 	source_files.sort()
 	return V3CgenCacheInput{
-		source_files:         source_files
-		dependency_inputs:    dependencies
+		source_files: source_files
+		dependency_inputs: dependencies
 		generation_signature: user_c_flags.join('\x00')
 	}
 }
@@ -2582,14 +2564,9 @@ fn prepare_v3_cache_external_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 		cache_input_modules[module_name] = true
 	}
 	cache_input_modules['main'] = true
-	native_inputs_language := cgen.cache_native_inputs_language(a, prefs.vroot, user_c_flags,
-		prefs.c99, prefs.target)
-	compiler_macros, compiler_macro_environment_complete := cache_c_compiler_predefined_macros(user_c_flags,
-		prefs.ccompiler, prefs.target, native_inputs_language)
-	mut external_inputs, mut native_source_roots, mut native_root_contexts, unscoped_inputs, static_storage_inputs, resolution_dirs, missing_resolution_paths, mut external_input_digests, has_untracked_c_include := cgen.cache_external_input_snapshot_with_resolved_flags(a,
-		prefs.vroot, cache_input_modules, user_c_flags, prefs.target,
-		module_cache_source_path_set(user_files), compiler_macros,
-		compiler_macro_environment_complete)
+	native_inputs_language := cgen.cache_native_inputs_language(a, prefs.vroot, user_c_flags, prefs.c99, prefs.target)
+	compiler_macros, compiler_macro_environment_complete := cache_c_compiler_predefined_macros(user_c_flags, prefs.ccompiler, prefs.target, native_inputs_language)
+	mut external_inputs, mut native_source_roots, mut native_root_contexts, unscoped_inputs, static_storage_inputs, resolution_dirs, missing_resolution_paths, mut external_input_digests, has_untracked_c_include := cgen.cache_external_input_snapshot_with_resolved_flags(a, prefs.vroot, cache_input_modules, user_c_flags, prefs.target, module_cache_source_path_set(user_files), compiler_macros, compiler_macro_environment_complete)
 	state.module_external_inputs = external_inputs.move()
 	state.module_native_roots = native_source_roots.move()
 	state.native_root_contexts = native_root_contexts.move()
@@ -2599,11 +2576,8 @@ fn prepare_v3_cache_external_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 	real_cache_dir := os.real_path(state.manager.dir)
 	state.external_resolution_dirs = resolution_dirs.filter(!v3_path_is_within(it, cache_dir)
 		&& !v3_path_is_within(it, real_cache_dir))
-	state.external_missing_paths = missing_resolution_paths.filter(
-		!v3_path_is_within(it, cache_dir) && !v3_path_is_within(it, real_cache_dir))
-	mut native_source_modules, can_scope_static_inputs := cache_external_input_owner_modules(state,
-		a, unscoped_inputs, static_storage_inputs, user_files, user_c_flags, prefs.ccompiler,
-		prefs.target)
+	state.external_missing_paths = missing_resolution_paths.filter(!v3_path_is_within(it, cache_dir) && !v3_path_is_within(it, real_cache_dir))
+	mut native_source_modules, can_scope_static_inputs := cache_external_input_owner_modules(state, a, unscoped_inputs, static_storage_inputs, user_files, user_c_flags, prefs.ccompiler, prefs.target)
 	state.native_source_modules = native_source_modules.move()
 	state.native_root_owners = map[string]string{}
 	for raw_module_name, roots in state.module_native_roots {
@@ -2619,8 +2593,7 @@ fn prepare_v3_cache_external_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 			state.native_root_owners[os.real_path(root)] = module_name
 		}
 	}
-	can_extract_native_types := prepare_v3_cache_native_type_declarations(mut state, user_c_flags,
-		prefs.ccompiler, prefs.target)
+	can_extract_native_types := prepare_v3_cache_native_type_declarations(mut state, user_c_flags, prefs.ccompiler, prefs.target)
 	state.external_inputs_ready = true
 	state.external_inputs_complete = !has_untracked_c_include
 		&& v3_external_input_digests_complete(state)
@@ -2669,14 +2642,9 @@ fn prepare_v3_checker_native_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 		cache_input_modules[module_name] = true
 	}
 	cache_input_modules['main'] = true
-	native_inputs_language := cgen.cache_native_inputs_language(a, prefs.vroot, user_c_flags,
-		prefs.c99, prefs.target)
-	compiler_macros, compiler_macro_environment_complete := cache_c_compiler_predefined_macros(user_c_flags,
-		prefs.ccompiler, prefs.target, native_inputs_language)
-	mut external_inputs, mut native_source_roots, mut native_root_contexts, _, _, resolution_dirs, missing_resolution_paths, mut external_input_digests, has_untracked_c_include := cgen.cache_external_input_snapshot_with_resolved_flags(a,
-		prefs.vroot, cache_input_modules, user_c_flags, prefs.target,
-		module_cache_source_path_set(user_files), compiler_macros,
-		compiler_macro_environment_complete)
+	native_inputs_language := cgen.cache_native_inputs_language(a, prefs.vroot, user_c_flags, prefs.c99, prefs.target)
+	compiler_macros, compiler_macro_environment_complete := cache_c_compiler_predefined_macros(user_c_flags, prefs.ccompiler, prefs.target, native_inputs_language)
+	mut external_inputs, mut native_source_roots, mut native_root_contexts, _, _, resolution_dirs, missing_resolution_paths, mut external_input_digests, has_untracked_c_include := cgen.cache_external_input_snapshot_with_resolved_flags(a, prefs.vroot, cache_input_modules, user_c_flags, prefs.target, module_cache_source_path_set(user_files), compiler_macros, compiler_macro_environment_complete)
 	state.module_external_inputs = external_inputs.move()
 	state.module_native_roots = native_source_roots.move()
 	state.native_root_contexts = native_root_contexts.move()
@@ -2686,8 +2654,7 @@ fn prepare_v3_checker_native_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 	real_cache_dir := os.real_path(state.manager.dir)
 	state.external_resolution_dirs = resolution_dirs.filter(!v3_path_is_within(it, cache_dir)
 		&& !v3_path_is_within(it, real_cache_dir))
-	state.external_missing_paths = missing_resolution_paths.filter(
-		!v3_path_is_within(it, cache_dir) && !v3_path_is_within(it, real_cache_dir))
+	state.external_missing_paths = missing_resolution_paths.filter(!v3_path_is_within(it, cache_dir) && !v3_path_is_within(it, real_cache_dir))
 	state.external_inputs_ready = true
 	// The macOS C-error fallback report requires a complete native-input
 	// manifest, and completeness here needs only resolved includes and valid
@@ -2728,8 +2695,7 @@ struct PrepareV3CheckerNativeInputsArgs {
 
 fn prepare_v3_checker_native_inputs_thread(args &PrepareV3CheckerNativeInputsArgs) {
 	mut state := unsafe { &V3ModuleCacheState(args.state) }
-	prepare_v3_checker_native_inputs_scoped(mut state, args.a, args.prefs, args.user_files,
-		args.user_c_flags, args.scope_enabled)
+	prepare_v3_checker_native_inputs_scoped(mut state, args.a, args.prefs, args.user_files, args.user_c_flags, args.scope_enabled)
 	args.done <- true
 }
 
@@ -2944,9 +2910,7 @@ fn cached_native_sources_require_monolithic_cgen(state &V3ModuleCacheState, a &f
 			source := os.read_file(path) or { continue }
 			if modulecache.c_source_declares_types(source) {
 				type_identifiers := modulecache.c_source_type_identifiers(source)
-				if cache_external_identifiers_are_private_to_module(a, state, raw_module_name,
-					type_identifiers, user_files, '')
-				{
+				if cache_external_identifiers_are_private_to_module(a, state, raw_module_name, type_identifiers, user_files, '') {
 					continue
 				}
 				if os.getenv('V3_CACHE_TRACE') != '' {
@@ -3007,8 +2971,7 @@ fn prepare_v3_cache_native_type_declarations(mut state V3ModuleCacheState, c_fla
 			cache_apply_native_root_context(state.native_root_contexts[os.real_path(root)] or {
 				[]string{}
 			}, mut declaration_macros)
-			active_source, declarations_complete := cache_c_source_definitely_active_code_for_path_with_status(root,
-				allowed_paths, mut declaration_active_paths, mut declaration_macros, false)
+			active_source, declarations_complete := cache_c_source_definitely_active_code_for_path_with_status(root, allowed_paths, mut declaration_active_paths, mut declaration_macros, false)
 			if !declarations_complete {
 				if os.getenv('V3_CACHE_TRACE') != '' {
 					eprintln('  V3 module cache unresolved native declaration guard: module=${module_name} path=${root}')
@@ -3081,10 +3044,8 @@ fn prepare_v3_cache_native_type_declarations(mut state V3ModuleCacheState, c_fla
 		mut types_complete_for_module := true
 		for root in roots {
 			real_root := os.real_path(root)
-			cache_apply_native_root_context(state.native_root_contexts[real_root] or { []string{} }, mut
-				include_macros)
-			declarations, complete := cache_native_type_declarations_for_path(real_root,
-				allowed_paths, mut include_macros)
+			cache_apply_native_root_context(state.native_root_contexts[real_root] or { []string{} }, mut include_macros)
+			declarations, complete := cache_native_type_declarations_for_path(real_root, allowed_paths, mut include_macros)
 			if !complete {
 				if os.getenv('V3_CACHE_TRACE') != '' {
 					eprintln('  V3 module cache unresolved native type include: module=${module_name} path=${real_root}')
@@ -3094,24 +3055,20 @@ fn prepare_v3_cache_native_type_declarations(mut state V3ModuleCacheState, c_fla
 			}
 			if roots_with_function_declarations[real_root] && !c_flag_is_c_source_file(real_root) {
 				context := state.native_root_contexts[real_root] or { []string{} }
-				implementation_macros := cache_native_implementation_context_macros(real_root,
-					context, allowed_paths, c_flags, ccompiler, target)
+				implementation_macros := cache_native_implementation_context_macros(real_root, context, allowed_paths, c_flags, ccompiler, target)
 				// The public replay only strips implementation code that its undefined
 				// macros gate. If a file-scope external definition would survive, the
 				// owner object and every dependent replay would define the symbol, so the
 				// warm cached link fails with a duplicate symbol. Fail closed instead of
 				// splitting. Keep safe function-only headers even when they declare no
 				// types, since dependent cache units still need their static inline APIs.
-				if cache_native_public_include_replays_external_definition(real_root, context,
-					implementation_macros, allowed_paths, c_flags, ccompiler, target)
-				{
+				if cache_native_public_include_replays_external_definition(real_root, context, implementation_macros, allowed_paths, c_flags, ccompiler, target) {
 					if os.getenv('V3_CACHE_TRACE') != '' {
 						eprintln('  V3 module cache ungated native definition: module=${module_name} path=${real_root}')
 					}
 					return false
 				}
-				state.native_type_declarations[real_root] = cache_native_public_include(real_root,
-					context, implementation_macros)
+				state.native_type_declarations[real_root] = cache_native_public_include(real_root, context, implementation_macros)
 			} else if declarations.len > 0 {
 				state.native_type_declarations[real_root] = declarations
 			}
@@ -3128,10 +3085,8 @@ fn prepare_v3_cache_native_type_declarations(mut state V3ModuleCacheState, c_fla
 					// Other cache objects still need the header's public ABI. Reinclude it
 					// without the implementation context; the consumer object receives the
 					// original context and full implementation in source order.
-					implementation_macros := cache_native_implementation_context_macros(real_root,
-						context, allowed_paths, c_flags, ccompiler, target)
-					state.native_type_declarations[real_root] = cache_native_public_include(real_root,
-						context, implementation_macros)
+					implementation_macros := cache_native_implementation_context_macros(real_root, context, allowed_paths, c_flags, ccompiler, target)
+					state.native_type_declarations[real_root] = cache_native_public_include(real_root, context, implementation_macros)
 				}
 				if os.getenv('V3_CACHE_TRACE') != '' {
 					eprintln('  V3 module cache grouped native type owner: module=${module_name} consumer=${consumer_module}')
@@ -3141,10 +3096,8 @@ fn prepare_v3_cache_native_type_declarations(mut state V3ModuleCacheState, c_fla
 			for root in roots {
 				real_root := os.real_path(root)
 				context := state.native_root_contexts[real_root] or { []string{} }
-				implementation_macros := cache_native_implementation_context_macros(real_root,
-					context, allowed_paths, c_flags, ccompiler, target)
-				state.native_type_declarations[real_root] = cache_native_public_include(real_root,
-					context, implementation_macros)
+				implementation_macros := cache_native_implementation_context_macros(real_root, context, allowed_paths, c_flags, ccompiler, target)
+				state.native_type_declarations[real_root] = cache_native_public_include(real_root, context, implementation_macros)
 			}
 			if os.getenv('V3_CACHE_TRACE') != '' {
 				eprintln('  V3 module cache exposing unresolved native headers as public ABI: module=${module_name}')
@@ -3277,8 +3230,7 @@ fn cache_native_public_include_replays_external_definition(path string, context 
 	mut replay_macros := cache_local_c_compiler_macros(c_flags, ccompiler, target)
 	cache_apply_native_root_context(replay_context, mut replay_macros)
 	mut active_paths := map[string]bool{}
-	active_source, active_complete := cache_c_source_definitely_active_code_for_path_with_status(path,
-		allowed_paths, mut active_paths, mut replay_macros, false)
+	active_source, active_complete := cache_c_source_definitely_active_code_for_path_with_status(path, allowed_paths, mut active_paths, mut replay_macros, false)
 	// Prefer compiler-expanded storage-class macros. Some public native headers
 	// deliberately require dependency declarations to have been included first,
 	// so an isolated preprocessing probe can fail even though the generated cache
@@ -3287,9 +3239,7 @@ fn cache_native_public_include_replays_external_definition(path string, context 
 	// continues to fail closed below.
 	mut linkage_source := active_source
 	mut preprocessed_complete_context := false
-	if preprocessed := cache_preprocessed_native_input(path, replay_context, c_flags, ccompiler,
-		target)
-	{
+	if preprocessed := cache_preprocessed_native_input(path, replay_context, c_flags, ccompiler, target) {
 		linkage_source = preprocessed
 		preprocessed_complete_context = true
 	} else if !active_complete {
@@ -3336,8 +3286,7 @@ fn cache_native_implementation_context_macros(path string, context []string, all
 	mut full_macros := cache_local_c_compiler_macros(c_flags, ccompiler, target)
 	cache_apply_native_root_context(context, mut full_macros)
 	mut full_active_paths := map[string]bool{}
-	full_source, _ := cache_c_source_definitely_active_code_for_path_with_status(path,
-		allowed_paths, mut full_active_paths, mut full_macros, false)
+	full_source, _ := cache_c_source_definitely_active_code_for_path_with_status(path, allowed_paths, mut full_active_paths, mut full_macros, false)
 	full_identifiers := cache_native_implementation_identifiers(full_source)
 	if full_identifiers.len == 0 {
 		return implementation_macros
@@ -3359,8 +3308,7 @@ fn cache_native_implementation_context_macros(path string, context []string, all
 			cache_apply_native_root_context([line], mut candidate_macros)
 		}
 		mut candidate_active_paths := map[string]bool{}
-		candidate_source, _ := cache_c_source_definitely_active_code_for_path_with_status(path,
-			allowed_paths, mut candidate_active_paths, mut candidate_macros, false)
+		candidate_source, _ := cache_c_source_definitely_active_code_for_path_with_status(path, allowed_paths, mut candidate_active_paths, mut candidate_macros, false)
 		candidate_identifiers := cache_native_implementation_identifiers(candidate_source)
 		if full_identifiers.keys().any(!candidate_identifiers[it]) {
 			implementation_macros[name] = true
@@ -3389,8 +3337,7 @@ fn cache_native_type_declarations_for_path(path string, allowed_paths map[string
 	mut extraction := V3CacheNativeTypeExtractionState{
 		complete: true
 	}
-	declarations := cache_native_type_declarations_for_path_rec(real_path, allowed_paths, mut
-		active_paths, mut include_macros, false, mut extraction)
+	declarations := cache_native_type_declarations_for_path_rec(real_path, allowed_paths, mut active_paths, mut include_macros, false, mut extraction)
 	return declarations, extraction.complete
 }
 
@@ -3431,8 +3378,7 @@ fn cache_native_type_declarations_for_path_rec(path string, allowed_paths map[st
 	mut conditionals := []V3CacheLocalCConditional{}
 	mut in_block_comment := false
 	for line in header.split_into_lines() {
-		directive, arg, next_block_comment := cache_local_c_directive_outside_comments(line,
-			in_block_comment)
+		directive, arg, next_block_comment := cache_local_c_directive_outside_comments(line, in_block_comment)
 		in_block_comment = next_block_comment
 		if directive in ['if', 'ifdef', 'ifndef'] {
 			parent_inactive := conditionals.any(it.inactive)
@@ -3440,9 +3386,9 @@ fn cache_native_type_declarations_for_path_rec(path string, allowed_paths map[st
 			condition := cache_local_c_known_condition(directive, arg, include_macros)
 			conditionals << V3CacheLocalCConditional{
 				parent_inactive: parent_inactive
-				condition:       condition
-				inactive:        parent_inactive || condition < 0
-				ambiguous:       parent_ambiguous || condition == 0
+				condition: condition
+				inactive: parent_inactive || condition < 0
+				ambiguous: parent_ambiguous || condition == 0
 			}
 			out.writeln(line)
 			continue
@@ -3481,13 +3427,10 @@ fn cache_native_type_declarations_for_path_rec(path string, allowed_paths map[st
 			out.writeln(line)
 			continue
 		}
-		if include_path := cache_local_c_include_path(line, real_path, allowed_paths,
-			include_macros)
-		{
+		if include_path := cache_local_c_include_path(line, real_path, allowed_paths, include_macros) {
 			real_include := os.real_path(include_path)
 			if allowed_paths[real_include] {
-				out.write_string(cache_native_type_declarations_for_path_rec(real_include,
-					allowed_paths, mut active_paths, mut include_macros, ambient_ambiguous
+				out.write_string(cache_native_type_declarations_for_path_rec(real_include, allowed_paths, mut active_paths, mut include_macros, ambient_ambiguous
 					|| conditionals.any(it.ambiguous), mut extraction))
 				continue
 			}
@@ -3565,9 +3508,9 @@ fn cache_record_local_c_include_macro(directive string, arg string, ambiguous bo
 		fields := arg.fields()
 		if fields.len > 0 {
 			include_macros[fields[0]] = V3CacheLocalCMacro{
-				known:      !ambiguous
+				known: !ambiguous
 				is_defined: false
-				truth:      -1
+				truth: -1
 			}
 		}
 		return
@@ -3588,11 +3531,11 @@ fn cache_record_local_c_include_macro(directive string, arg string, ambiguous bo
 		literal = value
 	}
 	include_macros[name] = V3CacheLocalCMacro{
-		known:       !ambiguous
-		is_defined:  true
-		literal:     literal
+		known: !ambiguous
+		is_defined: true
+		literal: literal
 		replacement: value
-		truth:       cache_local_c_integer_condition(value)
+		truth: cache_local_c_integer_condition(value)
 	}
 }
 
@@ -3609,8 +3552,7 @@ fn cache_local_c_define_name(arg string) string {
 fn cache_seed_locally_defined_c_macros(source string, mut macros map[string]V3CacheLocalCMacro) {
 	mut in_block_comment := false
 	for line in source.split_into_lines() {
-		directive, arg, next_block_comment := cache_local_c_directive_outside_comments(line,
-			in_block_comment)
+		directive, arg, next_block_comment := cache_local_c_directive_outside_comments(line, in_block_comment)
 		in_block_comment = next_block_comment
 		if directive != 'define' {
 			continue
@@ -3618,9 +3560,9 @@ fn cache_seed_locally_defined_c_macros(source string, mut macros map[string]V3Ca
 		name := cache_local_c_define_name(arg)
 		if name.len > 0 && name !in macros {
 			macros[name] = V3CacheLocalCMacro{
-				known:      true
+				known: true
 				is_defined: false
-				truth:      -1
+				truth: -1
 			}
 		}
 	}
@@ -3655,22 +3597,22 @@ fn cache_local_c_flag_macros(flags []string) map[string]V3CacheLocalCMacro {
 			}
 			if name.len > 0 {
 				macros[name] = V3CacheLocalCMacro{
-					known:       true
-					is_defined:  true
-					literal:     if cache_local_c_is_literal_include_value(value) {
+					known: true
+					is_defined: true
+					literal: if cache_local_c_is_literal_include_value(value) {
 						value
 					} else {
 						''
 					}
 					replacement: if open > 0 { '' } else { value }
-					truth:       if open > 0 { 0 } else { cache_local_c_integer_condition(value) }
+					truth: if open > 0 { 0 } else { cache_local_c_integer_condition(value) }
 				}
 			}
 		} else if undefinition.len > 0 {
 			macros[undefinition] = V3CacheLocalCMacro{
-				known:      true
+				known: true
 				is_defined: false
-				truth:      -1
+				truth: -1
 			}
 		}
 		i++
@@ -3688,16 +3630,16 @@ fn cache_local_c_compiler_macros(flags []string, ccompiler string, target pref.T
 		'_M_IX86', '_M_ARM', '_M_ARM64', '__LP64__', '_LP64', '__ILP32__']
 	for name in compiler_names {
 		macros[name] = V3CacheLocalCMacro{
-			known:      true
+			known: true
 			is_defined: false
-			truth:      -1
+			truth: -1
 		}
 	}
 	for name in target_names {
 		macros[name] = V3CacheLocalCMacro{
-			known:      true
+			known: true
 			is_defined: false
-			truth:      -1
+			truth: -1
 		}
 	}
 	mut defined := []string{}
@@ -3803,9 +3745,9 @@ fn cache_local_c_compiler_macros(flags []string, ccompiler string, target pref.T
 	}
 	for name in defined {
 		macros[name] = V3CacheLocalCMacro{
-			known:      true
+			known: true
 			is_defined: true
-			truth:      1
+			truth: 1
 		}
 	}
 	for name, macro in cache_local_c_flag_macros(flags) {
@@ -4092,8 +4034,7 @@ fn cache_local_c_known_integer_value_rec(raw string, macros map[string]V3CacheLo
 		return value
 	}
 	for operators in [[u8(`+`), `-`], [u8(`*`), `/`, `%`]] {
-		has_operator, left_text, operator, right_text := cache_local_c_condition_top_level_arithmetic(expression,
-			operators)
+		has_operator, left_text, operator, right_text := cache_local_c_condition_top_level_arithmetic(expression, operators)
 		if !has_operator {
 			continue
 		}
@@ -4188,7 +4129,9 @@ fn cache_local_c_known_expression_rec(raw string, macros map[string]V3CacheLocal
 			'<=' { left <= right }
 			'>' { left > right }
 			'>=' { left >= right }
-			else { return 0 }
+			else {
+				return 0
+			}
 		}
 		return if active { 1 } else { -1 }
 	}
@@ -4196,8 +4139,7 @@ fn cache_local_c_known_expression_rec(raw string, macros map[string]V3CacheLocal
 		return if value == 0 { -1 } else { 1 }
 	}
 	if expression.starts_with('!') {
-		condition := cache_local_c_known_expression_rec(expression[1..], macros, mut seen,
-			depth + 1)
+		condition := cache_local_c_known_expression_rec(expression[1..], macros, mut seen, depth + 1)
 		return if condition == 0 { 0 } else { -condition }
 	}
 	literal_condition := cache_local_c_integer_condition(expression)
@@ -4348,26 +4290,22 @@ fn cache_c_source_native_declarations_complete(scan V3CacheActiveCSourceScan) bo
 
 fn cache_c_source_definitely_active_code(source string, mut macros map[string]V3CacheLocalCMacro) string {
 	mut active_paths := map[string]bool{}
-	scan := cache_c_source_definitely_active_code_rec(source, '', map[string]bool{}, mut
-		active_paths, mut macros, false)
+	scan := cache_c_source_definitely_active_code_rec(source, '', map[string]bool{}, mut active_paths, mut macros, false)
 	return scan.active
 }
 
 fn cache_c_source_definitely_active_code_with_status(source string, mut macros map[string]V3CacheLocalCMacro) (string, bool) {
 	mut active_paths := map[string]bool{}
-	scan := cache_c_source_definitely_active_code_rec(source, '', map[string]bool{}, mut
-		active_paths, mut macros, false)
+	scan := cache_c_source_definitely_active_code_rec(source, '', map[string]bool{}, mut active_paths, mut macros, false)
 	return scan.active, cache_c_source_native_declarations_complete(scan)
 }
 
 fn cache_c_source_definitely_active_code_for_path(path string, allowed_paths map[string]bool, mut active_paths map[string]bool, mut macros map[string]V3CacheLocalCMacro, ambient_ambiguous bool) string {
-	return cache_c_source_active_code_scan_for_path(path, allowed_paths, mut active_paths, mut
-		macros, ambient_ambiguous).active
+	return cache_c_source_active_code_scan_for_path(path, allowed_paths, mut active_paths, mut macros, ambient_ambiguous).active
 }
 
 fn cache_c_source_definitely_active_code_for_path_with_status(path string, allowed_paths map[string]bool, mut active_paths map[string]bool, mut macros map[string]V3CacheLocalCMacro, ambient_ambiguous bool) (string, bool) {
-	scan := cache_c_source_active_code_scan_for_path(path, allowed_paths, mut active_paths, mut
-		macros, ambient_ambiguous)
+	scan := cache_c_source_active_code_scan_for_path(path, allowed_paths, mut active_paths, mut macros, ambient_ambiguous)
 	return scan.active, cache_c_source_native_declarations_complete(scan)
 }
 
@@ -4378,8 +4316,7 @@ fn cache_c_source_active_code_scan_for_path(path string, allowed_paths map[strin
 	}
 	source := os.read_file(real_path) or { return V3CacheActiveCSourceScan{} }
 	active_paths[real_path] = true
-	result := cache_c_source_definitely_active_code_rec(source, real_path, allowed_paths, mut
-		active_paths, mut macros, ambient_ambiguous)
+	result := cache_c_source_definitely_active_code_rec(source, real_path, allowed_paths, mut active_paths, mut macros, ambient_ambiguous)
 	active_paths.delete(real_path)
 	return result
 }
@@ -4392,8 +4329,7 @@ fn cache_c_source_definitely_active_code_rec(source string, source_path string, 
 	mut conditionals := []V3CacheLocalCConditional{}
 	mut in_block_comment := false
 	for line in source.split_into_lines() {
-		directive, arg, next_block_comment := cache_local_c_directive_outside_comments(line,
-			in_block_comment)
+		directive, arg, next_block_comment := cache_local_c_directive_outside_comments(line, in_block_comment)
 		in_block_comment = next_block_comment
 		if directive in ['if', 'ifdef', 'ifndef'] {
 			parent_inactive := conditionals.any(it.inactive)
@@ -4401,9 +4337,9 @@ fn cache_c_source_definitely_active_code_rec(source string, source_path string, 
 			condition := cache_local_c_known_condition(directive, arg, macros)
 			conditionals << V3CacheLocalCConditional{
 				parent_inactive: parent_inactive
-				condition:       condition
-				inactive:        parent_inactive || condition < 0
-				ambiguous:       parent_ambiguous || condition == 0
+				condition: condition
+				inactive: parent_inactive || condition < 0
+				ambiguous: parent_ambiguous || condition == 0
 			}
 			out.writeln('')
 			if has_ambiguity {
@@ -4453,8 +4389,7 @@ fn cache_c_source_definitely_active_code_rec(source string, source_path string, 
 			if include_path := cache_local_c_include_path(line, source_path, allowed_paths, macros) {
 				real_include := os.real_path(include_path)
 				if allowed_paths[real_include] {
-					include_scan := cache_c_source_active_code_scan_for_path(real_include,
-						allowed_paths, mut active_paths, mut macros, ambiguous)
+					include_scan := cache_c_source_active_code_scan_for_path(real_include, allowed_paths, mut active_paths, mut macros, ambiguous)
 					if include_scan.has_ambiguity {
 						if !has_ambiguity {
 							possible.write_string(out.after(0))
@@ -4492,8 +4427,8 @@ fn cache_c_source_definitely_active_code_rec(source string, source_path string, 
 		}
 	}
 	return V3CacheActiveCSourceScan{
-		active:        out.str()
-		possible:      possible.str()
+		active: out.str()
+		possible: possible.str()
 		has_ambiguity: has_ambiguity
 	}
 }
@@ -4537,7 +4472,7 @@ fn v3_external_cache_path(key string, prefix string) ?V3ExternalCachePath {
 	}
 	return V3ExternalCachePath{
 		module_name: value[..colon]
-		path:        value[colon + 1..]
+		path: value[colon + 1..]
 	}
 }
 
@@ -4547,17 +4482,13 @@ fn restore_v3_cache_external_inputs(mut state V3ModuleCacheState, user_files []s
 		'external-root-owner:', 'external-context:', 'external-owner:', 'external-dir:',
 		'external-missing:', 'external-state:']
 	mut restored := map[string]string{}
-	if exact := state.manager.cached_cgen_dependency_inputs(base_input.source_files,
-		base_input.generation_signature, base_input.dependency_inputs, prefixes)
-	{
+	if exact := state.manager.cached_cgen_dependency_inputs(base_input.source_files, base_input.generation_signature, base_input.dependency_inputs, prefixes) {
 		restored = exact.clone()
 	} else {
 		if incremental_declaration_signature.len == 0 {
 			return false
 		}
-		restored = state.manager.cached_incremental_dependency_inputs(base_input.source_files,
-			incremental_declaration_signature, base_input.generation_signature,
-			base_input.dependency_inputs, prefixes) or { return false }
+		restored = state.manager.cached_incremental_dependency_inputs(base_input.source_files, incremental_declaration_signature, base_input.generation_signature, base_input.dependency_inputs, prefixes) or { return false }
 	}
 	if restored['external-state:manifest'] or { '' } != 'v3-external-inputs-5' {
 		return false
@@ -4624,8 +4555,8 @@ fn restore_v3_cache_external_inputs(mut state V3ModuleCacheState, user_files []s
 		}
 		root_records << V3ExternalNativeRoot{
 			module_name: input.module_name
-			path:        path
-			index:       index
+			path: path
+			index: index
 		}
 	}
 	root_records.sort_with_compare(fn (a &V3ExternalNativeRoot, b &V3ExternalNativeRoot) int {
@@ -4791,14 +4722,14 @@ fn decode_v3_cgen_metadata(metadata string) ?V3CgenCacheMetadata {
 			return none
 		}
 		diagnostics << V3CachedTypeDiagnostic{
-			file:            parts[index]
-			msg:             parts[index + 1]
-			severity:        parts[index + 2]
-			node:            node
-			offset:          offset
-			end:             end
+			file: parts[index]
+			msg: parts[index + 1]
+			severity: parts[index + 2]
+			node: node
+			offset: offset
+			end: end
 			reported_column: reported_column
-			details:         parts[index + 8..index + 8 + detail_count].clone()
+			details: parts[index + 8..index + 8 + detail_count].clone()
 		}
 		index += 8 + detail_count
 	}
@@ -4807,9 +4738,9 @@ fn decode_v3_cgen_metadata(metadata string) ?V3CgenCacheMetadata {
 	}
 	return V3CgenCacheMetadata{
 		interface_impl_signature: parts[1]
-		prefix_source_identity:   parts[2]
-		flags:                    parts[4..4 + flag_count].clone()
-		diagnostics:              diagnostics
+		prefix_source_identity: parts[2]
+		flags: parts[4..4 + flag_count].clone()
+		diagnostics: diagnostics
 	}
 }
 
@@ -4826,14 +4757,14 @@ fn cache_v3_type_diagnostics(a &flat.FlatAst, diagnostics []types.TypeError) []V
 			file = os.real_path(file)
 		}
 		cached << V3CachedTypeDiagnostic{
-			file:            file.clone()
-			msg:             diagnostic.msg.clone()
-			severity:        diagnostic.severity.clone()
-			node:            int(diagnostic.node)
-			offset:          diagnostic.pos.offset
-			end:             diagnostic.pos.end
+			file: file.clone()
+			msg: diagnostic.msg.clone()
+			severity: diagnostic.severity.clone()
+			node: int(diagnostic.node)
+			offset: diagnostic.pos.offset
+			end: diagnostic.pos.end
 			reported_column: diagnostic.pos.reported_column()
-			details:         clone_string_list(diagnostic.details)
+			details: clone_string_list(diagnostic.details)
 		}
 	}
 	return cached
@@ -4864,12 +4795,12 @@ fn restore_v3_type_diagnostics(mut a flat.FlatAst, diagnostics []V3CachedTypeDia
 			}
 		}
 		restored << types.TypeError{
-			msg:      diagnostic.msg.clone()
-			kind:     .unknown_ident
-			node:     flat.NodeId(diagnostic.node)
-			file:     diagnostic.file.clone()
-			pos:      v3token.new_span(file_id, diagnostic.offset, diagnostic.end).with_reported_column(diagnostic.reported_column)
-			details:  clone_string_list(diagnostic.details)
+			msg: diagnostic.msg.clone()
+			kind: .unknown_ident
+			node: flat.NodeId(diagnostic.node)
+			file: diagnostic.file.clone()
+			pos: v3token.new_span(file_id, diagnostic.offset, diagnostic.end).with_reported_column(diagnostic.reported_column)
+			details: clone_string_list(diagnostic.details)
 			severity: diagnostic.severity.clone()
 		}
 	}
@@ -4898,8 +4829,9 @@ fn cacheable_runtime_string_nodes(a &flat.FlatAst) []bool {
 			current := a.nodes[node_idx]
 			current_blocked := parent_blocked
 				|| current.kind in [.comptime_if, .comptime_for, .directive, .asm_stmt, .sql_expr]
-				|| (current.kind == .call && (current.value.starts_with('$')
-				|| current.value in ['embed_file', 'tmpl', 'env', 'd', 'res', 'pkgconfig', 'compile_error', 'compile_warn']))
+				|| (current.kind == .call && (current.value.starts_with('\$')
+					|| current.value in ['embed_file', 'tmpl', 'env', 'd', 'res', 'pkgconfig',
+						'compile_error', 'compile_warn']))
 			if current.kind == .string_literal && !current_blocked {
 				cacheable[node_idx] = true
 			}
@@ -4973,8 +4905,7 @@ fn monomorph_cache_semantic_signature(a &flat.FlatAst, source_files []string) st
 		file_ids[j] = value
 	}
 	for idx in file_ids {
-		hash = c_hash_monomorph_node(hash, a, flat.NodeId(idx), cacheable_strings,
-			declaration_attributes)
+		hash = c_hash_monomorph_node(hash, a, flat.NodeId(idx), cacheable_strings, declaration_attributes)
 		file_node := a.nodes[idx]
 		mut module_name := ''
 		for child_idx in 0 .. file_node.children_count {
@@ -5020,8 +4951,7 @@ fn c_hash_monomorph_node(initial u64, a &flat.FlatAst, id flat.NodeId, cacheable
 		hash = c_hash_bytes(hash, [u8(0xfe)])
 	}
 	for child_idx in 0 .. node.children_count {
-		hash = c_hash_monomorph_node(hash, a, a.child(&node, child_idx), cacheable_strings,
-			declaration_attributes)
+		hash = c_hash_monomorph_node(hash, a, a.child(&node, child_idx), cacheable_strings, declaration_attributes)
 	}
 	return hash
 }
@@ -5190,8 +5120,7 @@ fn incremental_declaration_attribute_signatures(a &flat.FlatAst) map[int]string 
 		}
 		// The marker embeds its declaration's transient node id in value. Hash only
 		// the stable attribute kinds and payload, then attach it to that declaration.
-		result[declaration_id] = incremental_hash_node_header(u64(1469598103934665603), &node,
-			false).hex()
+		result[declaration_id] = incremental_hash_node_header(u64(1469598103934665603), &node, false).hex()
 	}
 	return result
 }
@@ -5230,31 +5159,27 @@ fn incremental_program_snapshot(a &flat.FlatAst, source_files []string) V3Increm
 				attribute_signature := declaration_attributes[idx] or { '' }
 				key := incremental_cache_fn_key(cur_file, cur_module, node.value)
 				functions << V3IncrementalFn{
-					key:       key
-					name:      incremental_qualified_fn_name(cur_module, node.value)
+					key: key
+					name: incremental_qualified_fn_name(cur_module, node.value)
 					signature: incremental_node_tree_signature(a, flat.NodeId(idx))
 				}
 				mut declaration := strings.new_builder(128)
 				declaration.write_string('fn\t${cur_file}\t${cur_module}\t')
-				declaration.write_string(incremental_hash_fn_declaration(u64(1469598103934665603),
-					&node).hex())
+				declaration.write_string(incremental_hash_fn_declaration(u64(1469598103934665603), &node).hex())
 				for child_idx in 0 .. node.children_count {
 					child_id := a.child(&node, child_idx)
 					child := a.nodes[int(child_id)]
 					if child.kind == .param {
 						declaration.write_u8(`\t`)
-						declaration.write_string(incremental_hash_node_header(u64(1469598103934665603),
-							&child, true).hex())
+						declaration.write_string(incremental_hash_node_header(u64(1469598103934665603), &child, true).hex())
 					}
 				}
 				declaration.write_string('\t${attribute_signature}')
 				declaration_parts << declaration.str()
 			}
-			.struct_decl, .global_decl, .const_decl, .enum_decl, .type_decl, .interface_decl,
-			.import_decl, .c_fn_decl {
+			.struct_decl, .global_decl, .const_decl, .enum_decl, .type_decl, .interface_decl, .import_decl, .c_fn_decl {
 				attribute_signature := declaration_attributes[idx] or { '' }
-				part := '${node.kind}\t${cur_file}\t${cur_module}\t${incremental_node_tree_signature(a,
-					flat.NodeId(idx))}\t${attribute_signature}'
+				part := '${node.kind}\t${cur_file}\t${cur_module}\t${incremental_node_tree_signature(a, flat.NodeId(idx))}\t${attribute_signature}'
 				declaration_parts << part
 				if node.kind == .import_decl {
 					ordered_import_directive_parts << part
@@ -5268,8 +5193,7 @@ fn incremental_program_snapshot(a &flat.FlatAst, source_files []string) V3Increm
 			}
 			.directive, .comptime_if, .comptime_for, .asm_stmt, .sql_expr, .fn_literal {
 				if top_level_nodes[idx] {
-					part := '${node.kind}\t${cur_file}\t${cur_module}\t${incremental_node_tree_signature(a,
-						flat.NodeId(idx))}'
+					part := '${node.kind}\t${cur_file}\t${cur_module}\t${incremental_node_tree_signature(a, flat.NodeId(idx))}'
 					declaration_parts << part
 					if node.kind == .directive {
 						ordered_import_directive_parts << part
@@ -5278,8 +5202,7 @@ fn incremental_program_snapshot(a &flat.FlatAst, source_files []string) V3Increm
 			}
 			else {
 				if top_level_nodes[idx] {
-					synthetic_main_parts << 'synthetic-main\t${node.kind}\t${cur_file}\t${cur_module}\t${incremental_node_tree_signature(a,
-						flat.NodeId(idx))}'
+					synthetic_main_parts << 'synthetic-main\t${node.kind}\t${cur_file}\t${cur_module}\t${incremental_node_tree_signature(a, flat.NodeId(idx))}'
 				}
 			}
 		}
@@ -5312,7 +5235,7 @@ fn incremental_program_snapshot(a &flat.FlatAst, source_files []string) V3Increm
 	}
 	return V3IncrementalSnapshot{
 		declaration_signature: declaration_hash.hex()
-		functions:             functions
+		functions: functions
 	}
 }
 
@@ -5443,7 +5366,7 @@ fn incremental_c_function_sections(source string) ?V3IncrementalCFunctionSection
 	}
 	return V3IncrementalCFunctionSections{
 		sections: sections
-		keys:     keys
+		keys: keys
 	}
 }
 
@@ -5639,8 +5562,8 @@ fn decode_monomorph_cache_specs(encoded string) []transform.MonomorphCacheSpec {
 		raw_args := if parts[2].len == 0 { []string{} } else { parts[2].split('\x1f') }
 		specs << transform.MonomorphCacheSpec{
 			decl_key: parts[0].clone()
-			module:   parts[1].clone()
-			args:     clone_string_list(raw_args)
+			module: parts[1].clone()
+			args: clone_string_list(raw_args)
 		}
 	}
 	return specs
@@ -5676,8 +5599,8 @@ fn clone_monomorph_cache_specs(specs []transform.MonomorphCacheSpec) []transform
 	for spec in specs {
 		cloned << transform.MonomorphCacheSpec{
 			decl_key: spec.decl_key.clone()
-			module:   spec.module.clone()
-			args:     clone_string_list(spec.args)
+			module: spec.module.clone()
+			args: clone_string_list(spec.args)
 		}
 	}
 	return cloned
@@ -5700,8 +5623,8 @@ fn merge_monomorph_cache_specs(cached []transform.MonomorphCacheSpec, generated 
 		spec := by_key[key]
 		merged << transform.MonomorphCacheSpec{
 			decl_key: spec.decl_key.clone()
-			module:   spec.module.clone()
-			args:     clone_string_list(spec.args)
+			module: spec.module.clone()
+			args: clone_string_list(spec.args)
 		}
 	}
 	return merged
@@ -5922,9 +5845,9 @@ fn clone_scoped_transform_regions(regions []transform.ScopedTransformRegion) []t
 	mut cloned := []transform.ScopedTransformRegion{cap: regions.len}
 	for region in regions {
 		cloned << transform.ScopedTransformRegion{
-			scope:      region.scope
-			new_start:  region.new_start
-			new_end:    region.new_end
+			scope: region.scope
+			new_start: region.new_start
+			new_end: region.new_end
 			base_nodes: region.base_nodes.clone()
 		}
 	}
@@ -5944,22 +5867,22 @@ fn clone_flat_ast_after_transform(ast &flat.FlatAst) &flat.FlatAst {
 	children << ast.children
 	text_values, text_ids := ast.clone_text_table_owned()
 	return &flat.FlatAst{
-		nodes:                  nodes
-		children:               children
-		user_code_start:        ast.user_code_start
-		disabled_fns:           ast.disabled_fns
-		export_fn_names:        ast.export_fn_names
-		noreturn_fns:           ast.noreturn_fns
-		source_files:           ast.source_files
-		template_call_sites:    ast.template_call_sites.clone()
-		template_actions:       clone_int_string_map(ast.template_actions)
-		source_buffers:         ast.source_buffers
-		text_values:            text_values
-		text_ids:               text_ids
-		worker_pool:            ast.worker_pool
-		specialized_fn_nodes:   ast.specialized_fn_nodes.clone()
+		nodes: nodes
+		children: children
+		user_code_start: ast.user_code_start
+		disabled_fns: ast.disabled_fns
+		export_fn_names: ast.export_fn_names
+		noreturn_fns: ast.noreturn_fns
+		source_files: ast.source_files
+		template_call_sites: ast.template_call_sites.clone()
+		template_actions: clone_int_string_map(ast.template_actions)
+		source_buffers: ast.source_buffers
+		text_values: text_values
+		text_ids: text_ids
+		worker_pool: ast.worker_pool
+		specialized_fn_nodes: ast.specialized_fn_nodes.clone()
 		specialized_fn_modules: clone_int_string_map(ast.specialized_fn_modules)
-		specialized_fn_files:   clone_int_string_map(ast.specialized_fn_files)
+		specialized_fn_files: clone_int_string_map(ast.specialized_fn_files)
 	}
 }
 
@@ -5997,11 +5920,11 @@ fn clone_struct_field_map(values map[string][]types.StructField) map[string][]ty
 		mut owned_fields := []types.StructField{cap: fields.len}
 		for field in fields {
 			owned_fields << types.StructField{
-				name:        field.name.clone()
-				typ:         types.clone_owned_type(field.typ)
+				name: field.name.clone()
+				typ: types.clone_owned_type(field.typ)
 				has_default: field.has_default
-				is_embed:    field.is_embed
-				is_mut:      field.is_mut
+				is_embed: field.is_embed
+				is_mut: field.is_mut
 			}
 		}
 		cloned[name.clone()] = owned_fields
@@ -6217,7 +6140,7 @@ fn v3_test_build_constraint(file string) V3TestBuildConstraint {
 		if line.starts_with('// vtest build:') {
 			return V3TestBuildConstraint{
 				expression: line.all_after(':').trim_space()
-				line:       index + 1
+				line: index + 1
 			}
 		}
 	}
@@ -6228,8 +6151,7 @@ fn v3_test_build_fact_name(name string) bool {
 	return name in ['windows', 'macos', 'linux', 'freebsd', 'openbsd', 'netbsd', 'dragonfly',
 		'android', 'termux', 'solaris', 'haiku', 'qnx', 'serenity', 'vinix', 'wasm32_emscripten',
 		'tinyc', 'tcc', 'clang', 'gcc', 'mingw', 'msvc', 'cplusplus', 'amd64', 'arm64', 'arm32',
-		'x86', 'i386', 'riscv64', 'ppc', 'ppc64', 'ppc64le', 's390x', 'loongarch64', 'wasm32',
-		'prod']
+		'x86', 'i386', 'riscv64', 'ppc', 'ppc64', 'ppc64le', 's390x', 'loongarch64', 'wasm32', 'prod']
 }
 
 fn v3_test_build_facts(target pref.Target, ccompiler string, is_prod bool) []string {
@@ -6293,8 +6215,8 @@ fn v3_test_dependency_probe_present(probe V3TestDependencyProbe) bool {
 
 fn v3_test_openssl_dependency_probe(command string, pkgconfig_name string) V3TestDependencyProbe {
 	return V3TestDependencyProbe{
-		command:        command
-		args:           ['version']
+		command: command
+		args: ['version']
 		pkgconfig_name: pkgconfig_name
 	}
 }
@@ -6304,27 +6226,27 @@ fn v3_test_standard_dependency_probe(define string) ?V3TestDependencyProbe {
 		'present_node' {
 			return V3TestDependencyProbe{
 				command: 'node'
-				args:    ['--version']
+				args: ['--version']
 			}
 		}
 		'present_python' {
 			return V3TestDependencyProbe{
-				command:        'python'
-				args:           ['--version']
+				command: 'python'
+				args: ['--version']
 				pkgconfig_name: 'python3'
 			}
 		}
 		'present_ruby' {
 			return V3TestDependencyProbe{
-				command:        'ruby'
-				args:           ['--version']
+				command: 'ruby'
+				args: ['--version']
 				pkgconfig_name: 'ruby'
 			}
 		}
 		'present_go' {
 			return V3TestDependencyProbe{
 				command: 'go'
-				args:    ['version']
+				args: ['version']
 			}
 		}
 		else {
@@ -6335,11 +6257,9 @@ fn v3_test_standard_dependency_probe(define string) ?V3TestDependencyProbe {
 
 fn v3_test_openssl_present() bool {
 	$if openbsd {
-		return v3_test_dependency_probe_present(v3_test_openssl_dependency_probe('eopenssl35',
-			'eopenssl35'))
+		return v3_test_dependency_probe_present(v3_test_openssl_dependency_probe('eopenssl35', 'eopenssl35'))
 	} $else {
-		return v3_test_dependency_probe_present(v3_test_openssl_dependency_probe('openssl',
-			'openssl'))
+		return v3_test_dependency_probe_present(v3_test_openssl_dependency_probe('openssl', 'openssl'))
 	}
 }
 
@@ -6374,7 +6294,7 @@ fn v3_test_sqlite_present(user_os string, vexeroot string) bool {
 	}
 	return v3_test_command_succeeds('sqlite3', ['--version'])
 		&& (v3_test_command_succeeds('pkgconf', ['sqlite3', '--libs'])
-		|| v3_test_command_succeeds('pkg-config', ['sqlite3', '--libs']))
+			|| v3_test_command_succeeds('pkg-config', ['sqlite3', '--libs']))
 }
 
 fn v3_test_build_defines(expression string, user_defines []string) []string {
@@ -6445,8 +6365,7 @@ fn v3_test_matches_build_constraint(file string, target pref.Target, ccompiler s
 	if details.expression.len == 0 {
 		return true
 	}
-	environment := build_constraint.new_environment(v3_test_build_facts(target, ccompiler, is_prod), v3_test_build_defines(details.expression,
-		user_defines))
+	environment := build_constraint.new_environment(v3_test_build_facts(target, ccompiler, is_prod), v3_test_build_defines(details.expression, user_defines))
 	return environment.eval(details.expression) or {
 		eprintln('${file}:${details.line}:17: error during parsing the `// vtest build` expression `${details.expression}`: ${err}')
 		false
@@ -6647,7 +6566,7 @@ fn restore_transformed_fn_value_types(mut tc types.TypeChecker, a &flat.FlatAst,
 		params := tc.fn_param_types[name] or { continue }
 		ret := tc.fn_ret_types[name] or { continue }
 		tc.expr_type_values[idx] = types.FnType{
-			params:      params
+			params: params
 			return_type: ret
 		}
 		tc.expr_type_set[idx] = true
@@ -6707,7 +6626,7 @@ fn restore_transformed_fn_value_types(mut tc types.TypeChecker, a &flat.FlatAst,
 							params := tc.fn_param_types[name] or { []types.Type{} }
 							if ret := tc.fn_ret_types[name] {
 								tc.expr_type_values[callee_idx] = types.FnType{
-									params:      params
+									params: params
 									return_type: ret
 								}
 								tc.expr_type_set[callee_idx] = true
@@ -6726,7 +6645,7 @@ fn restore_transformed_fn_value_types(mut tc types.TypeChecker, a &flat.FlatAst,
 						params := tc.fn_param_types[cname] or { []types.Type{} }
 						if ret := tc.fn_ret_types[cname] {
 							tc.expr_type_values[base_idx] = types.FnType{
-								params:      params
+								params: params
 								return_type: ret
 							}
 							tc.expr_type_set[base_idx] = true
@@ -6825,10 +6744,10 @@ fn v3_source_is_pure_v(path string) bool {
 	}
 	actual_language := if language == before_dot_v { language_with_underscore } else { language }
 	return actual_language !in ['c', 'js', 'amd64', 'x86_64', 'x64', 'x86', 'aarch64', 'arm64',
-		'aarch32', 'arm32', 'arm', 'rv64', 'riscv64', 'risc-v64', 'riscv', 'risc-v', 'rv32',
-		'riscv32', 'x86_32', 'x32', 'i386', 'IA-32', 'ia-32', 'ia32', 's390x', 'loongarch64',
-		'ppc64le', 'sparc64', 'ppc64', 'ppc', 'ppc32', 'powerpc', 'js_node', 'js_browser',
-		'js_freestanding', 'wasm32', 'wasm']
+		'aarch32', 'arm32', 'arm', 'rv64', 'riscv64', 'risc-v64', 'riscv', 'risc-v', 'rv32', 'riscv32',
+		'x86_32', 'x32', 'i386', 'IA-32', 'ia-32', 'ia32', 's390x', 'loongarch64', 'ppc64le',
+		'sparc64', 'ppc64', 'ppc', 'ppc32', 'powerpc', 'js_node', 'js_browser', 'js_freestanding',
+		'wasm32', 'wasm']
 }
 
 fn v3_type_text_uses_interop_namespace(text string, namespace string) bool {
@@ -6853,8 +6772,7 @@ fn v3_ast_node_uses_interop_namespace(a &flat.FlatAst, node &flat.Node, namespac
 			return true
 		}
 	}
-	if node.kind !in [.string_literal, .string_interp, .char_literal, .directive, .file]
-		&& node.value.starts_with(namespace + '.') {
+	if node.kind !in [.string_literal, .string_interp, .char_literal, .directive, .file] && node.value.starts_with(namespace + '.') {
 		return true
 	}
 	return v3_type_text_uses_interop_namespace(node.typ, namespace)
@@ -6937,12 +6855,12 @@ fn v3_impure_v_diagnostics(a &flat.FlatAst) []parser.Diagnostic {
 				column = position.column
 			}
 			diagnostics << parser.Diagnostic{
-				file:     file
-				pos:      pos
-				line:     line
-				column:   column
+				file: file
+				pos: pos
+				line: line
+				column: column
 				severity: 'warning:'
-				message:  '${namespace} code will not be allowed in pure .v files, please move it to a .${namespace.to_lower_ascii()}.v file instead'
+				message: '${namespace} code will not be allowed in pure .v files, please move it to a .${namespace.to_lower_ascii()}.v file instead'
 			}
 		}
 	}
@@ -6997,10 +6915,8 @@ fn write_macos_v3_fallback_source_digests(report_dir string, v_sources map[strin
 		v_source_paths_text.write_string(path)
 		v_source_digests_text.write_string(v_sources[path])
 	}
-	os.write_file(os.join_path(report_dir, macos_v3_c_error_v_sources_file),
-		v_source_paths_text.str()) or { return false }
-	os.write_file(os.join_path(report_dir, macos_v3_c_error_v_source_digests_file),
-		v_source_digests_text.str()) or { return false }
+	os.write_file(os.join_path(report_dir, macos_v3_c_error_v_sources_file), v_source_paths_text.str()) or { return false }
+	os.write_file(os.join_path(report_dir, macos_v3_c_error_v_source_digests_file), v_source_digests_text.str()) or { return false }
 	return true
 }
 
@@ -7026,8 +6942,7 @@ fn request_macos_v3_c_error_fallback_from_message(fallback_file string, report_d
 	}
 	for c_source in c_sources {
 		if os.is_file(c_source) {
-			return request_macos_v3_c_error_fallback(fallback_file, report_dir, ccompiler, message,
-				c_source, v_sources)
+			return request_macos_v3_c_error_fallback(fallback_file, report_dir, ccompiler, message, c_source, v_sources)
 		}
 	}
 	return false
@@ -7161,7 +7076,8 @@ fn record_v3_cached_source_digests(mut cache_state V3ModuleCacheState, source_di
 
 fn v3_fallback_backend_specific_builtin_source(path string, builtin_root string) bool {
 	return (path == builtin_root || path.starts_with(builtin_root + os.path_separator))
-		&& os.file_name(path) in ['ownership_interface_d_v3_backend.v', 'ownership_interface_notd_v3_backend.v', 'prealloc.c.v']
+		&& os.file_name(path) in ['ownership_interface_d_v3_backend.v',
+			'ownership_interface_notd_v3_backend.v', 'prealloc.c.v']
 }
 
 fn input_uses_minimal_literal_output_builtin(input_file string, prefs &pref.Preferences, is_test_command bool, is_checker_fixture bool) bool {
@@ -7317,8 +7233,7 @@ fn v3_prod_c_object_optimization_flags(is_prod bool, no_prod_options bool, is_sh
 	// Native support sources are cached as independently compiled objects. Emitting
 	// LLVM bitcode here makes every program link optimize those unchanged sources
 	// again; keep the per-object -O3 work in the cache instead.
-	return v3_prod_c_optimization_flags(is_prod, no_prod_options, is_shared, parallel_cc, false,
-		false, explicit_tcc).filter(it != '-flto')
+	return v3_prod_c_optimization_flags(is_prod, no_prod_options, is_shared, parallel_cc, false, false, explicit_tcc).filter(it != '-flto')
 }
 
 fn append_v3_c_compile_mode_flags(mut args []string, c_standard string, opt_flags string, pic_flag string) {
@@ -7349,8 +7264,8 @@ fn expand_v3_module_search_paths(spec string, vroot string) []string {
 fn v3_driver_option_requires_value(option string) bool {
 	return option in ['-o', '-output', '-b', '-backend', '-os', '-arch', '-compile-backend',
 		'--compile-backend', '-d', '-define', '-gc', '-cc', '-thread-stack-size', '-path', '-cov',
-		'-coverage', '-file-list', '-message-limit', '-printfn', '-generate-c-project',
-		'-test-runner', '-run-only', '-profile-fns']
+		'-coverage', '-file-list', '-message-limit', '-printfn', '-generate-c-project', '-test-runner',
+		'-run-only', '-profile-fns']
 }
 
 fn v3_driver_option_consumes_value(option string) bool {
@@ -7444,8 +7359,7 @@ $if !skip_fastc ? {
 		if !os.is_executable(tcc_path) {
 			return V3FastCCompileResult{}
 		}
-		build_dir := os.join_path_single(os.dir(os.real_path(bin_file)),
-			'.${os.file_name(bin_file)}.fastc.${tempname.unique_token()}')
+		build_dir := os.join_path_single(os.dir(os.real_path(bin_file)), '.${os.file_name(bin_file)}.fastc.${tempname.unique_token()}')
 		os.mkdir_all(build_dir) or { return V3FastCCompileResult{} }
 		defer {
 			cleanup_c_build_dir(build_dir)
@@ -7458,8 +7372,7 @@ $if !skip_fastc ? {
 		if bench_phases {
 			eprintln('fastc-phase tcc.setup ${cc_sw.elapsed().microseconds()}us')
 		}
-		unit_paths := fastc.fastc_write_c_units(os.join_path_single(build_dir, 'src'), pieces, units,
-			fastc.fastc_tcc_job_count(prefs)) or { return V3FastCCompileResult{} }
+		unit_paths := fastc.fastc_write_c_units(os.join_path_single(build_dir, 'src'), pieces, units, fastc.fastc_tcc_job_count(prefs)) or { return V3FastCCompileResult{} }
 		if unit_paths.len < 2 {
 			fastc.write_c_pieces(source_file, pieces) or { return V3FastCCompileResult{} }
 		}
@@ -7468,7 +7381,8 @@ $if !skip_fastc ? {
 		}
 		tcc_resources := v3_tcc_resource_flags(prefs.vroot)
 		mut cc_args := environment_c_flags.clone()
-		cc_args << ['-std=gnu11', tcc_resources.base_arg, tcc_resources.include_arg, tcc_resources.library_arg]
+		cc_args << ['-std=gnu11', tcc_resources.base_arg, tcc_resources.include_arg,
+			tcc_resources.library_arg]
 		cc_args << v3_tcc_host_system_flags(prefs.normalized_target_os(), macos_sdk_root)
 		cc_args << source_c_flags
 		// A call without a prototype would silently truncate a pointer result
@@ -7504,15 +7418,14 @@ $if !skip_fastc ? {
 		if unit_paths.len > 1 {
 			mut compile_args := compile_base_args.clone()
 			compile_args << user_compile_args
-			link_worker := spawn fastc.fastc_prepare_link(tcc_path,
-				os.join_path_single(tcc_dir, 'lib'), compile_base_args, final_args)
+			link_worker := spawn fastc.fastc_prepare_link(tcc_path, os.join_path_single(tcc_dir, 'lib'), compile_base_args, final_args)
 			unit_objects := fastc.fastc_compile_c_units(tcc_path, compile_args, unit_paths) or {
 				mut prepared_link := link_worker.wait()
 				fastc.fastc_discard_link(mut prepared_link)
 				fastc.write_c_pieces(source_file, pieces) or {}
 				return V3FastCCompileResult{
 					command: cmdexec.display(tcc_path, compile_args)
-					output:  err.msg()
+					output: err.msg()
 				}
 			}
 			if bench_phases {
@@ -7554,14 +7467,14 @@ $if !skip_fastc ? {
 			}
 			return V3FastCCompileResult{
 				command: command
-				output:  result.output
+				output: result.output
 			}
 		}
 		if sign_in_process {
 			fastc.fastc_sign_macho_adhoc(staged_binary) or {
 				return V3FastCCompileResult{
 					command: command
-					output:  'could not sign ${staged_binary}: ${err.msg()}'
+					output: 'could not sign ${staged_binary}: ${err.msg()}'
 				}
 			}
 		}
@@ -7571,13 +7484,13 @@ $if !skip_fastc ? {
 		os.mv(staged_binary, bin_file) or {
 			return V3FastCCompileResult{
 				command: command
-				output:  err.msg()
+				output: err.msg()
 			}
 		}
 		return V3FastCCompileResult{
 			success: true
 			command: command
-			output:  result.output
+			output: result.output
 		}
 	}
 }
@@ -7910,8 +7823,7 @@ pub fn run(args []string) {
 			no_cache = true
 			i += 2
 		} else if args[i] in ['-prof', '-profile'] {
-			parsed_profile_file, profile_file_consumed := v3_profile_optional_arg_value(args, i,
-				command_seen)
+			parsed_profile_file, profile_file_consumed := v3_profile_optional_arg_value(args, i, command_seen)
 			profile_file = parsed_profile_file
 			is_prof = true
 			no_cache = true
@@ -8185,8 +8097,7 @@ pub fn run(args []string) {
 			eprintln('cannot create output directory ${output_file}: ${err.msg()}')
 			exit(1)
 		}
-		output_file = os.join_path_single(output_file,
-			os.base(default_bin_file_for_input(input_file)))
+		output_file = os.join_path_single(output_file, os.base(default_bin_file_for_input(input_file)))
 	}
 	if is_debug && 'debug' !in user_defines {
 		user_defines << 'debug'
@@ -8288,8 +8199,7 @@ pub fn run(args []string) {
 	} else {
 		effective_c_compiler_name(c_compiler, target)
 	}
-	incompatible_direct_test := v3_direct_test_input_is_incompatible(is_test_command, input_file,
-		backend, target, constraint_ccompiler, is_prod, user_defines)
+	incompatible_direct_test := v3_direct_test_input_is_incompatible(is_test_command, input_file, backend, target, constraint_ccompiler, is_prod, user_defines)
 	if incompatible_direct_test {
 		// Directory test discovery already excludes incompatible backend/platform files.
 		// Apply the same backend, platform, and `// vtest build:` rules to a direct single-file
@@ -8386,8 +8296,7 @@ pub fn run(args []string) {
 		c_only = true
 		c_to_stdout = true
 		bin_file = ''
-		output_file = os.join_path_single(os.vtmp_dir(),
-			'v3_stdout_${os.getpid()}_${tempname.unique_token()}.c')
+		output_file = os.join_path_single(os.vtmp_dir(), 'v3_stdout_${os.getpid()}_${tempname.unique_token()}.c')
 	} else if backend in ['c', 'fastc'] && output_file.ends_with('.c') {
 		c_only = true
 		bin_file = output_file.all_before_last('.c')
@@ -8399,8 +8308,7 @@ pub fn run(args []string) {
 		output_file = bin_file + '.c'
 	}
 	if backend in ['c', 'fastc'] {
-		target_bin_file := c_executable_bin_file_for_target(bin_file, target.os, is_shared, is_o,
-			c_only)
+		target_bin_file := c_executable_bin_file_for_target(bin_file, target.os, is_shared, is_o, c_only)
 		if target_bin_file != bin_file {
 			bin_file = target_bin_file
 			output_file = bin_file + '.c'
@@ -8427,20 +8335,37 @@ pub fn run(args []string) {
 	for cb in compile_backends {
 		for name in cb.split(',') {
 			match name.trim_space() {
-				'fastc' { include_fastc = true }
-				'arm64', 'aarch64' { include_arm64 = true }
-				'wasm', 'wasm32' { include_wasm = true }
-				'eval' { include_eval = true }
+				'fastc' {
+					include_fastc = true
+				}
+				'arm64', 'aarch64' {
+					include_arm64 = true
+				}
+				'wasm', 'wasm32' {
+					include_wasm = true
+				}
+				'eval' {
+					include_eval = true
+				}
+
 				// 'c' is always built; there is no native amd64 backend in v3 yet.
 				else {}
 			}
 		}
 	}
 	match backend {
-		'fastc' { include_fastc = true }
-		'arm64' { include_arm64 = true }
-		'wasm' { include_wasm = true }
-		'eval' { include_eval = true }
+		'fastc' {
+			include_fastc = true
+		}
+		'arm64' {
+			include_arm64 = true
+		}
+		'wasm' {
+			include_wasm = true
+		}
+		'eval' {
+			include_eval = true
+		}
 		else {}
 	}
 
@@ -8572,6 +8497,7 @@ pub fn run(args []string) {
 			eprintln('fastc support is not compiled into this v3 executable')
 			exit(1)
 		} $else {
+
 			// FastC is a standalone parser that emits C while consuming scanner tokens.
 			// Never let an unsupported FastC input continue into the AST frontend below.
 			clear_macos_v3_compiler_error_fallback(macos_v3_fallback_file)
@@ -8654,8 +8580,7 @@ pub fn run(args []string) {
 				// Same-target FastC output is compiled by bundled TinyCC regardless of
 				// the host default, so compile-time compiler branches must see TinyCC.
 				prefs.ccompiler = 'tinyc'
-				add_v3_tcc_compat_defines(mut prefs.user_defines, target.os, target.arch, false,
-					true)
+				add_v3_tcc_compat_defines(mut prefs.user_defines, target.os, target.arch, false, true)
 			}
 			// FASTC_BENCH_LOOP=N repeats generation in-process so an external
 			// sampler can profile it (see the FastC section of the v3 README).
@@ -8701,8 +8626,7 @@ pub fn run(args []string) {
 			// Validate same-target generated C before publishing it. C-only builds use a
 			// throwaway executable; normal builds keep the binary produced by bundled TinyCC.
 			fastc_bin_file := if c_only {
-				os.join_path_single(os.vtmp_dir(),
-					'v3_fastc_validate_${os.getpid()}_${tempname.unique_token()}')
+				os.join_path_single(os.vtmp_dir(), 'v3_fastc_validate_${os.getpid()}_${tempname.unique_token()}')
 			} else {
 				bin_file
 			}
@@ -8711,9 +8635,7 @@ pub fn run(args []string) {
 			} else {
 				''
 			}
-			fastc_result := compile_v3_fastc_source(fastc_pieces, fastc_generation.units,
-				fastc_bin_file, prefs, environment_c_flags, fastc_generation.c_flags, user_c_flags,
-				environment_ld_flags, fastc_sdk_root, is_debug, fastc_generation.uses_threads)
+			fastc_result := compile_v3_fastc_source(fastc_pieces, fastc_generation.units, fastc_bin_file, prefs, environment_c_flags, fastc_generation.c_flags, user_c_flags, environment_ld_flags, fastc_sdk_root, is_debug, fastc_generation.uses_threads)
 			if (!silent || show_cc) && fastc_result.command.len > 0 {
 				if c_to_stdout {
 					eprintln('  > ${fastc_result.command}')
@@ -8828,8 +8750,7 @@ pub fn run(args []string) {
 	].join('\n')
 	build_pseudo_values := [prefs.build_date, prefs.build_time, prefs.build_timestamp].join('\n')
 	version_pseudo_values := [prefs.vhash, prefs.vcurrent_hash].join('\n')
-	cache_manager := modulecache.new_manager(prefs.vroot, cache_salt, cache_enabled,
-		build_pseudo_values, version_pseudo_values)
+	cache_manager := modulecache.new_manager(prefs.vroot, cache_salt, cache_enabled, build_pseudo_values, version_pseudo_values)
 	program_cache_enabled := persistent_program_cache_enabled(cache_enabled, is_test_command
 		|| is_v3_test_file(input_file, backend, target), os.vtmp_dir())
 	force_cache_source := os.getenv('V3_CACHE_FORCE_SOURCE') == '1'
@@ -8851,8 +8772,7 @@ pub fn run(args []string) {
 	if ownership_mode && 'ownership' !in builtin_defines {
 		builtin_defines << 'ownership'
 	}
-	mut builtin_files := pref.get_v_files_from_dir_for_target(builtin_dir, builtin_defines,
-		prefs.target)
+	mut builtin_files := pref.get_v_files_from_dir_for_target(builtin_dir, builtin_defines, prefs.target)
 	if no_builtin {
 		builtin_files = []
 	}
@@ -8861,30 +8781,30 @@ pub fn run(args []string) {
 	}
 	bundle_sources := builtin_bundle_source_files(prefs, builtin_files)
 	mut cache_state := V3ModuleCacheState{
-		manager:                   cache_manager
-		bundle_sources:            bundle_sources
-		bundle_source_paths:       module_cache_source_path_set(bundle_sources)
-		force_source:              force_cache_source
-		module_sources:            map[string][]string{}
-		module_import_paths:       map[string]string{}
-		module_dependencies:       map[string][]string{}
-		module_external_inputs:    map[string][]string{}
-		module_native_roots:       map[string][]string{}
-		native_root_contexts:      map[string][]string{}
-		native_root_owners:        map[string]string{}
+		manager: cache_manager
+		bundle_sources: bundle_sources
+		bundle_source_paths: module_cache_source_path_set(bundle_sources)
+		force_source: force_cache_source
+		module_sources: map[string][]string{}
+		module_import_paths: map[string]string{}
+		module_dependencies: map[string][]string{}
+		module_external_inputs: map[string][]string{}
+		module_native_roots: map[string][]string{}
+		native_root_contexts: map[string][]string{}
+		native_root_owners: map[string]string{}
 		external_input_signatures: map[string]string{}
-		external_input_digests:    map[string]string{}
-		dependency_metadata:       map[string]string{}
-		cached_source_digests:     map[string]string{}
+		external_input_digests: map[string]string{}
+		dependency_metadata: map[string]string{}
+		cached_source_digests: map[string]string{}
 		fallback_required_modules: map[string]bool{}
-		fallback_warmup_modules:   map[string]bool{}
-		parsed_from_source:        map[string]bool{}
-		source_body_modules:       map[string]bool{}
-		native_source_modules:     map[string]bool{}
-		native_type_declarations:  map[string]string{}
+		fallback_warmup_modules: map[string]bool{}
+		parsed_from_source: map[string]bool{}
+		source_body_modules: map[string]bool{}
+		native_source_modules: map[string]bool{}
+		native_type_declarations: map[string]string{}
 		native_declared_functions: map[string]map[string]bool{}
-		objects:                   map[string]string{}
-		headers:                   map[string]string{}
+		objects: map[string]string{}
+		headers: map[string]string{}
 	}
 	cache_state.module_sources['builtin'] = builtin_files
 	mut files := []string{}
@@ -8929,8 +8849,7 @@ pub fn run(args []string) {
 	// Test mode is a compile-time define as well as a harness mode. Install it
 	// after parsing builtin, but before collecting and parsing user inputs, so
 	// `$if test` and `_d_test.v` apply to both file and directory test commands.
-	if 'test' !in prefs.user_defines
-		&& (is_test_command || is_v3_test_file(input_file, backend, target)) {
+	if 'test' !in prefs.user_defines && (is_test_command || is_v3_test_file(input_file, backend, target)) {
 		prefs.user_defines << 'test'
 	}
 
@@ -8984,11 +8903,9 @@ pub fn run(args []string) {
 	// Resolve imports recursively
 	resolve_imports_started_us := b.current_step_time_us()
 	resolve_imports_parse_started_us := parse_timing.header_us + parse_timing.source_us
-	resolve_imports(mut a, mut p, prefs, user_files, !current_no_parallel, minimal_literal_output, mut
-		cache_state, mut parse_timing)
+	resolve_imports(mut a, mut p, prefs, user_files, !current_no_parallel, minimal_literal_output, mut cache_state, mut parse_timing)
 	resolve_imports_elapsed_us := b.current_step_time_us() - resolve_imports_started_us
-	resolve_imports_parse_us := parse_timing.header_us + parse_timing.source_us -
-		resolve_imports_parse_started_us
+	resolve_imports_parse_us := parse_timing.header_us + parse_timing.source_us - resolve_imports_parse_started_us
 	resolve_imports_coordination_us := if resolve_imports_parse_us < resolve_imports_elapsed_us {
 		resolve_imports_elapsed_us - resolve_imports_parse_us
 	} else {
@@ -9000,8 +8917,7 @@ pub fn run(args []string) {
 	// Preserve the digest of every exact source buffer V3 parsed before any parser or
 	// later compiler error can request the compatibility compiler. The dispatcher owns
 	// this staging directory and forwards only content plus verification metadata.
-	mut fallback_report_sources := macos_v3_fallback_report_sources(a, prefs.vroot,
-		cache_state.cached_source_digests, v3_fallback_ignored_warmup_source_paths(cache_state))
+	mut fallback_report_sources := macos_v3_fallback_report_sources(a, prefs.vroot, cache_state.cached_source_digests, v3_fallback_ignored_warmup_source_paths(cache_state))
 	_ = stage_macos_v3_fallback_source_digests(macos_v3_c_error_dir, fallback_report_sources)
 	if print_v_files || print_watched_files {
 		mut watched := map[string]bool{}
@@ -9049,8 +8965,7 @@ pub fn run(args []string) {
 					} else {
 						'error:'
 					}
-					eprintln(v3errors.formatted_parser_diagnostic(severity, diagnostic.message, a,
-						diagnostic.pos))
+					eprintln(v3errors.formatted_parser_diagnostic(severity, diagnostic.message, a, diagnostic.pos))
 				} else {
 					severity := if effective_warns_are_errors && diagnostic.severity == 'warning:' {
 						'error:'
@@ -9102,26 +9017,25 @@ pub fn run(args []string) {
 	parse_setup_us := parse_total_us - header_parse_us - source_parse_us - resolve_coordination_us
 	b.step_parts([
 		bench.StepPart{
-			name:    'parse setup/cache'
+			name: 'parse setup/cache'
 			time_us: parse_setup_us
 		},
 		bench.StepPart{
-			name:     'parse .vh'
-			time_us:  header_parse_us
+			name: 'parse .vh'
+			time_us: header_parse_us
 			parallel: parse_timing.header_parallel
 		},
 		bench.StepPart{
-			name:     'parse .v'
-			time_us:  source_parse_us
+			name: 'parse .v'
+			time_us: source_parse_us
 			parallel: parse_timing.source_parallel
 		},
 		bench.StepPart{
-			name:    'resolve imports'
+			name: 'resolve imports'
 			time_us: resolve_coordination_us
 		},
 	])
-	b.metric_items('parsed .vh files', p.parsed_v_header_files, 'files', '.vh files',
-		p.parsed_v_header_file_paths)
+	b.metric_items('parsed .vh files', p.parsed_v_header_files, 'files', '.vh files', p.parsed_v_header_file_paths)
 	if !silent {
 		println('    ${'parsed .vh lines':-28s} ${source_file_line_count(p.parsed_v_header_file_paths)} lines')
 	}
@@ -9141,12 +9055,9 @@ pub fn run(args []string) {
 			crun_build_identity = carried_identity
 		} else {
 			mut crun_c_flags := user_c_flags.clone()
-			crun_c_flags << cgen.cache_directive_flags(a, prefs.vroot, prefs.target,
-				prefs.compile_values)
-			_ = prepare_v3_cache_external_inputs_scoped(mut cache_state, a, prefs, user_files,
-				crun_c_flags, scope_prealloc_stages)
-			crun_build_identity = v3_crun_build_identity(&cache_state, prefs, user_files,
-				crun_c_flags, is_strict, enable_globals_compat, input_file)
+			crun_c_flags << cgen.cache_directive_flags(a, prefs.vroot, prefs.target, prefs.compile_values)
+			_ = prepare_v3_cache_external_inputs_scoped(mut cache_state, a, prefs, user_files, crun_c_flags, scope_prealloc_stages)
+			crun_build_identity = v3_crun_build_identity(&cache_state, prefs, user_files, crun_c_flags, is_strict, enable_globals_compat, input_file)
 			if crun_build_identity.len > 0 {
 				os.setenv(v3_crun_build_identity_env, crun_build_identity, true)
 			}
@@ -9183,8 +9094,7 @@ pub fn run(args []string) {
 	mut generated_monomorph_specs := []transform.MonomorphCacheSpec{}
 	mut cache_c_flags := user_c_flags.clone()
 	if backend == 'c' && cache_state.manager.enabled {
-		cache_c_flags << cgen.cache_directive_flags(a, prefs.vroot, prefs.target,
-			prefs.compile_values)
+		cache_c_flags << cgen.cache_directive_flags(a, prefs.vroot, prefs.target, prefs.compile_values)
 	}
 	use_macos_dev_program_cache := backend == 'c' && program_cache_enabled && !is_prod && !is_shared
 		&& !is_selfhost && prefs.normalized_target_os() == 'macos'
@@ -9203,17 +9113,14 @@ pub fn run(args []string) {
 	mut incremental_tcc_declarations_path := ''
 	if backend == 'c' && program_cache_enabled && !cache_state.force_source
 		&& cache_state.parsed_from_source.len == 0 {
-		mut external_inputs_ready := restore_v3_cache_external_inputs(mut cache_state, user_files,
-			cache_c_flags, prefs.ccompiler, prefs.target, '')
+		mut external_inputs_ready := restore_v3_cache_external_inputs(mut cache_state, user_files, cache_c_flags, prefs.ccompiler, prefs.target, '')
 		if !external_inputs_ready && incremental_cache_enabled {
 			incremental_snapshot = incremental_program_snapshot(a, user_files)
 			incremental_snapshot_ready = true
 			if os.getenv('V3_CACHE_TRACE') != '' {
 				eprintln('  V3 incremental snapshot: declarations=${incremental_snapshot.declaration_signature} functions=${incremental_snapshot.functions.len}')
 			}
-			external_inputs_ready = restore_v3_cache_external_inputs(mut cache_state, user_files,
-				cache_c_flags, prefs.ccompiler, prefs.target,
-				incremental_snapshot.declaration_signature)
+			external_inputs_ready = restore_v3_cache_external_inputs(mut cache_state, user_files, cache_c_flags, prefs.ccompiler, prefs.target, incremental_snapshot.declaration_signature)
 		}
 		if !external_inputs_ready
 			&& !prepare_v3_cache_external_inputs_scoped(mut cache_state, a, prefs, user_files, cache_c_flags, scope_prealloc_stages) {
@@ -9226,9 +9133,7 @@ pub fn run(args []string) {
 		}
 		input := v3_cgen_cache_input(cache_state, user_files, cache_c_flags)
 		cgen_cache_commit_exists = cache_state.manager.has_cgen_commit(input.source_files)
-		if entry := cache_state.manager.valid_cgen(input.source_files, input.generation_signature,
-			input.dependency_inputs)
-		{
+		if entry := cache_state.manager.valid_cgen(input.source_files, input.generation_signature, input.dependency_inputs) {
 			metadata := os.read_file(entry.metadata) or { '' }
 			if decoded := decode_v3_cgen_metadata(metadata) {
 				cgen_cache_entry = entry
@@ -9248,18 +9153,13 @@ pub fn run(args []string) {
 					eprintln('  V3 incremental snapshot: declarations=${incremental_snapshot.declaration_signature} functions=${incremental_snapshot.functions.len}')
 				}
 			}
-			if entry := cache_state.manager.valid_incremental_program(input.source_files,
-				incremental_snapshot.declaration_signature, input.generation_signature,
-				input.dependency_inputs)
-			{
+			if entry := cache_state.manager.valid_incremental_program(input.source_files, incremental_snapshot.declaration_signature, input.generation_signature, input.dependency_inputs) {
 				if os.getenv('V3_CACHE_TRACE') != '' {
 					eprintln('  V3 incremental cache stamp hit')
 				}
 				manifest_text := os.read_file(entry.manifest) or { '' }
 				if old_manifest := decode_incremental_manifest(manifest_text) {
-					if changed_keys, changed_names := incremental_changed_functions(incremental_snapshot,
-						old_manifest)
-					{
+					if changed_keys, changed_names := incremental_changed_functions(incremental_snapshot, old_manifest) {
 						spec_text := os.read_file(entry.specs) or { '' }
 						used_text := os.read_file(entry.used) or { '' }
 						body_text := os.read_file(entry.body) or { '' }
@@ -9279,21 +9179,19 @@ pub fn run(args []string) {
 								cached_program_used_fns = clone_string_bool_map(decoded_used)
 								cgen_cache_metadata = decoded_metadata
 								generic_cache_entry = modulecache.GenericProgramEntry{
-									specs:        entry.specs
-									used:         entry.used
-									prefix:       entry.prefix
+									specs: entry.specs
+									used: entry.used
+									prefix: entry.prefix
 									declarations: entry.declarations
-									body:         entry.body
-									metadata:     entry.metadata
+									body: entry.body
+									metadata: entry.metadata
 								}
 								generic_cache_hit = true
 								if changed_keys.len == 0 {
 									if decoded := decode_v3_cgen_metadata(metadata) {
 										materialized_body :=
 											modulecache.materialize_cached_body_string_definitions(body_text)
-										cgen_cache_entry = cache_state.manager.write_cgen(input.source_files,
-											input.generation_signature, input.dependency_inputs,
-											materialized_body, metadata) or {
+										cgen_cache_entry = cache_state.manager.write_cgen(input.source_files, input.generation_signature, input.dependency_inputs, materialized_body, metadata) or {
 											modulecache.CgenEntry{}
 										}
 										if cgen_cache_entry.stamp.len > 0 {
@@ -9320,9 +9218,7 @@ pub fn run(args []string) {
 			generic_cache_signature = monomorph_cache_semantic_signature(a, user_files)
 			generic_cache_runtime_strings = monomorph_cache_runtime_strings(a, user_files)
 			generic_cache_inputs_ready = true
-			if entry := cache_state.manager.valid_generic_program(input.source_files,
-				generic_cache_signature, input.generation_signature, input.dependency_inputs)
-			{
+			if entry := cache_state.manager.valid_generic_program(input.source_files, generic_cache_signature, input.generation_signature, input.dependency_inputs) {
 				spec_text := os.read_file(entry.specs) or { '' }
 				cached_monomorph_specs = decode_monomorph_cache_specs(spec_text)
 				used_text := os.read_file(entry.used) or { '' }
@@ -9337,13 +9233,9 @@ pub fn run(args []string) {
 					metadata := os.read_file(entry.metadata) or { '' }
 					if old_literals := decode_cached_runtime_strings(old_literal_text) {
 						if cgen_cache_commit_exists {
-							if rewritten := modulecache.rewrite_cached_runtime_strings(cached_body,
-								old_literals, generic_cache_runtime_strings)
-							{
+							if rewritten := modulecache.rewrite_cached_runtime_strings(cached_body, old_literals, generic_cache_runtime_strings) {
 								if decoded := decode_v3_cgen_metadata(metadata) {
-									cgen_cache_entry = cache_state.manager.write_cgen(input.source_files,
-										input.generation_signature, input.dependency_inputs,
-										rewritten, metadata) or { modulecache.CgenEntry{} }
+									cgen_cache_entry = cache_state.manager.write_cgen(input.source_files, input.generation_signature, input.dependency_inputs, rewritten, metadata) or { modulecache.CgenEntry{} }
 									if cgen_cache_entry.stamp.len > 0 {
 										cgen_cache_metadata = decoded
 										cgen_cache_hit = true
@@ -9387,33 +9279,30 @@ pub fn run(args []string) {
 	mut ck_stage_sw := time.new_stopwatch()
 	native_inputs_needed := !cache_state.external_inputs_ready && ast_has_native_source_include(a)
 	native_inputs_overlap := native_inputs_needed && building_v && !cache_state.manager.enabled
-	native_inputs_done := chan bool{cap: 1}
+	native_inputs_done := chan bool{ cap: 1 }
 	native_inputs_args := PrepareV3CheckerNativeInputsArgs{
-		state:         voidptr(&cache_state)
-		a:             a
-		prefs:         prefs
-		user_files:    user_files
-		user_c_flags:  cache_c_flags
+		state: voidptr(&cache_state)
+		a: a
+		prefs: prefs
+		user_files: user_files
+		user_c_flags: cache_c_flags
 		scope_enabled: scope_prealloc_stages
-		done:          native_inputs_done
+		done: native_inputs_done
 	}
 	if native_inputs_overlap {
 		spawn prepare_v3_checker_native_inputs_thread(&native_inputs_args)
 	} else if native_inputs_needed {
 		if cache_state.manager.enabled {
-			_ = prepare_v3_cache_external_inputs_scoped(mut cache_state, a, prefs, user_files,
-				cache_c_flags, scope_prealloc_stages)
+			_ = prepare_v3_cache_external_inputs_scoped(mut cache_state, a, prefs, user_files, cache_c_flags, scope_prealloc_stages)
 		} else {
-			prepare_v3_checker_native_inputs_scoped(mut cache_state, a, prefs, user_files,
-				cache_c_flags, scope_prealloc_stages)
+			prepare_v3_checker_native_inputs_scoped(mut cache_state, a, prefs, user_files, cache_c_flags, scope_prealloc_stages)
 		}
 	}
 	if verbose {
 		eprintln('  [ttime]   ck native inputs ${f64(ck_stage_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	}
 	if !native_inputs_overlap && backend == 'c' && cache_state.external_inputs_ready {
-		fallback_report_sources = macos_v3_fallback_report_inputs(fallback_report_sources,
-			&cache_state)
+		fallback_report_sources = macos_v3_fallback_report_inputs(fallback_report_sources, &cache_state)
 		_ = stage_macos_v3_fallback_source_digests(macos_v3_c_error_dir, fallback_report_sources)
 	}
 
@@ -9470,10 +9359,8 @@ pub fn run(args []string) {
 		if native_inputs_overlap {
 			_ := <-native_inputs_done
 			if backend == 'c' && cache_state.external_inputs_ready {
-				fallback_report_sources = macos_v3_fallback_report_inputs(fallback_report_sources,
-					&cache_state)
-				_ = stage_macos_v3_fallback_source_digests(macos_v3_c_error_dir,
-					fallback_report_sources)
+				fallback_report_sources = macos_v3_fallback_report_inputs(fallback_report_sources, &cache_state)
+				_ = stage_macos_v3_fallback_source_digests(macos_v3_c_error_dir, fallback_report_sources)
 			}
 		}
 		if has_conflicting_c_declaration_errors(pre_tc.errors) {
@@ -9524,8 +9411,7 @@ pub fn run(args []string) {
 			&& scope_prealloc_markused && !incremental_cache_hit && !generic_cache_hit
 			&& !cache_state.manager.enabled && test_files.len == 0 && !is_checker_fixture
 			&& !trivial_literal_output && !input_file.ends_with('.vsh') && !no_skip_unused
-		prepared_markused_thread := spawn markused.prepare_markused_declarations(a, &pre_tc,
-			prepare_markused_overlap)
+		prepared_markused_thread := spawn markused.prepare_markused_declarations(a, &pre_tc, prepare_markused_overlap)
 		mut check_was_parallel := false
 		if trivial_literal_output && !incremental_cache_hit {
 			used_fns = markused.mark_used_without_generic_detection(a, &pre_tc)
@@ -9538,7 +9424,7 @@ pub fn run(args []string) {
 			// retaining one semantic-check accumulator per worker.
 			parallel_semantic_check := !current_no_parallel && a.missing_imports.len == 0
 				&& (building_v || !scope_prealloc_check
-				|| a.nodes.len < scoped_serial_user_check_node_threshold)
+					|| a.nodes.len < scoped_serial_user_check_node_threshold)
 			check_was_parallel = pre_tc.check_semantics_opt(parallel_semantic_check)
 			if verbose {
 				eprintln('  [ttime]   ck semantics     ${f64(ck_stage_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
@@ -9565,12 +9451,10 @@ pub fn run(args []string) {
 		}
 		if pre_tc.errors.len > 0 {
 			if is_checker_fixture {
-				fixture_used_fns, fixture_uses_generics := markused.mark_used_with_generic_usage(a,
-					&pre_tc)
+				fixture_used_fns, fixture_uses_generics := markused.mark_used_with_generic_usage(a, &pre_tc)
 				has_invalid_comptime_struct_update :=
 					pre_tc.errors.any(it.msg == 'cannot use struct update syntax in compile time expressions')
-				has_missing_closure_generic := pre_tc.errors.any(
-					(it.msg.starts_with('Add the generic type `')
+				has_missing_closure_generic := pre_tc.errors.any((it.msg.starts_with('Add the generic type `')
 					&& it.msg.contains(' to the anon fn generic list type'))
 					|| it.msg.starts_with('generic closure fn must specify type parameter'))
 				has_instantiated_generic_as_cast_error := pre_tc.errors.any(int(it.node) >= 0
@@ -9578,22 +9462,18 @@ pub fn run(args []string) {
 					&& it.msg.starts_with('cannot cast `'))
 				has_empty_array_generic_error :=
 					pre_tc.errors.any(it.msg == 'cannot use empty array as generic argument')
-				has_generic_fntype_arg_mismatch := pre_tc.errors.any(
-					it.msg.starts_with('cannot use `fn ') && it.msg.contains('` as `fn ')
+				has_generic_fntype_arg_mismatch := pre_tc.errors.any(it.msg.starts_with('cannot use `fn ') && it.msg.contains('` as `fn ')
 					&& it.msg.contains(' in argument '))
-				has_generic_call_arg_mismatch := pre_tc.errors.any(
-					it.msg.starts_with('cannot use `') && it.msg.contains(' in argument '))
+				has_generic_call_arg_mismatch := pre_tc.errors.any(it.msg.starts_with('cannot use `') && it.msg.contains(' in argument '))
 				has_generic_inference_error :=
 					pre_tc.errors.any(it.msg.starts_with('could not infer generic type `'))
-				has_generic_struct_init_error := pre_tc.errors.any(
-					it.msg.starts_with('generic struct init type parameter `')
+				has_generic_struct_init_error := pre_tc.errors.any(it.msg.starts_with('generic struct init type parameter `')
 					|| it.msg.starts_with('generic struct init expects '))
 				has_generic_type_mismatch :=
 					pre_tc.errors.any(it.msg.starts_with('mismatched types `'))
-				has_unknown_method_error := pre_tc.errors.any(
-					it.msg.starts_with('unknown method or field: `')
+				has_unknown_method_error := pre_tc.errors.any(it.msg.starts_with('unknown method or field: `')
 					|| (it.msg.starts_with('method `')
-					&& it.msg.contains(' cannot bind `voidptr` to a generic receiver pattern')))
+						&& it.msg.contains(' cannot bind `voidptr` to a generic receiver pattern')))
 				mut has_instantiated_compile_error := false
 				for type_error in pre_tc.errors {
 					if type_error.kind != .compile_error || int(type_error.node) < 0
@@ -9616,8 +9496,7 @@ pub fn run(args []string) {
 					&& !has_generic_fntype_arg_mismatch && !has_generic_call_arg_mismatch
 					&& !has_generic_inference_error && !has_generic_struct_init_error
 					&& !has_generic_type_mismatch && !has_unknown_method_error {
-					_, _ = transform.monomorphize_with_used_checked_config(mut a, &pre_tc,
-						fixture_used_fns, false)
+					_, _ = transform.monomorphize_with_used_checked_config(mut a, &pre_tc, fixture_used_fns, false)
 				}
 			}
 			if !macos_v3_fallback_suppresses_diagnostics(macos_v3_fallback_file) {
@@ -9650,8 +9529,7 @@ pub fn run(args []string) {
 		}
 		if cache_state.manager.enabled {
 			const_init_order := cgen.module_const_init_order(a, pre_tc)
-			if !prepare_v3_cache_external_inputs_scoped(mut cache_state, a, prefs, user_files,
-				cache_c_flags, scope_prealloc_stages) {
+			if !prepare_v3_cache_external_inputs_scoped(mut cache_state, a, prefs, user_files, cache_c_flags, scope_prealloc_stages) {
 				trace_v3_cache_fallback('external C inputs cannot be assigned to cache units')
 				restart_v3_without_cache()
 			}
@@ -9663,8 +9541,7 @@ pub fn run(args []string) {
 				if !parsed {
 					continue
 				}
-				header := modulecache.module_header_with_const_order(a, pre_tc, module_name,
-					prefs.vroot, cache_state.module_import_paths, const_init_order)
+				header := modulecache.module_header_with_const_order(a, pre_tc, module_name, prefs.vroot, cache_state.module_import_paths, const_init_order)
 				if header.len > 0 {
 					cache_state.headers[module_name] = header
 				}
@@ -9705,8 +9582,7 @@ pub fn run(args []string) {
 		prepare_transform_overlap := building_v && current_parallel_transform
 			&& scope_prealloc_transform && !incremental_cache_hit && !generic_cache_hit
 			&& !cache_state.manager.enabled
-		prepared_transform_thread := spawn transform.prepare_selfhost_transform(a, &pre_tc,
-			prepare_transform_overlap)
+		prepared_transform_thread := spawn transform.prepare_selfhost_transform(a, &pre_tc, prepare_transform_overlap)
 		// Mark used functions (dead-code elimination). This is done before transform
 		// so the transformer can skip function bodies that the C backend will prune.
 		// Checking and inactive-comptime pruning can add or detach nodes. Rebuild the
@@ -9725,8 +9601,7 @@ pub fn run(args []string) {
 			markused_tc.verbose = prefs.verbose
 		}
 		if no_skip_unused {
-			used_fns, uses_generics = markused.mark_all_used_with_generic_usage(a, markused_tc,
-				test_files)
+			used_fns, uses_generics = markused.mark_all_used_with_generic_usage(a, markused_tc, test_files)
 		} else if generic_cache_hit && test_files.len == 0 {
 			used_fns = clone_string_bool_map(cached_program_used_fns)
 			uses_generics = true
@@ -9736,20 +9611,16 @@ pub fn run(args []string) {
 				restart_v3_after_cache_invalidation()
 			}
 		} else if test_files.len > 0 {
-			used_fns, uses_generics = markused.mark_used_for_tests_with_generic_usage(a,
-				markused_tc, test_files)
+			used_fns, uses_generics = markused.mark_used_for_tests_with_generic_usage(a, markused_tc, test_files)
 		} else if input_file.ends_with('.vsh') {
-			used_fns, uses_generics = markused.mark_used_with_generic_usage_full_runtime(a,
-				markused_tc)
+			used_fns, uses_generics = markused.mark_used_with_generic_usage_full_runtime(a, markused_tc)
 		} else if trivial_literal_output && used_fns.len > 0 {
 			uses_generics = false
 		} else if is_checker_fixture {
-			used_fns, uses_generics = markused.mark_used_with_generic_usage_full_runtime(a,
-				markused_tc)
+			used_fns, uses_generics = markused.mark_used_with_generic_usage_full_runtime(a, markused_tc)
 		} else if building_v {
 			if prepare_markused_overlap {
-				used_fns = markused.mark_used_without_generic_detection_prepared(a, markused_tc, mut
-					prepared_markused)
+				used_fns = markused.mark_used_without_generic_detection_prepared(a, markused_tc, mut prepared_markused)
 			} else {
 				used_fns = markused.mark_used_without_generic_detection(a, markused_tc)
 			}
@@ -9768,12 +9639,10 @@ pub fn run(args []string) {
 		}
 		if cache_state.manager.enabled && !generic_cache_hit {
 			if building_v && current_parallel_transform {
-				used_fns = markused.mark_used_for_cache_without_generic_detection(a, markused_tc,
-					test_files, cache_state.source_body_modules)
+				used_fns = markused.mark_used_for_cache_without_generic_detection(a, markused_tc, test_files, cache_state.source_body_modules)
 			} else {
 				mut cache_uses_generics := false
-				used_fns, cache_uses_generics = markused.mark_used_for_cache_with_generic_usage(a,
-					markused_tc, test_files, cache_state.source_body_modules)
+				used_fns, cache_uses_generics = markused.mark_used_for_cache_with_generic_usage(a, markused_tc, test_files, cache_state.source_body_modules)
 				uses_generics = uses_generics || cache_uses_generics
 			}
 		}
@@ -9825,8 +9694,7 @@ pub fn run(args []string) {
 			}
 		}
 		if unused_diag_scope != unsafe { nil } {
-			prealloc_scope_leave_for_v3(unused_diag_scope)
-			prealloc_scope_free_for_v3(unused_diag_scope)
+			release_unused_diagnostic_scope(mut pre_tc.notices, unused_diag_scope)
 		}
 		if backend == 'wasm' {
 			// Validate source-level operations before transform lowers aggregate
@@ -9849,14 +9717,11 @@ pub fn run(args []string) {
 		// incomplete, leave the manifest without its completeness marker so the stable
 		// retry prints the fallback notice but does not submit an unverified report.
 		if backend == 'c' && !cache_state.external_inputs_ready {
-			_ = prepare_v3_cache_external_inputs_scoped(mut cache_state, a, prefs, user_files,
-				cache_c_flags, scope_prealloc_stages)
+			_ = prepare_v3_cache_external_inputs_scoped(mut cache_state, a, prefs, user_files, cache_c_flags, scope_prealloc_stages)
 		}
 		if backend == 'c' && cache_state.external_inputs_ready {
-			fallback_report_sources = macos_v3_fallback_report_inputs(fallback_report_sources,
-				&cache_state)
-			_ = stage_macos_v3_fallback_source_digests(macos_v3_c_error_dir,
-				fallback_report_sources)
+			fallback_report_sources = macos_v3_fallback_report_inputs(fallback_report_sources, &cache_state)
+			_ = stage_macos_v3_fallback_source_digests(macos_v3_c_error_dir, fallback_report_sources)
 		}
 		// Transform (match lowering, string/in lowering, etc.). Threaded transform is enabled
 		// by default for compatible builds, and `-no-parallel` disables both threaded transform
@@ -9884,8 +9749,7 @@ pub fn run(args []string) {
 			transform_used_fns['main'] = true
 		}
 		if incremental_cache_hit {
-			transform_used_fns, transform_errors, incremental_synthesized_helpers = transform.transform_selected_functions(mut a,
-				&pre_tc, incremental_changed_names)
+			transform_used_fns, transform_errors, incremental_synthesized_helpers = transform.transform_selected_functions(mut a, &pre_tc, incremental_changed_names)
 			transform_texts_canonical = true
 		} else if scope_prealloc_transform {
 			if verbose {
@@ -9931,8 +9795,7 @@ pub fn run(args []string) {
 			mut scoped_owned_base_nodes := []int{}
 			mut retained_transform_regions := []transform.ScopedTransformRegion{}
 			if prepare_transform_overlap {
-				transform_used_fns, transform_was_parallel, transform_errors, scoped_owned_base_nodes, retained_transform_regions = transform.transform_prepared_selfhost_owned(mut prepared_transform, mut
-					a, &pre_tc, used_fns, transform_scope)
+				transform_used_fns, transform_was_parallel, transform_errors, scoped_owned_base_nodes, retained_transform_regions = transform.transform_prepared_selfhost_owned(mut prepared_transform, mut a, &pre_tc, used_fns, transform_scope)
 				retained_transform_prepare_scope = prepared_transform.take_scope()
 			} else {
 				// Large user programs keep more memory live when function-body workers
@@ -9940,10 +9803,7 @@ pub fn run(args []string) {
 				// for a substantially lower peak.
 				use_parallel_transform := current_parallel_transform
 					&& a.nodes.len < scoped_serial_user_transform_node_threshold
-				transform_used_fns, transform_was_parallel, transform_errors, scoped_owned_base_nodes, retained_transform_regions = transform.transform_with_used_opt_config_scoped_workers_checked_owned(mut a,
-					&pre_tc, used_fns, use_parallel_transform, skip_transform_generics, true,
-
-					building_v || trivial_literal_output, transform_scope)
+				transform_used_fns, transform_was_parallel, transform_errors, scoped_owned_base_nodes, retained_transform_regions = transform.transform_with_used_opt_config_scoped_workers_checked_owned(mut a, &pre_tc, used_fns, use_parallel_transform, skip_transform_generics, true, building_v || trivial_literal_output, transform_scope)
 			}
 			parse_cache_enabled := pre_tc.type_cache_parse_enabled()
 			mut post_sw := time.new_stopwatch()
@@ -9961,8 +9821,7 @@ pub fn run(args []string) {
 			} else {
 				retained_transform_regions =
 					clone_scoped_transform_regions(retained_transform_regions)
-				pre_tc.promote_scoped_transform_interners(base_type_count, base_symbol_count,
-					transform_scope)
+				pre_tc.promote_scoped_transform_interners(base_type_count, base_symbol_count, transform_scope)
 				if verbose {
 					eprintln('  [ttime] promote interners  ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 					post_sw.restart()
@@ -9990,8 +9849,7 @@ pub fn run(args []string) {
 					mut fused_text_promote := false
 					if retained_transform_regions.len == 0
 						&& os.getenv('V3_NO_FUSED_TEXT_PROMOTE') == '' {
-						fused_text_promote = transform.promote_scoped_texts_parallel(mut a,
-							transform_scope)
+						fused_text_promote = transform.promote_scoped_texts_parallel(mut a, transform_scope)
 						if fused_text_promote {
 							transform_texts_canonical = true
 						}
@@ -10002,15 +9860,12 @@ pub fn run(args []string) {
 					}
 					if !fused_text_promote {
 						mut scoped_text_flags := []u8{len: a.nodes.len}
-						if transform.scan_scoped_text_flags_parallel(a, transform_scope, mut
-							scoped_text_flags)
-						{
+						if transform.scan_scoped_text_flags_parallel(a, transform_scope, mut scoped_text_flags) {
 							mut canon_cache_ptrs := unsafe { []voidptr{len: 4096} }
 							mut canon_cache_vals := []string{len: 4096}
 							for idx, flag in scoped_text_flags {
 								if flag != 0 {
-									canonicalize_scoped_node_cached(mut a, idx, transform_scope, mut
-										canon_cache_ptrs, mut canon_cache_vals)
+									canonicalize_scoped_node_cached(mut a, idx, transform_scope, mut canon_cache_ptrs, mut canon_cache_vals)
 								}
 							}
 						} else {
@@ -10021,33 +9876,26 @@ pub fn run(args []string) {
 						}
 						if retained_transform_regions.len > 0 {
 							outer_new_end := retained_transform_regions[0].new_start
-							promote_scoped_ast_nodes_flagged(mut a, base_transform_nodes,
-								outer_new_end, scoped_owned_base_nodes, transform_scope,
-								scoped_text_flags)
+							promote_scoped_ast_nodes_flagged(mut a, base_transform_nodes, outer_new_end, scoped_owned_base_nodes, transform_scope, scoped_text_flags)
 							// Late lowering can rewrite nodes that live in a retained worker region
 							// while allocating their replacement text in the outer transform arena.
 							// Publish those strings before releasing that arena; the worker-owned
 							// fields in the same regions are canonicalized below from their own scope.
 							for region in retained_transform_regions {
-								canonicalize_scoped_transform_region_from_scope(mut a, region,
-									transform_scope)
+								canonicalize_scoped_transform_region_from_scope(mut a, region, transform_scope)
 							}
 							last_worker_end := retained_transform_regions.last().new_end
-							promote_scoped_ast_nodes_flagged(mut a, last_worker_end, a.nodes.len,
-								[]int{}, transform_scope, scoped_text_flags)
+							promote_scoped_ast_nodes_flagged(mut a, last_worker_end, a.nodes.len, []int{}, transform_scope, scoped_text_flags)
 						} else {
 							// Workers report every rewritten base node. Publish those and the
 							// appended range without rebuilding the text table for the source AST.
-							promote_scoped_ast_nodes_flagged(mut a, base_transform_nodes,
-								a.nodes.len, scoped_owned_base_nodes, transform_scope,
-								scoped_text_flags)
+							promote_scoped_ast_nodes_flagged(mut a, base_transform_nodes, a.nodes.len, scoped_owned_base_nodes, transform_scope, scoped_text_flags)
 							transform_texts_canonical = true
 						}
 					}
 				} else {
 					if verbose {
-						eprintln('  [leakcheck] canon SKIPPED: nodes cap ${a.nodes.cap} vs ${reserved_nodes_cap} children cap ${a.children.cap} vs ${reserved_children_cap} nodes.len ${a.nodes.len} owned n ${scoped_value_owned(transform_scope,
-							a.nodes.data)} c ${scoped_value_owned(transform_scope, a.children.data)}')
+						eprintln('  [leakcheck] canon SKIPPED: nodes cap ${a.nodes.cap} vs ${reserved_nodes_cap} children cap ${a.children.cap} vs ${reserved_children_cap} nodes.len ${a.nodes.len} owned n ${scoped_value_owned(transform_scope, a.nodes.data)} c ${scoped_value_owned(transform_scope, a.children.data)}')
 						eprintln('  [leakcheck] children.data pre ${u64(pre_scope_children_data)} now ${u64(unsafe { a.children.data })} moved ${pre_scope_children_data != unsafe { a.children.data }}')
 					}
 					// The flat arrays escaped into the stage arena, so their backing is
@@ -10071,8 +9919,7 @@ pub fn run(args []string) {
 					eprintln('  [ttime] promote ast nodes  ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 					post_sw.restart()
 				}
-				promote_scoped_checker_node_caches(mut pre_tc, a, transform_scope,
-					base_transform_nodes)
+				promote_scoped_checker_node_caches(mut pre_tc, a, transform_scope, base_transform_nodes)
 				if verbose {
 					eprintln('  [ttime]   pc node caches   ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 					post_sw.restart()
@@ -10168,10 +10015,7 @@ pub fn run(args []string) {
 				eprintln('  [ttime] regions+views      ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 			}
 		} else {
-			transform_used_fns, transform_was_parallel, transform_errors = transform.transform_with_used_opt_config_scoped_workers_checked(mut a,
-				&pre_tc, used_fns, current_parallel_transform, skip_transform_generics, false,
-
-				building_v || trivial_literal_output)
+			transform_used_fns, transform_was_parallel, transform_errors = transform.transform_with_used_opt_config_scoped_workers_checked(mut a, &pre_tc, used_fns, current_parallel_transform, skip_transform_generics, false, building_v || trivial_literal_output)
 		}
 		if !incremental_cache_hit {
 			used_fns = transform_used_fns.move()
@@ -10253,8 +10097,7 @@ pub fn run(args []string) {
 		b.step('annotate types')
 		if generic_cache_hit && (!incremental_cache_hit || incremental_needs_monomorphize) {
 			pre_tc.reset_resolution_type_view_cache()
-			transform.register_cached_monomorph_signatures(a, &pre_tc, used_fns,
-				cached_monomorph_specs)
+			transform.register_cached_monomorph_signatures(a, &pre_tc, used_fns, cached_monomorph_specs)
 		}
 	} else {
 		b.step('check (cached)')
@@ -10314,8 +10157,7 @@ pub fn run(args []string) {
 			monomorph_children_cap := a.children.cap
 			base_specialized_fns := a.specialized_fn_nodes.len
 			monomorph_scope := prealloc_scope_begin_for_v3()
-			monomorph_used_fns, monomorph_errors, generated_monomorph_specs = transform.monomorphize_with_used_checked_config_scoped_cached(mut a,
-				&pre_tc, monomorph_input_used, !current_no_parallel
+			monomorph_used_fns, monomorph_errors, generated_monomorph_specs = transform.monomorphize_with_used_checked_config_scoped_cached(mut a, &pre_tc, monomorph_input_used, !current_no_parallel
 				&& should_parallel_monomorphize(), monomorph_scope, cached_monomorph_specs)
 			prealloc_scope_leave_for_v3(monomorph_scope)
 			// The monomorphizer publishes rewritten and appended node text after
@@ -10353,10 +10195,8 @@ pub fn run(args []string) {
 			pre_tc.set_fresh_type_cache(false)
 			prealloc_scope_free_for_v3(monomorph_scope)
 		} else {
-			monomorph_used_fns, monomorph_errors, generated_monomorph_specs = transform.monomorphize_with_used_checked_config_scoped_cached(mut a,
-				&pre_tc, monomorph_input_used, !current_no_parallel
-				&& should_parallel_monomorphize() && !incremental_cache_hit, unsafe { nil },
-				cached_monomorph_specs)
+			monomorph_used_fns, monomorph_errors, generated_monomorph_specs = transform.monomorphize_with_used_checked_config_scoped_cached(mut a, &pre_tc, monomorph_input_used, !current_no_parallel
+				&& should_parallel_monomorphize() && !incremental_cache_hit, unsafe { nil }, cached_monomorph_specs)
 		}
 		texts_canonical_after_annotation = true
 		// Monomorphization publishes every synthesized or rewritten AST string
@@ -10454,7 +10294,7 @@ pub fn run(args []string) {
 			// Generate only after monomorphization has pruned deferred generic comptime
 			// branches. output_file is the exact path requested via -o (or the
 			// <name>.wasm default).
-			mut g := wasm.Gen.new(a, pre_tc, used_fns)
+			mut g := wasmgen.Gen.new(a, pre_tc, used_fns)
 			g.gen()
 			g.write(output_file) or {
 				eprintln('error writing ${output_file}')
@@ -10521,8 +10361,7 @@ pub fn run(args []string) {
 			} else {
 				os.getwd()
 			}
-			cc_dir = os.join_path_single(bin_dir,
-				'.${os.base(bin_file)}.v3cc.${tempname.unique_token()}')
+			cc_dir = os.join_path_single(bin_dir, '.${os.base(bin_file)}.v3cc.${tempname.unique_token()}')
 			os.mkdir(cc_dir) or {
 				eprintln('failed to create C build directory ${cc_dir}: ${err}')
 				exit(1)
@@ -10553,8 +10392,7 @@ pub fn run(args []string) {
 		} else {
 			''
 		}
-		incremental_known_declarations := incremental_c_declarations + '\n' +
-			incremental_cached_support
+		incremental_known_declarations := incremental_c_declarations + '\n' + incremental_cached_support
 		cgen_used_fns := if incremental_cache_hit {
 			incremental_stage_used_fns
 		} else {
@@ -10610,9 +10448,7 @@ pub fn run(args []string) {
 			g.set_incremental_fn_names(incremental_changed_names)
 			g.set_cached_support_declarations(incremental_known_declarations)
 			g.set_scope_parallel_workers(!generic_cache_hit)
-			g.gen_to_file_with_used_test_options(generated_path, a, cgen_used_fns, &pre_tc,
-
-				cache_no_parallel_cgen || test_files.len > 0, test_files) or {
+			g.gen_to_file_with_used_test_options(generated_path, a, cgen_used_fns, &pre_tc, cache_no_parallel_cgen || test_files.len > 0, test_files) or {
 				eprintln('error writing ${generated_path}: ${err}')
 				cleanup_c_build_dir(cc_dir)
 				exit(1)
@@ -10666,8 +10502,7 @@ pub fn run(args []string) {
 			g.set_cache_program_files(user_files)
 			g.set_incremental_fn_names(incremental_changed_names)
 			g.set_cached_support_declarations(incremental_known_declarations)
-			g.gen_to_file_with_used_test_options(generated_path, a, cgen_used_fns, &pre_tc,
-				cache_no_parallel_cgen, test_files) or {
+			g.gen_to_file_with_used_test_options(generated_path, a, cgen_used_fns, &pre_tc, cache_no_parallel_cgen, test_files) or {
 				eprintln('error writing ${generated_path}: ${err}')
 				cleanup_c_build_dir(cc_dir)
 				exit(1)
@@ -10688,8 +10523,7 @@ pub fn run(args []string) {
 				cleanup_c_build_dir(cc_dir)
 				exit(1)
 			}
-			merged_cached_source := merge_incremental_program_body(incremental_cached_body,
-				cached_prefix, changed_source, incremental_changed_keys) or {
+			merged_cached_source := merge_incremental_program_body(incremental_cached_body, cached_prefix, changed_source, incremental_changed_keys) or {
 				os.setenv('V3_CACHE_DISABLE_INCREMENTAL', '1', true)
 				restart_v3_after_cache_invalidation()
 				''
@@ -10754,16 +10588,14 @@ pub fn run(args []string) {
 			generated_c_flags.clone()
 		}
 		if !c_only || (dump_c_flags.len > 0 && generate_c_project.len == 0) {
-			object_optimization_flags := v3_prod_c_object_optimization_flags(is_prod, no_prod_options,
-				is_shared, parallel_cc, explicit_tcc)
-			resolved_c_flags = prepare_c_flags_for_link(generated_c_flags, environment_c_flags,
-				object_optimization_flags, prefs.c99, pic_flag, target_args, prefs.target, c_compiler,
-				cc_dir, mut c_object_cache_stats) or {
+			object_optimization_flags := v3_prod_c_object_optimization_flags(is_prod, no_prod_options, is_shared, parallel_cc, explicit_tcc)
+			resolved_c_flags = prepare_c_flags_for_link(generated_c_flags, environment_c_flags, object_optimization_flags, prefs.c99, pic_flag, target_args, prefs.target, c_compiler, cc_dir, mut c_object_cache_stats) or {
 				message := err.msg()
-				if request_macos_v3_c_error_fallback_from_message(macos_v3_fallback_file,
-					macos_v3_c_error_dir, c_compiler, message, [published_c_source, cache_plan_file,
-					cc_src], fallback_report_sources)
-				{
+				if request_macos_v3_c_error_fallback_from_message(macos_v3_fallback_file, macos_v3_c_error_dir, c_compiler, message, [
+					published_c_source,
+					cache_plan_file,
+					cc_src,
+				], fallback_report_sources) {
 					cleanup_c_build_dir(cc_dir)
 					exit(1)
 				}
@@ -10779,27 +10611,27 @@ pub fn run(args []string) {
 			''
 		}
 		c_flag_plan := v3_c_compiler_flag_plan(V3CCompilerFlagOptions{
-			environment_c_flags:  environment_c_flags
+			environment_c_flags: environment_c_flags
 			environment_ld_flags: environment_ld_flags
-			target_args:          target_args
-			link_c_standard:      link_c_standard
-			dependencies:         resolved_c_flags
-			warn_args:            warn_args
-			vroot:                prefs.vroot
-			target_os:            prefs.normalized_target_os()
-			target_arch:          prefs.normalized_target_arch()
-			macos_sdk_root:       flag_plan_sdk_root
-			pic_flag:             pic_flag
-			is_prod:              is_prod
-			no_prod_options:      no_prod_options
-			is_shared:            is_shared
-			parallel_cc:          parallel_cc
-			large_c_unit:         large_prod_c_unit
-			limit_inlining:       limit_large_unit_inlining
-			explicit_tcc:         explicit_tcc
-			is_c_debug:           is_c_debug
-			is_o:                 is_o
-			is_liveshared:        is_liveshared
+			target_args: target_args
+			link_c_standard: link_c_standard
+			dependencies: resolved_c_flags
+			warn_args: warn_args
+			vroot: prefs.vroot
+			target_os: prefs.normalized_target_os()
+			target_arch: prefs.normalized_target_arch()
+			macos_sdk_root: flag_plan_sdk_root
+			pic_flag: pic_flag
+			is_prod: is_prod
+			no_prod_options: no_prod_options
+			is_shared: is_shared
+			parallel_cc: parallel_cc
+			large_c_unit: large_prod_c_unit
+			limit_inlining: limit_large_unit_inlining
+			explicit_tcc: explicit_tcc
+			is_c_debug: is_c_debug
+			is_o: is_o
+			is_liveshared: is_liveshared
 		})
 		mut native_support_inputs := []string{}
 		if explicit_tcc {
@@ -10842,8 +10674,7 @@ pub fn run(args []string) {
 				print(source)
 				os.rm(cc_src) or {}
 			} else if generate_c_project.len > 0 {
-				write_v3_c_project(generate_c_project, cc_src, c_compiler, c_flag_plan,
-					native_support_inputs, needs_objective_c) or {
+				write_v3_c_project(generate_c_project, cc_src, c_compiler, c_flag_plan, native_support_inputs, needs_objective_c) or {
 					eprintln('cannot write generated C project: ${err.msg()}')
 					exit(1)
 				}
@@ -10875,12 +10706,9 @@ pub fn run(args []string) {
 			if interface_impl_signature.len == 0 {
 				interface_impl_signature = pre_tc.interface_impl_set_signature()
 			}
-			opt_flag := v3_prod_c_optimization_flags(is_prod, no_prod_options, is_shared,
-				parallel_cc, large_prod_c_unit, limit_large_unit_inlining, explicit_tcc).join(' ')
+			opt_flag := v3_prod_c_optimization_flags(is_prod, no_prod_options, is_shared, parallel_cc, large_prod_c_unit, limit_large_unit_inlining, explicit_tcc).join(' ')
 			warning_flags := warn_args.join(' ')
-			mut compile_signature := v3_cached_object_compile_signature(c_standard, opt_flag,
-				pic_flag, warning_flags, resolved_c_flags, needs_objective_c,
-				interface_impl_signature)
+			mut compile_signature := v3_cached_object_compile_signature(c_standard, opt_flag, pic_flag, warning_flags, resolved_c_flags, needs_objective_c, interface_impl_signature)
 			mut prepared_plan_entry := cgen_cache_entry
 			mut prepared_cache := V3PreparedModuleCache{}
 			if cgen_prepared_hit {
@@ -10904,22 +10732,19 @@ pub fn run(args []string) {
 					cleanup_c_build_dir(cc_dir)
 					exit(1)
 				}
-				compile_signature = v3_cached_object_wrapper_compile_signature(compile_signature,
-					prefix_source)
-				objects := cache_state.manager.valid_cgen_prepared_objects(cgen_cache_entry,
-					compile_signature) or {
+				compile_signature = v3_cached_object_wrapper_compile_signature(compile_signature, prefix_source)
+				objects := cache_state.manager.valid_cgen_prepared_objects(cgen_cache_entry, compile_signature) or {
 					if resolve_flag_specific_cache_objects(mut cache_state, compile_signature) {
 						os.setenv('V3_CACHE_FORCE_SOURCE', '1', true)
 						restart_v3_after_cache_invalidation()
 					}
 					resolved_objects := cache_object_paths(cache_state.objects)
-					cache_state.manager.write_cgen_prepared_objects(cgen_cache_entry,
-						compile_signature, resolved_objects) or {}
+					cache_state.manager.write_cgen_prepared_objects(cgen_cache_entry, compile_signature, resolved_objects) or {}
 					resolved_objects
 				}
 				prepared_cache = V3PreparedModuleCache{
 					program_prefix_source: prefix_source
-					objects:               objects
+					objects: objects
 				}
 				published_c_source = cgen_prepared_entry.main
 			} else {
@@ -10927,8 +10752,7 @@ pub fn run(args []string) {
 					eprintln('error reading cache-marked C source ${cache_plan_file}: ${err.msg()}')
 					exit(1)
 				}
-				compile_signature = v3_cached_object_wrapper_compile_signature(compile_signature,
-					generated_source)
+				compile_signature = v3_cached_object_wrapper_compile_signature(compile_signature, generated_source)
 				if generated_c_flags.len == 0 && !generic_cache_hit && !incremental_cache_hit
 					&& p.parsed_v_header_files == 0 {
 					cache_full_tcc_source = os.join_path_single(cc_dir, 'full.c')
@@ -10951,17 +10775,13 @@ pub fn run(args []string) {
 							cleanup_c_build_dir(cc_dir)
 							exit(1)
 						}
-						prepared_cache = prepare_v3_incremental_cached_body(cache_plan_file,
-							incremental_prefix_path, incremental_tcc_declarations_path,
-							cached_prefix, compile_signature, mut cache_state) or {
+						prepared_cache = prepare_v3_incremental_cached_body(cache_plan_file, incremental_prefix_path, incremental_tcc_declarations_path, cached_prefix, compile_signature, mut cache_state) or {
 							message := err.msg()
-							if request_macos_v3_c_error_fallback_from_message(macos_v3_fallback_file,
-								macos_v3_c_error_dir, c_compiler, message, [
+							if request_macos_v3_c_error_fallback_from_message(macos_v3_fallback_file, macos_v3_c_error_dir, c_compiler, message, [
 								cache_plan_file,
 								published_c_source,
 								cc_src,
-							], fallback_report_sources)
-							{
+							], fallback_report_sources) {
 								cleanup_c_build_dir(cc_dir)
 								exit(1)
 							}
@@ -10986,17 +10806,13 @@ pub fn run(args []string) {
 							cleanup_c_build_dir(cc_dir)
 							exit(1)
 						}
-						prepared_cache = prepare_v3_cached_generic_body(generated_source,
-							cached_prefix, cached_declarations, cached_body, compile_signature, mut
-							cache_state) or {
+						prepared_cache = prepare_v3_cached_generic_body(generated_source, cached_prefix, cached_declarations, cached_body, compile_signature, mut cache_state) or {
 							message := err.msg()
-							if request_macos_v3_c_error_fallback_from_message(macos_v3_fallback_file,
-								macos_v3_c_error_dir, c_compiler, message, [
+							if request_macos_v3_c_error_fallback_from_message(macos_v3_fallback_file, macos_v3_c_error_dir, c_compiler, message, [
 								cache_plan_file,
 								published_c_source,
 								cc_src,
-							], fallback_report_sources)
-							{
+							], fallback_report_sources) {
 								cleanup_c_build_dir(cc_dir)
 								exit(1)
 							}
@@ -11006,18 +10822,13 @@ pub fn run(args []string) {
 						}
 					}
 				} else {
-					prepared_cache = prepare_v3_module_cache(generated_source, &cgen_used_fns,
-						&program_used_fns, &pre_tc, c_standard, opt_flag, pic_flag, warning_flags,
-						resolved_c_flags, needs_objective_c, interface_impl_signature, mut
-						cache_state) or {
+					prepared_cache = prepare_v3_module_cache(generated_source, &cgen_used_fns, &program_used_fns, &pre_tc, c_standard, opt_flag, pic_flag, warning_flags, resolved_c_flags, needs_objective_c, interface_impl_signature, mut cache_state) or {
 						message := err.msg()
-						if request_macos_v3_c_error_fallback_from_message(macos_v3_fallback_file,
-							macos_v3_c_error_dir, c_compiler, message, [
+						if request_macos_v3_c_error_fallback_from_message(macos_v3_fallback_file, macos_v3_c_error_dir, c_compiler, message, [
 							cache_plan_file,
 							published_c_source,
 							cc_src,
-						], fallback_report_sources)
-						{
+						], fallback_report_sources) {
 							cleanup_c_build_dir(cc_dir)
 							exit(1)
 						}
@@ -11032,17 +10843,11 @@ pub fn run(args []string) {
 					exit(1)
 				}
 				if prefix_source_identity.len == 0 {
-					prefix_source_identity = v3_program_prefix_source_identity(prepared_cache.program_prefix_source,
-						prepared_cache.objects)
+					prefix_source_identity = v3_program_prefix_source_identity(prepared_cache.program_prefix_source, prepared_cache.objects)
 				}
 				if !cgen_cache_hit && program_cache_enabled {
-					published_cgen_cache_input := v3_cgen_cache_input(cache_state, user_files,
-						cache_c_flags)
-					prepared_plan_entry = cache_state.manager.write_cgen(published_cgen_cache_input.source_files,
-						published_cgen_cache_input.generation_signature,
-						published_cgen_cache_input.dependency_inputs, generated_source, encode_v3_cgen_metadata(generated_c_flags,
-						interface_impl_signature, prefix_source_identity,
-						cached_checker_diagnostics)) or { modulecache.CgenEntry{} }
+					published_cgen_cache_input := v3_cgen_cache_input(cache_state, user_files, cache_c_flags)
+					prepared_plan_entry = cache_state.manager.write_cgen(published_cgen_cache_input.source_files, published_cgen_cache_input.generation_signature, published_cgen_cache_input.dependency_inputs, generated_source, encode_v3_cgen_metadata(generated_c_flags, interface_impl_signature, prefix_source_identity, cached_checker_diagnostics)) or { modulecache.CgenEntry{} }
 				}
 				if incremental_cache_restored && prepared_plan_entry.source.len > 0 {
 					stable_body_source := os.read_file(prepared_plan_entry.source) or {
@@ -11051,10 +10856,8 @@ pub fn run(args []string) {
 						exit(1)
 					}
 					refreshed_incremental_body = stable_body_source
-					stable_main_source := v3_incremental_program_main_source(prepared_cache.program_prefix_source,
-						stable_body_source)
-					stable_tcc_main_source := v3_incremental_main_source(incremental_tcc_declarations_path,
-						prepared_plan_entry.source)
+					stable_main_source := v3_incremental_program_main_source(prepared_cache.program_prefix_source, stable_body_source)
+					stable_tcc_main_source := v3_incremental_main_source(incremental_tcc_declarations_path, prepared_plan_entry.source)
 					prepared_cache.main_source = stable_main_source
 					prepared_cache.tcc_main_source = stable_tcc_main_source
 					os.write_file(cc_src, stable_main_source) or {
@@ -11065,32 +10868,17 @@ pub fn run(args []string) {
 				}
 				if prepared_plan_entry.stamp.len > 0 {
 					cached_program_body_source = prepared_plan_entry.source
-					cache_state.manager.write_cgen_prepared(prepared_plan_entry,
-						prepared_cache.main_source, prepared_cache.tcc_main_source,
-						prepared_cache.program_prefix_source) or {}
-					cache_state.manager.write_cgen_prepared_objects(prepared_plan_entry,
-						compile_signature, prepared_cache.objects) or {}
+					cache_state.manager.write_cgen_prepared(prepared_plan_entry, prepared_cache.main_source, prepared_cache.tcc_main_source, prepared_cache.program_prefix_source) or {}
+					cache_state.manager.write_cgen_prepared_objects(prepared_plan_entry, compile_signature, prepared_cache.objects) or {}
 				}
 				if !generic_cache_hit && generic_cache_signature.len > 0
 					&& generated_monomorph_specs.len > 0 {
-					published_generic_input := v3_cgen_cache_input(cache_state, user_files,
-						cache_c_flags)
-					cache_state.manager.write_generic_program(published_generic_input.source_files,
-						generic_cache_signature, published_generic_input.generation_signature,
-						published_generic_input.dependency_inputs,
-						encode_monomorph_cache_specs(generated_monomorph_specs),
-						encode_cached_used_fns(program_used_fns),
-						prepared_cache.program_prefix_source,
-						modulecache.prune_unreferenced_static_string_definitions(prepared_cache.program_declarations),
-						prepared_cache.program_body_cache,
-						encode_cached_runtime_strings(generic_cache_runtime_strings), encode_v3_cgen_metadata(generated_c_flags,
-						interface_impl_signature, prefix_source_identity,
-						cached_checker_diagnostics)) or {}
+					published_generic_input := v3_cgen_cache_input(cache_state, user_files, cache_c_flags)
+					cache_state.manager.write_generic_program(published_generic_input.source_files, generic_cache_signature, published_generic_input.generation_signature, published_generic_input.dependency_inputs, encode_monomorph_cache_specs(generated_monomorph_specs), encode_cached_used_fns(program_used_fns), prepared_cache.program_prefix_source, modulecache.prune_unreferenced_static_string_definitions(prepared_cache.program_declarations), prepared_cache.program_body_cache, encode_cached_runtime_strings(generic_cache_runtime_strings), encode_v3_cgen_metadata(generated_c_flags, interface_impl_signature, prefix_source_identity, cached_checker_diagnostics)) or {}
 				}
 				if (!generic_cache_hit || incremental_cache_hit)
 					&& incremental_snapshot.declaration_signature.len > 0 {
-					published_incremental_input := v3_cgen_cache_input(cache_state, user_files,
-						cache_c_flags)
+					published_incremental_input := v3_cgen_cache_input(cache_state, user_files, cache_c_flags)
 					incremental_body := if incremental_cache_hit {
 						refreshed_incremental_body
 					} else {
@@ -11101,8 +10889,7 @@ pub fn run(args []string) {
 					} else {
 						program_used_fns
 					}
-					incremental_specs := merge_monomorph_cache_specs(cached_monomorph_specs,
-						generated_monomorph_specs)
+					incremental_specs := merge_monomorph_cache_specs(cached_monomorph_specs, generated_monomorph_specs)
 					incremental_declarations := if incremental_cache_hit {
 						os.read_file(generic_cache_entry.declarations) or { '' }
 					} else {
@@ -11113,17 +10900,7 @@ pub fn run(args []string) {
 					} else {
 						prepared_cache.tcc_program_declarations
 					}
-					cache_state.manager.write_incremental_program(published_incremental_input.source_files,
-						incremental_snapshot.declaration_signature,
-						published_incremental_input.generation_signature,
-						published_incremental_input.dependency_inputs,
-						encode_incremental_manifest(incremental_snapshot), incremental_body,
-						encode_cached_used_fns(incremental_used),
-						encode_monomorph_cache_specs(incremental_specs),
-						prepared_cache.program_prefix_source, incremental_declarations,
-						incremental_tcc_declarations, prepared_cache.objects, encode_v3_cgen_metadata(generated_c_flags,
-						interface_impl_signature, prefix_source_identity,
-						cached_checker_diagnostics)) or {}
+					cache_state.manager.write_incremental_program(published_incremental_input.source_files, incremental_snapshot.declaration_signature, published_incremental_input.generation_signature, published_incremental_input.dependency_inputs, encode_incremental_manifest(incremental_snapshot), incremental_body, encode_cached_used_fns(incremental_used), encode_monomorph_cache_specs(incremental_specs), prepared_cache.program_prefix_source, incremental_declarations, incremental_tcc_declarations, prepared_cache.objects, encode_v3_cgen_metadata(generated_c_flags, interface_impl_signature, prefix_source_identity, cached_checker_diagnostics)) or {}
 				}
 			}
 			prealloc_scope_leave_for_v3(cache_prepare_scope)
@@ -11160,23 +10937,15 @@ pub fn run(args []string) {
 					}
 				}
 				if prefix_source_identity.len == 0 {
-					prefix_source_identity = v3_program_prefix_source_identity(prepared_cache.program_prefix_source,
-						prepared_cache.objects)
+					prefix_source_identity = v3_program_prefix_source_identity(prepared_cache.program_prefix_source, prepared_cache.objects)
 				}
-				prefix_object := compile_v3_program_object('prefix',
-					prepared_cache.program_prefix_source, prefix_source_identity,
-					v3_program_external_input_paths(&cache_state), &cache_state.manager,
-					c_standard, opt_flag, pic_flag, warning_flags, resolved_c_flags,
-					needs_objective_c, target_args, prefs.target, c_compiler, mut
-					c_object_cache_stats) or {
+				prefix_object := compile_v3_program_object('prefix', prepared_cache.program_prefix_source, prefix_source_identity, v3_program_external_input_paths(&cache_state), &cache_state.manager, c_standard, opt_flag, pic_flag, warning_flags, resolved_c_flags, needs_objective_c, target_args, prefs.target, c_compiler, mut c_object_cache_stats) or {
 					message := err.msg()
-					if request_macos_v3_c_error_fallback_from_message(macos_v3_fallback_file,
-						macos_v3_c_error_dir, c_compiler, message, [
+					if request_macos_v3_c_error_fallback_from_message(macos_v3_fallback_file, macos_v3_c_error_dir, c_compiler, message, [
 						published_c_source,
 						cache_plan_file,
 						cc_src,
-					], fallback_report_sources)
-					{
+					], fallback_report_sources) {
 						cleanup_c_build_dir(cc_dir)
 						exit(1)
 					}
@@ -11184,17 +10953,13 @@ pub fn run(args []string) {
 					cleanup_c_build_dir(cc_dir)
 					exit(1)
 				}
-				cached_dev_dylib = compile_v3_dev_dylib(prefix_object, prepared_cache.objects,
-					resolved_c_flags, &cache_state.manager, target_args, prefs.target, c_compiler,
-					cc_dir, !silent || show_cc, mut c_object_cache_stats) or {
+				cached_dev_dylib = compile_v3_dev_dylib(prefix_object, prepared_cache.objects, resolved_c_flags, &cache_state.manager, target_args, prefs.target, c_compiler, cc_dir, !silent || show_cc, mut c_object_cache_stats) or {
 					message := err.msg()
-					if request_macos_v3_c_error_fallback_from_message(macos_v3_fallback_file,
-						macos_v3_c_error_dir, c_compiler, message, [
+					if request_macos_v3_c_error_fallback_from_message(macos_v3_fallback_file, macos_v3_c_error_dir, c_compiler, message, [
 						published_c_source,
 						cache_plan_file,
 						cc_src,
-					], fallback_report_sources)
-					{
+					], fallback_report_sources) {
 						cleanup_c_build_dir(cc_dir)
 						exit(1)
 					}
@@ -11242,19 +11007,13 @@ pub fn run(args []string) {
 				exit(1)
 			}
 			program_main_identity := modulecache.file_signature(published_c_source)
-			cached_program_main_object = compile_v3_program_object('main', program_main_source,
-				program_main_identity, v3_program_external_input_paths(&cache_state),
-				&cache_state.manager, c_standard, '', pic_flag, warn_args.join(' '),
-				resolved_c_flags, needs_objective_c, target_args, prefs.target, c_compiler, mut
-				c_object_cache_stats) or {
+			cached_program_main_object = compile_v3_program_object('main', program_main_source, program_main_identity, v3_program_external_input_paths(&cache_state), &cache_state.manager, c_standard, '', pic_flag, warn_args.join(' '), resolved_c_flags, needs_objective_c, target_args, prefs.target, c_compiler, mut c_object_cache_stats) or {
 				message := err.msg()
-				if request_macos_v3_c_error_fallback_from_message(macos_v3_fallback_file,
-					macos_v3_c_error_dir, c_compiler, message, [
+				if request_macos_v3_c_error_fallback_from_message(macos_v3_fallback_file, macos_v3_c_error_dir, c_compiler, message, [
 					published_c_source,
 					cache_plan_file,
 					cc_src,
-				], fallback_report_sources)
-				{
+				], fallback_report_sources) {
 					cleanup_c_build_dir(cc_dir)
 					exit(1)
 				}
@@ -11310,9 +11069,7 @@ pub fn run(args []string) {
 				''
 			}
 			tcc_args << v3_tcc_host_system_flags(prefs.normalized_target_os(), tcc_sdk_root)
-			if v3_tcc_backtrace_enabled(prefs.normalized_target_os(),
-				prefs.normalized_target_arch(), is_shared)
-			{
+			if v3_tcc_backtrace_enabled(prefs.normalized_target_os(), prefs.normalized_target_arch(), is_shared) {
 				tcc_args << '-bt25'
 			}
 			if wrapv_flag.len > 0 {
@@ -11333,9 +11090,7 @@ pub fn run(args []string) {
 			} else {
 				''
 			}}'
-			tcc_cached_executable := v3_cached_tcc_executable_path(&cache_state.manager,
-				program_source_identity, c_object_cache_stats.link_plan_signature, tcc_path,
-				tcc_resources.install_dir, tcc_args)
+			tcc_cached_executable := v3_cached_tcc_executable_path(&cache_state.manager, program_source_identity, c_object_cache_stats.link_plan_signature, tcc_path, tcc_resources.install_dir, tcc_args)
 			if os.is_file(tcc_cached_executable) {
 				os.cp(tcc_cached_executable, cc_out) or {}
 				tcc_cache_hit = os.is_file(cc_out)
@@ -11386,16 +11141,15 @@ pub fn run(args []string) {
 			if pic_flag.len > 0 {
 				tcc_args << pic_flag
 			}
-			tcc_args << [tcc_resources.base_arg, tcc_resources.include_arg, tcc_resources.library_arg]
+			tcc_args << [tcc_resources.base_arg, tcc_resources.include_arg,
+				tcc_resources.library_arg]
 			tcc_sdk_root := if prefs.normalized_target_os() == 'macos' {
 				macos_sdk_root_cache.get()
 			} else {
 				''
 			}
 			tcc_args << v3_tcc_host_system_flags(prefs.normalized_target_os(), tcc_sdk_root)
-			if v3_tcc_backtrace_enabled(prefs.normalized_target_os(),
-				prefs.normalized_target_arch(), is_shared)
-			{
+			if v3_tcc_backtrace_enabled(prefs.normalized_target_os(), prefs.normalized_target_arch(), is_shared) {
 				tcc_args << '-bt25'
 			}
 			tcc_args << warn_args
@@ -11475,10 +11229,7 @@ pub fn run(args []string) {
 					}
 					return
 				}
-				if request_macos_v3_c_error_fallback(macos_v3_fallback_file, macos_v3_c_error_dir,
-					c_compiler, result.output, os.join_path_single(cc_dir, fallback_source),
-					fallback_report_sources)
-				{
+				if request_macos_v3_c_error_fallback(macos_v3_fallback_file, macos_v3_c_error_dir, c_compiler, result.output, os.join_path_single(cc_dir, fallback_source), fallback_report_sources) {
 					cleanup_c_build_dir(cc_dir)
 					exit(1)
 				}
@@ -11573,8 +11324,7 @@ Please install the corresponding development package/libraries and make sure the
 	b.metric('C object dependency scans', c_object_cache_stats.dependency_scans, 'objects')
 	b.metric('C object dependency files', c_object_cache_stats.dependency_files, 'files')
 	b.metric('C object dependency reads', c_object_cache_stats.dependency_file_reads, 'files')
-	b.metric('C object dep-scan fallbacks', c_object_cache_stats.dependency_scan_fallbacks,
-		'objects')
+	b.metric('C object dep-scan fallbacks', c_object_cache_stats.dependency_scan_fallbacks, 'objects')
 	b.metric('C object publish races', c_object_cache_stats.publish_races, 'objects')
 	b.metric('C object input-snapshot races', c_object_cache_stats.input_snapshot_races, 'objects')
 	if retained_transform_scope != unsafe { nil } {
@@ -11781,7 +11531,11 @@ fn checker_fixture_missing_shader_message(target string, source_file string) ?st
 fn checker_fixture_header_exists(target string, source_file string, c_compiler string) bool {
 	if target.starts_with('"') && target.ends_with('"') {
 		path := target[1..target.len - 1]
-		resolved := if os.is_abs_path(path) { path } else { os.join_path(os.dir(source_file), path) }
+		resolved := if os.is_abs_path(path) {
+			path
+		} else {
+			os.join_path(os.dir(source_file), path)
+		}
 		return os.is_file(resolved)
 	}
 	if !target.starts_with('<') || !target.ends_with('>') {
@@ -11824,8 +11578,7 @@ fn v3_incremental_main_source(tcc_declarations_path string, body_path string) st
 	escaped_slash := [u8(92), 92].bytestr()
 	quote := [u8(34)].bytestr()
 	escaped_quote := [u8(92), 34].bytestr()
-	declarations_include := tcc_declarations_path.replace(slash, escaped_slash).replace(quote,
-		escaped_quote)
+	declarations_include := tcc_declarations_path.replace(slash, escaped_slash).replace(quote, escaped_quote)
 	body_include := body_path.replace(slash, escaped_slash).replace(quote, escaped_quote)
 	return '#define V3CACHE_PROGRAM_UNIT 1\n#include "${declarations_include}"\n#include "${body_include}"\n'
 }
@@ -11838,8 +11591,7 @@ fn c_include_path(path string) string {
 }
 
 fn v3_incremental_program_main_source(cached_prefix string, body_source string) string {
-	return cached_prefix +
-		modulecache.without_duplicate_static_string_definitions(body_source, cached_prefix)
+	return cached_prefix + modulecache.without_duplicate_static_string_definitions(body_source, cached_prefix)
 }
 
 fn prepare_v3_incremental_cached_body(body_path string, prefix_path string, tcc_declarations_path string, cached_prefix string, compile_signature string, mut state V3ModuleCacheState) !V3PreparedModuleCache {
@@ -11855,10 +11607,10 @@ fn prepare_v3_incremental_cached_body(body_path string, prefix_path string, tcc_
 	main_source := v3_incremental_program_main_source(cached_prefix, body_source)
 	tcc_main_source := v3_incremental_main_source(tcc_declarations_path, body_path)
 	return V3PreparedModuleCache{
-		main_source:           main_source
-		tcc_main_source:       tcc_main_source
+		main_source: main_source
+		tcc_main_source: tcc_main_source
 		program_prefix_source: cached_prefix
-		objects:               objects
+		objects: objects
 	}
 }
 
@@ -11874,25 +11626,23 @@ fn prepare_v3_cached_generic_body(generated_source string, cached_prefix string,
 		return error('v3 generic C function sections are unavailable')
 	}
 	materialized_cached_body := modulecache.materialize_cached_body_string_definitions(cached_body)
-	materialized_source := merge_cached_generic_program_body(materialized_cached_body,
-		generated_source) or { return error('v3 generic C body could not be reconstructed') }
+	materialized_source := merge_cached_generic_program_body(materialized_cached_body, generated_source) or { return error('v3 generic C body could not be reconstructed') }
 	split := modulecache.split_generated_c(materialized_source)!
 	main_body := split.modules['main'] or { '' }
 	current_string_definitions := modulecache.static_string_definitions(split.prefix)
 	combined_declarations := cached_declarations + current_string_definitions
 	tcc_declarations := tcc_cached_main_source(combined_declarations, main_body)
-	unique_string_definitions := modulecache.without_duplicate_static_string_definitions(current_string_definitions,
-		cached_prefix)
+	unique_string_definitions := modulecache.without_duplicate_static_string_definitions(current_string_definitions, cached_prefix)
 	main_source := cached_prefix + unique_string_definitions + main_body
 	tcc_main_source := '#define V3CACHE_PROGRAM_UNIT 1\n' + tcc_declarations + main_body
 	return V3PreparedModuleCache{
-		main_source:              main_source
-		tcc_main_source:          tcc_main_source
-		main_body:                main_body
-		program_prefix_source:    cached_prefix
-		program_declarations:     combined_declarations
+		main_source: main_source
+		tcc_main_source: tcc_main_source
+		main_body: main_body
+		program_prefix_source: cached_prefix
+		program_declarations: combined_declarations
 		tcc_program_declarations: tcc_declarations
-		objects:                  cache_object_paths(state.objects)
+		objects: cache_object_paths(state.objects)
 	}
 }
 
@@ -11924,9 +11674,7 @@ fn prepare_v3_module_cache(generated_source string, cache_used_fns &map[string]b
 		''
 	}
 	declarations := cache_source_without_cached_native_inputs(raw_declarations, state, false)
-	compile_signature := v3_cached_object_wrapper_compile_signature(v3_cached_object_compile_signature(c_standard,
-		opt_flag, pic_flag, warning_flags, generated_c_flags, objective_c, interface_impl_signature),
-		generated_source)
+	compile_signature := v3_cached_object_wrapper_compile_signature(v3_cached_object_compile_signature(c_standard, opt_flag, pic_flag, warning_flags, generated_c_flags, objective_c, interface_impl_signature), generated_source)
 	if resolve_flag_specific_cache_objects(mut state, compile_signature) {
 		os.setenv('V3_CACHE_FORCE_SOURCE', '1', true)
 		restart_v3_after_cache_invalidation()
@@ -11935,15 +11683,12 @@ fn prepare_v3_module_cache(generated_source string, cache_used_fns &map[string]b
 	program_specializations := split.modules['__v3_program_specializations'] or { '' }
 	program_support := split.modules['__v3_program_support'] or { '' }
 	program_generated_support := program_specializations + program_support + main_body
-	main_prefix := prune_cache_only_function_prototypes(prune_cached_native_function_prototypes(cache_source_without_cached_native_inputs(split.prefix,
-		state, true), state, ['main']), cache_used_fns, program_generated_support, tc, state)
-	dylib_prefix := modulecache.prune_unreferenced_static_string_definitions(main_prefix +
-		program_specializations + program_support)
-	main_source := '#define V3CACHE_PROGRAM_UNIT 1\n' + main_prefix + program_specializations +
-		program_support + main_body
-	main_declarations := prune_cache_only_function_prototypes(cache_source_without_cached_native_inputs(modulecache.declaration_header(
-		split.prefix + program_specializations + program_support), state, false), cache_used_fns,
-		program_generated_support, tc, state)
+	main_prefix := prune_cache_only_function_prototypes(prune_cached_native_function_prototypes(cache_source_without_cached_native_inputs(split.prefix, state, true), state, [
+		'main',
+	]), cache_used_fns, program_generated_support, tc, state)
+	dylib_prefix := modulecache.prune_unreferenced_static_string_definitions(main_prefix + program_specializations + program_support)
+	main_source := '#define V3CACHE_PROGRAM_UNIT 1\n' + main_prefix + program_specializations + program_support + main_body
+	main_declarations := prune_cache_only_function_prototypes(cache_source_without_cached_native_inputs(modulecache.declaration_header(split.prefix + program_specializations + program_support), state, false), cache_used_fns, program_generated_support, tc, state)
 	tcc_declarations := tcc_cached_main_source(main_declarations, main_body)
 	tcc_main := '#define V3CACHE_PROGRAM_UNIT 1\n' + tcc_declarations + main_body
 	mut object_paths := state.objects.clone()
@@ -11959,19 +11704,14 @@ fn prepare_v3_module_cache(generated_source string, cache_used_fns &map[string]b
 			}
 		}
 		bundle_roots := cache_builtin_bundle_roots(state)
-		bundle_declarations := prune_cached_native_function_prototypes(raw_declarations, state,
-			bundle_roots)
-		bundle_native := cache_source_with_cached_native_inputs(bundle_declarations, state,
-			bundle_roots)
+		bundle_declarations := prune_cached_native_function_prototypes(raw_declarations, state, bundle_roots)
+		bundle_native := cache_source_with_cached_native_inputs(bundle_declarations, state, bundle_roots)
 		module_source := if bundle_native.has_native {
-			'#define V3CACHE_PROGRAM_UNIT 1\n' + bundle_native.source +
-				'#undef V3CACHE_PROGRAM_UNIT\n' + bundle_native.remaining_includes +
-				bundle_body.str()
+			'#define V3CACHE_PROGRAM_UNIT 1\n' + bundle_native.source + '#undef V3CACHE_PROGRAM_UNIT\n' + bundle_native.remaining_includes + bundle_body.str()
 		} else {
 			declarations + bundle_body.str()
 		}
-		compile_v3_cached_object(entry, module_source, c_standard, opt_flag, pic_flag,
-			warning_flags, generated_c_flags, objective_c) or {
+		compile_v3_cached_object(entry, module_source, c_standard, opt_flag, pic_flag, warning_flags, generated_c_flags, objective_c) or {
 			prealloc_scope_leave_for_v3(bundle_compile_scope)
 			message := err.msg().clone()
 			prealloc_scope_free_for_v3(bundle_compile_scope)
@@ -11988,10 +11728,8 @@ fn prepare_v3_module_cache(generated_source string, cache_used_fns &map[string]b
 				state.manager.write_header(module_name, source_files, header)!
 			}
 		}
-		bundle_dependencies := cache_object_dependency_signatures(state,
-			cache_builtin_bundle_roots(state))
-		state.manager.write_stamp('builtin', state.bundle_sources, bundle_dependencies,
-			compile_signature)!
+		bundle_dependencies := cache_object_dependency_signatures(state, cache_builtin_bundle_roots(state))
+		state.manager.write_stamp('builtin', state.bundle_sources, bundle_dependencies, compile_signature)!
 		object_paths['builtin'] = entry.object
 		state.bundle_valid = true
 		for module_name in state.headers.keys() {
@@ -12026,13 +11764,11 @@ fn prepare_v3_module_cache(generated_source string, cache_used_fns &map[string]b
 			module_name,
 		])
 		module_source := if native.has_native {
-			'#define V3CACHE_PROGRAM_UNIT 1\n' + native.source + '#undef V3CACHE_PROGRAM_UNIT\n' +
-				native.remaining_includes + body
+			'#define V3CACHE_PROGRAM_UNIT 1\n' + native.source + '#undef V3CACHE_PROGRAM_UNIT\n' + native.remaining_includes + body
 		} else {
 			declarations + body
 		}
-		compile_v3_cached_object(entry, module_source, c_standard, opt_flag, pic_flag,
-			warning_flags, generated_c_flags, objective_c) or {
+		compile_v3_cached_object(entry, module_source, c_standard, opt_flag, pic_flag, warning_flags, generated_c_flags, objective_c) or {
 			prealloc_scope_leave_for_v3(module_compile_scope)
 			message := err.msg().clone()
 			prealloc_scope_free_for_v3(module_compile_scope)
@@ -12050,18 +11786,15 @@ fn prepare_v3_module_cache(generated_source string, cache_used_fns &map[string]b
 	}
 
 	return V3PreparedModuleCache{
-		main_source:              main_source
-		tcc_main_source:          tcc_main
-		main_body:                main_body
-		program_body_cache:       incremental_static_string_markers(split.prefix) +
-			'/* V3CACHE_BODY_BEGIN */\n/* V3CACHE_MODULE main */\n' + main_body +
-			'\n/* V3CACHE_BODY_END */\n'
-		program_prefix_source:    '#define V3CACHE_PROGRAM_UNIT 1\n' + dylib_prefix
-		program_declarations:     main_declarations
+		main_source: main_source
+		tcc_main_source: tcc_main
+		main_body: main_body
+		program_body_cache: incremental_static_string_markers(split.prefix) + '/* V3CACHE_BODY_BEGIN */\n/* V3CACHE_MODULE main */\n' + main_body + '\n/* V3CACHE_BODY_END */\n'
+		program_prefix_source: '#define V3CACHE_PROGRAM_UNIT 1\n' + dylib_prefix
+		program_declarations: main_declarations
 		tcc_program_declarations: tcc_declarations
-		objects:                  cache_used_object_paths(object_paths, program_used_fns,
-			program_generated_support, tc, state)
-		newly_cached_modules:     newly_cached_modules.len
+		objects: cache_used_object_paths(object_paths, program_used_fns, program_generated_support, tc, state)
+		newly_cached_modules: newly_cached_modules.len
 	}
 }
 
@@ -12073,9 +11806,7 @@ fn cache_used_object_paths(object_paths map[string]string, program_used_fns &map
 			selected[module_name] = object_path
 			continue
 		}
-		if cache_module_has_used_runtime(module_name, program_used_fns, program_generated_support,
-			tc)
-		{
+		if cache_module_has_used_runtime(module_name, program_used_fns, program_generated_support, tc) {
 			selected[module_name] = object_path
 			runtime_roots << module_name
 		}
@@ -12136,8 +11867,7 @@ fn prune_cache_only_function_prototypes(source string, cache_used_fns &map[strin
 		return source
 	}
 	source_references := cache_function_reference_counts(source, candidate_functions)
-	program_references := cache_function_reference_counts(program_generated_support,
-		candidate_functions)
+	program_references := cache_function_reference_counts(program_generated_support, candidate_functions)
 	mut cache_only_functions := map[string]bool{}
 	for c_name in candidate_functions.keys() {
 		// A cached module can expose a function value through a global initializer
@@ -12441,9 +12171,9 @@ fn cache_source_with_cached_native_inputs(source string, state &V3ModuleCacheSta
 		}
 	}
 	return V3CachedNativeSource{
-		source:             out.str()
+		source: out.str()
 		remaining_includes: remaining.str()
-		has_native:         true
+		has_native: true
 	}
 }
 
@@ -12738,8 +12468,7 @@ fn cache_external_input_owner_modules(state &V3ModuleCacheState, a &flat.FlatAst
 						}
 						return modules, false
 					}
-					if !cache_static_input_is_private_to_module(a, state, raw_module_name, path,
-						user_files, c_flags, ccompiler, target) {
+					if !cache_static_input_is_private_to_module(a, state, raw_module_name, path, user_files, c_flags, ccompiler, target) {
 						if os.getenv('V3_CACHE_TRACE') != '' {
 							eprintln('  V3 module cache shared static input: module=${raw_module_name} path=${path}')
 						}
@@ -12815,8 +12544,7 @@ fn cache_static_input_is_private_to_module(a &flat.FlatAst, state &V3ModuleCache
 	if header_identifiers.len == 0 && os.getenv('V3_CACHE_TRACE') != '' {
 		eprintln('  V3 module cache static input has no recoverable identifiers: path=${path}')
 	}
-	return cache_external_identifiers_are_private_to_module(a, state, raw_module_name,
-		header_identifiers, user_files, os.real_path(path))
+	return cache_external_identifiers_are_private_to_module(a, state, raw_module_name, header_identifiers, user_files, os.real_path(path))
 }
 
 fn cache_preprocessed_native_input(path string, context []string, c_flags []string, ccompiler string, target pref.Target) ?string {
@@ -12863,8 +12591,7 @@ fn cache_external_identifiers_are_private_to_module(a &flat.FlatAst, state &V3Mo
 	for path in owner_paths {
 		owner_sources << os.read_file(path) or { continue }
 	}
-	for identifier, present in modulecache.c_sources_macro_identifiers_referencing(owner_sources,
-		exposed_identifiers) {
+	for identifier, present in modulecache.c_sources_macro_identifiers_referencing(owner_sources, exposed_identifiers) {
 		if present {
 			exposed_identifiers[identifier] = true
 		}
@@ -13238,9 +12965,7 @@ fn resolve_flag_specific_cache_objects(mut state V3ModuleCacheState, compile_sig
 			state.module_sources[object_name] or { continue }
 		}
 		dependency_inputs := cache_object_dependency_signatures(state, roots)
-		if entry := state.manager.valid_object_for_compile_signature(object_name, source_files,
-			compile_signature, dependency_inputs)
-		{
+		if entry := state.manager.valid_object_for_compile_signature(object_name, source_files, compile_signature, dependency_inputs) {
 			state.objects[object_name] = entry.object
 		} else {
 			if os.getenv('V3_CACHE_TRACE') != '' {
@@ -13317,14 +13042,12 @@ fn v3_directory_user_files(dir string, prefs &pref.Preferences, is_test_command 
 	mut seen_files := map[string]bool{}
 	mut seen_dirs := map[string]bool{}
 	if recursive {
-		collect_v3_directory_user_files_rec(source_dir, source_dir, prefs, is_test_command, mut
-			seen_dirs, mut seen_files, mut files)
+		collect_v3_directory_user_files_rec(source_dir, source_dir, prefs, is_test_command, mut seen_dirs, mut seen_files, mut files)
 		return files
 	}
 	append_v3_directory_user_files(source_dir, prefs, is_test_command, mut seen_files, mut files)
 	for subdir in vmod_subdirs(dir)! {
-		collect_v3_directory_user_files_rec(source_dir, os.join_path_single(source_dir, subdir),
-			prefs, is_test_command, mut seen_dirs, mut seen_files, mut files)
+		collect_v3_directory_user_files_rec(source_dir, os.join_path_single(source_dir, subdir), prefs, is_test_command, mut seen_dirs, mut seen_files, mut files)
 	}
 	return files
 }
@@ -13347,8 +13070,7 @@ fn collect_v3_directory_user_files_rec(module_root string, dir string, prefs &pr
 	for entry in entries {
 		entry_path := os.join_path_single(real_dir, entry)
 		if os.is_dir(entry_path) {
-			collect_v3_directory_user_files_rec(module_root, entry_path, prefs, is_test_command, mut
-				seen_dirs, mut seen_files, mut files)
+			collect_v3_directory_user_files_rec(module_root, entry_path, prefs, is_test_command, mut seen_dirs, mut seen_files, mut files)
 		}
 	}
 }
@@ -13358,8 +13080,7 @@ fn append_v3_directory_user_files(dir string, prefs &pref.Preferences, is_test_c
 		append_unique_file(mut files, mut seen, file)
 	}
 	if is_test_command {
-		for file in pref.get_test_v_files_from_dir_for_target(dir, prefs.user_defines,
-			prefs.backend, prefs.target) {
+		for file in pref.get_test_v_files_from_dir_for_target(dir, prefs.user_defines, prefs.backend, prefs.target) {
 			append_unique_file(mut files, mut seen, file)
 		}
 	}
@@ -13668,8 +13389,7 @@ fn print_type_diagnostics(a &flat.FlatAst, notices []types.TypeError, type_error
 		eprintln(v3errors.formatted_error(severity, notice.msg, a, notice.node, notice.pos))
 		print_type_diagnostic_details(notice.details)
 	}
-	source_errors := reorder_chained_generic_inference_errors(a, dedupe_type_diagnostics(a,
-		type_errors))
+	source_errors := reorder_chained_generic_inference_errors(a, dedupe_type_diagnostics(a, type_errors))
 	mut ordered_errors := []types.TypeError{cap: source_errors.len}
 	for err in source_errors {
 		if !is_bare_generic_fntype_decl_error(err) {
@@ -13696,8 +13416,8 @@ fn print_type_diagnostics(a &flat.FlatAst, notices []types.TypeError, type_error
 fn has_conflicting_c_declaration_errors(errors []types.TypeError) bool {
 	return errors.any(it.kind == .duplicate_decl
 		&& (it.msg.starts_with('cannot redeclare C struct `')
-		|| (it.msg.starts_with('C function `')
-		&& it.msg.contains('was already declared with a different signature'))))
+			|| (it.msg.starts_with('C function `')
+				&& it.msg.contains('was already declared with a different signature'))))
 }
 
 fn unused_notice_is_parameter_redefinition_cascade(a &flat.FlatAst, notice types.TypeError, type_errors []types.TypeError) bool {
@@ -13724,14 +13444,14 @@ fn dedupe_type_diagnostics(a &flat.FlatAst, type_errors []types.TypeError) []typ
 	for err in type_errors {
 		if err.msg.ends_with('` must be initialized')
 			&& type_errors.any(it.msg.starts_with('enum `') && it.msg.ends_with('` is private')
-			&& it.pos.id == err.pos.id && err.pos.offset >= it.pos.offset
-			&& err.pos.end <= it.pos.end) {
+				&& it.pos.id == err.pos.id && err.pos.offset >= it.pos.offset
+				&& err.pos.end <= it.pos.end) {
 			continue
 		}
 		if err.msg.starts_with('unknown type `')
 			&& type_errors.any(it.msg == 'generic struct cannot be used in non-generic function'
-			&& it.pos.id == err.pos.id && err.pos.offset >= it.pos.offset
-			&& err.pos.end <= it.pos.end) {
+				&& it.pos.id == err.pos.id && err.pos.offset >= it.pos.offset
+				&& err.pos.end <= it.pos.end) {
 			continue
 		}
 		if err.msg.starts_with('unknown struct `') {
@@ -13739,7 +13459,7 @@ fn dedupe_type_diagnostics(a &flat.FlatAst, type_errors []types.TypeError) []typ
 			err_fn := type_diagnostic_enclosing_fn(a, err)
 			if int(err_fn) >= 0
 				&& type_errors.any(it.msg.starts_with('generic type name `${name}` is not mentioned in fn ')
-				&& type_diagnostic_enclosing_fn(a, it) == err_fn) {
+					&& type_diagnostic_enclosing_fn(a, it) == err_fn) {
 				continue
 			}
 		}
@@ -13750,8 +13470,7 @@ fn dedupe_type_diagnostics(a &flat.FlatAst, type_errors []types.TypeError) []typ
 		}
 		if deduped.any(it.msg == err.msg && it.pos.id == err.pos.id
 			&& it.pos.offset == err.pos.offset && it.pos.end == err.pos.end
-			&& it.severity == err.severity)
-		{
+			&& it.severity == err.severity) {
 			continue
 		}
 		deduped << err
@@ -13794,8 +13513,8 @@ fn type_diagnostic_enclosing_fn(a &flat.FlatAst, diagnostic types.TypeError) fla
 	mut nearest := flat.empty_node
 	mut nearest_offset := -1
 	for index, node in a.nodes {
-		if node.kind !in [.fn_decl, .struct_decl, .interface_decl, .type_decl, .enum_decl, .const_decl, .global_decl, .c_fn_decl, .module_decl, .import_decl]
-			|| !node.pos.is_valid() || !diagnostic_pos.is_valid()
+		if node.kind !in [.fn_decl, .struct_decl, .interface_decl, .type_decl, .enum_decl,
+			.const_decl, .global_decl, .c_fn_decl, .module_decl, .import_decl] || !node.pos.is_valid() || !diagnostic_pos.is_valid()
 			|| node.pos.id != diagnostic_pos.id || node.pos.offset > diagnostic_pos.offset
 			|| node.pos.offset <= nearest_offset {
 			continue
@@ -13967,15 +13686,11 @@ fn unsupported_backend_error(a &flat.FlatAst, tc &types.TypeChecker, used_fns ma
 				return '${fallback_location}error: result types are not implemented by the V3 wasm backend'
 			}
 			mut infix_visited := []bool{len: a.nodes.len}
-			if msg := unsupported_wasm_struct_infix_error(a, tc, flat.NodeId(idx),
-				fallback_location, mut infix_visited)
-			{
+			if msg := unsupported_wasm_struct_infix_error(a, tc, flat.NodeId(idx), fallback_location, mut infix_visited) {
 				return msg
 			}
 		}
-		if msg := unsupported_backend_node_error(a, tc, flat.NodeId(idx), backend,
-			diagnose_aggregates, fallback_location, mut visited)
-		{
+		if msg := unsupported_backend_node_error(a, tc, flat.NodeId(idx), backend, diagnose_aggregates, fallback_location, mut visited) {
 			return msg
 		}
 	}
@@ -14007,9 +13722,7 @@ fn unsupported_backend_error(a &flat.FlatAst, tc &types.TypeChecker, used_fns ma
 				diagnose_aggregates := tc.diagnostic_files.len == 0
 					|| cur_file in tc.diagnostic_files
 				fallback_location := backend_node_location(a, *field)
-				if msg := unsupported_backend_node_error(a, tc, a.child(field, 0), backend,
-					diagnose_aggregates, fallback_location, mut visited)
-				{
+				if msg := unsupported_backend_node_error(a, tc, a.child(field, 0), backend, diagnose_aggregates, fallback_location, mut visited) {
 					return msg
 				}
 			}
@@ -14026,9 +13739,7 @@ fn unsupported_backend_error(a &flat.FlatAst, tc &types.TypeChecker, used_fns ma
 				diagnose_aggregates := tc.diagnostic_files.len == 0
 					|| cur_file in tc.diagnostic_files
 				fallback_location := backend_node_location(a, *field)
-				if msg := unsupported_backend_node_error(a, tc, expr_id, backend,
-					diagnose_aggregates, fallback_location, mut visited)
-				{
+				if msg := unsupported_backend_node_error(a, tc, expr_id, backend, diagnose_aggregates, fallback_location, mut visited) {
 					return msg
 				}
 			}
@@ -14041,9 +13752,7 @@ fn unsupported_backend_error(a &flat.FlatAst, tc &types.TypeChecker, used_fns ma
 				|| source_file.name in tc.diagnostic_files
 		}
 		fallback_location := backend_node_location(a, *a.node(expr_id))
-		if msg := unsupported_backend_node_error(a, tc, expr_id, backend, diagnose_aggregates,
-			fallback_location, mut visited)
-		{
+		if msg := unsupported_backend_node_error(a, tc, expr_id, backend, diagnose_aggregates, fallback_location, mut visited) {
 			return msg
 		}
 	}
@@ -14078,9 +13787,7 @@ fn unsupported_wasm_struct_infix_error(a &flat.FlatAst, tc &types.TypeChecker, i
 		}
 	}
 	for i in 0 .. node.children_count {
-		if msg := unsupported_wasm_struct_infix_error(a, tc, a.child(&node, i), fallback_location, mut
-			visited)
-		{
+		if msg := unsupported_wasm_struct_infix_error(a, tc, a.child(&node, i), fallback_location, mut visited) {
 			return msg
 		}
 	}
@@ -14166,12 +13873,10 @@ fn unsupported_backend_node_error(a &flat.FlatAst, tc &types.TypeChecker, id fla
 		} else {
 			fallback_location
 		}
-		return '${location}error: `$res()` is not supported by the V3 ${backend} backend'
+		return '${location}error: `\$res()` is not supported by the V3 ${backend} backend'
 	}
 	for i in 0 .. node.children_count {
-		if msg := unsupported_backend_node_error(a, tc, a.child(&node, i), backend,
-			diagnose_aggregates, fallback_location, mut visited)
-		{
+		if msg := unsupported_backend_node_error(a, tc, a.child(&node, i), backend, diagnose_aggregates, fallback_location, mut visited) {
 			return msg
 		}
 	}
@@ -14284,8 +13989,7 @@ fn test_file_has_executable_top_level_stmt(a &flat.FlatAst, node &flat.Node) boo
 
 fn test_file_is_executable_top_level_stmt(node &flat.Node) bool {
 	return match node.kind {
-		.expr_stmt, .assign, .decl_assign, .selector_assign, .index_assign, .for_stmt,
-		.for_in_stmt, .if_expr, .match_stmt, .assert_stmt, .defer_stmt {
+		.expr_stmt, .assign, .decl_assign, .selector_assign, .index_assign, .for_stmt, .for_in_stmt, .if_expr, .match_stmt, .assert_stmt, .defer_stmt {
 			true
 		}
 		else {
@@ -14468,23 +14172,23 @@ fn seed_implicit_imports(mut a flat.FlatAst, skip_closure_runtime bool) {
 
 fn sync_import_node() flat.Node {
 	return flat.Node{
-		kind:  .import_decl
+		kind: .import_decl
 		value: 'sync'
-		typ:   'sync'
+		typ: 'sync'
 	}
 }
 
 fn embed_file_import_node() flat.Node {
 	return flat.Node{
-		kind:  .import_decl
+		kind: .import_decl
 		value: 'v.embed_file'
-		typ:   'embed_file'
+		typ: 'embed_file'
 	}
 }
 
 fn closure_import_node() flat.Node {
 	return flat.Node{
-		kind:  .import_decl
+		kind: .import_decl
 		value: 'builtin.closure'
 		// This node is appended in the last user file's scope. A compiler-private
 		// alias prevents it from overwriting a user import named `closure`; generated
@@ -14495,9 +14199,9 @@ fn closure_import_node() flat.Node {
 
 fn debugger_import_node() flat.Node {
 	return flat.Node{
-		kind:  .import_decl
+		kind: .import_decl
 		value: 'v.debug'
-		typ:   '__v3_debugger_runtime'
+		typ: '__v3_debugger_runtime'
 	}
 }
 
@@ -14509,18 +14213,18 @@ fn seed_cached_builtin_bundle_imports(mut a flat.FlatAst, enabled bool, builtin_
 	// these boundaries the checker assigns them to the last parsed user file.
 	start := a.nodes.len
 	a.nodes << flat.Node{
-		kind:  .file
+		kind: .file
 		value: cache_bundle_import_file(builtin_dir)
 	}
 	a.nodes << flat.Node{
-		kind:  .module_decl
+		kind: .module_decl
 		value: 'builtin'
 	}
 	for import_path in modulecache.builtin_bundle_imports {
 		a.nodes << flat.Node{
-			kind:  .import_decl
+			kind: .import_decl
 			value: import_path
-			typ:   import_path.all_after_last('.')
+			typ: import_path.all_after_last('.')
 		}
 	}
 	a.intern_node_texts_from(start)
@@ -14552,8 +14256,7 @@ fn scan_implicit_imports(a &flat.FlatAst, end_node int, mut scan ImplicitImportS
 	known_field_selectors := if scan.needs_closure {
 		map[int]bool{}
 	} else {
-		implicit_field_scan_index_append(a, scan.field_index_node_idx, end_node, mut
-			scan.field_index)
+		implicit_field_scan_index_append(a, scan.field_index_node_idx, end_node, mut scan.field_index)
 		scan.field_index_node_idx = end_node
 		implicit_known_field_selectors(a, scan.node_idx, end_node, scan.field_index)
 	}
@@ -14602,8 +14305,7 @@ fn scan_implicit_imports(a &flat.FlatAst, end_node int, mut scan ImplicitImportS
 						break
 					}
 				}
-			} else if node.kind == .selector && node.children_count > 0 && i !in call_callees
-				&& i !in known_field_selectors && !implicit_selector_is_interop_symbol(a, node) {
+			} else if node.kind == .selector && node.children_count > 0 && i !in call_callees && i !in known_field_selectors && !implicit_selector_is_interop_symbol(a, node) {
 				// A remaining selector used as a value may be a bound method. Full type
 				// information is unavailable during import discovery, so conservatively
 				// load the runtime; calls, C/JS symbols, and provable fields are excluded.
@@ -14864,8 +14566,7 @@ fn implicit_expr_type(a &flat.FlatAst, id flat.NodeId, bindings map[string]strin
 		}
 		.block {
 			if node.children_count > 0 {
-				return implicit_expr_type(a, a.child(node, node.children_count - 1), bindings,
-					index, depth + 1)
+				return implicit_expr_type(a, a.child(node, node.children_count - 1), bindings, index, depth + 1)
 			}
 		}
 		.if_expr {
@@ -14881,8 +14582,7 @@ fn implicit_expr_type(a &flat.FlatAst, id flat.NodeId, bindings map[string]strin
 				}
 				if typ == '' {
 					typ = branch_type
-				} else if implicit_normalize_type(typ, index.aliases) != implicit_normalize_type(branch_type,
-					index.aliases) {
+				} else if implicit_normalize_type(typ, index.aliases) != implicit_normalize_type(branch_type, index.aliases) {
 					return ''
 				}
 			}
@@ -14899,8 +14599,7 @@ fn implicit_expr_type(a &flat.FlatAst, id flat.NodeId, bindings map[string]strin
 		}
 		.index {
 			if node.children_count > 0 {
-				base_type := implicit_normalize_type(implicit_expr_type(a, a.child(node, 0),
-					bindings, index, depth + 1), index.aliases)
+				base_type := implicit_normalize_type(implicit_expr_type(a, a.child(node, 0), bindings, index, depth + 1), index.aliases)
 				if base_type.starts_with('[]') {
 					return base_type[2..]
 				}
@@ -14943,8 +14642,7 @@ fn implicit_call_return_type(a &flat.FlatAst, call &flat.Node, bindings map[stri
 		return ''
 	}
 	base_id := a.child(callee, 0)
-	base_type := implicit_normalize_type(implicit_expr_type(a, base_id, bindings, index, depth + 1),
-		index.aliases)
+	base_type := implicit_normalize_type(implicit_expr_type(a, base_id, bindings, index, depth + 1), index.aliases)
 	if base_type == 'string' {
 		if callee.value == 'runes' {
 			return '[]rune'
@@ -15080,8 +14778,7 @@ fn insert_synthetic_imports(mut a flat.FlatAst, insertions []SyntheticInsertion)
 		if node.kind == .directive && node.value.starts_with('@attributes:') {
 			target_idx := node.value['@attributes:'.len..].int()
 			if target_idx >= 0 && target_idx < old_len {
-				node.value = '@attributes:${target_idx +
-					synthetic_index_shift(insertions, target_idx)}'
+				node.value = '@attributes:${target_idx + synthetic_index_shift(insertions, target_idx)}'
 				node = canonical_node_texts(mut a, node)
 			}
 		}
@@ -15237,15 +14934,12 @@ fn eager_selfhost_resolve_thread(arg voidptr) voidptr {
 	// Every wave contains each import path once, and the chosen result is cached
 	// for the authoritative pass by discover_eager_selfhost_modules.
 	mut local_cache := map[string]string{}
-	result.dir = resolve_project_or_pref_module_path(prefs, result.path, result.importing_file,
-		result.project_root, mut local_cache)
+	result.dir = resolve_project_or_pref_module_path(prefs, result.path, result.importing_file, result.project_root, mut local_cache)
 	if result.dir.len > 0 && os.is_dir(result.dir) {
 		result.real_dir = os.real_path(result.dir)
-		result.files = pref.get_v_files_from_dir_for_target(result.dir, prefs.user_defines,
-			prefs.target)
+		result.files = pref.get_v_files_from_dir_for_target(result.dir, prefs.user_defines, prefs.target)
 		if result.files.len > 0 {
-			result.identity = import_module_identity_with_path_cache(prefs, result.path,
-				result.importing_file, result.project_root, result.dir, mut local_cache)
+			result.identity = import_module_identity_with_path_cache(prefs, result.path, result.importing_file, result.project_root, result.dir, mut local_cache)
 		}
 	}
 	return unsafe { nil }
@@ -15256,14 +14950,14 @@ fn resolve_eager_selfhost_wave(a &flat.FlatAst, prefs &pref.Preferences, request
 	mut tasks := []workers.Task{cap: requests.len}
 	for i, import_req in requests {
 		results << EagerSelfhostResolveArgs{
-			prefs:          voidptr(prefs)
-			path:           import_req.path
+			prefs: voidptr(prefs)
+			path: import_req.path
 			importing_file: import_req.importing_file
-			project_root:   project_root
+			project_root: project_root
 		}
 		tasks << workers.Task{
-			run:        eager_selfhost_resolve_thread
-			arg:        unsafe { voidptr(&results[i]) }
+			run: eager_selfhost_resolve_thread
+			arg: unsafe { voidptr(&results[i]) }
 			force_sync: i == 0
 		}
 	}
@@ -15456,8 +15150,8 @@ fn source_imports_fast_parallel(a &flat.FlatAst, files []string) [][]string {
 			path: file
 		}
 		tasks << workers.Task{
-			run:        eager_selfhost_scan_thread
-			arg:        unsafe { voidptr(&scans[i]) }
+			run: eager_selfhost_scan_thread
+			arg: unsafe { voidptr(&scans[i]) }
 			force_sync: i == 0
 		}
 	}
@@ -15484,7 +15178,7 @@ fn discover_eager_selfhost_modules(a &flat.FlatAst, prefs &pref.Preferences, fir
 			cur_file = node.value
 		} else if node.kind == .import_decl && node.value.len > 0 {
 			pending << EagerSelfhostImport{
-				path:           node.value
+				path: node.value
 				importing_file: cur_file
 			}
 		}
@@ -15525,11 +15219,11 @@ fn discover_eager_selfhost_modules(a &flat.FlatAst, prefs &pref.Preferences, fir
 			}
 			module_by_real_dir[result.real_dir] = modules.len
 			modules << EagerSelfhostModule{
-				path:         import_req.path
-				dir:          result.dir
-				real_dir:     result.real_dir
-				files:        result.files
-				identity:     result.identity
+				path: import_req.path
+				dir: result.dir
+				real_dir: result.real_dir
+				files: result.files
+				identity: result.identity
 				import_paths: [import_req.path]
 			}
 			wave_files << result.files
@@ -15538,7 +15232,7 @@ fn discover_eager_selfhost_modules(a &flat.FlatAst, prefs &pref.Preferences, fir
 		for i, file in wave_files {
 			for imported in wave_imports[i] {
 				pending << EagerSelfhostImport{
-					path:           imported
+					path: imported
 					importing_file: file
 				}
 			}
@@ -15618,8 +15312,7 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 	// eager discovery duplicates import-identity and collision work for this graph.
 	if prefs.building_v && !prefs.selfhost && allow_parallel && !cache_state.manager.enabled
 		&& os.getenv('V3_NO_EAGER_SELFHOST_IMPORTS') == '' {
-		modules := discover_eager_selfhost_modules(a, prefs, first_file, project_root, mut
-			parsed_modules, mut module_path_cache)
+		modules := discover_eager_selfhost_modules(a, prefs, first_file, project_root, mut parsed_modules, mut module_path_cache)
 		mut eager_files := []string{}
 		mut eager_canons := []string{}
 		for module_info in modules {
@@ -15643,8 +15336,7 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 			}
 		}
 		if eager_files.len > 0 {
-			starts, eager_parallel := parse_files_dispatch_profiled(mut p, eager_files,
-				allow_parallel, mut parse_timing)
+			starts, eager_parallel := parse_files_dispatch_profiled(mut p, eager_files, allow_parallel, mut parse_timing)
 			was_parallel = was_parallel || eager_parallel
 			end_node := a.nodes.len
 			for i, canon in eager_canons {
@@ -15729,7 +15421,7 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 			scan_importing_file := if scan_file.len > 0 { scan_file } else { first_file }
 			mut collision_seeds := [
 				ImportCollisionSeed{
-					path:           scan_path
+					path: scan_path
 					importing_file: scan_importing_file
 				},
 			]
@@ -15757,11 +15449,8 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 					continue
 				}
 				resolved_collision_seeds[seed_key] = true
-				scan_dir := resolve_project_or_pref_module_path_cached(prefs, seed.path,
-					seed.importing_file, project_root, mut module_path_cache)
-				scan_identity := import_module_identity_cached(prefs, seed.path,
-					seed.importing_file, project_root, scan_dir, mut module_path_cache, mut
-					module_identity_cache)
+				scan_dir := resolve_project_or_pref_module_path_cached(prefs, seed.path, seed.importing_file, project_root, mut module_path_cache)
+				scan_identity := import_module_identity_cached(prefs, seed.path, seed.importing_file, project_root, scan_dir, mut module_path_cache, mut module_identity_cache)
 				if owner_path := identity_source_paths[scan_identity] {
 					owner_dir := identity_source_dirs[scan_identity] or { '' }
 					if owner_path != seed.path && owner_dir.len > 0 && scan_dir.len > 0
@@ -15819,8 +15508,7 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 			}
 			if is_bundle_warmup_import && cache_state.bundle_valid {
 				warmup_dir := prefs.get_vlib_module_path(mod_name)
-				warmup_files := pref.get_v_files_from_dir_for_target(warmup_dir,
-					prefs.user_defines, prefs.target)
+				warmup_files := pref.get_v_files_from_dir_for_target(warmup_dir, prefs.user_defines, prefs.target)
 				if cache_state.manager.valid_header(mod_name, warmup_files) == none {
 					// The cached bundle may have been built while a project module
 					// shadowed this optional warmup import. An actual user import was
@@ -15836,8 +15524,7 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 				if module_identity.len > 0 {
 					set_node_value_canonical(mut a, node_idx, module_identity)
 				}
-				record_v3_fallback_module_use(mut cache_state, module_identity,
-					is_bundle_warmup_import)
+				record_v3_fallback_module_use(mut cache_state, module_identity, is_bundle_warmup_import)
 				record_cache_module_dependency(mut cache_state, cur_module, module_identity)
 				node_idx++
 				continue
@@ -15855,11 +15542,9 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 			mod_dir := if is_bundle_warmup_import {
 				prefs.get_vlib_module_path(mod_name)
 			} else {
-				resolve_project_or_pref_module_path_cached(prefs, mod_name, importing_file,
-					project_root, mut module_path_cache)
+				resolve_project_or_pref_module_path_cached(prefs, mod_name, importing_file, project_root, mut module_path_cache)
 			}
-			mut module_identity := import_module_identity_cached(prefs, mod_name, importing_file,
-				project_root, mod_dir, mut module_path_cache, mut module_identity_cache)
+			mut module_identity := import_module_identity_cached(prefs, mod_name, importing_file, project_root, mod_dir, mut module_path_cache, mut module_identity_cache)
 			if forced_full_module_paths[mod_name] {
 				module_identity = mod_name
 			}
@@ -15922,8 +15607,7 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 						if declared_module.all_after_last('.') != expected_module {
 							message := 'bad module definition: ${importing_file} imports module "${mod_name}" but ${imported_file} is defined as module `${declared_module}`'
 							eprintln('error: ${message}')
-							formatted := v3errors.formatted_error('error:', message, a,
-								flat.NodeId(node_idx), a.nodes[node_idx].pos)
+							formatted := v3errors.formatted_error('error:', message, a, flat.NodeId(node_idx), a.nodes[node_idx].pos)
 							context := formatted.all_after_first('\n')
 							if context.len > 0 {
 								eprintln(context)
@@ -15967,9 +15651,7 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 						cache_state.source_body_modules[cache_module] = true
 					}
 				} else if !cache_state.force_source {
-					if cached := cache_state.manager.valid_entry_with_metadata_cache(cache_module,
-						mod_files, mut cache_state.dependency_metadata)
-					{
+					if cached := cache_state.manager.valid_entry_with_metadata_cache(cache_module, mod_files, mut cache_state.dependency_metadata) {
 						record_v3_cached_source_digests(mut cache_state, cached.source_digests)
 						if !modulecache.header_needs_source(cached) {
 							parse_files = [cached.header]
@@ -16009,8 +15691,7 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 			}
 			break
 		}
-		starts, wave_parallel := parse_files_dispatch_profiled(mut p, wave_files, allow_parallel, mut
-			parse_timing)
+		starts, wave_parallel := parse_files_dispatch_profiled(mut p, wave_files, allow_parallel, mut parse_timing)
 		was_parallel = was_parallel || wave_parallel
 		wave_end_nodes := a.nodes.len
 		for i, canon in wave_canon {
@@ -16043,7 +15724,7 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 			scan_implicit_imports(a, region_end, mut implicit_imports)
 			if !synthetic_sync_added && implicit_imports.needs_sync && !implicit_imports.has_sync {
 				insertions << SyntheticInsertion{
-					pos:  region_end
+					pos: region_end
 					node: sync_import_node()
 				}
 				synthetic_sync_added = true
@@ -16051,7 +15732,7 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 			if !synthetic_embed_file_added && implicit_imports.needs_embed
 				&& !implicit_imports.has_embed_import {
 				insertions << SyntheticInsertion{
-					pos:  region_end
+					pos: region_end
 					node: embed_file_import_node()
 				}
 				synthetic_embed_file_added = true
@@ -16059,7 +15740,7 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 			if !skip_closure_runtime && !synthetic_closure_added && implicit_imports.needs_closure
 				&& !implicit_imports.has_closure {
 				insertions << SyntheticInsertion{
-					pos:  region_end
+					pos: region_end
 					node: closure_import_node()
 				}
 				synthetic_closure_added = true
@@ -16067,7 +15748,7 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 			if !synthetic_debugger_added && implicit_imports.needs_debugger
 				&& !implicit_imports.has_debugger {
 				insertions << SyntheticInsertion{
-					pos:  region_end
+					pos: region_end
 					node: debugger_import_node()
 				}
 				synthetic_debugger_added = true
@@ -16306,8 +15987,7 @@ fn import_module_identity_cached(prefs &pref.Preferences, import_path string, im
 	if identity := identity_cache[key] {
 		return identity
 	}
-	identity := import_module_identity_with_path_cache(prefs, import_path, importing_file,
-		project_root, import_dir, mut path_cache)
+	identity := import_module_identity_with_path_cache(prefs, import_path, importing_file, project_root, import_dir, mut path_cache)
 	identity_cache[key] = identity
 	return identity
 }
@@ -16335,8 +16015,7 @@ fn import_module_identity_with_path_cache(prefs &pref.Preferences, import_path s
 			return import_path
 		}
 	}
-	short_dir := resolve_project_or_pref_module_path_cached(prefs, short_name, importing_file,
-		project_root, mut path_cache)
+	short_dir := resolve_project_or_pref_module_path_cached(prefs, short_name, importing_file, project_root, mut path_cache)
 	if short_dir.len > 0 && import_dir.len > 0 && os.is_dir(short_dir)
 		&& os.real_path(short_dir) != os.real_path(import_dir) {
 		return import_path
@@ -16383,16 +16062,14 @@ fn resolve_project_or_pref_module_path_cached(prefs &pref.Preferences, mod_name 
 	if path := cache[key] {
 		return path
 	}
-	path := resolve_project_or_pref_module_path(prefs, mod_name, importing_file, project_root, mut
-		cache)
+	path := resolve_project_or_pref_module_path(prefs, mod_name, importing_file, project_root, mut cache)
 	cache[key] = path
 	return path
 }
 
 fn resolve_project_or_pref_module_path(prefs &pref.Preferences, mod_name string, importing_file string, project_root string, mut cache map[string]string) string {
 	mod_path := mod_name.replace('.', os.path_separator)
-	local_path := resolve_local_or_project_module_path(mod_name, mod_path, importing_file,
-		project_root)
+	local_path := resolve_local_or_project_module_path(mod_name, mod_path, importing_file, project_root)
 	if local_path.len > 0 {
 		return local_path
 	}

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -77,9 +77,9 @@ fn configure_selfhost_parallelism(building_v bool) {
 }
 
 const embedded_parallel_transform_node_limit = 10_000_000
-const scoped_serial_user_check_node_threshold = 400_000
-const scoped_serial_user_transform_node_threshold = 400_000
-const scoped_serial_user_cgen_node_threshold = 500_000
+const scoped_serial_user_check_node_threshold = 1_000_000
+const scoped_serial_user_transform_node_threshold = 1_000_000
+const scoped_serial_user_cgen_node_threshold = 2_000_000
 const scoped_linux_user_job_limit = 4
 const scoped_transform_signature_headroom = 2048
 const v3_vvmrc_file_name = '.vvmrc'
@@ -290,7 +290,7 @@ fn add_c_language_runtime_link_flags(mut prepared []string, original []string, l
 	}
 }
 
-fn prepare_c_flags_for_link(flags []string, environment_c_flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, c_compiler string, uncached_dir string, mut stats CObjectCacheStats) ![]string {
+fn prepare_c_flags_for_link(flags []string, environment_c_flags []string, optimization_flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, c_compiler string, uncached_dir string, mut stats CObjectCacheStats) ![]string {
 	// Nothing to cache: without object-file or native-source flags the link
 	// plan adds no value, and preparing it costs a compiler-identity probe
 	// (subprocess) plus plan-file signatures on every build.
@@ -313,6 +313,7 @@ fn prepare_c_flags_for_link(flags []string, environment_c_flags []string, c99 bo
 		return passthrough
 	}
 	mut support_flags := environment_c_flags.clone()
+	support_flags << optimization_flags
 	support_flags << c_object_compile_support_flags(flags)
 	cache_dir := os.join_path(os.vtmp_dir(), 'v3_thirdparty_objs')
 	os.mkdir_all(cache_dir)!
@@ -1815,6 +1816,8 @@ struct V3CCompilerFlagOptions {
 	no_prod_options      bool
 	is_shared            bool
 	parallel_cc          bool
+	large_c_unit         bool
+	limit_inlining       bool
 	explicit_tcc         bool
 	is_c_debug           bool
 	is_o                 bool
@@ -1961,7 +1964,8 @@ fn v3_c_compiler_flag_plan(options V3CCompilerFlagOptions) V3CCompilerFlagPlan {
 		before_inputs << options.link_c_standard
 	}
 	before_inputs << v3_prod_c_optimization_flags(options.is_prod, options.no_prod_options,
-		options.is_shared, options.parallel_cc, options.explicit_tcc)
+		options.is_shared, options.parallel_cc, options.large_c_unit, options.limit_inlining,
+		options.explicit_tcc)
 	if options.pic_flag.len > 0 {
 		before_inputs << options.pic_flag
 	}
@@ -2351,7 +2355,7 @@ fn cli_usage() string {
 		'  -profile [file]              write V1-compatible function profile data\n' +
 		'  -profile-fns <names>         profile only named functions and their callees\n' +
 		'  -profile-no-inline           omit @[inline] functions from the profile\n' +
-		'  -no-memory-limit             disable the 3840 MiB memory safety limit\n' +
+		'  -no-memory-limit             disable the 4032 MiB user-build memory safety limit\n' +
 		'  -d <name>                    compile-time define'
 }
 
@@ -7285,15 +7289,36 @@ fn v3_effective_warns_are_errors(explicit bool, is_prod bool) bool {
 	return explicit || is_prod
 }
 
-fn v3_prod_c_optimization_flags(is_prod bool, no_prod_options bool, is_shared bool, parallel_cc bool, explicit_tcc bool) []string {
+const v3_large_prod_c_unit_threshold = u64(8 * 1024 * 1024)
+
+fn v3_is_large_prod_c_unit(source_size u64) bool {
+	return source_size >= v3_large_prod_c_unit_threshold
+}
+
+fn v3_prod_c_optimization_flags(is_prod bool, no_prod_options bool, is_shared bool, parallel_cc bool, large_c_unit bool, limit_inlining bool, explicit_tcc bool) []string {
 	if !is_prod || no_prod_options {
 		return []
 	}
-	mut flags := ['-O3']
+	// Clang's -O3 compile cost grows sharply on very large generated translation
+	// units. -O2 retains whole-program LTO while avoiding those costly passes.
+	mut flags := [if large_c_unit { '-O2' } else { '-O3' }]
 	if !is_shared && !parallel_cc && !explicit_tcc {
 		flags << '-flto'
 	}
+	if large_c_unit && limit_inlining {
+		// Large V translation units expose many mechanically generated candidates.
+		// Bound Clang's inliner search without disabling profitable inlining.
+		flags << ['-mllvm', '-inline-threshold=75']
+	}
 	return flags
+}
+
+fn v3_prod_c_object_optimization_flags(is_prod bool, no_prod_options bool, is_shared bool, parallel_cc bool, explicit_tcc bool) []string {
+	// Native support sources are cached as independently compiled objects. Emitting
+	// LLVM bitcode here makes every program link optimize those unchanged sources
+	// again; keep the per-object -O3 work in the cache instead.
+	return v3_prod_c_optimization_flags(is_prod, no_prod_options, is_shared, parallel_cc, false,
+		false, explicit_tcc).filter(it != '-flto')
 }
 
 fn append_v3_c_compile_mode_flags(mut args []string, c_standard string, opt_flags string, pic_flag string) {
@@ -7375,183 +7400,185 @@ fn add_v3_profile_used_fns(mut used_fns map[string]bool) {
 	}
 }
 
-struct V3FastCCompileResult {
-	success bool
-	command string
-	output  string
-}
+$if !skip_fastc ? {
+	struct V3FastCCompileResult {
+		success bool
+		command string
+		output  string
+	}
 
-fn publish_v3_fastc_c_source(pieces []string, output_file string, c_to_stdout bool) ! {
-	if c_to_stdout {
-		for piece in pieces {
-			print(piece)
+	fn publish_v3_fastc_c_source(pieces []string, output_file string, c_to_stdout bool) ! {
+		if c_to_stdout {
+			for piece in pieces {
+				print(piece)
+			}
+			return
 		}
-		return
+		staged_output := '${output_file}.stage.${tempname.unique_token()}'
+		fastc.write_c_pieces(staged_output, pieces) or {
+			return error('error writing fastc output ${output_file}: ${err.msg()}')
+		}
+		os.mv(staged_output, output_file) or {
+			os.rm(staged_output) or {}
+			return error('error finalizing fastc output ${output_file}: ${err.msg()}')
+		}
 	}
-	staged_output := '${output_file}.stage.${tempname.unique_token()}'
-	fastc.write_c_pieces(staged_output, pieces) or {
-		return error('error writing fastc output ${output_file}: ${err.msg()}')
-	}
-	os.mv(staged_output, output_file) or {
-		os.rm(staged_output) or {}
-		return error('error finalizing fastc output ${output_file}: ${err.msg()}')
-	}
-}
 
-fn canonical_v3_fastc_output_path(path string) string {
-	if path == '' {
-		return ''
+	fn canonical_v3_fastc_output_path(path string) string {
+		if path == '' {
+			return ''
+		}
+		if os.exists(path) {
+			return os.real_path(path)
+		}
+		absolute_path := os.abs_path(path)
+		canonical_parent := os.real_path(os.dir(absolute_path))
+		return os.join_path_single(canonical_parent, os.file_name(absolute_path))
 	}
-	if os.exists(path) {
-		return os.real_path(path)
-	}
-	absolute_path := os.abs_path(path)
-	canonical_parent := os.real_path(os.dir(absolute_path))
-	return os.join_path_single(canonical_parent, os.file_name(absolute_path))
-}
 
-fn compile_v3_fastc_source(pieces []string, units fastc.FastcUnitLayout, bin_file string, prefs &pref.Preferences, environment_c_flags []string, source_c_flags []string, user_c_flags []string, environment_ld_flags []string, macos_sdk_root string, is_debug bool, uses_threads bool) V3FastCCompileResult {
-	bench_phases := os.getenv('FASTC_BENCH_PHASES') != ''
-	cc_sw := time.new_stopwatch()
-	tcc_dir := os.join_path(prefs.vroot, 'thirdparty', 'tcc')
-	tcc_path := os.join_path_single(tcc_dir, 'tcc.exe')
-	if !os.is_executable(tcc_path) {
-		return V3FastCCompileResult{}
-	}
-	build_dir := os.join_path_single(os.dir(os.real_path(bin_file)),
-		'.${os.file_name(bin_file)}.fastc.${tempname.unique_token()}')
-	os.mkdir_all(build_dir) or { return V3FastCCompileResult{} }
-	defer {
-		cleanup_c_build_dir(build_dir)
-	}
-	source_file := os.join_path_single(build_dir, 'src.c')
-	staged_binary := os.join_path_single(build_dir, 'out')
-	// The program's translation units are compiled by concurrent TinyCC
-	// processes and linked; a program that does not split is compiled as
-	// one file.
-	if bench_phases {
-		eprintln('fastc-phase tcc.setup ${cc_sw.elapsed().microseconds()}us')
-	}
-	unit_paths := fastc.fastc_write_c_units(os.join_path_single(build_dir, 'src'), pieces, units,
-		fastc.fastc_tcc_job_count(prefs)) or { return V3FastCCompileResult{} }
-	if unit_paths.len < 2 {
-		fastc.write_c_pieces(source_file, pieces) or { return V3FastCCompileResult{} }
-	}
-	if bench_phases {
-		eprintln('fastc-phase tcc.units_written ${cc_sw.elapsed().microseconds()}us units=${unit_paths.len}')
-	}
-	tcc_resources := v3_tcc_resource_flags(prefs.vroot)
-	mut cc_args := environment_c_flags.clone()
-	cc_args << ['-std=gnu11', tcc_resources.base_arg, tcc_resources.include_arg, tcc_resources.library_arg]
-	cc_args << v3_tcc_host_system_flags(prefs.normalized_target_os(), macos_sdk_root)
-	cc_args << source_c_flags
-	// A call without a prototype would silently truncate a pointer result
-	// (the C carries no headers): it is an error, not a warning.
-	cc_args << '-Werror=implicit-function-declaration'
-	if v3_tcc_backtrace_enabled(prefs.normalized_target_os(), prefs.normalized_target_arch(), false) {
-		cc_args << '-bt25'
-	}
-	if is_debug {
-		cc_args << '-g'
-	}
-	// Keep archives and other link-only source directives after the generated
-	// object inputs. Only their state-affecting options are applied while
-	// preparing libtcc; static archives remain order-sensitive link operands.
-	compile_base_args := c_object_compile_flags(cc_args)
-	base_link_args := c_dylib_link_flags(cc_args)
-	user_compile_args := c_object_compile_flags(user_c_flags)
-	user_link_args := c_dylib_link_flags(user_c_flags)
-	mut final_args := base_link_args.clone()
-	final_args << user_link_args
-	if uses_threads {
-		final_args << '-lpthread'
-	}
-	final_args << '-lm'
-	final_args << environment_ld_flags
-	mut shim_dir := fastc.FastcCodesignShim{}
-	defer {
-		fastc.fastc_remove_codesign_shim_dir(shim_dir)
-	}
-	mut result := os.Result{}
-	mut command := ''
-	mut sign_in_process := false
-	if unit_paths.len > 1 {
-		mut compile_args := compile_base_args.clone()
-		compile_args << user_compile_args
-		link_worker := spawn fastc.fastc_prepare_link(tcc_path,
-			os.join_path_single(tcc_dir, 'lib'), compile_base_args, final_args)
-		unit_objects := fastc.fastc_compile_c_units(tcc_path, compile_args, unit_paths) or {
+	fn compile_v3_fastc_source(pieces []string, units fastc.FastcUnitLayout, bin_file string, prefs &pref.Preferences, environment_c_flags []string, source_c_flags []string, user_c_flags []string, environment_ld_flags []string, macos_sdk_root string, is_debug bool, uses_threads bool) V3FastCCompileResult {
+		bench_phases := os.getenv('FASTC_BENCH_PHASES') != ''
+		cc_sw := time.new_stopwatch()
+		tcc_dir := os.join_path(prefs.vroot, 'thirdparty', 'tcc')
+		tcc_path := os.join_path_single(tcc_dir, 'tcc.exe')
+		if !os.is_executable(tcc_path) {
+			return V3FastCCompileResult{}
+		}
+		build_dir := os.join_path_single(os.dir(os.real_path(bin_file)),
+			'.${os.file_name(bin_file)}.fastc.${tempname.unique_token()}')
+		os.mkdir_all(build_dir) or { return V3FastCCompileResult{} }
+		defer {
+			cleanup_c_build_dir(build_dir)
+		}
+		source_file := os.join_path_single(build_dir, 'src.c')
+		staged_binary := os.join_path_single(build_dir, 'out')
+		// The program's translation units are compiled by concurrent TinyCC
+		// processes and linked; a program that does not split is compiled as
+		// one file.
+		if bench_phases {
+			eprintln('fastc-phase tcc.setup ${cc_sw.elapsed().microseconds()}us')
+		}
+		unit_paths := fastc.fastc_write_c_units(os.join_path_single(build_dir, 'src'), pieces, units,
+			fastc.fastc_tcc_job_count(prefs)) or { return V3FastCCompileResult{} }
+		if unit_paths.len < 2 {
+			fastc.write_c_pieces(source_file, pieces) or { return V3FastCCompileResult{} }
+		}
+		if bench_phases {
+			eprintln('fastc-phase tcc.units_written ${cc_sw.elapsed().microseconds()}us units=${unit_paths.len}')
+		}
+		tcc_resources := v3_tcc_resource_flags(prefs.vroot)
+		mut cc_args := environment_c_flags.clone()
+		cc_args << ['-std=gnu11', tcc_resources.base_arg, tcc_resources.include_arg, tcc_resources.library_arg]
+		cc_args << v3_tcc_host_system_flags(prefs.normalized_target_os(), macos_sdk_root)
+		cc_args << source_c_flags
+		// A call without a prototype would silently truncate a pointer result
+		// (the C carries no headers): it is an error, not a warning.
+		cc_args << '-Werror=implicit-function-declaration'
+		if v3_tcc_backtrace_enabled(prefs.normalized_target_os(), prefs.normalized_target_arch(), false) {
+			cc_args << '-bt25'
+		}
+		if is_debug {
+			cc_args << '-g'
+		}
+		// Keep archives and other link-only source directives after the generated
+		// object inputs. Only their state-affecting options are applied while
+		// preparing libtcc; static archives remain order-sensitive link operands.
+		compile_base_args := c_object_compile_flags(cc_args)
+		base_link_args := c_dylib_link_flags(cc_args)
+		user_compile_args := c_object_compile_flags(user_c_flags)
+		user_link_args := c_dylib_link_flags(user_c_flags)
+		mut final_args := base_link_args.clone()
+		final_args << user_link_args
+		if uses_threads {
+			final_args << '-lpthread'
+		}
+		final_args << '-lm'
+		final_args << environment_ld_flags
+		mut shim_dir := fastc.FastcCodesignShim{}
+		defer {
+			fastc.fastc_remove_codesign_shim_dir(shim_dir)
+		}
+		mut result := os.Result{}
+		mut command := ''
+		mut sign_in_process := false
+		if unit_paths.len > 1 {
+			mut compile_args := compile_base_args.clone()
+			compile_args << user_compile_args
+			link_worker := spawn fastc.fastc_prepare_link(tcc_path,
+				os.join_path_single(tcc_dir, 'lib'), compile_base_args, final_args)
+			unit_objects := fastc.fastc_compile_c_units(tcc_path, compile_args, unit_paths) or {
+				mut prepared_link := link_worker.wait()
+				fastc.fastc_discard_link(mut prepared_link)
+				fastc.write_c_pieces(source_file, pieces) or {}
+				return V3FastCCompileResult{
+					command: cmdexec.display(tcc_path, compile_args)
+					output:  err.msg()
+				}
+			}
+			if bench_phases {
+				eprintln('fastc-phase tcc.units_compiled ${cc_sw.elapsed().microseconds()}us')
+			}
+			link_inputs := unit_objects.clone()
+			mut display_args := compile_base_args.clone()
+			display_args << ['-o', staged_binary]
+			display_args << link_inputs
+			display_args << final_args
+			command = cmdexec.display(tcc_path, display_args)
 			mut prepared_link := link_worker.wait()
-			fastc.fastc_discard_link(mut prepared_link)
-			fastc.write_c_pieces(source_file, pieces) or {}
+			sign_in_process = fastc.fastc_prepared_link_skips_codesign(&prepared_link)
+			if !sign_in_process {
+				// The executable-based linker still needs the PATH shim; the prepared
+				// libtcc linker suppresses its codesign call without a subprocess.
+				shim_dir = fastc.fastc_codesign_shim_dir()
+				sign_in_process = shim_dir.dir != ''
+			}
+			result = fastc.fastc_finish_link(mut prepared_link, link_inputs, final_args, staged_binary)
+			if bench_phases {
+				eprintln('fastc-phase tcc.linked ${cc_sw.elapsed().microseconds()}us')
+			}
+		} else {
+			cc_args = compile_base_args.clone()
+			cc_args << user_compile_args
+			cc_args << ['-o', 'out', 'src.c']
+			cc_args << final_args
+			command = cmdexec.display(tcc_path, cc_args)
+			shim_dir = fastc.fastc_codesign_shim_dir()
+			sign_in_process = shim_dir.dir != ''
+			result = cmdexec.run_in(tcc_path, cc_args, build_dir)
+		}
+		if result.exit_code != 0 || !os.is_file(staged_binary) {
+			if keep_dir := os.getenv_opt('V3_FASTC_KEEP_FAILED_C') {
+				if keep_dir.len > 0 {
+					os.cp(source_file, keep_dir) or {}
+				}
+			}
 			return V3FastCCompileResult{
-				command: cmdexec.display(tcc_path, compile_args)
+				command: command
+				output:  result.output
+			}
+		}
+		if sign_in_process {
+			fastc.fastc_sign_macho_adhoc(staged_binary) or {
+				return V3FastCCompileResult{
+					command: command
+					output:  'could not sign ${staged_binary}: ${err.msg()}'
+				}
+			}
+		}
+		if bench_phases {
+			eprintln('fastc-phase tcc.signed ${cc_sw.elapsed().microseconds()}us')
+		}
+		os.mv(staged_binary, bin_file) or {
+			return V3FastCCompileResult{
+				command: command
 				output:  err.msg()
 			}
 		}
-		if bench_phases {
-			eprintln('fastc-phase tcc.units_compiled ${cc_sw.elapsed().microseconds()}us')
-		}
-		link_inputs := unit_objects.clone()
-		mut display_args := compile_base_args.clone()
-		display_args << ['-o', staged_binary]
-		display_args << link_inputs
-		display_args << final_args
-		command = cmdexec.display(tcc_path, display_args)
-		mut prepared_link := link_worker.wait()
-		sign_in_process = fastc.fastc_prepared_link_skips_codesign(&prepared_link)
-		if !sign_in_process {
-			// The executable-based linker still needs the PATH shim; the prepared
-			// libtcc linker suppresses its codesign call without a subprocess.
-			shim_dir = fastc.fastc_codesign_shim_dir()
-			sign_in_process = shim_dir.dir != ''
-		}
-		result = fastc.fastc_finish_link(mut prepared_link, link_inputs, final_args, staged_binary)
-		if bench_phases {
-			eprintln('fastc-phase tcc.linked ${cc_sw.elapsed().microseconds()}us')
-		}
-	} else {
-		cc_args = compile_base_args.clone()
-		cc_args << user_compile_args
-		cc_args << ['-o', 'out', 'src.c']
-		cc_args << final_args
-		command = cmdexec.display(tcc_path, cc_args)
-		shim_dir = fastc.fastc_codesign_shim_dir()
-		sign_in_process = shim_dir.dir != ''
-		result = cmdexec.run_in(tcc_path, cc_args, build_dir)
-	}
-	if result.exit_code != 0 || !os.is_file(staged_binary) {
-		if keep_dir := os.getenv_opt('V3_FASTC_KEEP_FAILED_C') {
-			if keep_dir.len > 0 {
-				os.cp(source_file, keep_dir) or {}
-			}
-		}
 		return V3FastCCompileResult{
+			success: true
 			command: command
 			output:  result.output
 		}
-	}
-	if sign_in_process {
-		fastc.fastc_sign_macho_adhoc(staged_binary) or {
-			return V3FastCCompileResult{
-				command: command
-				output:  'could not sign ${staged_binary}: ${err.msg()}'
-			}
-		}
-	}
-	if bench_phases {
-		eprintln('fastc-phase tcc.signed ${cc_sw.elapsed().microseconds()}us')
-	}
-	os.mv(staged_binary, bin_file) or {
-		return V3FastCCompileResult{
-			command: command
-			output:  err.msg()
-		}
-	}
-	return V3FastCCompileResult{
-		success: true
-		command: command
-		output:  result.output
 	}
 }
 
@@ -9419,6 +9446,7 @@ pub fn run(args []string) {
 	mut uses_generics := false
 	mut skip_transform_generics := true
 	mut transform_texts_canonical := cgen_cache_hit
+	mut texts_canonical_after_annotation := cgen_cache_hit
 	mut retained_transform_scope := unsafe { nil }
 	mut retained_transform_prepare_scope := unsafe { nil }
 	mut trivial_literal_output := false
@@ -9506,7 +9534,7 @@ pub fn run(args []string) {
 			pre_tc.check_semantics_selected(incremental_changed_names)
 		} else {
 			ck_stage_sw.restart()
-			// On large user import graphs, scoped serial batches use less memory than
+			// On very large user import graphs, serial checking uses less memory than
 			// retaining one semantic-check accumulator per worker.
 			parallel_semantic_check := !current_no_parallel && a.missing_imports.len == 0
 				&& (building_v || !scope_prealloc_check
@@ -9764,6 +9792,13 @@ pub fn run(args []string) {
 		b.step('markused')
 		b.metric('reachable symbols', used_fns.len, 'symbols')
 		mut tfpre_sw := time.new_stopwatch()
+		// Formatting unused-declaration diagnostics allocates source excerpts and
+		// rendered messages that are dead before transform starts. Keep that scratch
+		// out of the compilation arena on cache-disabled prealloc builds.
+		mut unused_diag_scope := voidptr(unsafe { nil })
+		if scope_prealloc_stages && !cache_state.manager.enabled {
+			unused_diag_scope = prealloc_scope_begin_for_v3()
+		}
 		if !is_repl && !pre_tc.valid_diagnostic_fast {
 			pre_tc.diagnose_unused_private_declarations(used_fns)
 		}
@@ -9773,7 +9808,9 @@ pub fn run(args []string) {
 		}
 		if pre_tc.notices.len > 0 {
 			checker_sql_warnings_only := is_checker_fixture && ast_contains_sql_expr(a)
-			cached_checker_diagnostics << cache_v3_type_diagnostics(a, pre_tc.notices)
+			if cache_state.manager.enabled {
+				cached_checker_diagnostics << cache_v3_type_diagnostics(a, pre_tc.notices)
+			}
 			print_type_diagnostics(a, pre_tc.notices, []types.TypeError{}, is_checker_fixture)
 			for notice in pre_tc.notices {
 				if notice.severity == 'warning:' {
@@ -9786,6 +9823,10 @@ pub fn run(args []string) {
 			if checker_sql_warnings_only {
 				exit(0)
 			}
+		}
+		if unused_diag_scope != unsafe { nil } {
+			prealloc_scope_leave_for_v3(unused_diag_scope)
+			prealloc_scope_free_for_v3(unused_diag_scope)
 		}
 		if backend == 'wasm' {
 			// Validate source-level operations before transform lowers aggregate
@@ -10277,12 +10318,8 @@ pub fn run(args []string) {
 				&pre_tc, monomorph_input_used, !current_no_parallel
 				&& should_parallel_monomorphize(), monomorph_scope, cached_monomorph_specs)
 			prealloc_scope_leave_for_v3(monomorph_scope)
-			// Specialization can rewrite payload text on pre-existing nodes as
-			// well as append new nodes. Publish every string still owned by the
-			// disposable monomorph arena before it is released.
-			for idx in 0 .. a.nodes.len {
-				canonicalize_scoped_node(mut a, idx, monomorph_scope)
-			}
+			// The monomorphizer publishes rewritten and appended node text after
+			// its final worker merge while all worker arenas are still live.
 			if verbose {
 				eprintln('mono AST after pass: ${a.nodes.len}/${a.nodes.cap} nodes, ${a.children.len}/${a.children.cap} children')
 			}
@@ -10321,6 +10358,7 @@ pub fn run(args []string) {
 				&& should_parallel_monomorphize() && !incremental_cache_hit, unsafe { nil },
 				cached_monomorph_specs)
 		}
+		texts_canonical_after_annotation = true
 		// Monomorphization publishes every synthesized or rewritten AST string
 		// after its final worker merge, including the serial/no-worker path.
 		transform_texts_canonical = true
@@ -10338,7 +10376,9 @@ pub fn run(args []string) {
 			pre_tc.notices.clear()
 		}
 		if pre_tc.notices.len > 0 || pre_tc.errors.len > 0 {
-			cached_checker_diagnostics << cache_v3_type_diagnostics(a, pre_tc.notices)
+			if cache_state.manager.enabled {
+				cached_checker_diagnostics << cache_v3_type_diagnostics(a, pre_tc.notices)
+			}
 			if pre_tc.errors.len == 0
 				|| !macos_v3_fallback_suppresses_diagnostics(macos_v3_fallback_file) {
 				print_type_diagnostics(a, pre_tc.notices, pre_tc.errors, is_checker_fixture)
@@ -10376,7 +10416,7 @@ pub fn run(args []string) {
 	// annotation only runs outside -building-v builds. Self-host builds skip
 	// it, and their transform-canonical texts are already final, so this
 	// full-AST walk would be a no-op there.
-	annotation_can_rewrite_texts := !building_v
+	annotation_can_rewrite_texts := !building_v && !texts_canonical_after_annotation
 	if (scope_prealloc_stages && annotation_can_rewrite_texts) || !transform_texts_canonical {
 		a.intern_node_texts_from(0)
 	}
@@ -10699,6 +10739,9 @@ pub fn run(args []string) {
 		mut all_compile_c_flags := environment_c_flags.clone()
 		all_compile_c_flags << generated_c_flags
 		needs_objective_c := c_flags_need_objective_c(all_compile_c_flags)
+		large_prod_c_unit := os.is_file(published_c_source)
+			&& v3_is_large_prod_c_unit(os.file_size(published_c_source))
+		limit_large_unit_inlining := large_prod_c_unit && effective_c_compiler == 'clang'
 		link_uses_non_c_language := c_link_flags_use_non_c_language(all_compile_c_flags)
 		link_c_standard := if link_uses_non_c_language {
 			''
@@ -10711,9 +10754,11 @@ pub fn run(args []string) {
 			generated_c_flags.clone()
 		}
 		if !c_only || (dump_c_flags.len > 0 && generate_c_project.len == 0) {
+			object_optimization_flags := v3_prod_c_object_optimization_flags(is_prod, no_prod_options,
+				is_shared, parallel_cc, explicit_tcc)
 			resolved_c_flags = prepare_c_flags_for_link(generated_c_flags, environment_c_flags,
-				prefs.c99, pic_flag, target_args, prefs.target, c_compiler, cc_dir, mut
-				c_object_cache_stats) or {
+				object_optimization_flags, prefs.c99, pic_flag, target_args, prefs.target, c_compiler,
+				cc_dir, mut c_object_cache_stats) or {
 				message := err.msg()
 				if request_macos_v3_c_error_fallback_from_message(macos_v3_fallback_file,
 					macos_v3_c_error_dir, c_compiler, message, [published_c_source, cache_plan_file,
@@ -10749,6 +10794,8 @@ pub fn run(args []string) {
 			no_prod_options:      no_prod_options
 			is_shared:            is_shared
 			parallel_cc:          parallel_cc
+			large_c_unit:         large_prod_c_unit
+			limit_inlining:       limit_large_unit_inlining
 			explicit_tcc:         explicit_tcc
 			is_c_debug:           is_c_debug
 			is_o:                 is_o
@@ -10829,7 +10876,7 @@ pub fn run(args []string) {
 				interface_impl_signature = pre_tc.interface_impl_set_signature()
 			}
 			opt_flag := v3_prod_c_optimization_flags(is_prod, no_prod_options, is_shared,
-				parallel_cc, explicit_tcc).join(' ')
+				parallel_cc, large_prod_c_unit, limit_large_unit_inlining, explicit_tcc).join(' ')
 			warning_flags := warn_args.join(' ')
 			mut compile_signature := v3_cached_object_compile_signature(c_standard, opt_flag,
 				pic_flag, warning_flags, resolved_c_flags, needs_objective_c,

--- a/vlib/v3/driver/environment_test.v
+++ b/vlib/v3/driver/environment_test.v
@@ -6,6 +6,7 @@ import v3.ansi
 import v3.flat
 import v3.parser
 import v3.pref
+import v3.types
 
 fn restore_driver_environment(name string, old_value string, was_set bool) {
 	if was_set {
@@ -112,6 +113,21 @@ fn test_v3_default_diagnostic_color_uses_environment() {
 	os.setenv(name, 'always', true)
 	apply_v3_default_diagnostic_color()
 	assert ansi.red('error') == '\x1b[31merror\x1b[39m'
+}
+
+fn test_release_unused_diagnostic_scope_rebinds_notices() {
+	mut notices := []types.TypeError{cap: 1}
+	scope := prealloc_scope_begin_for_v3()
+	notices << types.TypeError{ msg: 'first' }
+	notices << types.TypeError{ msg: 'second' }
+	$if prealloc {
+		assert scoped_value_owned(scope, notices.data)
+	}
+	release_unused_diagnostic_scope(mut notices, scope)
+	assert notices.len == 0
+	assert notices.cap == 0
+	notices << types.TypeError{ msg: 'parent owned' }
+	assert notices[0].msg == 'parent owned'
 }
 
 fn test_macos_v3_fallback_payload_validation() {

--- a/vlib/v3/driver/environment_test.v
+++ b/vlib/v3/driver/environment_test.v
@@ -132,8 +132,7 @@ fn test_macos_v3_fallback_report_sources_keep_parser_digests() {
 		os.rmdir_all(root) or {}
 	}
 	path := os.join_path(root, 'main.v')
-	backend_builtin_path := os.join_path(root, 'vlib', 'builtin',
-		'ownership_interface_d_v3_backend.v')
+	backend_builtin_path := os.join_path(root, 'vlib', 'builtin', 'ownership_interface_d_v3_backend.v')
 	shared_builtin_path := os.join_path(root, 'vlib', 'builtin', 'internal.v')
 	prealloc_builtin_path := os.join_path(root, 'vlib', 'builtin', 'prealloc.c.v')
 	shared_vlib_path := os.join_path(root, 'vlib', 'os', 'shared.v')
@@ -186,11 +185,10 @@ fn test_macos_v3_fallback_report_sources_keep_parser_digests() {
 	staged_paths := os.read_file(os.join_path(report_dir, macos_v3_c_error_v_sources_file))!
 	staged_digests :=
 		os.read_file(os.join_path(report_dir, macos_v3_c_error_v_source_digests_file))!
-	assert staged_paths == [os.real_path(cached_source), real_path, os.real_path(shared_builtin_path),
-		os.real_path(shared_vlib_path)].join('\x00')
-	assert staged_digests == [sha256.hexhash(cached_source_text),
-		sha256.hexhash(parsed_source), sha256.hexhash(shared_builtin_source),
-		sha256.hexhash(shared_vlib_source)].join('\x00')
+	assert staged_paths == [os.real_path(cached_source), real_path,
+		os.real_path(shared_builtin_path), os.real_path(shared_vlib_path)].join('\x00')
+	assert staged_digests == [sha256.hexhash(cached_source_text), sha256.hexhash(parsed_source),
+		sha256.hexhash(shared_builtin_source), sha256.hexhash(shared_vlib_source)].join('\x00')
 }
 
 fn test_macos_v3_fallback_report_inputs_snapshot_native_dependencies() {
@@ -211,17 +209,17 @@ fn test_macos_v3_fallback_report_inputs_snapshot_native_dependencies() {
 	header_digest := sha256.hexhash(header_source)
 	source_digest := sha256.hexhash(native_source)
 	state := V3ModuleCacheState{
-		module_external_inputs:   {
+		module_external_inputs: {
 			'main': [header_path, source_path]
 		}
-		module_native_roots:      {
+		module_native_roots: {
 			'main': [source_path]
 		}
-		external_input_digests:   {
+		external_input_digests: {
 			header_path: header_digest
 			source_path: source_digest
 		}
-		external_inputs_ready:    true
+		external_inputs_ready: true
 		external_inputs_complete: true
 	}
 	// A watcher can replace a root after traversal. The fallback manifest must retain
@@ -240,11 +238,11 @@ fn test_macos_v3_fallback_report_inputs_snapshot_native_dependencies() {
 fn test_v3_fallback_ignores_only_warmup_only_module_sources() {
 	hash_source := os.real_path(os.join_path(os.vtmp_dir(), 'v3_fallback_hash.v'))
 	mut state := V3ModuleCacheState{
-		module_sources:            {
+		module_sources: {
 			'hash': [hash_source]
 		}
 		fallback_required_modules: map[string]bool{}
-		fallback_warmup_modules:   {
+		fallback_warmup_modules: {
 			'hash': true
 		}
 	}
@@ -268,13 +266,13 @@ fn test_parallel_cc_external_definition_precheck_uses_active_ast_directives() {
 	mut a := &flat.FlatAst{
 		nodes: [
 			flat.Node{
-				kind:  .file
+				kind: .file
 				value: source
 			},
 			flat.Node{
-				kind:  .directive
+				kind: .directive
 				value: 'include'
-				typ:   '"@DIR/windows_impl.h"'
+				typ: '"@DIR/windows_impl.h"'
 			},
 		]
 	}
@@ -295,8 +293,7 @@ fn test_impure_v_diagnostics_inspect_ast_nodes_in_every_pure_v_file() {
 	js_file := os.join_path(root, 'js_usage.v')
 	allowed_c_file := os.join_path(root, 'allowed.c.v')
 	allowed_js_file := os.join_path(root, 'allowed.js.v')
-	os.write_file(clean_file,
-		"// C.comment() and JS.comment()\nfn clean() { println('C.foo JS.bar') }\n")!
+	os.write_file(clean_file, "// C.comment() and JS.comment()\nfn clean() { println('C.foo JS.bar') }\n")!
 	os.write_file(c_file, 'fn C.do_work()\nfn use_c(value &C.Widget) { C.do_work() }\n')!
 	os.write_file(js_file, 'fn JS.do_work()\nfn use_js(value JS.Number) { JS.do_work() }\n')!
 	os.write_file(allowed_c_file, 'fn C.allowed()\nfn use_c() { C.allowed() }\n')!
@@ -327,8 +324,7 @@ fn test_wayland_gg_precheck_inspects_parsed_imports_in_every_user_file() {
 	gg_file := os.join_path(root, 'gg.v')
 	sapp_file := os.join_path(root, 'sapp.v')
 	os.write_file(comment_file, 'module main\n// import gg\nfn comment_only() {}\n')!
-	os.write_file(string_file,
-		"module main\nconst import_text = 'import sokol.sapp'\nfn string_only() {}\n")!
+	os.write_file(string_file, "module main\nconst import_text = 'import sokol.sapp'\nfn string_only() {}\n")!
 	os.write_file(gg_file, 'module main\nimport gg\nfn gg_import() {}\n')!
 	os.write_file(sapp_file, 'module main\nimport sokol.sapp\nfn sapp_import() {}\n')!
 	prefs := pref.new_preferences()
@@ -433,10 +429,8 @@ fn test_v3_build_constraints_are_evaluated_only_for_direct_tests() {
 	os.write_file(malformed_file, '// vtest build: ((malformed\nmodule main\n')!
 	os.write_file(false_test_file, '// vtest build: windows && linux\nmodule main\n')!
 	target := pref.host_target()
-	assert !v3_direct_test_input_is_incompatible(false, malformed_file, 'c', target, 'clang',
-		false, [])
-	assert v3_direct_test_input_is_incompatible(true, false_test_file, 'c', target, 'clang', false,
-		[])
+	assert !v3_direct_test_input_is_incompatible(false, malformed_file, 'c', target, 'clang', false, [])
+	assert v3_direct_test_input_is_incompatible(true, false_test_file, 'c', target, 'clang', false, [])
 }
 
 fn test_v3_test_sqlite_present_uses_bundled_windows_source() {
@@ -452,12 +446,44 @@ fn test_v3_test_sqlite_present_uses_bundled_windows_source() {
 }
 
 fn test_v3_prod_c_optimization_flags_skip_lto_for_tcc() {
-	assert v3_prod_c_optimization_flags(true, false, false, false, false) == ['-O3', '-flto']
-	assert v3_prod_c_optimization_flags(true, false, false, false, true) == ['-O3']
-	assert v3_prod_c_optimization_flags(true, false, true, false, false) == ['-O3']
-	assert v3_prod_c_optimization_flags(true, false, false, true, false) == ['-O3']
-	assert v3_prod_c_optimization_flags(false, false, false, false, false) == []
-	assert v3_prod_c_optimization_flags(true, true, false, false, false) == []
+	assert v3_prod_c_optimization_flags(true, false, false, false, false, false, false) == [
+		'-O3',
+		'-flto',
+	]
+	assert v3_prod_c_optimization_flags(true, false, false, false, true, false, false) == [
+		'-O2',
+		'-flto',
+	]
+	assert v3_prod_c_optimization_flags(true, false, false, false, true, true, false) == [
+		'-O2',
+		'-flto',
+		'-mllvm',
+		'-inline-threshold=75',
+	]
+	assert v3_prod_c_optimization_flags(true, false, false, false, false, false, true) == [
+		'-O3',
+	]
+	assert v3_prod_c_optimization_flags(true, false, true, false, false, false, false) == [
+		'-O3',
+	]
+	assert v3_prod_c_optimization_flags(true, false, false, true, false, false, false) == [
+		'-O3',
+	]
+	assert v3_prod_c_optimization_flags(false, false, false, false, false, false, false) == []
+	assert v3_prod_c_optimization_flags(true, true, false, false, false, false, false) == []
+	assert !v3_is_large_prod_c_unit(v3_large_prod_c_unit_threshold - 1)
+	assert v3_is_large_prod_c_unit(v3_large_prod_c_unit_threshold)
+}
+
+fn test_v3_prod_c_object_optimization_flags_keep_cached_objects_out_of_lto() {
+	assert v3_prod_c_object_optimization_flags(true, false, false, false, false) == [
+		'-O3',
+	]
+	assert v3_prod_c_object_optimization_flags(true, false, false, true, false) == [
+		'-O3',
+	]
+	assert v3_prod_c_object_optimization_flags(false, false, false, false, false) == []
+	assert v3_prod_c_object_optimization_flags(true, true, false, false, false) == []
 }
 
 fn test_effective_c_compiler_name_detects_path_valued_tcc() {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -4219,8 +4219,7 @@ fn (mut g FlatGen) collect_gen_info(no_parallel bool) {
 			continue
 		}
 		if node.kind == .directive {
-			directive_handled := g.collect_c_directive(cur_module, node, cur_file,
-				!seen_import_in_file)
+			directive_handled := g.collect_c_directive(cur_module, node, cur_file, !seen_import_in_file)
 			if directive_handled {
 				continue
 			}
@@ -4824,19 +4823,15 @@ fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, sourc
 		// compiler has to parse them either way; expanding them into the generated
 		// translation unit first only makes V scan and copy several megabytes.
 		if !g.cache_split && node.value == 'include' {
-			if header_path := c_compiler_header_to_preserve(include_arg, g.compiler_vroot,
-				source_file, include_dirs)
-			{
+			if header_path := c_compiler_header_to_preserve(include_arg, g.compiler_vroot, source_file, include_dirs) {
 				header_text := os.read_file(header_path) or { '' }
 				if header_text.len > 0 {
-					g.record_header_owned_include(module_name, include_arg, source_file,
-						before_import, true)
+					g.record_header_owned_include(module_name, include_arg, source_file, before_import, true)
 					g.collect_inlined_c_structs_ex(header_text, true)
 					g.prescanned_header_files[os.real_path(header_path)] = true
 					g.collect_inlined_c_fns(header_text)
 					g.collect_inlined_c_declared_fns(header_text)
-					if c_header_text_needs_objective_c_for_target(header_text, g.c_flags,
-						g.c99_mode, g.target) && 'objective-c' !in g.c_flags {
+					if c_header_text_needs_objective_c_for_target(header_text, g.c_flags, g.c99_mode, g.target) && 'objective-c' !in g.c_flags {
 						g.c_flags << ['-x', 'objective-c', '-x', 'none']
 					}
 					g.add_c_directive(module_name, '#include ${include_arg}', before_import)
@@ -5087,8 +5082,7 @@ fn (mut g FlatGen) collect_header_owned_c_typedefs_with_include_dirs(include_arg
 	g.ensure_header_owned_macro_context()
 	if c_header_owned_system_include_skips_tree_scan(include_arg) {
 		g.collect_known_header_owned_c_typedef_names(include_arg)
-		g.header_owned_macro_context.state = c_header_macro_state_after_unknown_include(
-			g.header_owned_macro_context.state)
+		g.header_owned_macro_context.state = c_header_macro_state_after_unknown_include(g.header_owned_macro_context.state)
 		return
 	}
 	quote_include_dirs := c_flag_quote_include_dirs(g.header_owned_effective_c_flags())
@@ -5771,8 +5765,7 @@ fn (mut g FlatGen) collect_header_owned_c_typedef_file(path string, include_dirs
 			framework_include_dirs: framework_include_dirs
 			feature_predicates: feature_predicates
 		}
-		scan := c_header_definitely_active_scan_with_include_results(text, state, strict_iso_mode,
-			g.target, include_results, include_context)
+		scan := c_header_definitely_active_scan_with_include_results(text, state, strict_iso_mode, g.target, include_results, include_context)
 		cgen_worker_scope_leave(scan_scope)
 		if scan.has_pragma_once {
 			g.header_owned_pragma_once_seen[real_path] = true
@@ -5808,8 +5801,7 @@ fn (mut g FlatGen) collect_header_owned_c_typedef_file(path string, include_dirs
 			raw_include_arg = raw_include_arg.clone()
 		}
 		cgen_worker_scope_free(scan_scope)
-		include_args := c_header_owned_include_args(raw_include_arg, include_state,
-			g.compiler_vroot, real_path)
+		include_args := c_header_owned_include_args(raw_include_arg, include_state, g.compiler_vroot, real_path)
 		mut found := false
 		mut result_state := CHeaderMacroState{}
 		mut result_typedef_aliases := []string{}
@@ -5901,15 +5893,14 @@ fn (mut g FlatGen) collect_header_owned_c_typedef_file(path string, include_dirs
 		}
 	}
 	fallback_scope := cgen_worker_scope_begin(g.scope_parallel_workers)
-	fallback_scan := c_header_definitely_active_scan_in_file(text, state, strict_iso_mode, g.target,
-		CHeaderIncludeContext{
-			vroot: g.compiler_vroot
-			source_file: real_path
-			include_dirs: include_dirs
-			quote_include_dirs: quote_include_dirs
-			framework_include_dirs: framework_include_dirs
-			feature_predicates: feature_predicates
-		})
+	fallback_scan := c_header_definitely_active_scan_in_file(text, state, strict_iso_mode, g.target, CHeaderIncludeContext{
+		vroot: g.compiler_vroot
+		source_file: real_path
+		include_dirs: include_dirs
+		quote_include_dirs: quote_include_dirs
+		framework_include_dirs: framework_include_dirs
+		feature_predicates: feature_predicates
+	})
 	cgen_worker_scope_leave(fallback_scope)
 	if fallback_scan.has_pragma_once {
 		g.header_owned_pragma_once_seen[real_path] = true
@@ -6292,8 +6283,7 @@ fn (mut g FlatGen) collect_preserved_header_file_with_state_and_scope(path strin
 			}
 		}
 		if unresolved_include < 0 {
-			result := g.finish_preserved_header_scan(scan, visit_key, collect_declarations,
-				scan_scope)
+			result := g.finish_preserved_header_scan(scan, visit_key, collect_declarations, scan_scope)
 			cgen_worker_scope_free(scan_scope)
 			return result
 		}
@@ -6347,8 +6337,7 @@ fn (mut g FlatGen) collect_preserved_header_file_with_state_and_scope(path strin
 		feature_predicates: feature_predicates
 	})
 	cgen_worker_scope_leave(fallback_scope)
-	result := g.finish_preserved_header_scan(fallback_scan, visit_key, collect_declarations,
-		fallback_scope)
+	result := g.finish_preserved_header_scan(fallback_scan, visit_key, collect_declarations, fallback_scope)
 	cgen_worker_scope_free(fallback_scope)
 	return result
 }
@@ -6463,12 +6452,11 @@ fn c_header_macro_state_clone(state CHeaderMacroState) CHeaderMacroState {
 
 fn c_header_macro_state_promote(state CHeaderMacroState, scope voidptr) CHeaderMacroState {
 	return CHeaderMacroState{
-		defined:                  promote_cgen_string_bool_lookup(state.defined, scope)
-		undefined:                promote_cgen_string_bool_lookup(state.undefined, scope)
-		uncertain:                promote_cgen_string_bool_lookup(state.uncertain, scope)
-		macro_values:             promote_cgen_string_string_lookup(state.macro_values, scope)
-		function_macro_values:    promote_cgen_string_string_lookup(state.function_macro_values,
-			scope)
+		defined: promote_cgen_string_bool_lookup(state.defined, scope)
+		undefined: promote_cgen_string_bool_lookup(state.undefined, scope)
+		uncertain: promote_cgen_string_bool_lookup(state.uncertain, scope)
+		macro_values: promote_cgen_string_string_lookup(state.macro_values, scope)
+		function_macro_values: promote_cgen_string_string_lookup(state.function_macro_values, scope)
 		external_macros_possible: state.external_macros_possible
 	}
 }
@@ -9696,9 +9684,8 @@ fn c_include_should_remain_in_inlined_text(include_arg string) bool {
 
 fn c_preserved_system_include_skips_tree_scan(include_arg string) bool {
 	return trimmed_space(include_arg) in ['<Cocoa/Cocoa.h>', '<Foundation/Foundation.h>',
-		'<AppKit/AppKit.h>', '<mbedtls/net_sockets.h>', '<mbedtls/ssl.h>',
-		'<mbedtls/entropy.h>', '<mbedtls/ctr_drbg.h>', '<mbedtls/error.h>',
-		'<mbedtls/threading.h>', '<mbedtls/oid.h>']
+		'<AppKit/AppKit.h>', '<mbedtls/net_sockets.h>', '<mbedtls/ssl.h>', '<mbedtls/entropy.h>',
+		'<mbedtls/ctr_drbg.h>', '<mbedtls/error.h>', '<mbedtls/threading.h>', '<mbedtls/oid.h>']
 }
 
 fn c_header_owned_system_include_skips_tree_scan(include_arg string) bool {
@@ -9722,13 +9709,11 @@ fn c_header_owned_uses_single_scan(path string, vroot string) bool {
 		return false
 	}
 	relative_path := clean_path.trim_string_left(clean_vroot)
-	return relative_path in ['/thirdparty/sokol/sokol_app.h',
-		'/thirdparty/sokol/sokol_gfx.h', '/thirdparty/sokol/util/sokol_gl.h',
-		'/thirdparty/sokol/sokol_v.post.h', '/thirdparty/stb_image/stb_image.h',
-		'/thirdparty/stb_image/stb_image_write.h',
-		'/thirdparty/stb_image/stb_image_resize2.h',
-		'/thirdparty/stb_image/stb_v_header.h', '/thirdparty/fontstash/fontstash.h',
-		'/thirdparty/sokol/util/sokol_fontstash.h']
+	return relative_path in ['/thirdparty/sokol/sokol_app.h', '/thirdparty/sokol/sokol_gfx.h',
+		'/thirdparty/sokol/util/sokol_gl.h', '/thirdparty/sokol/sokol_v.post.h',
+		'/thirdparty/stb_image/stb_image.h', '/thirdparty/stb_image/stb_image_write.h',
+		'/thirdparty/stb_image/stb_image_resize2.h', '/thirdparty/stb_image/stb_v_header.h',
+		'/thirdparty/fontstash/fontstash.h', '/thirdparty/sokol/util/sokol_fontstash.h']
 }
 
 fn c_compiler_header_to_preserve(include_arg string, vroot string, source_file string, include_dirs []string) ?string {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -97,6 +97,41 @@ fn clone_cgen_string_bool_lookup(values map[string]bool) map[string]bool {
 	return cloned
 }
 
+@[inline]
+fn cgen_scope_owns(scope voidptr, ptr voidptr) bool {
+	$if prealloc {
+		if scope != unsafe { nil } {
+			return unsafe { prealloc_scope_owns(scope, ptr) }
+		}
+	}
+	return false
+}
+
+fn promote_cgen_string_bool_lookup(values map[string]bool, scope voidptr) map[string]bool {
+	mut promoted := map[string]bool{}
+	promoted.reserve(u32(values.len))
+	for key, value in values {
+		owned_key := if key.len > 0 && cgen_scope_owns(scope, key.str) { key.clone() } else { key }
+		promoted[owned_key] = value
+	}
+	return promoted
+}
+
+fn promote_cgen_string_string_lookup(values map[string]string, scope voidptr) map[string]string {
+	mut promoted := map[string]string{}
+	promoted.reserve(u32(values.len))
+	for key, value in values {
+		owned_key := if key.len > 0 && cgen_scope_owns(scope, key.str) { key.clone() } else { key }
+		owned_value := if value.len > 0 && cgen_scope_owns(scope, value.str) {
+			value.clone()
+		} else {
+			value
+		}
+		promoted[owned_key] = owned_value
+	}
+	return promoted
+}
+
 fn clone_c_inline_header(header CInlineHeader) CInlineHeader {
 	mut preserved_headers := []CPreservedHeader{cap: header.preserved_headers.len}
 	for preserved_header in header.preserved_headers {
@@ -385,6 +420,8 @@ mut:
 	module_imports                 map[string][]string // module -> imported modules
 	c_directives                   []CDirective
 	header_owned_c_typedefs        map[string]bool
+	prescanned_header_c_typedefs   map[string]bool
+	prescanned_header_files        map[string]bool
 	inlined_c_source_typedefs      map[string]bool
 	header_owned_directives        []CHeaderOwnershipDirective
 	preinclude_header_owned        []CHeaderOwnershipDirective
@@ -1126,6 +1163,8 @@ pub fn FlatGen.new() FlatGen {
 		module_imports: map[string][]string{}
 		c_directives: []CDirective{}
 		header_owned_c_typedefs: map[string]bool{}
+		prescanned_header_c_typedefs: map[string]bool{}
+		prescanned_header_files: map[string]bool{}
 		inlined_c_source_typedefs: map[string]bool{}
 		header_owned_directives: []CHeaderOwnershipDirective{}
 		preinclude_header_owned: []CHeaderOwnershipDirective{}
@@ -2924,6 +2963,8 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.module_imports.clear()
 	g.c_directives = []CDirective{}
 	g.header_owned_c_typedefs.clear()
+	g.prescanned_header_c_typedefs.clear()
+	g.prescanned_header_files.clear()
 	g.inlined_c_source_typedefs.clear()
 	g.header_owned_directives = []CHeaderOwnershipDirective{}
 	g.preinclude_header_owned = []CHeaderOwnershipDirective{}
@@ -4177,8 +4218,12 @@ fn (mut g FlatGen) collect_gen_info(no_parallel bool) {
 		if g.incremental_fn_names.len > 0 && node.kind == .directive {
 			continue
 		}
-		if g.collect_c_directive(cur_module, node, cur_file, !seen_import_in_file) {
-			continue
+		if node.kind == .directive {
+			directive_handled := g.collect_c_directive(cur_module, node, cur_file,
+				!seen_import_in_file)
+			if directive_handled {
+				continue
+			}
 		}
 		if node.kind == .directive && node.value == 'flag' {
 			continue
@@ -4559,35 +4604,45 @@ fn (mut g FlatGen) preseed_unused_fn_ptr_param_types(node flat.Node, module_name
 
 fn (mut g FlatGen) collect_c_flags_from_directives() {
 	mut cur_file := ''
+	mut cur_module := ''
 	mut seen_groups := map[string]bool{}
+	mut main_groups := [][]string{}
 	for node_idx in g.top_level_nodes() {
 		node := g.a.nodes[node_idx]
 		kind_id := node_kind_id(node)
 		if kind_id == 77 {
 			cur_file = node.value
+			cur_module = ''
 			g.note_compiler_source_file(node.value)
+			continue
+		}
+		if node.kind == .module_decl {
+			cur_module = node.value
 			continue
 		}
 		if node.kind != .directive || node.typ.len == 0 {
 			continue
 		}
-		if node.value == 'flag' {
-			flags := c_flag_args_with_values(node.typ, g.compiler_vroot, cur_file, g.target, g.compile_values)
-			key := flags.join('\x00')
-			if flags.len > 0 && key !in seen_groups {
-				seen_groups[key] = true
-				g.c_flags << flags
-			}
+		flags := if node.value == 'flag' {
+			c_flag_args_with_values(node.typ, g.compiler_vroot, cur_file, g.target, g.compile_values)
+		} else if node.value == 'pkgconfig' {
+			c_pkgconfig_flags(node.typ)
+		} else {
 			continue
 		}
-		if node.value == 'pkgconfig' {
-			flags := c_pkgconfig_flags(node.typ)
-			key := flags.join('\x00')
-			if flags.len > 0 && key !in seen_groups {
-				seen_groups[key] = true
-				g.c_flags << flags
-			}
+		key := flags.join('\x00')
+		if flags.len == 0 || key in seen_groups {
+			continue
 		}
+		seen_groups[key] = true
+		if cur_module in ['', 'main'] {
+			main_groups << flags
+		} else {
+			g.c_flags << flags
+		}
+	}
+	for flags in main_groups {
+		g.c_flags << flags
 	}
 }
 
@@ -4596,9 +4651,16 @@ pub fn cache_directive_flags(a &flat.FlatAst, vroot string, target pref.Target, 
 	mut result := []string{}
 	mut seen_groups := map[string]bool{}
 	mut cur_file := ''
+	mut cur_module := ''
+	mut main_groups := [][]string{}
 	for node in a.nodes {
 		if node.kind == .file {
 			cur_file = node.value
+			cur_module = ''
+			continue
+		}
+		if node.kind == .module_decl {
+			cur_module = node.value
 			continue
 		}
 		if node.kind != .directive || node.typ.len == 0 {
@@ -4614,8 +4676,15 @@ pub fn cache_directive_flags(a &flat.FlatAst, vroot string, target pref.Target, 
 		key := flags.join('\x00')
 		if flags.len > 0 && key !in seen_groups {
 			seen_groups[key] = true
-			result << flags
+			if cur_module in ['', 'main'] {
+				main_groups << flags
+			} else {
+				result << flags
+			}
 		}
+	}
+	for flags in main_groups {
+		result << flags
 	}
 	return result
 }
@@ -4751,6 +4820,30 @@ fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, sourc
 		if !c_include_arg_is_source_file(include_arg) {
 			g.add_native_source_context_directive(module_name, c_native_source_context_header_include(include_arg, g.compiler_vroot, source_file, include_dirs), before_import)
 		}
+		// Keep large compiler-shipped implementation headers as real includes. The C
+		// compiler has to parse them either way; expanding them into the generated
+		// translation unit first only makes V scan and copy several megabytes.
+		if !g.cache_split && node.value == 'include' {
+			if header_path := c_compiler_header_to_preserve(include_arg, g.compiler_vroot,
+				source_file, include_dirs)
+			{
+				header_text := os.read_file(header_path) or { '' }
+				if header_text.len > 0 {
+					g.record_header_owned_include(module_name, include_arg, source_file,
+						before_import, true)
+					g.collect_inlined_c_structs_ex(header_text, true)
+					g.prescanned_header_files[os.real_path(header_path)] = true
+					g.collect_inlined_c_fns(header_text)
+					g.collect_inlined_c_declared_fns(header_text)
+					if c_header_text_needs_objective_c_for_target(header_text, g.c_flags,
+						g.c99_mode, g.target) && 'objective-c' !in g.c_flags {
+						g.c_flags << ['-x', 'objective-c', '-x', 'none']
+					}
+					g.add_c_directive(module_name, '#include ${include_arg}', before_import)
+					return true
+				}
+			}
+		}
 		if trimmed_space(include_arg) == '<objc/message.h>' {
 			g.record_header_owned_include(module_name, include_arg, source_file, before_import, true)
 			g.collect_preserved_c_fns(c_preserved_system_include_declared_fns(include_arg))
@@ -4863,6 +4956,9 @@ fn (mut g FlatGen) record_header_owned_include(module_name string, include_arg s
 fn (mut g FlatGen) rebuild_header_owned_c_typedefs() {
 	g.header_owned_c_typedefs.clear()
 	for alias, _ in g.inlined_c_source_typedefs {
+		g.header_owned_c_typedefs[alias] = true
+	}
+	for alias, _ in g.prescanned_header_c_typedefs {
 		g.header_owned_c_typedefs[alias] = true
 	}
 	g.header_owned_pragma_once_seen.clear()
@@ -4989,6 +5085,12 @@ fn (mut g FlatGen) collect_header_owned_c_typedefs_with_include_dirs(include_arg
 		return
 	}
 	g.ensure_header_owned_macro_context()
+	if c_header_owned_system_include_skips_tree_scan(include_arg) {
+		g.collect_known_header_owned_c_typedef_names(include_arg)
+		g.header_owned_macro_context.state = c_header_macro_state_after_unknown_include(
+			g.header_owned_macro_context.state)
+		return
+	}
 	quote_include_dirs := c_flag_quote_include_dirs(g.header_owned_effective_c_flags())
 	framework_include_dirs := c_flag_framework_include_dirs(g.header_owned_effective_c_flags())
 	if g.header_owned_macro_context.conditionals.any(!it.current_possible) {
@@ -5637,11 +5739,20 @@ fn (mut g FlatGen) collect_header_owned_c_typedef_file(path string, include_dirs
 	if real_path.len == 0 || seen[real_path] || g.header_owned_pragma_once_seen[real_path] {
 		return c_header_macro_state_clone(state)
 	}
+	if g.prescanned_header_files[real_path] {
+		return c_header_macro_state_after_unknown_include(state)
+	}
 	seen[real_path] = true
 	defer {
 		seen.delete(real_path)
 	}
 	text := os.read_file(real_path) or { return c_header_macro_state_clone(state) }
+	// These compiler-shipped header-only libraries declare the public typedefs
+	// consumed by V in the parent file; their platform includes add no such names.
+	if c_header_owned_uses_single_scan(real_path, g.compiler_vroot) {
+		g.collect_header_owned_c_typedef_text(text)
+		return c_header_macro_state_after_unknown_include(state)
+	}
 	feature_predicates := c_header_compiler_feature_predicate_values(g.ccompiler, g.header_owned_effective_c_flags(), g.c99_mode, g.target, text)
 	strict_iso_mode := c_effective_strict_iso_mode(g.c_flags, g.c99_mode)
 	quote_include_dirs := c_flag_quote_include_dirs(g.header_owned_effective_c_flags())
@@ -5651,6 +5762,7 @@ fn (mut g FlatGen) collect_header_owned_c_typedef_file(path string, include_dirs
 	// Resolve includes from left to right so child macro effects determine later
 	// branches. Only the final definitely active text can own a typedef name.
 	for _ in 0 .. c_join_continued_lines(text).len + 2 {
+		scan_scope := cgen_worker_scope_begin(g.scope_parallel_workers)
 		include_context := CHeaderIncludeContext{
 			vroot: g.compiler_vroot
 			source_file: real_path
@@ -5659,7 +5771,9 @@ fn (mut g FlatGen) collect_header_owned_c_typedef_file(path string, include_dirs
 			framework_include_dirs: framework_include_dirs
 			feature_predicates: feature_predicates
 		}
-		scan := c_header_definitely_active_scan_with_include_results(text, state, strict_iso_mode, g.target, include_results, include_context)
+		scan := c_header_definitely_active_scan_with_include_results(text, state, strict_iso_mode,
+			g.target, include_results, include_context)
+		cgen_worker_scope_leave(scan_scope)
 		if scan.has_pragma_once {
 			g.header_owned_pragma_once_seen[real_path] = true
 		}
@@ -5675,22 +5789,53 @@ fn (mut g FlatGen) collect_header_owned_c_typedef_file(path string, include_dirs
 			c_record_active_include_macro_definitions(scan.text, macro_line_index, -1, mut include_macros, mut dynamic_include_macros, mut literal_include_macros)
 			g.collect_header_owned_c_typedef_text(scan.text)
 			g.collect_header_owned_c_typedef_text(scan.typedef_macro_expansions)
-			return c_header_macro_state_clone(scan.final_state)
+			result := c_header_macro_state_promote(scan.final_state, scan_scope)
+			cgen_worker_scope_free(scan_scope)
+			return result
 		}
-		include_key := scan.include_keys[unresolved_include]
+		mut include_key := scan.include_keys[unresolved_include]
 		include_line_index := include_key.all_before(':').int()
 		c_record_active_include_macro_definitions(scan.text, macro_line_index, include_line_index, mut include_macros, mut dynamic_include_macros, mut literal_include_macros)
 		macro_line_index = include_line_index + 1
-		include_state := scan.include_states[unresolved_include]
+		mut include_state := scan.include_states[unresolved_include]
 		include_is_definitely_active := scan.include_definitely_active[unresolved_include]
 		include_at_file_scope := scan.include_at_file_scope[unresolved_include]
 		include_is_next := scan.include_next[unresolved_include]
-		raw_include_arg := scan.include_args[unresolved_include]
-		include_args := c_header_owned_include_args(raw_include_arg, include_state, g.compiler_vroot, real_path)
+		mut raw_include_arg := scan.include_args[unresolved_include]
+		if scan_scope != unsafe { nil } {
+			include_state = c_header_macro_state_promote(include_state, scan_scope)
+			include_key = include_key.clone()
+			raw_include_arg = raw_include_arg.clone()
+		}
+		cgen_worker_scope_free(scan_scope)
+		include_args := c_header_owned_include_args(raw_include_arg, include_state,
+			g.compiler_vroot, real_path)
 		mut found := false
 		mut result_state := CHeaderMacroState{}
 		mut result_typedef_aliases := []string{}
-		if include_is_definitely_active {
+		for nested_include_arg in include_args {
+			if !c_header_owned_system_include_skips_tree_scan(nested_include_arg) {
+				continue
+			}
+			if include_at_file_scope {
+				if include_is_definitely_active {
+					g.collect_known_header_owned_c_typedef_names(nested_include_arg)
+				} else {
+					mut owned_before := g.header_owned_c_typedefs.clone()
+					g.collect_known_header_owned_c_typedef_names(nested_include_arg)
+					for alias, _ in g.header_owned_c_typedefs {
+						if alias !in owned_before {
+							result_typedef_aliases << alias
+						}
+					}
+					g.header_owned_c_typedefs = owned_before.move()
+				}
+			}
+			result_state = c_header_macro_state_after_unknown_include(include_state)
+			found = true
+			break
+		}
+		if !found && include_is_definitely_active {
 			for nested_include_arg in include_args {
 				paths := c_header_owned_include_file_paths(nested_include_arg, g.compiler_vroot, real_path, include_dirs, quote_include_dirs, framework_include_dirs, include_is_next)
 				for nested_path in paths {
@@ -5712,7 +5857,7 @@ fn (mut g FlatGen) collect_header_owned_c_typedef_file(path string, include_dirs
 					break
 				}
 			}
-		} else {
+		} else if !found {
 			for nested_include_arg in include_args {
 				paths := c_header_owned_include_file_paths(nested_include_arg, g.compiler_vroot, real_path, include_dirs, quote_include_dirs, framework_include_dirs, include_is_next)
 				for nested_path in paths {
@@ -5755,21 +5900,26 @@ fn (mut g FlatGen) collect_header_owned_c_typedef_file(path string, include_dirs
 			typedef_aliases: result_typedef_aliases
 		}
 	}
-	fallback_scan := c_header_definitely_active_scan_in_file(text, state, strict_iso_mode, g.target, CHeaderIncludeContext{
-		vroot: g.compiler_vroot
-		source_file: real_path
-		include_dirs: include_dirs
-		quote_include_dirs: quote_include_dirs
-		framework_include_dirs: framework_include_dirs
-		feature_predicates: feature_predicates
-	})
+	fallback_scope := cgen_worker_scope_begin(g.scope_parallel_workers)
+	fallback_scan := c_header_definitely_active_scan_in_file(text, state, strict_iso_mode, g.target,
+		CHeaderIncludeContext{
+			vroot: g.compiler_vroot
+			source_file: real_path
+			include_dirs: include_dirs
+			quote_include_dirs: quote_include_dirs
+			framework_include_dirs: framework_include_dirs
+			feature_predicates: feature_predicates
+		})
+	cgen_worker_scope_leave(fallback_scope)
 	if fallback_scan.has_pragma_once {
 		g.header_owned_pragma_once_seen[real_path] = true
 	}
 	c_record_active_include_macro_definitions(fallback_scan.text, macro_line_index, -1, mut include_macros, mut dynamic_include_macros, mut literal_include_macros)
 	g.collect_header_owned_c_typedef_text(fallback_scan.text)
 	g.collect_header_owned_c_typedef_text(fallback_scan.typedef_macro_expansions)
-	return c_header_macro_state_clone(fallback_scan.final_state)
+	result := c_header_macro_state_promote(fallback_scan.final_state, fallback_scope)
+	cgen_worker_scope_free(fallback_scope)
+	return result
 }
 
 fn c_header_owned_include_args(raw string, state CHeaderMacroState, vroot string, source_file string) []string {
@@ -5981,6 +6131,15 @@ fn (mut g FlatGen) collect_preserved_include_metadata_with_state(include_arg str
 }
 
 fn (mut g FlatGen) collect_preserved_header_tree(include_arg string, source_file string, include_dirs []string) bool {
+	if c_preserved_system_include_skips_tree_scan(include_arg) {
+		// Apple umbrella headers expand into a very large, cyclic framework graph.
+		// Preserve the compiler-owned include and use the small ABI metadata table;
+		// propagating every framework macro state is both redundant and unbounded.
+		g.collect_preserved_c_fns(c_preserved_system_include_declared_fns(include_arg))
+		g.collect_preserved_c_structs(c_preserved_system_include_struct_names(include_arg))
+		g.collect_preserved_c_typedef_names(c_preserved_system_include_typedef_names(include_arg))
+		return true
+	}
 	probe_scope := cgen_worker_scope_begin(g.scope_parallel_workers)
 	mut preserved_path := ''
 	for path in c_include_file_paths(include_arg, g.compiler_vroot, source_file, include_dirs) {
@@ -6133,7 +6292,8 @@ fn (mut g FlatGen) collect_preserved_header_file_with_state_and_scope(path strin
 			}
 		}
 		if unresolved_include < 0 {
-			result := g.finish_preserved_header_scan(scan, visit_key, collect_declarations)
+			result := g.finish_preserved_header_scan(scan, visit_key, collect_declarations,
+				scan_scope)
 			cgen_worker_scope_free(scan_scope)
 			return result
 		}
@@ -6143,7 +6303,7 @@ fn (mut g FlatGen) collect_preserved_header_file_with_state_and_scope(path strin
 		include_is_next := scan.include_next[unresolved_include]
 		mut raw_include_arg := scan.include_args[unresolved_include]
 		if scan_scope != unsafe { nil } {
-			include_state = c_header_macro_state_clone(include_state)
+			include_state = c_header_macro_state_promote(include_state, scan_scope)
 			include_key = include_key.clone()
 			raw_include_arg = raw_include_arg.clone()
 		}
@@ -6187,12 +6347,13 @@ fn (mut g FlatGen) collect_preserved_header_file_with_state_and_scope(path strin
 		feature_predicates: feature_predicates
 	})
 	cgen_worker_scope_leave(fallback_scope)
-	result := g.finish_preserved_header_scan(fallback_scan, visit_key, collect_declarations)
+	result := g.finish_preserved_header_scan(fallback_scan, visit_key, collect_declarations,
+		fallback_scope)
 	cgen_worker_scope_free(fallback_scope)
 	return result
 }
 
-fn (mut g FlatGen) finish_preserved_header_scan(final_scan CHeaderActiveScan, visit_key string, collect_declarations bool) CHeaderMacroState {
+fn (mut g FlatGen) finish_preserved_header_scan(final_scan CHeaderActiveScan, visit_key string, collect_declarations bool, scope voidptr) CHeaderMacroState {
 	if collect_declarations {
 		g.collect_inlined_c_structs(final_scan.text)
 		g.collect_inlined_c_fns(final_scan.text)
@@ -6215,7 +6376,7 @@ fn (mut g FlatGen) finish_preserved_header_scan(final_scan CHeaderActiveScan, vi
 			g.possibly_active_c_macros[macro_name] = true
 		}
 	}
-	result := c_header_macro_state_clone(final_scan.final_state)
+	result := c_header_macro_state_promote(final_scan.final_state, scope)
 	g.preserved_header_scan_results[visit_key] = c_header_macro_state_clone(result)
 	g.preserved_header_scans_active.delete(visit_key)
 	return result
@@ -6296,6 +6457,18 @@ fn c_header_macro_state_clone(state CHeaderMacroState) CHeaderMacroState {
 		uncertain: state.uncertain.clone()
 		macro_values: state.macro_values.clone()
 		function_macro_values: state.function_macro_values.clone()
+		external_macros_possible: state.external_macros_possible
+	}
+}
+
+fn c_header_macro_state_promote(state CHeaderMacroState, scope voidptr) CHeaderMacroState {
+	return CHeaderMacroState{
+		defined:                  promote_cgen_string_bool_lookup(state.defined, scope)
+		undefined:                promote_cgen_string_bool_lookup(state.undefined, scope)
+		uncertain:                promote_cgen_string_bool_lookup(state.uncertain, scope)
+		macro_values:             promote_cgen_string_string_lookup(state.macro_values, scope)
+		function_macro_values:    promote_cgen_string_string_lookup(state.function_macro_values,
+			scope)
 		external_macros_possible: state.external_macros_possible
 	}
 }
@@ -9521,6 +9694,52 @@ fn c_include_should_remain_in_inlined_text(include_arg string) bool {
 	return clean in ['<dlfcn.h>', '<limits.h>', '<arm_neon.h>', '<objc/message.h>']
 }
 
+fn c_preserved_system_include_skips_tree_scan(include_arg string) bool {
+	return trimmed_space(include_arg) in ['<Cocoa/Cocoa.h>', '<Foundation/Foundation.h>',
+		'<AppKit/AppKit.h>', '<mbedtls/net_sockets.h>', '<mbedtls/ssl.h>',
+		'<mbedtls/entropy.h>', '<mbedtls/ctr_drbg.h>', '<mbedtls/error.h>',
+		'<mbedtls/threading.h>', '<mbedtls/oid.h>']
+}
+
+fn c_header_owned_system_include_skips_tree_scan(include_arg string) bool {
+	if c_preserved_system_include_skips_tree_scan(include_arg) {
+		return true
+	}
+	clean := trimmed_space(include_arg)
+	if clean.len < 3 || clean[0] != `<` || clean[clean.len - 1] != `>` {
+		return false
+	}
+	framework := clean[1..clean.len - 1].all_before('/')
+	return framework in ['AVFoundation', 'CoreFoundation', 'CoreGraphics', 'CoreVideo', 'GLKit',
+		'IOKit', 'Metal', 'MetalKit', 'OpenGL', 'OpenGLES', 'QuartzCore', 'UIKit', 'WebKit']
+}
+
+fn c_header_owned_uses_single_scan(path string, vroot string) bool {
+	clean_path := path.replace('\\', '/')
+	resolved_vroot := if os.exists(vroot) { os.real_path(vroot) } else { vroot }
+	clean_vroot := resolved_vroot.replace('\\', '/').trim_right('/')
+	if clean_vroot.len == 0 {
+		return false
+	}
+	relative_path := clean_path.trim_string_left(clean_vroot)
+	return relative_path in ['/thirdparty/sokol/sokol_app.h',
+		'/thirdparty/sokol/sokol_gfx.h', '/thirdparty/sokol/util/sokol_gl.h',
+		'/thirdparty/sokol/sokol_v.post.h', '/thirdparty/stb_image/stb_image.h',
+		'/thirdparty/stb_image/stb_image_write.h',
+		'/thirdparty/stb_image/stb_image_resize2.h',
+		'/thirdparty/stb_image/stb_v_header.h', '/thirdparty/fontstash/fontstash.h',
+		'/thirdparty/sokol/util/sokol_fontstash.h']
+}
+
+fn c_compiler_header_to_preserve(include_arg string, vroot string, source_file string, include_dirs []string) ?string {
+	for path in c_include_file_paths(include_arg, vroot, source_file, include_dirs) {
+		if os.is_file(path) && c_header_owned_uses_single_scan(os.real_path(path), vroot) {
+			return path
+		}
+	}
+	return none
+}
+
 fn c_preserved_system_include_declared_fns(include_arg string) []string {
 	if include_arg in ['"sqlite3.h"', '<sqlite3.h>'] {
 		return [
@@ -9752,7 +9971,7 @@ fn c_preserved_system_include_declared_fns(include_arg string) []string {
 		return ['EC_POINT_mul', 'EC_POINT_new', 'EC_POINT_point2buf', 'OPENSSL_free']
 	}
 	if include_arg == '<objc/message.h>' {
-		return ['objc_msgSend']
+		return ['objc_msgSend', 'objc_msgSendSuper']
 	}
 	return []string{}
 }
@@ -9818,6 +10037,27 @@ fn c_preserved_system_include_struct_names(include_arg string) []string {
 fn c_preserved_system_include_typedef_names(include_arg string) []string {
 	if include_arg.starts_with('<X11/') {
 		return c_preserved_system_include_struct_names(include_arg)
+	}
+	if include_arg == '<mbedtls/net_sockets.h>' {
+		return ['mbedtls_net_context']
+	}
+	if include_arg == '<mbedtls/ssl.h>' {
+		return [
+			'mbedtls_ssl_context',
+			'mbedtls_ssl_config',
+			'mbedtls_ssl_send_t',
+			'mbedtls_ssl_recv_t',
+			'mbedtls_ssl_recv_timeout_t',
+			'mbedtls_pk_context',
+			'mbedtls_x509_crt',
+			'mbedtls_x509_crl',
+		]
+	}
+	if include_arg == '<mbedtls/entropy.h>' {
+		return ['mbedtls_entropy_context']
+	}
+	if include_arg == '<mbedtls/ctr_drbg.h>' {
+		return ['mbedtls_ctr_drbg_context']
 	}
 	if include_arg in ['<Cocoa/Cocoa.h>', '<Foundation/Foundation.h>', '<AppKit/AppKit.h>'] {
 		return ['BOOL', 'NSRange', 'NSRect']
@@ -9943,6 +10183,10 @@ typedef unsigned long long uintmax_t;
 }
 
 fn (mut g FlatGen) collect_inlined_c_structs(text string) {
+	g.collect_inlined_c_structs_ex(text, false)
+}
+
+fn (mut g FlatGen) collect_inlined_c_structs_ex(text string, prescan_header_typedefs bool) {
 	for line in text.split_into_lines() {
 		clean := trimmed_space(line)
 		mut rest := ''
@@ -9979,10 +10223,16 @@ fn (mut g FlatGen) collect_inlined_c_structs(text string) {
 	for alias in c_typedef_all_aggregate_aliases(text) {
 		g.inlined_c_structs[alias] = true
 		g.inlined_c_typedef_names[alias] = true
+		if prescan_header_typedefs && 'C.${alias}' in g.tc.c_typedef_structs {
+			g.prescanned_header_c_typedefs[alias] = true
+		}
 	}
 	for alias in c_typedef_plain_aliases(text) {
 		g.inlined_c_structs[alias] = true
 		g.inlined_c_typedef_names[alias] = true
+		if prescan_header_typedefs && 'C.${alias}' in g.tc.c_typedef_structs {
+			g.prescanned_header_c_typedefs[alias] = true
+		}
 	}
 	for alias in c_typedef_fn_aliases(text) {
 		g.inlined_c_structs[alias] = true

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -140,12 +140,10 @@ fn (mut g FlatGen) collect_fn_gen_items() []FlatFnGenItem {
 	// the parallel path asks for prep, that walk also collects C-extern refs.
 	prep := g.want_parallel_prep
 	mut candidates := if prep && g.scope_parallel_workers && par_cgen_prep_enabled() {
-		g.collect_fn_gen_candidates_parallel(direct_array_access_fns, ignore_overflow_fns,
-			program_modules)
+		g.collect_fn_gen_candidates_parallel(direct_array_access_fns, ignore_overflow_fns, program_modules)
 	} else {
 		nodes := g.top_level_nodes()
-		g.collect_fn_gen_candidates_range(nodes, 0, nodes.len, '', '', direct_array_access_fns,
-			ignore_overflow_fns, program_modules)
+		g.collect_fn_gen_candidates_range(nodes, 0, nodes.len, '', '', direct_array_access_fns, ignore_overflow_fns, program_modules)
 	}
 	mut preferred_fns := map[string]PreferredFlatFnCandidate{}
 	preferred_fns.reserve(u32(candidates.len))
@@ -207,15 +205,15 @@ fn (mut g FlatGen) collect_fn_gen_items() []FlatFnGenItem {
 			flat_fn_gen_item_cost(g.a, item.node_id)
 		}
 		items << FlatFnGenItem{
-			node_id:                   item.node_id
-			file:                      item.file
-			module:                    item.module
-			c_name:                    item.c_name
-			cost:                      cost
+			node_id: item.node_id
+			file: item.file
+			module: item.module
+			c_name: item.c_name
+			cost: cost
 			is_program_specialization: preferred.has_program_specialization
-			is_program:                item.is_program
-			direct_array_access:       item.direct_array_access
-			ignore_overflow:           item.ignore_overflow
+			is_program: item.is_program
+			direct_array_access: item.direct_array_access
+			ignore_overflow: item.ignore_overflow
 		}
 	}
 	items.sort(a.c_name < b.c_name)
@@ -271,23 +269,22 @@ fn (mut g FlatGen) collect_fn_gen_candidates_range(nodes []int, start int, end i
 		}
 		qfn := g.qualified_fn_name_in_module_c(item_module, node.value)
 		is_program_specialization := g.is_program_specialization_fn_node_with_qfn(node, i, qfn)
-		if !g.should_emit_fn_node_in_module_known(node, item_module, item_file, qfn,
-			is_program_specialization) {
+		if !g.should_emit_fn_node_in_module_known(node, item_module, item_file, qfn, is_program_specialization) {
 			continue
 		}
 		preferred_name := g.fn_c_name_in_module(item_module, node.value)
 		candidates << FlatFnGenCandidate{
 			preferred_name: preferred_name
-			item:           FlatFnGenItem{
-				node_id:                   flat.NodeId(i)
-				file:                      item_file
-				module:                    item_module
-				c_name:                    preferred_name
+			item: FlatFnGenItem{
+				node_id: flat.NodeId(i)
+				file: item_file
+				module: item_module
+				c_name: preferred_name
 				is_program_specialization: is_program_specialization
-				is_program:                g.cache_program_files[item_file]
+				is_program: g.cache_program_files[item_file]
 					|| program_modules[item_module]
-				direct_array_access:       direct_array_access_fns.contains(i, node)
-				ignore_overflow:           ignore_overflow_fns.contains(i, node)
+				direct_array_access: direct_array_access_fns.contains(i, node)
+				ignore_overflow: ignore_overflow_fns.contains(i, node)
 			}
 		}
 	}
@@ -352,10 +349,10 @@ fn (g &FlatGen) fn_gen_selection_info() (DirectArrayAccessFns, DirectArrayAccess
 		}
 	}
 	return DirectArrayAccessFns{
-		node_ids:         direct_node_ids
+		node_ids: direct_node_ids
 		source_positions: direct_source_positions
 	}, DirectArrayAccessFns{
-		node_ids:         overflow_node_ids
+		node_ids: overflow_node_ids
 		source_positions: overflow_source_positions
 	}, program_modules
 }
@@ -669,8 +666,8 @@ fn (g &FlatGen) top_level_stmts() []TopLevelStmt {
 			}
 			if g.cgen_is_top_level_stmt(child_id) {
 				stmts << TopLevelStmt{
-					id:     child_id
-					file:   file_node.value
+					id: child_id
+					file: file_node.value
 					module: if module_name.len == 0 { 'main' } else { module_name }
 				}
 			}
@@ -703,8 +700,7 @@ fn (g &FlatGen) cgen_is_top_level_stmt(id flat.NodeId) bool {
 	}
 	node := g.a.nodes[int(id)]
 	return match node.kind {
-		.expr_stmt, .assign, .decl_assign, .selector_assign, .index_assign, .for_stmt,
-		.for_in_stmt, .if_expr, .assert_stmt, .defer_stmt {
+		.expr_stmt, .assign, .decl_assign, .selector_assign, .index_assign, .for_stmt, .for_in_stmt, .if_expr, .assert_stmt, .defer_stmt {
 			true
 		}
 		.block, .comptime_if {
@@ -730,8 +726,7 @@ fn (mut g FlatGen) should_emit_fn_node(node flat.Node, node_index int) bool {
 fn (mut g FlatGen) should_emit_fn_node_in_module(node flat.Node, node_index int, module_name string, file_name string) bool {
 	qfn := g.qualified_fn_name_in_module_c(module_name, node.value)
 	is_program_specialization := g.is_program_specialization_fn_node_with_qfn(node, node_index, qfn)
-	return g.should_emit_fn_node_in_module_known(node, module_name, file_name, qfn,
-		is_program_specialization)
+	return g.should_emit_fn_node_in_module_known(node, module_name, file_name, qfn, is_program_specialization)
 }
 
 fn (mut g FlatGen) should_emit_fn_node_in_module_known(node flat.Node, module_name string, file_name string, qfn string, is_program_specialization bool) bool {
@@ -742,7 +737,8 @@ fn (mut g FlatGen) should_emit_fn_node_in_module_known(node flat.Node, module_na
 		return true
 	}
 	if module_name == 'sync' && g.needs_shared_runtime
-		&& node.value in ['cpanic', 'cpanic_errno', 'should_be_zero', 'RwMutex.init', 'RwMutex.lazy_init', 'RwMutex.lock', 'RwMutex.unlock', 'RwMutex.rlock', 'RwMutex.runlock'] {
+		&& node.value in ['cpanic', 'cpanic_errno', 'should_be_zero', 'RwMutex.init',
+			'RwMutex.lazy_init', 'RwMutex.lock', 'RwMutex.unlock', 'RwMutex.rlock', 'RwMutex.runlock'] {
 		return true
 	}
 	// `array.pointers` is emitted as an intrinsic at call sites; the raw
@@ -765,9 +761,10 @@ fn (mut g FlatGen) should_emit_fn_node_in_module_known(node flat.Node, module_na
 		return true
 	}
 	if module_name == 'c'
-		&& (node.value in ['sum_type_index', 'sum_type_index_resolved', 'FlatGen.sum_type_index', 'FlatGen.sum_type_index_resolved']
-		|| qfn.ends_with('__FlatGen__sum_type_index')
-		|| qfn.ends_with('__FlatGen__sum_type_index_resolved')) {
+		&& (node.value in ['sum_type_index', 'sum_type_index_resolved', 'FlatGen.sum_type_index',
+			'FlatGen.sum_type_index_resolved']
+			|| qfn.ends_with('__FlatGen__sum_type_index')
+			|| qfn.ends_with('__FlatGen__sum_type_index_resolved')) {
 		return true
 	}
 	is_anon_fn := node.value.starts_with('__anon_fn_') || qfn.contains('__anon_fn_')
@@ -1015,8 +1012,8 @@ fn (mut g FlatGen) precompute_generic_method_candidate_index() {
 			continue
 		}
 		candidate := GenericMethodCandidate{
-			name:   name
-			ret:    ret
+			name: name
+			ret: ret
 			params: g.tc.fn_param_types[name] or { []types.Type{} }
 		}
 		g.add_generic_method_candidate(base_receiver, method, candidate)
@@ -1545,9 +1542,7 @@ fn (mut g FlatGen) direct_call_name_for_call_node(id flat.NodeId, node flat.Node
 	if (name in g.tc.fn_ret_types || name in g.tc.fn_param_types) && name !in g.tc.fn_generic_params {
 		return g.direct_call_name(name)
 	}
-	if specialized := g.specialized_generic_method_name_for_call_args(node, name,
-		int(node.children_count) - 1)
-	{
+	if specialized := g.specialized_generic_method_name_for_call_args(node, name, int(node.children_count) - 1) {
 		return g.cname(specialized)
 	}
 	return g.direct_call_name_for_call(id, name)
@@ -2118,8 +2113,7 @@ fn (g &FlatGen) receiver_method_registered(type_name string, method string) bool
 		return false
 	}
 	mut receivers := []string{}
-	for receiver in [type_name, type_name.all_after_last('.'),
-		g.tc.qualify_name(type_name)] {
+	for receiver in [type_name, type_name.all_after_last('.'), g.tc.qualify_name(type_name)] {
 		if receiver.len > 0 && receiver !in receivers {
 			receivers << receiver
 		}
@@ -2176,14 +2170,10 @@ fn (g &FlatGen) method_call_name_for_call(id flat.NodeId, node flat.Node, method
 	if concrete := g.concrete_generic_method_name_from_call_receiver(node, method_name) {
 		return concrete
 	}
-	if specialized := g.specialized_generic_method_name_for_call_args(node, method_name,
-		int(node.children_count))
-	{
+	if specialized := g.specialized_generic_method_name_for_call_args(node, method_name, int(node.children_count)) {
 		return specialized
 	}
-	if specialized := g.specialized_generic_method_name_for_call_with_arg_count(id, method_name,
-		int(node.children_count))
-	{
+	if specialized := g.specialized_generic_method_name_for_call_with_arg_count(id, method_name, int(node.children_count)) {
 		return specialized
 	}
 	return method_name
@@ -2411,8 +2401,7 @@ fn (g &FlatGen) specialized_generic_method_name_for_call_with_arg_count(id flat.
 		}
 	}
 	for lookup_receiver in generic_method_lookup_receivers(receiver) {
-		candidates := g.generic_method_candidates[generic_method_candidate_key(lookup_receiver,
-			method)] or { continue }
+		candidates := g.generic_method_candidates[generic_method_candidate_key(lookup_receiver, method)] or { continue }
 		for candidate in candidates {
 			if arg_count >= 0 && candidate.params.len != arg_count {
 				continue
@@ -2443,8 +2432,7 @@ fn (g &FlatGen) specialized_generic_method_name_for_call_args(node flat.Node, me
 	mut best_preference := -1
 	mut ambiguous := false
 	for lookup_receiver in generic_method_lookup_receivers(receiver) {
-		candidates := g.generic_method_candidates[generic_method_candidate_key(lookup_receiver,
-			method)] or { continue }
+		candidates := g.generic_method_candidates[generic_method_candidate_key(lookup_receiver, method)] or { continue }
 		for candidate in candidates {
 			if arg_count >= 0 && candidate.params.len != arg_count {
 				continue
@@ -3037,7 +3025,7 @@ fn (g &FlatGen) arg_is_null_pointer_literal(arg_id flat.NodeId, arg_node flat.No
 	return g.expr_is_nil_value(arg_id)
 		|| (arg_node.kind == .int_literal && (arg_node.value == '0' || arg_node.value.len == 0))
 		|| (arg_node.kind == .selector && arg_node.value == 'NULL' && arg_node.children_count > 0
-		&& g.a.child_node(&arg_node, 0).kind == .ident && g.a.child_node(&arg_node, 0).value == 'C')
+			&& g.a.child_node(&arg_node, 0).kind == .ident && g.a.child_node(&arg_node, 0).value == 'C')
 }
 
 fn (mut g FlatGen) gen_pointer_builtin_method_call(node flat.Node, fn_node &flat.Node, base_type types.Type) bool {
@@ -3244,8 +3232,7 @@ fn (g &FlatGen) expr_is_stable_for_reuse(id flat.NodeId) bool {
 	}
 	node := g.a.nodes[int(id)]
 	return match node.kind {
-		.ident, .int_literal, .float_literal, .bool_literal, .char_literal, .string_literal,
-		.nil_literal, .none_expr, .enum_val, .sizeof_expr, .typeof_expr {
+		.ident, .int_literal, .float_literal, .bool_literal, .char_literal, .string_literal, .nil_literal, .none_expr, .enum_val, .sizeof_expr, .typeof_expr {
 			true
 		}
 		.selector, .paren, .cast_expr {
@@ -3421,11 +3408,9 @@ fn (mut g FlatGen) gen_method_value_closure(selector_id flat.NodeId, base_id fla
 			params = g.interface_method_param_types(method_key) or { return false }
 			decl_key := g.interface_method_signature_key(receiver_name, method) or { method_key }
 			ret = g.tc.fn_ret_types[decl_key] or { types.Type(types.void_) }
-			g.add_spawn_wrapper_def('${g.interface_dispatch_signature(receiver_name,
-				g.cname(receiver_name), method)};')
+			g.add_spawn_wrapper_def('${g.interface_dispatch_signature(receiver_name, g.cname(receiver_name), method)};')
 			if !g.should_emit_interface_dispatch(receiver_name, method) {
-				g.add_spawn_wrapper_def(g.interface_dispatch_def_string(receiver_name,
-					g.cname(receiver_name), method))
+				g.add_spawn_wrapper_def(g.interface_dispatch_def_string(receiver_name, g.cname(receiver_name), method))
 			}
 		}
 		cname = g.cname(method_key)
@@ -3713,18 +3698,15 @@ fn (mut g FlatGen) gen_spawn_expr(node flat.Node) {
 				if call_node.children_count == 1 {
 					if receiver_type is types.Pointer {
 						if base_type is types.Pointer {
-							wrapper = g.ensure_receiver_spawn_wrapper(g.cname(method_name),
-								receiver_ct, ret_ct)
+							wrapper = g.ensure_receiver_spawn_wrapper(g.cname(method_name), receiver_ct, ret_ct)
 							base_expr := g.expr_to_string(base_id)
 							arg_expr = '(${receiver_ct})(${base_expr})'
 						} else if g.expr_is_addressable(base_id) {
-							wrapper = g.ensure_receiver_spawn_wrapper(g.cname(method_name),
-								receiver_ct, ret_ct)
+							wrapper = g.ensure_receiver_spawn_wrapper(g.cname(method_name), receiver_ct, ret_ct)
 							base_expr := g.expr_to_string(base_id)
 							arg_expr = '(${receiver_ct})(&(${base_expr}))'
 						} else {
-							receiver_value := g.spawn_packed_arg_for_call_param(method_name,
-								base_id, receiver_type, 0)
+							receiver_value := g.spawn_packed_arg_for_call_param(method_name, base_id, receiver_type, 0)
 							g.emit_args_spawn_expr(g.cname(method_name), [
 								receiver_value,
 							], ret_ct)
@@ -3734,21 +3716,18 @@ fn (mut g FlatGen) gen_spawn_expr(node flat.Node) {
 						// Casting the void* thread argument straight to a struct type
 						// is invalid C, so copy the value receiver into the heap arg
 						// struct and dispatch through the argument-packing path.
-						receiver_value := g.spawn_packed_arg_for_call_param(method_name, base_id,
-							receiver_type, 0)
+						receiver_value := g.spawn_packed_arg_for_call_param(method_name, base_id, receiver_type, 0)
 						g.emit_args_spawn_expr(g.cname(method_name), [receiver_value], ret_ct)
 						return
 					}
 				} else if param_types.len == int(call_node.children_count) {
 					// `spawn recv.method(a, b)` packs the receiver and arguments
 					// into a heap struct rather than dropping the call.
-					receiver_arg := g.spawn_packed_arg_for_call_param(method_name, base_id,
-						receiver_type, 0)
+					receiver_arg := g.spawn_packed_arg_for_call_param(method_name, base_id, receiver_type, 0)
 					mut packed_args := [receiver_arg]
 					for i in 1 .. param_types.len {
 						arg_id := g.a.child(&call_node, i)
-						packed_args << g.spawn_packed_arg_for_call_param(method_name, arg_id,
-							param_types[i], i)
+						packed_args << g.spawn_packed_arg_for_call_param(method_name, arg_id, param_types[i], i)
 					}
 					g.emit_args_spawn_expr(g.cname(method_name), packed_args, ret_ct)
 					return
@@ -3766,8 +3745,7 @@ fn (mut g FlatGen) gen_spawn_expr(node flat.Node) {
 				}
 				packed_args << g.spawn_packed_arg_for_param(arg_id, pt, expected_ct, i)
 			}
-			g.emit_fn_value_spawn_expr(call_id, g.a.child_node(&call_node, 0), fn_type,
-				packed_args, ret_ct)
+			g.emit_fn_value_spawn_expr(call_id, g.a.child_node(&call_node, 0), fn_type, packed_args, ret_ct)
 			return
 		}
 	}
@@ -3930,8 +3908,7 @@ fn (mut g FlatGen) ensure_fn_value_spawn_wrapper(fn_ct string, args []SpawnPacke
 	} else {
 		''
 	}
-	body := spawn_wrapper_body_with_pre('p->f(${call_args.join(', ')})', ret_ct, pre,
-		'${destroy}free(p); ')
+	body := spawn_wrapper_body_with_pre('p->f(${call_args.join(', ')})', ret_ct, pre, '${destroy}free(p); ')
 	g.add_spawn_wrapper_def('static void* ${wrapper_name}(void* arg) { ${struct_name}* p = (${struct_name}*)arg; ${body} }')
 	return wrapper_name, struct_name
 }
@@ -3946,8 +3923,7 @@ fn (mut g FlatGen) emit_fn_value_spawn_expr(call_id flat.NodeId, fn_node flat.No
 	// Only compiler-created immediate closures are consumed by spawn. A named local
 	// remains owned by the caller and may be invoked again after the worker joins.
 	destroys_fn := callable.kind == .ident && callable.value.starts_with('__immediate_closure_')
-	wrapper, struct_name := g.ensure_fn_value_spawn_wrapper(fn_ct, args, ret_ct, captures,
-		destroys_fn)
+	wrapper, struct_name := g.ensure_fn_value_spawn_wrapper(fn_ct, args, ret_ct, captures, destroys_fn)
 	tmp := g.tmp_count
 	g.tmp_count++
 	g.write('({ ${struct_name}* _sa${tmp} = (${struct_name}*)__v_thread_alloc(sizeof(${struct_name})); ')
@@ -4023,8 +3999,8 @@ fn (mut g FlatGen) spawn_fn_literal_captures(cfn string) []SpawnClosureCapture {
 		}
 		captures << SpawnClosureCapture{
 			global_cname: g.cname(name)
-			field_ct:     ct
-			copy_array:   decl_typ is types.ArrayFixed
+			field_ct: ct
+			copy_array: decl_typ is types.ArrayFixed
 		}
 	}
 	return captures
@@ -4107,9 +4083,9 @@ fn (mut g FlatGen) spawn_packed_arg_for_call_param(fn_name string, arg_id flat.N
 		if expr := g.shared_arg_storage_c_expr(arg_id) {
 			wrapper_ct := g.shared_spawn_wrapper_c_type(expected)
 			return SpawnPackedArg{
-				field_ct:    wrapper_ct
+				field_ct: wrapper_ct
 				assign_expr: expr
-				call_expr:   'p->a${field_idx}'
+				call_expr: 'p->a${field_idx}'
 			}
 		}
 	}
@@ -4158,17 +4134,17 @@ fn (mut g FlatGen) spawn_packed_arg_for_param(arg_id flat.NodeId, expected types
 	if expr := g.shared_lowered_spawn_arg_storage_c_expr(arg_id) {
 		wrapper_ct := g.shared_spawn_wrapper_c_type(expected)
 		return SpawnPackedArg{
-			field_ct:    wrapper_ct
+			field_ct: wrapper_ct
 			assign_expr: expr
-			call_expr:   'p->a${field_idx}'
+			call_expr: 'p->a${field_idx}'
 		}
 	}
 	if fixed := array_fixed_type(expected) {
 		return SpawnPackedArg{
-			field_ct:    expected_ct
+			field_ct: expected_ct
 			assign_expr: g.fixed_array_copy_source_string(arg_id, types.Type(fixed))
-			call_expr:   'p->a${field_idx}'
-			copy_array:  true
+			call_expr: 'p->a${field_idx}'
+			copy_array: true
 		}
 	}
 	if spawn_c_type_is_pointer(expected_ct) {
@@ -4176,70 +4152,70 @@ fn (mut g FlatGen) spawn_packed_arg_for_param(arg_id flat.NodeId, expected types
 		if storage := g.spawn_shared_value_arg_storage(arg_id) {
 			wrapper_ct := g.shared_spawn_wrapper_c_type(expected)
 			return SpawnPackedArg{
-				field_ct:    wrapper_ct
+				field_ct: wrapper_ct
 				assign_expr: storage
-				call_expr:   'p->a${field_idx}'
+				call_expr: 'p->a${field_idx}'
 			}
 		}
 		if child_id := g.spawn_materialized_pointer_rvalue_arg(arg_node) {
 			value_type := types.unwrap_pointer(expected)
 			return SpawnPackedArg{
-				field_ct:    g.tc.c_type(value_type)
+				field_ct: g.tc.c_type(value_type)
 				assign_expr: g.expr_to_string_with_expected_type(child_id, value_type)
-				call_expr:   '&p->a${field_idx}'
+				call_expr: '&p->a${field_idx}'
 			}
 		}
 		if child_id := g.addressed_rvalue_arg(arg_node) {
 			value_type := types.unwrap_pointer(expected)
 			return SpawnPackedArg{
-				field_ct:    g.tc.c_type(value_type)
+				field_ct: g.tc.c_type(value_type)
 				assign_expr: g.expr_to_string_with_expected_type(child_id, value_type)
-				call_expr:   '&p->a${field_idx}'
+				call_expr: '&p->a${field_idx}'
 			}
 		}
 		if child_id := g.spawn_stack_address_value(arg_id) {
 			value_type := types.unwrap_pointer(expected)
 			return SpawnPackedArg{
-				field_ct:    g.tc.c_type(value_type)
+				field_ct: g.tc.c_type(value_type)
 				assign_expr: g.expr_to_string_with_expected_type(child_id, value_type)
-				call_expr:   '&p->a${field_idx}'
+				call_expr: '&p->a${field_idx}'
 			}
 		}
 		if g.spawn_arg_expr_is_pointer_value(arg_id) {
 			return SpawnPackedArg{
-				field_ct:    expected_ct
+				field_ct: expected_ct
 				assign_expr: g.expr_to_string(arg_id)
-				call_expr:   'p->a${field_idx}'
+				call_expr: 'p->a${field_idx}'
 			}
 		}
 		if g.expr_is_addressable(arg_id) {
 			expr := g.expr_to_string(arg_id)
 			return SpawnPackedArg{
-				field_ct:    expected_ct
+				field_ct: expected_ct
 				assign_expr: '&${expr}'
-				call_expr:   'p->a${field_idx}'
+				call_expr: 'p->a${field_idx}'
 			}
 		}
 		value_type := types.unwrap_pointer(expected)
 		return SpawnPackedArg{
-			field_ct:    g.tc.c_type(value_type)
+			field_ct: g.tc.c_type(value_type)
 			assign_expr: g.expr_to_string_with_expected_type(arg_id, value_type)
-			call_expr:   '&p->a${field_idx}'
+			call_expr: '&p->a${field_idx}'
 		}
 	}
 	assign_expr := g.expr_to_string_with_expected_type(arg_id, expected)
 	if storage_expr := shared_storage_from_payload_value_expr(assign_expr) {
 		wrapper_ct := g.shared_spawn_wrapper_c_type(expected)
 		return SpawnPackedArg{
-			field_ct:    wrapper_ct
+			field_ct: wrapper_ct
 			assign_expr: storage_expr
-			call_expr:   'p->a${field_idx}'
+			call_expr: 'p->a${field_idx}'
 		}
 	}
 	return SpawnPackedArg{
-		field_ct:    expected_ct
+		field_ct: expected_ct
 		assign_expr: assign_expr
-		call_expr:   'p->a${field_idx}'
+		call_expr: 'p->a${field_idx}'
 	}
 }
 
@@ -4690,8 +4666,7 @@ fn (mut g FlatGen) gen_fn_in_module(node_id flat.NodeId, node flat.Node, module_
 		g.writeln('_vno_main_init_caller();')
 	}
 	g.gen_function_defer_prelude()
-	g.gen_profile_fn_begin(generated_fn_name, module_name, node.value, g.tc.declaration_has_attribute(node_id,
-		'inline'))
+	g.gen_profile_fn_begin(generated_fn_name, module_name, node.value, g.tc.declaration_has_attribute(node_id, 'inline'))
 
 	for i in 0 .. node.children_count {
 		id := g.a.child(&node, i)
@@ -4703,8 +4678,7 @@ fn (mut g FlatGen) gen_fn_in_module(node_id flat.NodeId, node flat.Node, module_
 	}
 	g.gen_all_defers()
 	g.gen_profile_fn_exit()
-	g.gen_ownership_drops(g.tc.ownership_drop_entries_at_fn_exit(qualify_name_in_module(module_name,
-		node.value)))
+	g.gen_ownership_drops(g.tc.ownership_drop_entries_at_fn_exit(qualify_name_in_module(module_name, node.value)))
 	if is_entry_main {
 		g.writeln('return 0;')
 	} else if g.cur_fn_ret_is_optional {
@@ -4802,8 +4776,7 @@ fn (mut g FlatGen) emit_object_file_export_wrappers() {
 		g.tc.cur_file = item.file
 		g.tc.cur_module = item.module
 		ret_type := g.fn_node_return_type(node, item.module)
-		concrete_optional := g.is_program_specialization_fn_node(node, int(item.node_id),
-			item.module)
+		concrete_optional := g.is_program_specialization_fn_node(node, int(item.node_id), item.module)
 		g.write(g.fn_return_type_name_for_context(ret_type, concrete_optional))
 		g.write(' ')
 		g.write(export_name)
@@ -5242,11 +5215,11 @@ fn (mut g FlatGen) gen_test_main() {
 		g.writeln('double __v3_test_suite_elapsed_ms = __v3_test_now_ms() - __v3_test_suite_start_ms;')
 		g.writeln('if (__v3_test_failures > 0) {')
 		g.indent++
-		g.writeln("printf(\"     Summary for running V tests in \\\"%s\\\": %d failed, %d passed, ${tests.len} total. Elapsed time: %.3f ms.\\n\", \"${c_escape(file_name)}\", ${tests.len} - __v3_test_passes, __v3_test_passes, __v3_test_suite_elapsed_ms);")
+		g.writeln('printf("     Summary for running V tests in \\"%s\\": %d failed, %d passed, ${tests.len} total. Elapsed time: %.3f ms.\\n", "${c_escape(file_name)}", ${tests.len} - __v3_test_passes, __v3_test_passes, __v3_test_suite_elapsed_ms);')
 		g.indent--
 		g.writeln('} else {')
 		g.indent++
-		g.writeln("printf(\"     Summary for running V tests in \\\"%s\\\": %d passed, ${tests.len} total. Elapsed time: %.3f ms.\\n\", \"${c_escape(file_name)}\", __v3_test_passes, __v3_test_suite_elapsed_ms);")
+		g.writeln('printf("     Summary for running V tests in \\"%s\\": %d passed, ${tests.len} total. Elapsed time: %.3f ms.\\n", "${c_escape(file_name)}", __v3_test_passes, __v3_test_suite_elapsed_ms);')
 		g.indent--
 		g.writeln('}')
 	}
@@ -5328,11 +5301,11 @@ fn (g &FlatGen) test_harness_fns() ([]TestHarnessFn, TestHarnessHooks) {
 							continue
 						}
 						tests << TestHarnessFn{
-							node_id:      child_id
-							name:         child.value
-							c_name:       cname
-							ret:          g.parse_node_type(&child)
-							file:         file_node.value
+							node_id: child_id
+							name: child.value
+							c_name: cname
+							ret: g.parse_node_type(&child)
+							file: file_node.value
 							failure_line: g.test_fn_failure_line(child_id)
 						}
 					}
@@ -5950,8 +5923,9 @@ fn (g &FlatGen) owned_capture_context_type(data_id flat.NodeId) ?types.Type {
 fn (mut g FlatGen) gen_owned_capture_closure_create(id flat.NodeId, node flat.Node, fn_name string, target_name string, resolved_target_name string) bool {
 	if node.children_count != 4
 		|| !(fn_name in ['closure.closure_create_with_data', 'closure__closure_create_with_data']
-		|| target_name in ['closure.closure_create_with_data', 'closure__closure_create_with_data']
-		|| resolved_target_name in ['closure.closure_create_with_data', 'closure__closure_create_with_data']) {
+			|| target_name in ['closure.closure_create_with_data', 'closure__closure_create_with_data']
+			|| resolved_target_name in ['closure.closure_create_with_data',
+				'closure__closure_create_with_data']) {
 		return false
 	}
 	context_type := g.owned_capture_context_type(g.a.child(&node, 2)) or { return false }
@@ -6095,9 +6069,7 @@ fn (mut g FlatGen) gen_c_call_int_out_wrap(id flat.NodeId, node flat.Node) bool 
 		if arg_id in g.cabi_int_out_args {
 			continue
 		}
-		if g.c_call_is_int_out_arg(arg_id, i - 1, param_types, typed_param_count,
-			is_native_variadic)
-		{
+		if g.c_call_is_int_out_arg(arg_id, i - 1, param_types, typed_param_count, is_native_variadic) {
 			out_args << arg_id
 		}
 	}
@@ -6301,15 +6273,13 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 	// stringification, instead of passing a scalar directly to `println(string)`.
 	if node.children_count == 2 && fn_name in ['println', 'eprintln', 'print', 'eprint']
 		&& (resolved_target_name.len == 0 || resolved_target_name == fn_name
-		|| resolved_target_name == 'builtin.${fn_name}') {
+			|| resolved_target_name == 'builtin.${fn_name}') {
 		arg_id := g.a.child(&node, 1)
 		arg_type := g.usable_expr_type(arg_id)
 		if g.interface_unaliased_type(arg_type) !is types.String {
 			arg_expr := g.expr_to_string(arg_id)
 			mut stringify_stack := []string{}
-			if str_expr := g.interface_implicit_str_expr(arg_type, arg_expr, false, mut
-				stringify_stack)
-			{
+			if str_expr := g.interface_implicit_str_expr(arg_type, arg_expr, false, mut stringify_stack) {
 				g.write(fn_name)
 				g.write('(')
 				g.write(str_expr)
@@ -6328,7 +6298,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 			|| (target_name.len > 0 && g.ownership_drop_intrinsic_name(target_name))
 			|| (g.tc.cur_module == 'builtin' && ownership_synthetic_drop_name(fn_name))
 			|| (resolved_target_name.len > 0
-			&& g.ownership_drop_intrinsic_name(resolved_target_name))
+				&& g.ownership_drop_intrinsic_name(resolved_target_name))
 	}
 	if node.children_count == 2 && is_ownership_drop {
 		arg_id := g.a.child(&node, 1)
@@ -6367,9 +6337,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 		g.gen_ownership_clone_ierror(g.a.child(&node, 1))
 		return
 	}
-	if g.gen_map_mutation_call_with_loop_copyback_guard(node, fn_name, target_name,
-		resolved_target_name)
-	{
+	if g.gen_map_mutation_call_with_loop_copyback_guard(node, fn_name, target_name, resolved_target_name) {
 		return
 	}
 	if fn_node.kind == .index && fn_node.value != 'range' {
@@ -6377,16 +6345,12 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 		arg_count := int(node.children_count) - runtime_start
 		mut specialized_name := ''
 		if target_name.contains('.') {
-			if specialized := g.specialized_generic_method_name_for_call_with_arg_count(id,
-				target_name, arg_count)
-			{
+			if specialized := g.specialized_generic_method_name_for_call_with_arg_count(id, target_name, arg_count) {
 				specialized_name = specialized
 			}
 		}
 		if specialized_name.len == 0 {
-			if specialized := g.specialized_generic_plain_fn_name_for_explicit_call(id, fn_node,
-				target_name)
-			{
+			if specialized := g.specialized_generic_plain_fn_name_for_explicit_call(id, fn_node, target_name) {
 				specialized_name = specialized
 			}
 		}
@@ -6474,7 +6438,8 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 		return
 	}
 	if target_name in ['json.encode', 'json__encode', 'json.encode_pretty', 'json__encode_pretty']
-		|| resolved_target_name in ['json.encode', 'json__encode', 'json.encode_pretty', 'json__encode_pretty']
+		|| resolved_target_name in ['json.encode', 'json__encode', 'json.encode_pretty',
+			'json__encode_pretty']
 		|| (g.tc.cur_module == 'json' && target_name in ['encode', 'encode_pretty']) {
 		// Old `json` module only; `json2`/`x.json2` are pure V (see
 		// is_json_decode_target_name).
@@ -6511,9 +6476,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 				&& !g.method_decl_receiver_wants_ptr(method_name, method_name, method_name) {
 				mut stack := []string{}
 				base_expr := g.expr_to_string(base_id)
-				if pointer_str := g.interface_pointer_str_expr(base_type.base_type, base_expr,
-					true, mut stack)
-				{
+				if pointer_str := g.interface_pointer_str_expr(base_type.base_type, base_expr, true, mut stack) {
 					g.write(pointer_str)
 					return
 				}
@@ -6568,9 +6531,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 		return
 	}
 	if resolved_module_call := g.selector_module_call_name(id, fn_node, node) {
-		call_args_name := if specialized := g.specialized_generic_plain_fn_name_for_call(id, node,
-			resolved_module_call)
-		{
+		call_args_name := if specialized := g.specialized_generic_plain_fn_name_for_call(id, node, resolved_module_call) {
 			specialized
 		} else {
 			resolved_module_call
@@ -6583,9 +6544,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 		return
 	}
 	if resolved_module_call := g.target_module_call_name(target_name, node) {
-		call_args_name := if specialized := g.specialized_generic_plain_fn_name_for_call(id, node,
-			resolved_module_call)
-		{
+		call_args_name := if specialized := g.specialized_generic_plain_fn_name_for_call(id, node, resolved_module_call) {
 			specialized
 		} else {
 			resolved_module_call
@@ -6769,9 +6728,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 			mut base_id := flat.NodeId(0)
 			mut emitted_callee_name := ''
 			mut emitted_param_name := ''
-			if g.is_explicit_generic_method_call_selector(fn_node, resolved_target_name,
-				target_name)
-			{
+			if g.is_explicit_generic_method_call_selector(fn_node, resolved_target_name, target_name) {
 				fn_node = g.a.child_node(fn_node, 0)
 			}
 			if fn_node.kind == .selector {
@@ -6947,8 +6904,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 							if clean_type is types.Struct {
 								struct_name = clean_type.name
 							}
-							method_name = g.resolved_receiver_method_for_call(resolved_target_name,
-								node, fn_node.value) or {
+							method_name = g.resolved_receiver_method_for_call(resolved_target_name, node, fn_node.value) or {
 								g.resolve_method_name(struct_name, fn_node.value)
 							}
 							if method_name.len == 0 {
@@ -6973,9 +6929,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 									method_name = str_method
 									base_id = g.a.child(fn_node, 0)
 									g.write(g.cname(str_method))
-								} else if embedded_method := g.embedded_method_name_for_type(clean_type,
-									fn_node.value)
-								{
+								} else if embedded_method := g.embedded_method_name_for_type(clean_type, fn_node.value) {
 									is_method = true
 									method_name = embedded_method
 									base_id = g.a.child(fn_node, 0)
@@ -6994,7 +6948,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 					}
 				} else if base.kind == .ident
 					&& (base.value in g.tc.structs || base.value in g.tc.enum_names || g.tc.qualify_name(base.value) in g.tc.structs
-					|| g.tc.qualify_name(base.value) in g.tc.enum_names) {
+						|| g.tc.qualify_name(base.value) in g.tc.enum_names) {
 					qname := if base.value in g.tc.structs || base.value in g.tc.enum_names {
 						base.value
 					} else {
@@ -7091,12 +7045,10 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 					}
 					if !is_method && clean_type is types.Struct && clean_type.name == 'IError' {
 						if fn_node.value == 'msg' {
-							g.gen_ierror_dynamic_method_expr(g.a.child(fn_node, 0), base_type,
-								'msg')
+							g.gen_ierror_dynamic_method_expr(g.a.child(fn_node, 0), base_type, 'msg')
 							return
 						} else if fn_node.value == 'code' {
-							g.gen_ierror_dynamic_method_expr(g.a.child(fn_node, 0), base_type,
-								'code')
+							g.gen_ierror_dynamic_method_expr(g.a.child(fn_node, 0), base_type, 'code')
 							return
 						}
 					}
@@ -7145,9 +7097,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 						// no value type, so handle it before the instance-method fallback.
 						base_node_s := g.a.child_node(fn_node, 0)
 						if base_node_s.kind == .ident {
-							if static_fn := g.static_method_fn_name(base_node_s.value,
-								fn_node.value)
-							{
+							if static_fn := g.static_method_fn_name(base_node_s.value, fn_node.value) {
 								g.write(g.direct_call_name(static_fn))
 								g.write('(')
 								for i in 1 .. node.children_count {
@@ -7166,8 +7116,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 						if clean_type is types.Struct {
 							struct_name = clean_type.name
 						}
-						method_name = g.resolved_receiver_method_for_call(resolved_target_name,
-							node, fn_node.value) or {
+						method_name = g.resolved_receiver_method_for_call(resolved_target_name, node, fn_node.value) or {
 							g.resolve_method_name(struct_name, fn_node.value)
 						}
 						if method_name.len == 0 {
@@ -7192,9 +7141,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 								method_name = str_method
 								base_id = g.a.child(fn_node, 0)
 								g.write(g.cname(str_method))
-							} else if embedded_method := g.embedded_method_name_for_type(clean_type,
-								fn_node.value)
-							{
+							} else if embedded_method := g.embedded_method_name_for_type(clean_type, fn_node.value) {
 								is_method = true
 								method_name = embedded_method
 								base_id = g.a.child(fn_node, 0)
@@ -7266,11 +7213,8 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 					} else if looked_up !is types.Void && fn_type_from(looked_up) != none {
 						emitted_callee_name = g.local_decl_cname(fn_ident.value)
 						g.write(emitted_callee_name)
-					} else if specialized := g.specialized_generic_plain_fn_name_for_call(id, node,
-						fn_ident.value)
-					{
-						emitted_callee_name = g.direct_call_name_for_call_node(id, node,
-							specialized)
+					} else if specialized := g.specialized_generic_plain_fn_name_for_call(id, node, fn_ident.value) {
+						emitted_callee_name = g.direct_call_name_for_call_node(id, node, specialized)
 						g.write(emitted_callee_name)
 					} else if g.resolved_name_is_generic_plain(call_key)
 						&& g.plain_concrete_fn_name_shadows_generic(fn_ident.value) {
@@ -7279,9 +7223,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 					} else if call_key in g.tc.fn_ret_types || call_key in g.tc.fn_param_types {
 						emitted_callee_name = g.direct_call_name_for_call_node(id, node, call_key)
 						g.write(emitted_callee_name)
-					} else if specialized := g.specialized_generic_method_name_for_call_with_arg_count(id,
-						fn_ident.value, -1)
-					{
+					} else if specialized := g.specialized_generic_method_name_for_call_with_arg_count(id, fn_ident.value, -1) {
 						emitted_param_name = specialized
 						emitted_callee_name = g.cname(specialized)
 						g.write(emitted_callee_name)
@@ -7388,14 +7330,14 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 					|| method_name.starts_with('AtomicVal_')
 					|| method_name.starts_with('AtomicVal.')
 					|| (receiver_type_name.contains('AtomicVal')
-					&& method_short in ['load', 'store', 'add', 'sub', 'swap', 'compare_and_swap'])
+						&& method_short in ['load', 'store', 'add', 'sub', 'swap', 'compare_and_swap'])
 				receiver_wants_ptr := wants_ptr || atomic_receiver_wants_ptr
 					|| g.method_receiver_is_mut(method_name)
 					|| g.fn_first_param_is_mut_receiver(base_method_name)
 					|| g.fn_first_param_is_mut_receiver(base_local_method_name)
 				receiver_wants_shared :=
 					g.fn_param_is_shared_for_call(0, actual_fn, emitted_callee_name, method_name, fn_name)
-					|| g.fn_param_is_shared_for_call(0, base_method_name, g.cname(base_method_name), '', '')
+						|| g.fn_param_is_shared_for_call(0, base_method_name, g.cname(base_method_name), '', '')
 				if receiver_wants_shared && (g.gen_shared_local_receiver_arg(base_id)
 					|| g.gen_shared_storage_expr(base_id)) {
 					arg_start = 1
@@ -7504,7 +7446,11 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 			expected_non_ctx := if is_method { param_types.len - 1 } else { param_types.len }
 			may_forward_ctx := callee_has_implicit_ctx && param_types.len > 1
 				&& num_call_args < expected_non_ctx && g.is_implicit_veb_ctx_param(param_types[1])
-			mut current_ctx_name := if may_forward_ctx { g.cur_veb_ctx_name() or { '' } } else { '' }
+			mut current_ctx_name := if may_forward_ctx {
+				g.cur_veb_ctx_name() or { '' }
+			} else {
+				''
+			}
 			forward_ctx := may_forward_ctx && current_ctx_name.len > 0
 			if forward_ctx && is_method {
 				g.write(', ${g.cname(current_ctx_name)}')
@@ -7554,14 +7500,11 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 					g.write('sizeof(${g.sizeof_target(arg_node.value)})')
 					continue
 				}
-				if g.gen_array_equality_literal_arg([emitted_callee_name, actual_fn, fn_name],
-					arg_idx, arg_id, arg_node)
-				{
+				if g.gen_array_equality_literal_arg([emitted_callee_name, actual_fn, fn_name], arg_idx, arg_id, arg_node) {
 					continue
 				}
 				if !is_c_call && arg_idx < typed_param_count {
-					arg_param_is_shared := g.fn_param_is_shared_for_call(arg_idx, actual_fn,
-						target_name, emitted_callee_name, fn_name)
+					arg_param_is_shared := g.fn_param_is_shared_for_call(arg_idx, actual_fn, target_name, emitted_callee_name, fn_name)
 					if arg_param_is_shared && (g.gen_shared_local_receiver_arg(arg_id)
 						|| g.gen_shared_storage_expr(arg_id)) {
 						continue
@@ -7605,8 +7548,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 				if g.gen_new_array_fixed_data_arg(node, arg_start, arg_idx, arg_id, [
 					emitted_callee_name,
 					actual_fn,
-				])
-				{
+				]) {
 					continue
 				}
 				if fixed := array_fixed_type(g.tc.resolve_type(arg_id)) {
@@ -7718,8 +7660,8 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 				}
 				if !is_c_call && !needs_addr && arg_idx == 0
 					&& (g.mut_receiver_arg_wants_addr(actual_fn, arg_id)
-					|| g.mut_receiver_arg_wants_addr(emitted_callee_name, arg_id)
-					|| g.mut_receiver_arg_wants_addr(fn_name, arg_id)) {
+						|| g.mut_receiver_arg_wants_addr(emitted_callee_name, arg_id)
+						|| g.mut_receiver_arg_wants_addr(fn_name, arg_id)) {
 					needs_addr = true
 				}
 				if !is_c_call && arg_idx < typed_param_count {
@@ -7805,9 +7747,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 						} else if is_c_call && !needs_addr {
 							// Lower the argument to the C ABI: platform `int` stays C `int`
 							// (value and callback-pointer args), matching the extern signature.
-							if cabi := g.c_call_arg_cabi_cast(arg_idx, typed_param_count,
-								param_types, arg_id, is_native_variadic_fn)
-							{
+							if cabi := g.c_call_arg_cabi_cast(arg_idx, typed_param_count, param_types, arg_id, is_native_variadic_fn) {
 								g.write('(${cabi})(')
 								g.gen_expr(arg_id)
 								g.write(')')
@@ -7922,8 +7862,8 @@ fn (g &FlatGen) expr_is_non_string_scalar_value(id flat.NodeId) bool {
 	}
 	if node.kind == .ident {
 		if c_type := g.local_storage_c_type(node.value) {
-			return c_type in ['bool', 'char', 'i8', 'i16', 'int', 'i64', 'isize', 'u8', 'u16',
-				'u32', 'u64', 'usize', 'f32', 'f64', 'rune']
+			return c_type in ['bool', 'char', 'i8', 'i16', 'int', 'i64', 'isize', 'u8', 'u16', 'u32',
+				'u64', 'usize', 'f32', 'f64', 'rune']
 		}
 		if raw_type := g.local_storage_raw_type(node.value) {
 			clean := cgen_unalias_type(g.tc.parse_type(raw_type))
@@ -8573,9 +8513,7 @@ fn (mut g FlatGen) gen_interface_method_call(node flat.Node, fn_node flat.Node, 
 			if !emitted_variant {
 				if g.gen_optional_arg(arg_id, param_types[param_idx]) {
 					// handled
-				} else if g.gen_embedded_interface_receiver(arg_id, g.usable_expr_type(arg_id),
-					param_types[param_idx], param_types[param_idx] is types.Pointer)
-				{
+				} else if g.gen_embedded_interface_receiver(arg_id, g.usable_expr_type(arg_id), param_types[param_idx], param_types[param_idx] is types.Pointer) {
 					// handled
 				} else {
 					g.gen_arg_for_expected_type(arg_id, param_types[param_idx])
@@ -9085,8 +9023,7 @@ fn (mut g FlatGen) collect_json_pointer_types(typ types.Type, seen []string, mut
 		mut next_seen := seen.clone()
 		next_seen << sum_key
 		for variant in g.tc.sum_types[sum_name] or { []string{} } {
-			g.collect_json_pointer_types(g.json_sum_variant_type(variant), next_seen, mut
-				pointer_types)
+			g.collect_json_pointer_types(g.json_sum_variant_type(variant), next_seen, mut pointer_types)
 		}
 		return
 	}
@@ -9141,8 +9078,7 @@ fn (mut g FlatGen) collect_json_encode_sum_types(typ types.Type, seen []string, 
 		mut next_seen := seen.clone()
 		next_seen << sum_key
 		for variant in g.tc.sum_types[sum_name] or { []string{} } {
-			g.collect_json_encode_sum_types(g.json_sum_variant_type(variant), next_seen, mut
-				sum_types)
+			g.collect_json_encode_sum_types(g.json_sum_variant_type(variant), next_seen, mut sum_types)
 		}
 		return
 	}
@@ -9193,9 +9129,9 @@ fn (mut g FlatGen) prepare_json_encode_pointer_helpers() []JsonEncodePointerHelp
 		pointer_type := pointer_types[pointer_ct]
 		body := g.json_encode_value_c_expr(pointer_type.base_type, '(*value)') or { continue }
 		helpers << JsonEncodePointerHelper{
-			name:       json_encode_pointer_helper_name(pointer_ct)
+			name: json_encode_pointer_helper_name(pointer_ct)
 			pointer_ct: pointer_ct
-			body:       body
+			body: body
 		}
 	}
 	return helpers
@@ -9229,9 +9165,9 @@ fn (mut g FlatGen) prepare_json_encode_sum_helpers() []JsonEncodeSumHelper {
 		sum_type := sum_types[sum_ct]
 		body := g.json_encode_value_c_expr(sum_type, 'value') or { continue }
 		helpers << JsonEncodeSumHelper{
-			name:   json_encode_sum_helper_name(sum_ct)
+			name: json_encode_sum_helper_name(sum_ct)
 			sum_ct: sum_ct
-			body:   body
+			body: body
 		}
 	}
 	return helpers
@@ -9329,12 +9265,12 @@ fn (mut g FlatGen) prepare_json_decode_pointer_helpers() []JsonDecodePointerHelp
 		g.sb = old_sb
 		g.line_start = old_line_start
 		helpers << JsonDecodePointerHelper{
-			name:        json_decode_pointer_helper_name(pointer_ct)
-			pointer_ct:  pointer_ct
-			base_ct:     base_ct
-			valid_expr:  valid_expr
+			name: json_decode_pointer_helper_name(pointer_ct)
+			pointer_ct: pointer_ct
+			base_ct: base_ct
+			valid_expr: valid_expr
 			assign_body: assign_body
-			copy_expr:   g.heap_local_memdup_expr('decoded', base_type, base_ct, false)
+			copy_expr: g.heap_local_memdup_expr('decoded', base_type, base_ct, false)
 		}
 	}
 	return helpers
@@ -9481,8 +9417,7 @@ fn (mut g FlatGen) json_encode_sum_variant_c_expr(typ types.Type, expr string, s
 		}
 		if base_clean is types.Struct {
 			encoded := g.json_encode_value_c_expr_inner(clean, expr, seen) or { return none }
-			return g.json_encode_add_sum_discriminator_c_expr(encoded,
-				base_clean.name.all_after_last('.'))
+			return g.json_encode_add_sum_discriminator_c_expr(encoded, base_clean.name.all_after_last('.'))
 		}
 		if base_clean is types.Array || base_clean is types.ArrayFixed {
 			pointer_ct := g.value_c_type(clean)
@@ -9628,7 +9563,7 @@ fn (mut g FlatGen) json_encode_value_c_expr_inner(typ types.Type, expr string, s
 			value_name := g.tmp_name()
 			encoded_name := g.tmp_name()
 			null_sid := g.intern_string('null')
-			return '({ double ${value_name} = (double)(${expr}); string ${encoded_name} = _str_${null_sid}; if (isfinite(${value_name})) { ${encoded_name} = f64__str(${value_name}); if (${encoded_name}.len >= 2 && ${encoded_name}.str[${encoded_name}.len - 2] == \'.\' && ${encoded_name}.str[${encoded_name}.len - 1] == \'0\') ${encoded_name}.len -= 2; } ${encoded_name}; })'
+			return "({ double ${value_name} = (double)(${expr}); string ${encoded_name} = _str_${null_sid}; if (isfinite(${value_name})) { ${encoded_name} = f64__str(${value_name}); if (${encoded_name}.len >= 2 && ${encoded_name}.str[${encoded_name}.len - 2] == '.' && ${encoded_name}.str[${encoded_name}.len - 1] == '0') ${encoded_name}.len -= 2; } ${encoded_name}; })"
 		}
 		return none
 	}
@@ -9755,8 +9690,7 @@ fn (mut g FlatGen) json_encode_value_c_expr_inner(typ types.Type, expr string, s
 		comma := g.intern_string(',')
 		colon := g.intern_string(':')
 		empty := g.intern_string('')
-		value_expr := g.json_encode_value_c_expr_inner(clean.value_type,
-			'(*(${value_ct}*)${value_name})', seen) or { return none }
+		value_expr := g.json_encode_value_c_expr_inner(clean.value_type, '(*(${value_ct}*)${value_name})', seen) or { return none }
 		return '({ map ${map_name} = ${expr}; string ${out_name} = _str_${open}; int ${count_name} = 0; for (int ${idx_name} = 0; ${idx_name} < ${map_name}.key_values.len; ++${idx_name}) { if (${map_name}.key_values.deletes != 0 && ${map_name}.key_values.all_deleted != 0 && ${map_name}.key_values.all_deleted[${idx_name}] != 0) continue; string ${key_name} = *(string*)(${map_name}.key_values.keys + ${idx_name} * ${map_name}.key_values.key_bytes); void* ${value_name} = (void*)(${map_name}.key_values.values + ${idx_name} * ${map_name}.key_values.value_bytes); ${out_name} = string__plus(${out_name}, ${count_name} == 0 ? _str_${empty} : _str_${comma}); ${out_name} = string__plus(${out_name}, v3_json_encode_string(${key_name})); ${out_name} = string__plus(${out_name}, _str_${colon}); ${out_name} = string__plus(${out_name}, ${value_expr}); ${count_name}++; } string__plus(${out_name}, _str_${close}); })'
 	}
 	return none
@@ -9788,8 +9722,8 @@ fn (g &FlatGen) json_encode_struct_field_exprs(struct_name string, expr string, 
 		}
 		out << JsonEncodeFieldExpr{
 			label: json_struct_field_label(field.name, attrs)
-			typ:   field.typ
-			expr:  field_expr
+			typ: field.typ
+			expr: field_expr
 			attrs: attrs
 		}
 	}
@@ -9814,7 +9748,11 @@ fn (g &FlatGen) json_struct_field_is_embedded(field types.StructField, type_name
 	if g.embedded_field_type_name(field).len > 0 {
 		return true
 	}
-	short_field := if field.name.contains('.') { field.name.all_after_last('.') } else { field.name }
+	short_field := if field.name.contains('.') {
+		field.name.all_after_last('.')
+	} else {
+		field.name
+	}
 	short_type := if type_name.contains('.') { type_name.all_after_last('.') } else { type_name }
 	return field.name == type_name || short_field == short_type
 		|| embedded_field_c_names_match(field.name, type_name)
@@ -9869,8 +9807,7 @@ fn (mut g FlatGen) json_encode_equal_c_expr(typ types.Type, left string, right s
 		index_name := g.tmp_name()
 		left_elem := g.tmp_name()
 		right_elem := g.tmp_name()
-		elem_equal := g.json_encode_equal_c_expr(clean.elem_type, '(*${left_elem})',
-			'(*${right_elem})', seen) or { return none }
+		elem_equal := g.json_encode_equal_c_expr(clean.elem_type, '(*${left_elem})', '(*${right_elem})', seen) or { return none }
 		return '({ Array ${left_name} = ${left}; Array ${right_name} = ${right}; bool ${equal_name} = ${left_name}.len == ${right_name}.len; for (int ${index_name} = 0; ${equal_name} && ${index_name} < ${left_name}.len; ++${index_name}) { ${elem_ct}* ${left_elem} = (${elem_ct}*)array_get(${left_name}, ${index_name}); ${elem_ct}* ${right_elem} = (${elem_ct}*)array_get(${right_name}, ${index_name}); if (!(${elem_equal})) ${equal_name} = false; } ${equal_name}; })'
 	}
 	if clean is types.Map {
@@ -9890,8 +9827,7 @@ fn (mut g FlatGen) json_encode_equal_c_expr(typ types.Type, left string, right s
 		key_name := g.tmp_name()
 		left_value := g.tmp_name()
 		right_value := g.tmp_name()
-		value_equal := g.json_encode_equal_c_expr(clean.value_type, '(*${left_value})',
-			'(*${right_value})', seen) or { return none }
+		value_equal := g.json_encode_equal_c_expr(clean.value_type, '(*${left_value})', '(*${right_value})', seen) or { return none }
 		return '({ map ${left_name} = ${left}; map ${right_name} = ${right}; bool ${equal_name} = ${left_name}.len == ${right_name}.len; for (int ${index_name} = 0; ${equal_name} && ${index_name} < ${left_name}.key_values.len; ++${index_name}) { if (${left_name}.key_values.deletes != 0 && ${left_name}.key_values.all_deleted != 0 && ${left_name}.key_values.all_deleted[${index_name}] != 0) continue; string* ${key_name} = (string*)(${left_name}.key_values.keys + ${index_name} * ${left_name}.key_values.key_bytes); ${value_ct}* ${left_value} = (${value_ct}*)(${left_name}.key_values.values + ${index_name} * ${left_name}.key_values.value_bytes); if (!map__exists(&${right_name}, ${key_name})) { ${equal_name} = false; break; } ${value_ct}* ${right_value} = (${value_ct}*)map__get(&${right_name}, ${key_name}, ${left_value}); if (!(${value_equal})) ${equal_name} = false; } ${equal_name}; })'
 	}
 	if clean is types.Struct {
@@ -9904,8 +9840,7 @@ fn (mut g FlatGen) json_encode_equal_c_expr(typ types.Type, left string, right s
 		mut conditions := []string{cap: fields.len}
 		for field in fields {
 			field_name := g.cname(field.name)
-			condition := g.json_encode_equal_c_expr(field.typ, '(${left}).${field_name}',
-				'(${right}).${field_name}', next_seen) or { return none }
+			condition := g.json_encode_equal_c_expr(field.typ, '(${left}).${field_name}', '(${right}).${field_name}', next_seen) or { return none }
 			conditions << condition
 		}
 		return if conditions.len == 0 { 'true' } else { conditions.join(' && ') }
@@ -9933,8 +9868,7 @@ fn (mut g FlatGen) json_encode_equal_c_expr(typ types.Type, left string, right s
 			} else {
 				'(*(${right}).${field})'
 			}
-			variant_equal := g.json_encode_equal_c_expr(variant_type, left_variant, right_variant,
-				next_seen) or { return none }
+			variant_equal := g.json_encode_equal_c_expr(variant_type, left_variant, right_variant, next_seen) or { return none }
 			index := g.sum_type_index(sum_name, variant)
 			active_equal = '((${left}).typ == ${index} ? ${variant_equal} : ${active_equal})'
 		}
@@ -10082,8 +10016,7 @@ fn (mut g FlatGen) gen_json_decode_call(node flat.Node) bool {
 			continue
 		}
 		if !json_attrs_have_name(attrs, 'raw') {
-			field_valid := g.json_decode_field_valid_expr(item_name, field.typ, json_attrs_have_name(attrs,
-				'required'))
+			field_valid := g.json_decode_field_valid_expr(item_name, field.typ, json_attrs_have_name(attrs, 'required'))
 			mismatch_message := if container_message := json_decode_container_mismatch_message(field.typ) {
 				container_message
 			} else if sum_name := g.json_decode_nested_sum_name(field.typ, 0) {
@@ -10232,7 +10165,7 @@ fn (mut g FlatGen) json_decode_value_valid_expr_at_depth(item string, typ types.
 			return '(${item} == NULL || cJSON_IsNull(${item}) || cJSON_IsBool(${item}))'
 		}
 		if clean.props.has(.integer) || clean.props.has(.float) {
-			return '(${item} == NULL || cJSON_IsNull(${item}) || cJSON_IsNumber(${item}) || (cJSON_IsString(${item}) && ${item}->valuestring != NULL && ${item}->valuestring[0] != \'\\0\'))'
+			return "(${item} == NULL || cJSON_IsNull(${item}) || cJSON_IsNumber(${item}) || (cJSON_IsString(${item}) && ${item}->valuestring != NULL && ${item}->valuestring[0] != '\\0'))"
 		}
 		return 'true'
 	}
@@ -10254,8 +10187,7 @@ fn (mut g FlatGen) json_decode_value_valid_expr_at_depth(item string, typ types.
 		item_name := g.tmp_name()
 		elem_name := g.tmp_name()
 		valid_name := g.tmp_name()
-		elem_valid := g.json_decode_value_valid_expr_at_depth(elem_name, clean.value_type,
-			depth + 1)
+		elem_valid := g.json_decode_value_valid_expr_at_depth(elem_name, clean.value_type, depth + 1)
 		return '({ cJSON* ${item_name} = ${item}; bool ${valid_name} = (${item_name} == NULL || cJSON_IsNull(${item_name}) || cJSON_IsObject(${item_name})); if (${valid_name} && ${item_name} != NULL && cJSON_IsObject(${item_name})) { for (cJSON* ${elem_name} = ${item_name}->child; ${elem_name} != NULL; ${elem_name} = ${elem_name}->next) { if (!(${elem_valid})) { ${valid_name} = false; break; } } } ${valid_name}; })'
 	}
 	if clean is types.SumType {
@@ -10539,8 +10471,7 @@ fn (g &FlatGen) json_decode_value_supported_inner(typ types.Type, depth int, see
 		mut next_seen := seen.clone()
 		next_seen << key
 		for variant in variants {
-			if !g.json_decode_value_supported_inner(g.json_sum_variant_type(variant), depth + 1,
-				next_seen) {
+			if !g.json_decode_value_supported_inner(g.json_sum_variant_type(variant), depth + 1, next_seen) {
 				return false
 			}
 		}
@@ -10722,9 +10653,7 @@ fn (mut g FlatGen) gen_json_decode_value_assign(target string, item string, typ 
 		c_elem, dims := g.fixed_array_decl_parts(clean)
 		default_init := g.empty_fixed_array_initializer_string(clean)
 		g.write('{ cJSON* ${item_name} = ${item}; memmove(${target}, (${c_elem}${dims})${default_init}, sizeof(${target})); if (${item_name} != NULL && cJSON_IsArray(${item_name})) { int ${idx_name} = 0; cJSON* ${elem_name} = NULL; cJSON_ArrayForEach(${elem_name}, ${item_name}) { if (${idx_name} >= ${len}) break; ')
-		g.gen_json_decode_value_assign('${target}[${idx_name}]', elem_name, clean.elem_type,
-
-			depth + 1)
+		g.gen_json_decode_value_assign('${target}[${idx_name}]', elem_name, clean.elem_type, depth + 1)
 		g.write('${idx_name}++; } } } ')
 		return
 	}
@@ -10830,7 +10759,7 @@ fn (mut g FlatGen) gen_json_decode_value_expr_at_depth(item string, typ types.Ty
 			} else {
 				'(${is_negative_name} ? (${magnitude_name} == 9223372036854775808ULL ? (i64)(-9223372036854775807LL - 1LL) : -(i64)${magnitude_name}) : (i64)${magnitude_name})'
 			}
-			g.write('({ cJSON* ${item_name} = ${item}; const char* ${raw_name} = ${item_name} != NULL ? ${item_name}->valuestring : NULL; const char* ${scan_name} = ${raw_name}; bool ${is_decimal_name} = ${scan_name} != NULL; bool ${is_negative_name} = false; if (${is_decimal_name} && (*${scan_name} == \'-\' || *${scan_name} == \'+\')) { ${is_negative_name} = *${scan_name} == \'-\'; ${scan_name}++; } if (${is_decimal_name} && *${scan_name} == \'\\0\') { ${is_decimal_name} = false; } u64 ${magnitude_name} = 0; u64 ${limit_name} = ${limit_expr}; while (${is_decimal_name} && *${scan_name} != \'\\0\') { if (*${scan_name} < \'0\' || *${scan_name} > \'9\') { ${is_decimal_name} = false; break; } u64 ${digit_name} = (u64)(*${scan_name} - \'0\'); if (${magnitude_name} > (${limit_name} - ${digit_name}) / 10) { ${is_decimal_name} = false; break; } ${magnitude_name} = ${magnitude_name} * 10 + ${digit_name}; ${scan_name}++; } ${ct} ${out_name} = ${item_name} != NULL ? (${ct})${item_name}->valuedouble : 0; if (${is_decimal_name}) { ${out_name} = (${ct})${value_expr}; } ${out_name}; })')
+			g.write("({ cJSON* ${item_name} = ${item}; const char* ${raw_name} = ${item_name} != NULL ? ${item_name}->valuestring : NULL; const char* ${scan_name} = ${raw_name}; bool ${is_decimal_name} = ${scan_name} != NULL; bool ${is_negative_name} = false; if (${is_decimal_name} && (*${scan_name} == '-' || *${scan_name} == '+')) { ${is_negative_name} = *${scan_name} == '-'; ${scan_name}++; } if (${is_decimal_name} && *${scan_name} == '\\0') { ${is_decimal_name} = false; } u64 ${magnitude_name} = 0; u64 ${limit_name} = ${limit_expr}; while (${is_decimal_name} && *${scan_name} != '\\0') { if (*${scan_name} < '0' || *${scan_name} > '9') { ${is_decimal_name} = false; break; } u64 ${digit_name} = (u64)(*${scan_name} - '0'); if (${magnitude_name} > (${limit_name} - ${digit_name}) / 10) { ${is_decimal_name} = false; break; } ${magnitude_name} = ${magnitude_name} * 10 + ${digit_name}; ${scan_name}++; } ${ct} ${out_name} = ${item_name} != NULL ? (${ct})${item_name}->valuedouble : 0; if (${is_decimal_name}) { ${out_name} = (${ct})${value_expr}; } ${out_name}; })")
 			return
 		}
 		g.write('(${item} != NULL ? (${g.value_c_type(clean)})${item}->valuedouble : 0)')
@@ -10897,8 +10826,7 @@ fn (mut g FlatGen) gen_json_decode_value_expr_at_depth(item string, typ types.Ty
 			if json_attrs_skip_field(attrs) {
 				continue
 			}
-			g.gen_json_decode_field_assign('${out_name}.${g.cname(field.name)}', item, clean.name,
-				field, depth + 1)
+			g.gen_json_decode_field_assign('${out_name}.${g.cname(field.name)}', item, clean.name, field, depth + 1)
 		}
 		g.write('${out_name}; })')
 		return
@@ -10996,8 +10924,7 @@ fn (g &FlatGen) json_struct_has_decode_field_attrs(struct_name string) bool {
 	// json_decode_field_item. Skip/required and other attributes still need the
 	// full decoder.
 	if g.json_struct_has_disallowed_field_attrs(struct_name, ['json', 'omitempty', 'json_null',
-		'raw'])
-	{
+		'raw']) {
 		return true
 	}
 	info := g.find_struct_decl(json_struct_decl_name(struct_name)) or { return false }
@@ -11688,8 +11615,7 @@ fn (mut g FlatGen) gen_embedded_interface_receiver(base_id flat.NodeId, base_typ
 		g.write('({ ${source_ct} ${tmp} = ')
 		g.gen_expr(base_id)
 		g.write('; ')
-		g.gen_embedded_interface_receiver_from_expr(tmp, base_is_ptr, target_ct, target_iface,
-			mappings)
+		g.gen_embedded_interface_receiver_from_expr(tmp, base_is_ptr, target_ct, target_iface, mappings)
 		g.write('; })')
 		return true
 	}
@@ -11786,8 +11712,7 @@ fn (g &FlatGen) interface_impl_field_access_suffix(impl_name string, field_name 
 
 fn (g &FlatGen) interface_impl_field_access_expr(object_expr string, impl_name string, field_name string) string {
 	impl_ct := g.tc.c_type(g.tc.parse_type(impl_name))
-	return '((${impl_ct}*)${object_expr})${g.interface_impl_field_access_suffix(impl_name,
-		field_name)}'
+	return '((${impl_ct}*)${object_expr})${g.interface_impl_field_access_suffix(impl_name, field_name)}'
 }
 
 struct InterfaceReceiverIdMapping {
@@ -11807,7 +11732,7 @@ fn (g &FlatGen) interface_receiver_type_id_mappings(source_iface string, target_
 		mappings << InterfaceReceiverIdMapping{
 			source_id: source_id
 			target_id: target_id
-			impl:      impl
+			impl: impl
 		}
 	}
 	return mappings
@@ -11913,9 +11838,7 @@ fn (g &FlatGen) embedded_receiver_path_for_expected_name(base_name string, expec
 		if g.embedded_receiver_type_names_match(embedded_type_name, expected_name) {
 			return [field]
 		}
-		if nested := g.embedded_receiver_path_for_expected_name(embedded_type_name, expected_name, mut
-			seen)
-		{
+		if nested := g.embedded_receiver_path_for_expected_name(embedded_type_name, expected_name, mut seen) {
 			mut path := [field]
 			path << nested
 			return path
@@ -12140,8 +12063,7 @@ fn (mut g FlatGen) fn_node_param_types_or_decl(node flat.Node, module_name strin
 }
 
 fn (mut g FlatGen) register_concrete_optional_abi_fn(module_name string, name string) {
-	for candidate in concrete_optional_abi_fn_name_candidates(module_name, name, g.fn_c_name_in_module(module_name,
-		name)) {
+	for candidate in concrete_optional_abi_fn_name_candidates(module_name, name, g.fn_c_name_in_module(module_name, name)) {
 		if candidate.len > 0 {
 			g.concrete_optional_abi_fns[candidate] = true
 		}
@@ -13016,7 +12938,11 @@ fn (mut g FlatGen) gen_arg_for_expected_type(arg_id flat.NodeId, expected types.
 }
 
 fn (mut g FlatGen) gen_interface_pointer_arg(arg_id flat.NodeId, expected types.Type) bool {
-	ptr_type := if expected is types.Pointer { expected } else { return false }
+	ptr_type := if expected is types.Pointer {
+		expected
+	} else {
+		return false
+	}
 	node := g.a.nodes[int(arg_id)]
 	mut iface_type := ptr_type.base_type
 	if iface_type is types.Alias {
@@ -13039,7 +12965,7 @@ fn (mut g FlatGen) gen_interface_pointer_arg(arg_id flat.NodeId, expected types.
 	actual_unaliased := cgen_unalias_type(actual)
 	if actual_unaliased is types.Nil || actual_unaliased is types.Void
 		|| (actual_unaliased is types.Pointer
-		&& cgen_unalias_type(actual_unaliased.base_type) is types.Void) {
+			&& cgen_unalias_type(actual_unaliased.base_type) is types.Void) {
 		g.write('(${g.tc.c_type(iface_type)}*)')
 		g.gen_expr(arg_id)
 		return true
@@ -13099,9 +13025,7 @@ fn (mut g FlatGen) gen_callback_fn_value_for_expected_c_abi(arg_id flat.NodeId, 
 	}
 	if actual_name.len > 0 {
 		actual_fn := g.callback_fn_value_type(actual_name) or { return false }
-		if wrapper := g.ensure_callback_userdata_wrapper(actual_name, actual_fn, expected_fn,
-			expected_c_abi)
-		{
+		if wrapper := g.ensure_callback_userdata_wrapper(actual_name, actual_fn, expected_fn, expected_c_abi) {
 			g.write(wrapper)
 			return true
 		}
@@ -13291,7 +13215,7 @@ fn (mut g FlatGen) callback_fn_value_type(name string) ?types.FnType {
 		types.Type(types.void_)
 	}
 	return types.FnType{
-		params:      params.clone()
+		params: params.clone()
 		return_type: ret
 	}
 }
@@ -13332,13 +13256,11 @@ fn (mut g FlatGen) callback_fn_types_direct_compatible(actual types.FnType, expe
 	if actual.params.len != expected.params.len {
 		return false
 	}
-	if g.callback_c_type(actual.return_type) != g.callback_expected_return_c_type(expected.return_type,
-		expected_c_abi) {
+	if g.callback_c_type(actual.return_type) != g.callback_expected_return_c_type(expected.return_type, expected_c_abi) {
 		return false
 	}
 	for i in 0 .. expected.params.len {
-		if g.callback_c_type(fn_type_param(actual, i)) != g.callback_expected_param_c_type(expected,
-			i, expected_c_abi) {
+		if g.callback_c_type(fn_type_param(actual, i)) != g.callback_expected_param_c_type(expected, i, expected_c_abi) {
 			return false
 		}
 	}
@@ -13692,8 +13614,7 @@ fn (mut g FlatGen) gen_optional_arg_with_abi(arg_id flat.NodeId, expected types.
 		raw_arg_type := g.parse_node_type(&arg_node)
 		if raw_arg_type is types.OptionType || raw_arg_type is types.ResultType {
 			if concrete_abi {
-				g.gen_concrete_optional_arg_from_optional_expr(arg_id, raw_arg_type, expected,
-					base_type)
+				g.gen_concrete_optional_arg_from_optional_expr(arg_id, raw_arg_type, expected, base_type)
 				return true
 			}
 			if g.type_names_match(raw_arg_type, expected) || g.expr_really_returns_optional(arg_id) {
@@ -13727,8 +13648,7 @@ fn (mut g FlatGen) gen_optional_arg_with_abi(arg_id flat.NodeId, expected types.
 	if !plain_call_in_optional_context
 		&& (arg_optional_type is types.OptionType || arg_optional_type is types.ResultType) {
 		if concrete_abi {
-			g.gen_concrete_optional_arg_from_optional_expr(arg_id, arg_optional_type, expected,
-				base_type)
+			g.gen_concrete_optional_arg_from_optional_expr(arg_id, arg_optional_type, expected, base_type)
 			return true
 		}
 		if g.type_names_match(arg_optional_type, expected)
@@ -14674,8 +14594,7 @@ fn codegen_generic_type_suffix_variants(args []string) []string {
 	mut full_parts := []string{cap: args.len}
 	for arg in args {
 		clean := trimmed_space(arg)
-		short_raw := generic_receiver_type_arg_short(clean).replace('[]', 'Array_').replace('&',
-			'ptr_')
+		short_raw := generic_receiver_type_arg_short(clean).replace('[]', 'Array_').replace('&', 'ptr_')
 		short_raw_parts << short_raw
 		short_parts << c_name(short_raw)
 		full_parts << c_name(clean.replace('[]', 'Array_').replace('&', 'ptr_'))
@@ -14946,7 +14865,7 @@ fn (mut g FlatGen) guarded_anon_self_call(node flat.Node) ?GuardedAnonSelfCall {
 		callee_ct = g.resolve_fn_ptr_type(callee_ct)
 	}
 	return GuardedAnonSelfCall{
-		callee:    g.cname(callee_node.value)
+		callee: g.cname(callee_node.value)
 		callee_ct: callee_ct
 	}
 }
@@ -15080,9 +14999,7 @@ fn (g &FlatGen) selector_module_call_name(id flat.NodeId, fn_node flat.Node, nod
 					}
 					return none
 				}
-				if g.module_call_arg_count_matches(call_name, params,
-					node.children_count - arg_start)
-				{
+				if g.module_call_arg_count_matches(call_name, params, node.children_count - arg_start) {
 					return call_name
 				}
 			}
@@ -15422,7 +15339,7 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 		}
 		if !is_c_call && arg_idx == 0 && start == 1 && arg_node.kind == .ident
 			&& (g.mut_receiver_arg_wants_addr(fn_name, arg_id)
-			|| (!callee_is_module_selector && g.mut_receiver_arg_wants_addr(callee_name, arg_id))) {
+				|| (!callee_is_module_selector && g.mut_receiver_arg_wants_addr(callee_name, arg_id))) {
 			param_type := g.current_param_type(arg_node.value) or { types.Type(types.void_) }
 			if g.local_storage_is_pointer(arg_node.value) || param_type is types.Pointer
 				|| g.usable_expr_type(arg_id) is types.Pointer {
@@ -15575,9 +15492,7 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 				&& g.voidptr_value_arg_needs_address(arg_id, arg_node, g.usable_expr_type(arg_id), param_types[arg_idx], true) {
 				g.write('&')
 				g.gen_expr(arg_id)
-			} else if cabi := g.c_call_arg_cabi_cast(arg_idx, typed_param_count, param_types,
-				arg_id, is_native_variadic_fn)
-			{
+			} else if cabi := g.c_call_arg_cabi_cast(arg_idx, typed_param_count, param_types, arg_id, is_native_variadic_fn) {
 				// Lower the argument to the C ABI: platform `int` stays C `int` (value
 				// and callback-pointer args, plus `%d`-style value varargs), matching the
 				// extern signature.
@@ -15648,10 +15563,8 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 				&& !arg_is_pointer_global
 			explicit_mut_value := arg_node.is_mut && !(arg_node.kind == .ident
 				&& (g.local_storage_is_pointer(arg_node.value)
-				|| arg_is_pointer_param || arg_is_pointer_global))
-			if g.fn_value_arg_passes_direct_to_voidptr(arg_id, arg_node, arg_type,
-				param_types[arg_idx])
-			{
+					|| arg_is_pointer_param || arg_is_pointer_global))
+			if g.fn_value_arg_passes_direct_to_voidptr(arg_id, arg_node, arg_type, param_types[arg_idx]) {
 				needs_addr = false
 			} else if arg_is_shared_local && !arg_param_is_shared
 				&& !g.c_string_pointer_arg(arg_node, param_types[arg_idx]) {
@@ -16063,12 +15976,10 @@ fn (mut g FlatGen) gen_transformed_method_ident_call(id flat.NodeId, node flat.N
 	receiver_wants_ptr := params[0] is types.Pointer
 		|| g.mut_receiver_arg_wants_addr(fn_node.value, receiver_id)
 		|| g.mut_receiver_arg_wants_addr(emitted_name, receiver_id)
-	receiver_wants_shared := g.fn_param_is_shared_for_call(0, fn_node.value, emitted_name,
-		g.cname(fn_node.value), g.cname(emitted_name))
+	receiver_wants_shared := g.fn_param_is_shared_for_call(0, fn_node.value, emitted_name, g.cname(fn_node.value), g.cname(emitted_name))
 	receiver := g.a.nodes[int(receiver_id)]
 	receiver_type := g.receiver_base_type(receiver_id)
-	receiver_declares_method := g.emitted_method_belongs_to_receiver(receiver_type, method_short,
-		emitted_name)
+	receiver_declares_method := g.emitted_method_belongs_to_receiver(receiver_type, method_short, emitted_name)
 	receiver_is_shared_payload := g.shared_local_arg_c_expr(receiver_id) != none
 		|| g.shared_payload_deref_storage_c_expr(receiver_id) != none
 	receiver_is_ptr := !receiver_is_shared_payload
@@ -16076,9 +15987,7 @@ fn (mut g FlatGen) gen_transformed_method_ident_call(id flat.NodeId, node flat.N
 	if fn_node.value.ends_with('.str') && !receiver_wants_ptr && receiver_is_ptr {
 		mut stack := []string{}
 		receiver_expr := g.expr_to_string(receiver_id)
-		if pointer_str := g.interface_pointer_str_expr(types.unwrap_pointer(params[0]),
-			receiver_expr, true, mut stack)
-		{
+		if pointer_str := g.interface_pointer_str_expr(types.unwrap_pointer(params[0]), receiver_expr, true, mut stack) {
 			g.write(pointer_str)
 			return true
 		}
@@ -16409,7 +16318,7 @@ fn (mut g FlatGen) gen_flag_enum_from_call(id flat.NodeId, fn_node flat.Node, no
 	}
 	is_flag := enum_name in g.tc.flag_enums
 	enum_info := types.Enum{
-		name:    enum_name
+		name: enum_name
 		is_flag: is_flag
 	}
 	enum_type := types.Type(enum_info)
@@ -16758,7 +16667,7 @@ fn (g &FlatGen) arg_is_const_ident(arg_node flat.Node) bool {
 		key := owner.storage_key()
 		if !owner.belongs_to_scope(g.tc.file_scope) && key.len > 0
 			&& (key in g.local_c_type_by_owner || key in g.local_raw_type_by_owner
-			|| key in g.shadowed_global_locals) {
+				|| key in g.shadowed_global_locals) {
 			return false
 		}
 	}
@@ -17002,8 +16911,7 @@ fn (mut g FlatGen) forward_decl_items(items []FlatFnGenItem, mut forwarded_expor
 		g.tc.cur_file = item.file
 		g.tc.cur_module = item.module
 		ret_type := g.fn_node_return_type(node, item.module)
-		concrete_optional := g.is_program_specialization_fn_node(node, int(item.node_id),
-			item.module)
+		concrete_optional := g.is_program_specialization_fn_node(node, int(item.node_id), item.module)
 		if export_name := g.export_fn_name_in_module(item.module, node.value) {
 			if export_name == qfn {
 				g.write(g.exported_symbol_attribute())
@@ -17064,9 +16972,9 @@ fn (mut g FlatGen) cached_header_forward_decls() {
 		}
 		items << FlatFnGenItem{
 			node_id: flat.NodeId(node_idx)
-			file:    cur_file
-			module:  cur_module
-			c_name:  g.fn_c_name_in_module(cur_module, node.value)
+			file: cur_file
+			module: cur_module
+			c_name: g.fn_c_name_in_module(cur_module, node.value)
 		}
 	}
 	items.sort(a.c_name < b.c_name)
@@ -17081,8 +16989,7 @@ fn (mut g FlatGen) cached_header_forward_decls() {
 		g.tc.cur_file = item.file
 		g.tc.cur_module = item.module
 		ret_type := g.fn_node_return_type(node, item.module)
-		concrete_optional := g.is_program_specialization_fn_node(node, int(item.node_id),
-			item.module)
+		concrete_optional := g.is_program_specialization_fn_node(node, int(item.node_id), item.module)
 		g.write(g.fn_return_type_name_for_context(ret_type, concrete_optional))
 		g.write(' ')
 		g.write(qfn)
@@ -17170,8 +17077,8 @@ fn (mut g FlatGen) c_extern_forward_decls() {
 		specificity := program_decl_priority + c_extern_decl_specificity(g.a, node)
 		if cfn !in decls || specificity > decls[cfn].specificity {
 			decls[cfn] = CExternForwardDecl{
-				node_idx:    i
-				file:        cur_file
+				node_idx: i
+				file: cur_file
 				module_name: cur_module
 				specificity: specificity
 			}
@@ -17183,8 +17090,7 @@ fn (mut g FlatGen) c_extern_forward_decls() {
 		g.tc.cur_file = decl.file
 		g.tc.cur_module = decl.module_name
 		node := g.a.nodes[decl.node_idx]
-		line := g.c_possibly_active_macro_extern_decl(name, c_macro_safe_extern_decl(name,
-			g.c_extern_decl_line(node, name)))
+		line := g.c_possibly_active_macro_extern_decl(name, c_macro_safe_extern_decl(name, g.c_extern_decl_line(node, name)))
 		if g.c_extern_decl_is_cached_object_fallback(name) {
 			g.writeln('#ifndef V3CACHE_PROGRAM_UNIT')
 			g.writeln(line)
@@ -17445,8 +17351,7 @@ fn (g &FlatGen) should_emit_c_extern_decl(cfn string) bool {
 		return false
 	}
 	if cfn in g.inlined_c_fns {
-		if g.cache_split && cfn in g.cache_omitted_c_fns && cfn !in g.inlined_c_declared_fns
-			&& cfn !in g.inlined_c_active_macros {
+		if g.cache_split && cfn in g.cache_omitted_c_fns && cfn !in g.inlined_c_declared_fns && cfn !in g.inlined_c_active_macros {
 			return true
 		}
 		return false
@@ -18007,28 +17912,72 @@ fn c_extern_calling_convention(cfn string) string {
 
 fn c_winapi_wide_export_name(cfn string) string {
 	match cfn {
-		'CopyFile' { return 'CopyFileW' }
-		'CreateDirectory' { return 'CreateDirectoryW' }
-		'CreateFile' { return 'CreateFileW' }
-		'CreateWindowEx' { return 'CreateWindowExW' }
-		'DefWindowProc' { return 'DefWindowProcW' }
-		'FindFirstFile' { return 'FindFirstFileW' }
-		'FindNextFile' { return 'FindNextFileW' }
-		'GetCommandLine' { return 'GetCommandLineW' }
-		'GetFullPathName' { return 'GetFullPathNameW' }
-		'GetLongPathName' { return 'GetLongPathNameW' }
-		'GetModuleFileName' { return 'GetModuleFileNameW' }
-		'LoadLibrary' { return 'LoadLibraryW' }
-		'ReadConsole' { return 'ReadConsoleW' }
-		'RegOpenKeyEx' { return 'RegOpenKeyExW' }
-		'RegQueryValueEx' { return 'RegQueryValueExW' }
-		'RegSetValueEx' { return 'RegSetValueExW' }
-		'RegisterClassEx' { return 'RegisterClassExW' }
-		'RemoveDirectory' { return 'RemoveDirectoryW' }
-		'SendMessageTimeout' { return 'SendMessageTimeoutW' }
-		'SetConsoleTitle' { return 'SetConsoleTitleW' }
-		'WriteConsole' { return 'WriteConsoleW' }
-		else { return cfn }
+		'CopyFile' {
+			return 'CopyFileW'
+		}
+		'CreateDirectory' {
+			return 'CreateDirectoryW'
+		}
+		'CreateFile' {
+			return 'CreateFileW'
+		}
+		'CreateWindowEx' {
+			return 'CreateWindowExW'
+		}
+		'DefWindowProc' {
+			return 'DefWindowProcW'
+		}
+		'FindFirstFile' {
+			return 'FindFirstFileW'
+		}
+		'FindNextFile' {
+			return 'FindNextFileW'
+		}
+		'GetCommandLine' {
+			return 'GetCommandLineW'
+		}
+		'GetFullPathName' {
+			return 'GetFullPathNameW'
+		}
+		'GetLongPathName' {
+			return 'GetLongPathNameW'
+		}
+		'GetModuleFileName' {
+			return 'GetModuleFileNameW'
+		}
+		'LoadLibrary' {
+			return 'LoadLibraryW'
+		}
+		'ReadConsole' {
+			return 'ReadConsoleW'
+		}
+		'RegOpenKeyEx' {
+			return 'RegOpenKeyExW'
+		}
+		'RegQueryValueEx' {
+			return 'RegQueryValueExW'
+		}
+		'RegSetValueEx' {
+			return 'RegSetValueExW'
+		}
+		'RegisterClassEx' {
+			return 'RegisterClassExW'
+		}
+		'RemoveDirectory' {
+			return 'RemoveDirectoryW'
+		}
+		'SendMessageTimeout' {
+			return 'SendMessageTimeoutW'
+		}
+		'SetConsoleTitle' {
+			return 'SetConsoleTitleW'
+		}
+		'WriteConsole' {
+			return 'WriteConsoleW'
+		}
+		else {
+			return cfn
+		}
 	}
 }
 
@@ -18543,7 +18492,7 @@ fn (mut g FlatGen) fn_node_return_type(node flat.Node, module_name string) types
 				clean_return := raw_return.trim_space()
 				if target := g.tc.type_aliases[clean_return] {
 					return types.Type(types.Alias{
-						name:      clean_return
+						name: clean_return
 						base_type: g.tc.parse_type(target)
 					})
 				}

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -786,6 +786,10 @@ fn (mut g FlatGen) should_emit_fn_node_in_module_known(node flat.Node, module_na
 	if g.should_emit_ierror_method(node.value, qfn) {
 		return true
 	}
+	if is_program_specialization
+		&& g.specialization_signature_has_missing_nominal(node, module_name) {
+		return false
+	}
 	if g.fn_node_is_open_generic_template(node, module_name) {
 		return false
 	}
@@ -806,6 +810,83 @@ fn (mut g FlatGen) should_emit_fn_node_in_module_known(node flat.Node, module_na
 			|| g.interface_dispatch_method_is_required(qfn)
 	}
 	return true
+}
+
+fn (mut g FlatGen) specialization_signature_has_missing_nominal(node flat.Node, module_name string) bool {
+	if g.type_has_missing_qualified_nominal(g.fn_node_return_type(node, module_name)) {
+		return true
+	}
+	for param_type in g.fn_node_param_types(node, module_name) {
+		if g.type_has_missing_qualified_nominal(param_type) {
+			return true
+		}
+	}
+	return false
+}
+
+fn (g &FlatGen) type_has_missing_qualified_nominal(t types.Type) bool {
+	return match t {
+		types.Array {
+			g.type_has_missing_qualified_nominal(t.elem_type)
+		}
+		types.ArrayFixed {
+			g.type_has_missing_qualified_nominal(t.elem_type)
+		}
+		types.Channel {
+			g.type_has_missing_qualified_nominal(t.elem_type)
+		}
+		types.Map {
+			g.type_has_missing_qualified_nominal(t.key_type)
+				|| g.type_has_missing_qualified_nominal(t.value_type)
+		}
+		types.Pointer {
+			g.type_has_missing_qualified_nominal(t.base_type)
+		}
+		types.FnType {
+			if g.type_has_missing_qualified_nominal(t.return_type) {
+				return true
+			}
+			for param in t.params {
+				if g.type_has_missing_qualified_nominal(param) {
+					return true
+				}
+			}
+			false
+		}
+		types.OptionType {
+			g.type_has_missing_qualified_nominal(t.base_type)
+		}
+		types.ResultType {
+			g.type_has_missing_qualified_nominal(t.base_type)
+		}
+		types.Struct {
+			t.name.contains('.') && !t.name.starts_with('C.') && !t.name.contains('[')
+				&& t.name !in g.tc.structs
+		}
+		types.Interface {
+			t.name.contains('.') && !t.name.contains('[') && t.name !in g.tc.interface_names
+		}
+		types.Enum {
+			t.name.contains('.') && !t.name.contains('[') && t.name !in g.tc.enum_names
+		}
+		types.SumType {
+			t.name.contains('.') && !t.name.contains('[') && t.name !in g.tc.sum_types
+		}
+		types.Alias {
+			g.type_has_missing_qualified_nominal(t.base_type)
+		}
+		types.MultiReturn {
+			for part in t.types {
+				if g.type_has_missing_qualified_nominal(part) {
+					return true
+				}
+			}
+			false
+		}
+		else {
+			false
+		}
+	}
 }
 
 fn (g &FlatGen) fn_node_is_open_generic_template(node flat.Node, module_name string) bool {
@@ -970,6 +1051,72 @@ fn (g &FlatGen) export_fn_name_in_module(module_name string, name string) ?strin
 	return none
 }
 
+fn (g &FlatGen) export_fn_c_abi_key(module_name string, name string) ?string {
+	export_name := g.export_fn_name_in_module(module_name, name) or { return none }
+	mut owners := [module_name]
+	if module_name == 'main' {
+		owners << ''
+	} else if module_name == '' {
+		owners << 'main'
+	}
+	for owner in owners {
+		key := '${owner}\x01C.${export_name}'
+		if key in g.tc.c_fn_module_ret_types {
+			return key
+		}
+	}
+	suffix := '\x01C.${export_name}'
+	for key, _ in g.tc.c_fn_module_ret_types {
+		if key.ends_with(suffix) {
+			return key
+		}
+	}
+	return none
+}
+
+fn (g &FlatGen) export_fn_c_abi_decl(module_name string, name string) ?flat.Node {
+	export_name := g.export_fn_name_in_module(module_name, name) or { return none }
+	mut cur_module := ''
+	for idx in g.top_level_nodes() {
+		node := g.a.nodes[idx]
+		if node.kind == .file {
+			cur_module = ''
+			continue
+		}
+		if node.kind == .module_decl {
+			cur_module = node.value
+			continue
+		}
+		if node.kind != .c_fn_decl || node.value.trim_string_left('C.') != export_name {
+			continue
+		}
+		if cur_module == module_name
+			|| (cur_module in ['', 'main'] && module_name in ['', 'main']) {
+			return node
+		}
+	}
+	return none
+}
+
+fn (g &FlatGen) export_fn_uses_c_abi(module_name string, name string) bool {
+	if _ := g.export_fn_c_abi_decl(module_name, name) {
+		return true
+	}
+	if _ := g.export_fn_c_abi_key(module_name, name) {
+		return true
+	}
+	export_name := g.export_fn_name_in_module(module_name, name) or { return false }
+	return export_name in g.inlined_c_declared_fns
+}
+
+fn (g &FlatGen) main_export_needs_internal_name(module_name string, name string) bool {
+	if module_name !in ['', 'main'] || !g.export_fn_uses_c_abi(module_name, name) {
+		return false
+	}
+	export_name := g.export_fn_name_in_module(module_name, name) or { return false }
+	return export_name == g.cname(name.trim_string_left('main.'))
+}
+
 // qualified_fn_name_in_module supports qualified fn name in module handling for c.
 // qualified_fn_name_in_module_c is the memoizing FlatGen variant of
 // qualified_fn_name_in_module (the c_name cache absorbs the sanitize cost;
@@ -1054,6 +1201,9 @@ fn (g &FlatGen) fn_c_name_in_module(module_name string, name string) string {
 	if g.should_rename_user_main_for_tests(module_name, name) {
 		return g.test_user_main_c_name()
 	}
+	if g.main_export_needs_internal_name(module_name, name) {
+		return g.cname('main.${name}')
+	}
 	if shadow_name := g.main_runtime_shadow_fn_c_name(module_name, name) {
 		return shadow_name
 	}
@@ -1067,15 +1217,34 @@ const c_main_runtime_shadow_fn_names = {
 }
 
 fn (g &FlatGen) main_runtime_shadow_fn_c_name(module_name string, name string) ?string {
+	if name.starts_with('C.') {
+		return none
+	}
 	c_type_name := !isnil(g.tc)
 		&& ('C.${name}' in g.tc.structs || 'C.${name}' in g.tc.c_typedef_structs)
-	if !c_main_runtime_shadow_fn_names[name] && !g.inlined_c_typedef_names[name] && !c_type_name {
+	needs_export_wrapper := g.main_export_needs_internal_name(module_name, name)
+	export_name_owned := g.main_export_name_owned_by_other_fn(module_name, name)
+	if !c_main_runtime_shadow_fn_names[name] && !g.inlined_c_typedef_names[name] && !c_type_name
+		&& !needs_export_wrapper && !export_name_owned {
 		return none
 	}
 	if module_name.len == 0 || module_name == 'main' {
 		return g.cname('main.${name}')
 	}
 	return none
+}
+
+fn (g &FlatGen) main_export_name_owned_by_other_fn(module_name string, name string) bool {
+	if module_name !in ['', 'main'] {
+		return false
+	}
+	natural_name := g.cname(name.trim_string_left('main.'))
+	for qname, export_name in g.a.export_fn_names {
+		if export_name == natural_name && qname != name && qname != 'main.${name}' {
+			return true
+		}
+	}
+	return false
 }
 
 fn (g &FlatGen) test_user_main_c_name() string {
@@ -1150,6 +1319,9 @@ fn (mut g FlatGen) direct_call_name(name string) string {
 		// `-d no_main` renames the entry `main` to `main__main`; a call to it must use
 		// the renamed symbol rather than the bare `main`.
 		return g.cname('main.main')
+	}
+	if shadow_name := g.main_runtime_shadow_fn_c_name(g.tc.cur_module, name) {
+		return shadow_name
 	}
 	if name == 'free' {
 		return 'v_free'
@@ -4561,13 +4733,13 @@ fn (mut g FlatGen) gen_export_wrapper_for_fn(node flat.Node, module_name string)
 		return
 	}
 	ret_type := g.fn_node_return_type(node, module_name)
-	ret_ct := g.fn_return_type_name(ret_type)
+	ret_ct := g.export_wrapper_return_c_type(node, module_name, ret_type)
 	g.write(g.exported_symbol_attribute())
 	g.write(ret_ct)
 	g.write(' ')
 	g.write(export_name)
 	g.write('(')
-	g.write_fn_node_params(node)
+	g.write_export_wrapper_params(node, module_name)
 	g.writeln(') {')
 	g.indent++
 	args := g.export_wrapper_arg_names(node)
@@ -4597,11 +4769,11 @@ fn (mut g FlatGen) emit_object_file_export_wrappers() {
 				g.tc.cur_module = item.module
 				ret_type := g.fn_node_return_type(node, item.module)
 				g.write(g.exported_symbol_attribute())
-				g.write(g.fn_return_type_name(ret_type))
+				g.write(g.export_wrapper_return_c_type(node, item.module, ret_type))
 				g.write(' ')
 				g.write(export_name)
 				g.write('(')
-				g.write_fn_node_params(node)
+				g.write_export_wrapper_params(node, item.module)
 				g.writeln(') {')
 				g.indent++
 				if g.needs_no_main_runtime_init_caller() {
@@ -4686,6 +4858,147 @@ fn (mut g FlatGen) export_wrapper_arg_names(node flat.Node) []string {
 		args << 'ctx'
 	}
 	return args
+}
+
+fn (mut g FlatGen) export_wrapper_return_c_type(node flat.Node, module_name string, fallback types.Type) string {
+	if abi_decl := g.export_fn_c_abi_decl(module_name, node.value) {
+		abi_type := g.parse_node_type(&abi_decl)
+		return g.c_extern_interop_type_name(abi_type) or { g.fn_return_type_name(abi_type) }
+	}
+	if key := g.export_fn_c_abi_key(module_name, node.value) {
+		if abi_type := g.tc.c_fn_module_ret_types[key] {
+			return g.c_extern_interop_type_name(abi_type) or {
+				g.fn_return_type_name(abi_type)
+			}
+		}
+	}
+	return g.c_extern_interop_type_name(fallback) or { g.fn_return_type_name(fallback) }
+}
+
+fn (mut g FlatGen) write_export_wrapper_params(node flat.Node, module_name string) {
+	if abi_decl := g.export_fn_c_abi_decl(module_name, node.value) {
+		g.write_export_wrapper_c_abi_params(node, abi_decl)
+		return
+	}
+	key := g.export_fn_c_abi_key(module_name, node.value) or {
+		g.write_export_wrapper_v_c_abi_params(node, module_name)
+		return
+	}
+	params := g.tc.c_fn_module_param_types[key] or {
+		g.write_export_wrapper_v_c_abi_params(node, module_name)
+		return
+	}
+	is_variadic := g.tc.c_fn_module_variadic[key] or { false }
+	if params.len == 0 && !is_variadic {
+		g.write('void')
+		return
+	}
+	names := g.export_wrapper_arg_names(node)
+	for i, param in params {
+		mut ct := g.tc.c_type(param)
+		if ct.starts_with('fn_ptr:') {
+			ct = g.resolve_fn_ptr_type(ct)
+		}
+		g.write(ct)
+		g.write(' ')
+		if i < names.len {
+			g.write(names[i])
+		} else {
+			g.write('_${i}')
+		}
+		if i + 1 < params.len || is_variadic {
+			g.write(', ')
+		}
+	}
+	if is_variadic {
+		g.write('...')
+	}
+}
+
+fn (mut g FlatGen) write_export_wrapper_v_c_abi_params(node flat.Node, module_name string) {
+	typed_params := g.fn_node_param_types(node, module_name)
+	mut param_idx := 0
+	mut written := 0
+	for i in 0 .. node.children_count {
+		param := g.a.child_node(&node, i)
+		if param.kind != .param {
+			continue
+		}
+		if param.typ == '...' {
+			if written > 0 {
+				g.write(', ')
+			}
+			g.write('...')
+			written++
+			continue
+		}
+		raw_type := if param_idx < typed_params.len {
+			typed_params[param_idx]
+		} else {
+			g.tc.parse_resolution_type(param.typ)
+		}
+		param_type := g.fn_node_effective_param_type(param, raw_type)
+		param_idx++
+		mut ct := g.c_extern_interop_type_name(param_type) or {
+			g.c_extern_param_c_type(param_type)
+		}
+		if ct.starts_with('fn_ptr:') {
+			ct = g.resolve_fn_ptr_type(ct)
+		}
+		if written > 0 {
+			g.write(', ')
+		}
+		g.write(ct)
+		if param.value.len > 0 {
+			g.write(' ')
+			g.write(if param.value == '_' { '_${written}' } else { g.cname(param.value) })
+		}
+		written++
+	}
+	if written == 0 {
+		g.write('void')
+	}
+}
+
+fn (mut g FlatGen) write_export_wrapper_c_abi_params(node flat.Node, abi_decl flat.Node) {
+	names := g.export_wrapper_arg_names(node)
+	mut written := 0
+	for i in 0 .. abi_decl.children_count {
+		param := g.a.child_node(&abi_decl, i)
+		if param.kind != .param {
+			continue
+		}
+		raw_type := if param.typ.len > 0 { param.typ } else { param.value }
+		if raw_type.starts_with('...') {
+			if written > 0 {
+				g.write(', ')
+			}
+			g.write('...')
+			written++
+			continue
+		}
+		param_type := g.tc.parse_type(raw_type)
+		mut ct := g.c_extern_interop_type_name(param_type) or {
+			g.c_extern_param_c_type(param_type)
+		}
+		if ct.starts_with('fn_ptr:') {
+			ct = g.resolve_fn_ptr_type(ct)
+		}
+		if written > 0 {
+			g.write(', ')
+		}
+		g.write(ct)
+		g.write(' ')
+		if written < names.len {
+			g.write(names[written])
+		} else {
+			g.write('_${written}')
+		}
+		written++
+	}
+	if written == 0 {
+		g.write('void')
+	}
 }
 
 fn (mut g FlatGen) gen_top_level_main(stmts []TopLevelStmt) {
@@ -11779,6 +12092,19 @@ fn (mut g FlatGen) precompute_concrete_optional_abi_fns() {
 		}
 		params := g.fn_node_param_types_or_decl(node, cur_module)
 		ret_type := g.fn_node_return_type(node, cur_module)
+		if g.type_has_missing_qualified_nominal(ret_type) {
+			continue
+		}
+		mut has_missing_param_type := false
+		for param in params {
+			if g.type_has_missing_qualified_nominal(param) {
+				has_missing_param_type = true
+				break
+			}
+		}
+		if has_missing_param_type {
+			continue
+		}
 		if !params_have_optional_result(params) && !type_is_optional_result(ret_type) {
 			continue
 		}
@@ -16694,11 +17020,11 @@ fn (mut g FlatGen) forward_decl_items(items []FlatFnGenItem, mut forwarded_expor
 				if export_name != qfn && export_name !in forwarded_exports {
 					forwarded_exports << export_name
 					g.write(g.exported_symbol_attribute())
-					g.write(g.fn_return_type_name_for_context(ret_type, concrete_optional))
+					g.write(g.export_wrapper_return_c_type(node, item.module, ret_type))
 					g.write(' ')
 					g.write(export_name)
 					g.write('(')
-					g.write_fn_node_params(node)
+					g.write_export_wrapper_params(node, item.module)
 					g.writeln(');')
 				}
 			}
@@ -17276,6 +17602,7 @@ const c_system_libc_preamble_declared_fns = {
 	'cosf':                          true
 	'_dyld_get_image_header':        true
 	'execve':                        true
+	'execl':                         true
 	'exit':                          true
 	'fdopen':                        true
 	'feof':                          true

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -2429,6 +2429,12 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		module_cleanup_fn_modules: g.module_cleanup_fn_modules
 		module_imports: g.module_imports
 		preserved_header_files_seen: g.preserved_header_files_seen
+		inlined_c_structs: g.inlined_c_structs
+		inlined_c_typedef_names: g.inlined_c_typedef_names
+		inlined_c_fns: g.inlined_c_fns
+		inlined_c_declared_fns: g.inlined_c_declared_fns
+		inlined_c_active_macros: g.inlined_c_active_macros
+		inlined_c_static_fns: g.inlined_c_static_fns
 		libc_compat_fns: g.libc_compat_fns.clone()
 		tc: if result_only {
 			unsafe { g.tc }
@@ -3016,10 +3022,15 @@ fn (mut g FlatGen) run_pre_dispatch_parallel(no_parallel bool) bool {
 		}
 		mut fs_worker := g.new_parallel_worker(0)
 		fs_worker.tc.verbose = g.tc.verbose
+		// These helpers can intern C names concurrently. Give each a detached cache
+		// instead of racing through the shared master cache backing.
+		fs_worker.c_name_cache = &CNameCache{}
 		mut fixed_array_worker := g.new_parallel_worker(1)
 		fixed_array_worker.tc.verbose = g.tc.verbose
+		fixed_array_worker.c_name_cache = &CNameCache{}
 		mut optional_worker := g.new_parallel_worker(2)
 		optional_worker.tc.verbose = g.tc.verbose
+		optional_worker.c_name_cache = &CNameCache{}
 		fail := os.getenv('V3_TEST_PTHREAD_CREATE_FAIL')
 		if fail.len > 0 {
 			// prepare_pre_dispatch_master can submit its own selection/cost batches to

--- a/vlib/v3/gen/c/if.v
+++ b/vlib/v3/gen/c/if.v
@@ -732,12 +732,34 @@ fn (mut g FlatGen) if_expr_block_tail_type(block &flat.Node) types.Type {
 	}
 	last := g.a.child_node(block, block.children_count - 1)
 	ret := if last.kind == .expr_stmt {
-		g.usable_expr_type(g.a.child(last, 0))
+		g.if_expr_tail_value_type(g.a.child(last, 0))
 	} else {
-		g.usable_expr_type(g.a.child(block, block.children_count - 1))
+		g.if_expr_tail_value_type(g.a.child(block, block.children_count - 1))
 	}
 	g.pop_scope()
 	return ret
+}
+
+fn (mut g FlatGen) if_expr_tail_value_type(id flat.NodeId) types.Type {
+	t := g.usable_expr_type(id)
+	if int(id) < 0 || int(id) >= g.a.nodes.len {
+		return t
+	}
+	node := g.a.nodes[int(id)]
+	if node.kind != .or_expr || node.children_count == 0 {
+		return t
+	}
+	source_id := g.a.child(&node, 0)
+	source_node := g.a.nodes[int(source_id)]
+	source_type := g.optional_source_type_for_expr(source_id,
+		g.or_expr_source_type(source_id, source_node))
+	if source_type is types.OptionType {
+		return source_type.base_type
+	}
+	if source_type is types.ResultType {
+		return source_type.base_type
+	}
+	return t
 }
 
 // if_expr_type supports if expr type handling for FlatGen.
@@ -769,8 +791,14 @@ fn (mut g FlatGen) if_expr_type(node &flat.Node) types.Type {
 
 // gen_if_expr_stmt emits if expr stmt output for c.
 fn (mut g FlatGen) gen_if_expr_stmt(node flat.Node) {
+	inferred_type := g.if_expr_type(&node)
 	ret_type := if node.typ.len > 0 {
-		g.parse_node_type(&node)
+		annotated_type := g.parse_node_type(&node)
+		if annotated_type is types.Primitive && inferred_type !is types.Primitive {
+			inferred_type
+		} else {
+			annotated_type
+		}
 	} else if g.expected_expr_type !is types.Void {
 		g.expected_expr_type
 	} else {

--- a/vlib/v3/gen/c/if.v
+++ b/vlib/v3/gen/c/if.v
@@ -49,8 +49,7 @@ fn (mut g FlatGen) gen_if(node flat.Node) {
 		if g.valid_node_id(then_id) {
 			then_block := g.a.nodes[int(then_id)]
 			then_scope_drop_prefix_count = g.block_scope_drop_prefix_count(then_block)
-			then_scope_drops_consumed = g.gen_branch_block_children(then_block, 1 +
-				then_scope_drop_prefix_count)
+			then_scope_drops_consumed = g.gen_branch_block_children(then_block, 1 + then_scope_drop_prefix_count)
 			if !g.block_consumes_scope_ownership_drops(then_block) {
 				then_scope_drops_consumed = true
 			}
@@ -104,8 +103,7 @@ fn (mut g FlatGen) gen_if(node flat.Node) {
 			g.enter_conditional_branch(true)
 			mut else_scope_drops_consumed := false
 			else_scope_drop_prefix_count := g.block_scope_drop_prefix_count(else_node)
-			else_scope_drops_consumed = g.gen_branch_block_children(else_node, 1 +
-				else_scope_drop_prefix_count)
+			else_scope_drops_consumed = g.gen_branch_block_children(else_node, 1 + else_scope_drop_prefix_count)
 			if !g.block_consumes_scope_ownership_drops(else_node) {
 				else_scope_drops_consumed = true
 			}
@@ -311,8 +309,7 @@ fn (mut g FlatGen) gen_if_guard(node flat.Node, cond flat.Node) {
 		then_block := g.a.nodes[int(then_id)]
 		then_scope_drop_prefix_count = g.block_scope_drop_prefix_count(then_block)
 		g.enter_conditional_branch(true)
-		then_scope_drops_consumed = g.gen_branch_block_children(then_block, 2 +
-			then_scope_drop_prefix_count)
+		then_scope_drops_consumed = g.gen_branch_block_children(then_block, 2 + then_scope_drop_prefix_count)
 		g.leave_conditional_branch()
 		if !g.block_consumes_scope_ownership_drops(then_block) {
 			then_scope_drops_consumed = true
@@ -427,8 +424,7 @@ fn (mut g FlatGen) gen_if_else(node flat.Node) {
 			g.enter_conditional_branch(true)
 			mut else_scope_drops_consumed := false
 			else_scope_drop_prefix_count := g.block_scope_drop_prefix_count(else_node)
-			else_scope_drops_consumed = g.gen_branch_block_children(else_node, 1 +
-				else_scope_drop_prefix_count)
+			else_scope_drops_consumed = g.gen_branch_block_children(else_node, 1 + else_scope_drop_prefix_count)
 			if !g.block_consumes_scope_ownership_drops(else_node) {
 				else_scope_drops_consumed = true
 			}
@@ -568,7 +564,7 @@ fn (g &FlatGen) multi_return_tail_parts(block &flat.Node, count int) ?MultiRetur
 			if nested.prefix_count == 0 {
 				return MultiReturnTailParts{
 					prefix_count: int(block.children_count) - 1
-					values:       nested.values.clone()
+					values: nested.values.clone()
 				}
 			}
 		}
@@ -589,7 +585,7 @@ fn (g &FlatGen) multi_return_tail_parts(block &flat.Node, count int) ?MultiRetur
 		if values.len == count {
 			return MultiReturnTailParts{
 				prefix_count: i
-				values:       values.clone()
+				values: values.clone()
 			}
 		}
 	}
@@ -684,12 +680,7 @@ fn (mut g FlatGen) gen_multi_return_tail_temp(ct string, ret_types []types.Type,
 // is_expr_kind reports whether is expr kind applies in c.
 fn (g &FlatGen) is_expr_kind(kind flat.NodeKind) bool {
 	return match kind {
-		.int_literal, .float_literal, .bool_literal, .char_literal, .string_literal,
-		.string_interp, .ident, .infix, .prefix, .postfix, .paren, .call, .selector, .index,
-		.if_expr, .struct_init, .field_init, .array_literal, .array_init, .map_init, .fn_literal,
-		.or_expr, .cast_expr, .as_expr, .enum_val, .assoc, .range, .nil_literal, .none_expr,
-		.spawn_expr, .lock_expr, .lambda_expr, .sizeof_expr, .typeof_expr, .dump_expr,
-		.offsetof_expr, .is_expr, .in_expr {
+		.int_literal, .float_literal, .bool_literal, .char_literal, .string_literal, .string_interp, .ident, .infix, .prefix, .postfix, .paren, .call, .selector, .index, .if_expr, .struct_init, .field_init, .array_literal, .array_init, .map_init, .fn_literal, .or_expr, .cast_expr, .as_expr, .enum_val, .assoc, .range, .nil_literal, .none_expr, .spawn_expr, .lock_expr, .lambda_expr, .sizeof_expr, .typeof_expr, .dump_expr, .offsetof_expr, .is_expr, .in_expr {
 			true
 		}
 		else {
@@ -751,8 +742,7 @@ fn (mut g FlatGen) if_expr_tail_value_type(id flat.NodeId) types.Type {
 	}
 	source_id := g.a.child(&node, 0)
 	source_node := g.a.nodes[int(source_id)]
-	source_type := g.optional_source_type_for_expr(source_id,
-		g.or_expr_source_type(source_id, source_node))
+	source_type := g.optional_source_type_for_expr(source_id, g.or_expr_source_type(source_id, source_node))
 	if source_type is types.OptionType {
 		return source_type.base_type
 	}

--- a/vlib/v3/gen/c/names_test.v
+++ b/vlib/v3/gen/c/names_test.v
@@ -451,7 +451,9 @@ fn test_compiler_header_to_preserve_is_anchored_to_vroot() {
 		return
 	}
 	assert os.real_path(resolved) == os.real_path(header_path)
-	assert c_compiler_header_to_preserve('"sokol_app.h"', '/different/vroot', '', [header_dir]) == none
+	assert c_compiler_header_to_preserve('"sokol_app.h"', '/different/vroot', '', [
+		header_dir,
+	]) == none
 }
 
 fn test_unresolved_openssl_headers_are_preserved() {

--- a/vlib/v3/gen/c/names_test.v
+++ b/vlib/v3/gen/c/names_test.v
@@ -407,6 +407,17 @@ fn test_system_libc_preamble_identifies_glibc_before_manual_stdio_declarations()
 }
 
 fn test_preserved_system_include_declarations_are_header_specific() {
+	assert c_preserved_system_include_skips_tree_scan('<Cocoa/Cocoa.h>')
+	assert c_preserved_system_include_skips_tree_scan('<Foundation/Foundation.h>')
+	assert !c_preserved_system_include_skips_tree_scan('<stdio.h>')
+	assert c_header_owned_system_include_skips_tree_scan('<Metal/Metal.h>')
+	assert c_header_owned_system_include_skips_tree_scan(' <QuartzCore/CAMetalLayer.h> ')
+	assert c_header_owned_system_include_skips_tree_scan('<mbedtls/ssl.h>')
+	assert 'mbedtls_ssl_context' in c_preserved_system_include_typedef_names('<mbedtls/ssl.h>')
+	assert c_header_owned_uses_single_scan('/vroot/thirdparty/sokol/sokol_app.h', '/vroot')
+	assert c_header_owned_uses_single_scan('/vroot/thirdparty/sokol/sokol_gfx.h', '/vroot')
+	assert c_header_owned_uses_single_scan('/vroot/thirdparty/stb_image/stb_image.h', '/vroot')
+	assert !c_header_owned_uses_single_scan('/project/sokol_app.h', '/vroot')
 	assert c_preserved_system_include_declared_fns('<stdio.h>').len == 0
 	assert 'sqlite3_bind_text' in c_preserved_system_include_declared_fns('"sqlite3.h"')
 	assert 'sqlite3_column_name' in c_preserved_system_include_declared_fns('<sqlite3.h>')
@@ -420,8 +431,27 @@ fn test_preserved_system_include_declarations_are_header_specific() {
 	assert 'OPENSSL_free' in c_preserved_system_include_declared_fns('<openssl/ec.h>')
 	assert c_preserved_system_include_declared_fns('<objc/message.h>') == [
 		'objc_msgSend',
+		'objc_msgSendSuper',
 	]
 	assert c_preserved_system_include_struct_names('<poll.h>') == ['pollfd']
+}
+
+fn test_compiler_header_to_preserve_is_anchored_to_vroot() {
+	root := os.join_path(os.vtmp_dir(), 'v3_preserve_header_${os.getpid()}')
+	header_dir := os.join_path(root, 'thirdparty', 'sokol')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(header_dir)!
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	header_path := os.join_path(header_dir, 'sokol_app.h')
+	os.write_file(header_path, 'typedef int sapp_test;\n')!
+	resolved := c_compiler_header_to_preserve('"sokol_app.h"', root, '', [header_dir]) or {
+		assert false
+		return
+	}
+	assert os.real_path(resolved) == os.real_path(header_path)
+	assert c_compiler_header_to_preserve('"sokol_app.h"', '/different/vroot', '', [header_dir]) == none
 }
 
 fn test_unresolved_openssl_headers_are_preserved() {

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -6921,7 +6921,8 @@ fn (g &FlatGen) index_rhs_alias_elem_type(rhs flat.Node) ?types.Type {
 }
 
 fn (g &FlatGen) preserve_specialized_alias_decl_type(rhs_id flat.NodeId, rhs flat.Node, v_type types.Type) types.Type {
-	if v_type is types.Alias || !g.name_uses_specialized_generic_abi(g.cur_fn_name) {
+	if v_type is types.Alias
+		|| (!g.cur_fn_is_specialized && !g.name_uses_specialized_generic_abi(g.cur_fn_name)) {
 		return v_type
 	}
 	rhs_type := g.decl_rhs_fallback_type(rhs_id, rhs)

--- a/vlib/v3/gen/c/str_intp.v
+++ b/vlib/v3/gen/c/str_intp.v
@@ -367,13 +367,13 @@ fn (mut g FlatGen) string_literals_from(start int) {
 		for s in literals {
 			i := g.str_lit_ids[s]
 			escaped := c_escape(s)
-			g.writeln('static string _str_${i} = {"${escaped}", ${s.len}, 1};')
+			g.writeln('static const string _str_${i} = {"${escaped}", ${s.len}, 1};')
 		}
 	} else {
 		for i := start; i < g.str_lits.len; i++ {
 			s := g.str_lits[i]
 			escaped := c_escape(s)
-			g.writeln('string _str_${i} = {"${escaped}", ${s.len}, 1};')
+			g.writeln('static const string _str_${i} = {"${escaped}", ${s.len}, 1};')
 		}
 	}
 	if g.str_lits.len > start {

--- a/vlib/v3/gen/c/str_intp_test.v
+++ b/vlib/v3/gen/c/str_intp_test.v
@@ -27,6 +27,13 @@ fn formatted_u8_interp_c_expr(format string) string {
 	return g.sb.str()
 }
 
+fn test_string_literal_table_has_internal_const_linkage() {
+	mut g := FlatGen.new()
+	g.intern_string('literal')
+	g.string_literals()
+	assert g.sb.str() == 'static const string _str_0 = {"literal", 7, 1};\n\n'
+}
+
 fn test_character_interpolation_uses_rune_text() {
 	assert formatted_u8_interp_c_expr('1c') == 'rune__str((u32)(102))'
 	assert formatted_u8_interp_c_expr('3c') == 'v3_string_pad(rune__str((u32)(102)), 3, 0)'

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -721,16 +721,7 @@ fn (g &FlatGen) unique_qualified_struct_c_type(short_ct string) ?string {
 			return cached
 		}
 	}
-	mut matches := []string{}
-	for type_name, _ in g.tc.structs {
-		candidate_ct := g.struct_cname(type_name)
-		if candidate_ct != short_ct && !candidate_ct.ends_with('__${short_ct}') {
-			continue
-		}
-		if candidate_ct !in matches {
-			matches << candidate_ct
-		}
-	}
+	matches := g.qualified_struct_c_types(short_ct)
 	if matches.len == 1 && matches[0] != short_ct {
 		if !isnil(g.unique_struct_ct_cache) {
 			mut cache := g.unique_struct_ct_cache
@@ -743,6 +734,37 @@ fn (g &FlatGen) unique_qualified_struct_c_type(short_ct string) ?string {
 		cache.put(short_ct, '')
 	}
 	return none
+}
+
+fn (g &FlatGen) qualified_struct_c_types(short_ct string) []string {
+	if short_ct.len == 0 {
+		return []string{}
+	}
+	mut matches := []string{}
+	for type_name, _ in g.tc.structs {
+		candidate_ct := g.struct_cname(type_name)
+		if candidate_ct != short_ct && !candidate_ct.ends_with('__${short_ct}') {
+			continue
+		}
+		if candidate_ct !in matches {
+			matches << candidate_ct
+		}
+	}
+	return matches
+}
+
+fn (g &FlatGen) stale_ambiguous_qualified_struct_c_type(short_ct string) bool {
+	matches := g.qualified_struct_c_types(short_ct)
+	return matches.len > 1 && short_ct !in matches
+}
+
+fn (g &FlatGen) stale_missing_qualified_struct_c_type(ct string) bool {
+	if !ct.contains('__') {
+		return false
+	}
+	short_ct := ct.all_after_last('__')
+	matches := g.qualified_struct_c_types(short_ct)
+	return matches.len > 0 && ct !in matches
 }
 
 fn (g &FlatGen) unique_qualified_interface_c_type(short_ct string) ?string {

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -973,6 +973,14 @@ fn (mut g FlatGen) emit_optional_typedef(opt_name string, val_type string) bool 
 		return false
 	}
 	bare_val_type := val_type.trim_right('*')
+	if g.stale_ambiguous_qualified_struct_c_type(bare_val_type)
+		|| g.stale_missing_qualified_struct_c_type(bare_val_type) {
+		// Stale generic annotations can lose the declaration module or inherit the
+		// generic helper's module. The correctly qualified specialization registers
+		// the usable optional; do not emit a phantom payload type here.
+		g.emitted_optional_types[opt_name] = true
+		return false
+	}
 	if !bare_val_type.contains('__') && g.stale_ambiguous_qualified_interface_c_type(bare_val_type) {
 		// A stale unqualified signature cannot identify which imported interface it
 		// belongs to. Its concrete, module-qualified signature registers the usable

--- a/vlib/v3/gen/fastc/match.v
+++ b/vlib/v3/gen/fastc/match.v
@@ -173,8 +173,10 @@ fn (mut g Parser) read_match_expression() !string {
 				is_mut: smartcast_saved.is_mut
 				is_reference: smartcast_is_reference
 				typ: if smartcast_is_reference {
-					smartcast_type + '*'} else {
-					smartcast_type}
+					smartcast_type + '*'
+				} else {
+					smartcast_type
+				}
 			}
 		}
 		projection_path := if subject_member_path != '' {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -6300,7 +6300,7 @@ fn (mut p Parser) stmt() flat.NodeId {
 				p.next()
 			}
 			return p.add_node(flat.Node{
-				kind:           .expr_stmt
+				kind: .expr_stmt
 				children_start: p.add_child(expr_id)
 				children_count: 1
 			})

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -6291,7 +6291,19 @@ fn (mut p Parser) stmt() flat.NodeId {
 		.key_unsafe {
 			unsafe_start := p.span_start()
 			p.next()
-			return p.unsafe_block_stmt(unsafe_start)
+			unsafe_id := p.unsafe_block_stmt(unsafe_start)
+			expr_id := p.expr_with_lhs(unsafe_id, .lowest)
+			if expr_id == unsafe_id {
+				return unsafe_id
+			}
+			if p.tok == .semicolon {
+				p.next()
+			}
+			return p.add_node(flat.Node{
+				kind:           .expr_stmt
+				children_start: p.add_child(expr_id)
+				children_count: 1
+			})
 		}
 		.key_defer {
 			return p.defer_stmt()
@@ -12515,7 +12527,7 @@ fn (p &Parser) shared_token_gap_has_line_boundary() bool {
 }
 
 fn token_can_start_type_name(tok token.Token) bool {
-	return tok == .name || tok == .amp || tok == .question || tok == .not || tok == .lsbr
+	return tok == .name || tok == .amp || tok == .and || tok == .question || tok == .not || tok == .lsbr
 		|| tok == .lpar || tok == .key_fn || tok == .key_struct || tok == .ellipsis
 		|| tok == .key_mut || tok == .key_shared || tok == .key_atomic || tok == .key_typeof
 }

--- a/vlib/v3/scanner/scanner.v
+++ b/vlib/v3/scanner/scanner.v
@@ -38,6 +38,8 @@ pub mut:
 	in_str_inter_format bool
 	str_inter_cbr_depth int
 	str_quote           u8
+	str_parent_quotes   []u8
+	str_parent_depths   []int
 	diagnostics         []Diagnostic
 }
 
@@ -86,6 +88,8 @@ pub fn (mut s Scanner) init(file &token.File, src string) {
 	s.in_str_inter_format = false
 	s.str_inter_cbr_depth = 0
 	s.str_quote = 0
+	s.str_parent_quotes = []u8{}
+	s.str_parent_depths = []int{}
 	s.diagnostics = []Diagnostic{}
 	s.file = unsafe { file }
 	s.src = src
@@ -165,6 +169,9 @@ pub fn (mut s Scanner) scan() token.Token {
 		s.pos = s.offset
 		s.string_literal(false, s.str_quote)
 		s.lit = s.source_lit(s.pos, s.offset)
+		if !s.in_str_inter {
+			s.restore_parent_string_interpolation()
+		}
 		return .string
 	}
 	follows_dot := s.after_dot
@@ -253,11 +260,17 @@ pub fn (mut s Scanner) scan() token.Token {
 			&& (s.src[s.offset] == `'` || s.src[s.offset] == `"`) {
 			quote := s.src[s.offset]
 			s.offset++
-			if !s.in_str_inter {
+			nested_interpolation := s.in_str_inter && !s.skip_interpolation
+			if nested_interpolation {
+				s.begin_nested_string_interpolation(quote)
+			} else if !s.in_str_inter {
 				s.str_quote = quote
 			}
 			s.string_literal(false, quote)
 			s.lit = s.source_lit(s.pos, s.offset)
+			if nested_interpolation && !s.in_str_inter {
+				s.restore_parent_string_interpolation()
+			}
 			s.insert_semi = true
 			return .string
 		}
@@ -269,11 +282,17 @@ pub fn (mut s Scanner) scan() token.Token {
 		return tok
 	} else if c == `'` || c == `"` {
 		s.offset++
-		if !s.in_str_inter {
+		nested_interpolation := s.in_str_inter && !s.skip_interpolation
+		if nested_interpolation {
+			s.begin_nested_string_interpolation(c)
+		} else if !s.in_str_inter {
 			s.str_quote = c
 		}
 		s.string_literal(s.in_str_inter || (s.offset >= 2 && s.src[s.offset - 2] == `r`), c)
 		s.lit = s.source_lit(s.pos, s.offset)
+		if nested_interpolation && !s.in_str_inter {
+			s.restore_parent_string_interpolation()
+		}
 		s.insert_semi = true
 		return .string
 	} else if c == `\`` {
@@ -666,6 +685,26 @@ fn (mut s Scanner) string_literal(scan_as_raw bool, c_quote u8) {
 		s.offset++
 	}
 	s.error('unfinished string literal', s.src.len)
+}
+
+fn (mut s Scanner) begin_nested_string_interpolation(quote u8) {
+	s.str_parent_quotes << s.str_quote
+	s.str_parent_depths << s.str_inter_cbr_depth
+	s.in_str_inter = false
+	s.str_inter_cbr_depth = 0
+	s.str_quote = quote
+}
+
+fn (mut s Scanner) restore_parent_string_interpolation() {
+	if s.str_parent_quotes.len == 0 {
+		return
+	}
+	last := s.str_parent_quotes.len - 1
+	s.str_quote = s.str_parent_quotes[last]
+	s.str_inter_cbr_depth = s.str_parent_depths[last]
+	s.str_parent_quotes.delete_last()
+	s.str_parent_depths.delete_last()
+	s.in_str_inter = true
 }
 
 fn (mut s Scanner) check_string_escape(backslash_offset int) {

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -1765,7 +1765,7 @@ fn test_driver_rejects_invalid_cli_and_parses_vmod_subdirs() {
 	help := cmdexec.run(v3_bin, ['--help'])
 	assert help.exit_code == 0
 	assert help.output.contains('-cc <compiler>')
-	assert help.output.contains('-no-memory-limit             disable the 3840 MiB memory safety limit')
+	assert help.output.contains('-no-memory-limit             disable the 4032 MiB user-build memory safety limit')
 	c_output := os.join_path(root, 'hello.c')
 	c_compile := cmdexec.run(v3_bin, ['-no-memory-limit', '-o', c_output, source])
 	assert c_compile.exit_code == 0, c_compile.output

--- a/vlib/v3/tests/global_decl_codegen_test.v
+++ b/vlib/v3/tests/global_decl_codegen_test.v
@@ -231,3 +231,10 @@ fn main() {
 ")
 	assert out == 'ready\nshared-ready\nstring:\nstring:'
 }
+
+fn test_inferred_generic_atomic_globals_keep_concrete_types() {
+	v3_bin := global_decl_build_v3()
+	out := global_decl_run_good(v3_bin, 'inferred_generic_atomic_globals',
+		"import sync.stdatomic\n\n__global flag = stdatomic.new_atomic(false)\n__global number = stdatomic.new_atomic(7)\n\nfn main() {\n\tprintln(int_str(number.load()))\n\tprintln(flag.load())\n}\n")
+	assert out == '7\nfalse'
+}

--- a/vlib/v3/tests/global_decl_codegen_test.v
+++ b/vlib/v3/tests/global_decl_codegen_test.v
@@ -38,43 +38,37 @@ fn global_decl_generate_c(v3_bin string, name string, source string) string {
 
 fn test_typed_global_initializers_in_group_keep_type_and_value() {
 	v3_bin := global_decl_build_v3()
-	out := global_decl_run_good(v3_bin, 'typed_global_initializers_in_group',
-		'import sync.stdatomic\n\n__global (\n\tfirst_flag &stdatomic.AtomicVal[bool] = stdatomic.new_atomic(false)\n\tsecond_flag &stdatomic.AtomicVal[bool] = stdatomic.new_atomic(false)\n)\n\nfn main() {\n\tfirst_flag.store(true)\n\tprintln(first_flag.load())\n\tprintln(second_flag.load())\n\tsecond_flag.store(true)\n\tprintln(second_flag.load())\n}\n')
+	out := global_decl_run_good(v3_bin, 'typed_global_initializers_in_group', 'import sync.stdatomic\n\n__global (\n\tfirst_flag &stdatomic.AtomicVal[bool] = stdatomic.new_atomic(false)\n\tsecond_flag &stdatomic.AtomicVal[bool] = stdatomic.new_atomic(false)\n)\n\nfn main() {\n\tfirst_flag.store(true)\n\tprintln(first_flag.load())\n\tprintln(second_flag.load())\n\tsecond_flag.store(true)\n\tprintln(second_flag.load())\n}\n')
 	assert out == 'true\nfalse\ntrue'
 }
 
 fn test_implicit_global_dynamic_array_is_initialized_before_append() {
 	v3_bin := global_decl_build_v3()
-	out := global_decl_run_good(v3_bin, 'implicit_global_dynamic_array',
-		"struct Entry {\n\tname string\n}\n\n__global entries []Entry\n\nfn main() {\n\tentries << Entry{name: 'ok'}\n\tprintln(entries[0].name)\n}\n")
+	out := global_decl_run_good(v3_bin, 'implicit_global_dynamic_array', "struct Entry {\n\tname string\n}\n\n__global entries []Entry\n\nfn main() {\n\tentries << Entry{name: 'ok'}\n\tprintln(entries[0].name)\n}\n")
 	assert out == 'ok'
 }
 
 fn test_implicit_global_containers_keep_synthesized_runtime_helpers() {
 	v3_bin := global_decl_build_v3()
-	out := global_decl_run_good(v3_bin, 'implicit_global_container_helpers',
-		"__global names []string\n__global lookup map[string]int\n\nfn main() {\n\tprintln('ok')\n}\n")
+	out := global_decl_run_good(v3_bin, 'implicit_global_container_helpers', "__global names []string\n__global lookup map[string]int\n\nfn main() {\n\tprintln('ok')\n}\n")
 	assert out == 'ok'
 }
 
 fn test_global_runtime_initializers_preserve_channels_arrays_and_fn_values() {
 	v3_bin := global_decl_build_v3()
-	out := global_decl_run_good(v3_bin, 'global_runtime_initializers',
-		"__global (\n\tch chan int\n\tvalues = []int{len: 3, init: 7}\n\tcallback = fn (n int) int {\n\t\treturn n + 1\n\t}\n)\n\nfn send_value() {\n\tch <- 9\n}\n\nfn main() {\n\tt := spawn send_value()\n\tgot := <-ch\n\tt.wait()\n\tprintln(int_str(got))\n\tprintln(int_str(values.len) + ':' + int_str(values[2]))\n\tprintln(int_str(callback(4)))\n}\n")
+	out := global_decl_run_good(v3_bin, 'global_runtime_initializers', "__global (\n\tch chan int\n\tvalues = []int{len: 3, init: 7}\n\tcallback = fn (n int) int {\n\t\treturn n + 1\n\t}\n)\n\nfn send_value() {\n\tch <- 9\n}\n\nfn main() {\n\tt := spawn send_value()\n\tgot := <-ch\n\tt.wait()\n\tprintln(int_str(got))\n\tprintln(int_str(values.len) + ':' + int_str(values[2]))\n\tprintln(int_str(callback(4)))\n}\n")
 	assert out == '9\n3:7\n5'
 }
 
 fn test_explicit_shared_and_fixed_array_global_initializers() {
 	v3_bin := global_decl_build_v3()
-	out := global_decl_run_good(v3_bin, 'shared_and_fixed_array_global_initializers',
-		"struct Counter {\n\tvalue int\n}\n\n__global counter shared Counter = Counter{value: 7}\n__global fixed_values shared [2]int = [3, 4]!\n__global values = [][2]int{len: 1, init: [1, 2]!}\n\nfn main() {\n\tvalue := rlock counter {\n\t\tcounter.value\n\t}\n\tfixed_value := rlock fixed_values {\n\t\tfixed_values[0] * 10 + fixed_values[1]\n\t}\n\tprintln(int_str(value))\n\tprintln(int_str(fixed_value))\n\tprintln(int_str(values[0][0]) + ':' + int_str(values[0][1]))\n}\n")
+	out := global_decl_run_good(v3_bin, 'shared_and_fixed_array_global_initializers', "struct Counter {\n\tvalue int\n}\n\n__global counter shared Counter = Counter{value: 7}\n__global fixed_values shared [2]int = [3, 4]!\n__global values = [][2]int{len: 1, init: [1, 2]!}\n\nfn main() {\n\tvalue := rlock counter {\n\t\tcounter.value\n\t}\n\tfixed_value := rlock fixed_values {\n\t\tfixed_values[0] * 10 + fixed_values[1]\n\t}\n\tprintln(int_str(value))\n\tprintln(int_str(fixed_value))\n\tprintln(int_str(values[0][0]) + ':' + int_str(values[0][1]))\n}\n")
 	assert out == '7\n34\n1:2'
 }
 
 fn test_aliased_fixed_array_global_initializer_uses_copy() {
 	v3_bin := global_decl_build_v3()
-	out := global_decl_run_good(v3_bin, 'aliased_fixed_array_global_initializer',
-		'type Pair = [2]int\n\n__global pair Pair = [2]int{init: 7}\n\nfn main() {\n\tprintln(int_str(pair[0]) + ":" + int_str(pair[1]))\n}\n')
+	out := global_decl_run_good(v3_bin, 'aliased_fixed_array_global_initializer', 'type Pair = [2]int\n\n__global pair Pair = [2]int{init: 7}\n\nfn main() {\n\tprintln(int_str(pair[0]) + ":" + int_str(pair[1]))\n}\n')
 	assert out == '7:7'
 }
 
@@ -150,22 +144,19 @@ fn main() {
 
 fn test_global_array_initializers_fill_runtime_defaults() {
 	v3_bin := global_decl_build_v3()
-	out := global_decl_run_good(v3_bin, 'global_array_runtime_defaults',
-		"struct Config {\nmut:\n\tretries int = 7\n\tnames []string\n\tscores map[string]int\n}\n\n__global configs = []Config{len: 2}\n__global nested = [][]int{len: 2}\n__global lookups = []map[string]int{len: 2}\n\nfn main() {\n\tconfigs[0].names << 'ok'\n\tconfigs[0].scores['x'] = 5\n\tnested[0] << 9\n\tlookups[0]['x'] = 11\n\tprintln(int_str(configs[0].retries))\n\tprintln(configs[0].names[0])\n\tprintln(int_str(configs[0].scores['x']))\n\tprintln(int_str(nested[0][0]))\n\tprintln(int_str(lookups[0]['x']))\n\tprintln(int_str(configs[1].names.len) + ':' + int_str(configs[1].scores.len) + ':' + int_str(nested[1].len) + ':' + int_str(lookups[1].len))\n}\n")
+	out := global_decl_run_good(v3_bin, 'global_array_runtime_defaults', "struct Config {\nmut:\n\tretries int = 7\n\tnames []string\n\tscores map[string]int\n}\n\n__global configs = []Config{len: 2}\n__global nested = [][]int{len: 2}\n__global lookups = []map[string]int{len: 2}\n\nfn main() {\n\tconfigs[0].names << 'ok'\n\tconfigs[0].scores['x'] = 5\n\tnested[0] << 9\n\tlookups[0]['x'] = 11\n\tprintln(int_str(configs[0].retries))\n\tprintln(configs[0].names[0])\n\tprintln(int_str(configs[0].scores['x']))\n\tprintln(int_str(nested[0][0]))\n\tprintln(int_str(lookups[0]['x']))\n\tprintln(int_str(configs[1].names.len) + ':' + int_str(configs[1].scores.len) + ':' + int_str(nested[1].len) + ':' + int_str(lookups[1].len))\n}\n")
 	assert out == '7\nok\n5\n9\n11\n0:0:0:0'
 }
 
 fn test_global_arrays_fill_nested_fixed_array_defaults() {
 	v3_bin := global_decl_build_v3()
-	out := global_decl_run_good(v3_bin, 'global_nested_fixed_array_defaults',
-		"struct Config {\nmut:\n\tretries int = 7\n\tnames []string\n\tscores map[string]int\n}\n\n__global rows = [][2]map[string]int{len: 1}\n__global config_rows = [][2]Config{len: 1}\n__global grids = [][2][2]map[string]int{len: 1}\n\nfn main() {\n\trows[0][0]['x'] = 13\n\tconfig_rows[0][0].names << 'fixed'\n\tconfig_rows[0][0].scores['x'] = 17\n\tgrids[0][1][1]['x'] = 19\n\tprintln(int_str(rows[0][0]['x']))\n\tprintln(int_str(config_rows[0][0].retries) + ':' + config_rows[0][0].names[0] + ':' + int_str(config_rows[0][0].scores['x']))\n\tprintln(int_str(grids[0][1][1]['x']))\n\tprintln(int_str(rows[0][1].len) + ':' + int_str(config_rows[0][1].retries) + ':' + int_str(grids[0][0][0].len))\n}\n")
+	out := global_decl_run_good(v3_bin, 'global_nested_fixed_array_defaults', "struct Config {\nmut:\n\tretries int = 7\n\tnames []string\n\tscores map[string]int\n}\n\n__global rows = [][2]map[string]int{len: 1}\n__global config_rows = [][2]Config{len: 1}\n__global grids = [][2][2]map[string]int{len: 1}\n\nfn main() {\n\trows[0][0]['x'] = 13\n\tconfig_rows[0][0].names << 'fixed'\n\tconfig_rows[0][0].scores['x'] = 17\n\tgrids[0][1][1]['x'] = 19\n\tprintln(int_str(rows[0][0]['x']))\n\tprintln(int_str(config_rows[0][0].retries) + ':' + config_rows[0][0].names[0] + ':' + int_str(config_rows[0][0].scores['x']))\n\tprintln(int_str(grids[0][1][1]['x']))\n\tprintln(int_str(rows[0][1].len) + ':' + int_str(config_rows[0][1].retries) + ':' + int_str(grids[0][0][0].len))\n}\n")
 	assert out == '13\n7:fixed:17\n19\n0:7:0'
 }
 
 fn test_global_array_initializer_call_preserves_fixed_array_elements() {
 	v3_bin := global_decl_build_v3()
-	out := global_decl_run_good(v3_bin, 'global_fixed_array_elements_from_call',
-		"fn make_rows() [][2]int {\n\treturn [[1, 2]!, [3, 4]!]\n}\n\n__global rows = make_rows()\n\nfn main() {\n\tprintln(int_str(rows[0][0]) + ':' + int_str(rows[0][1]))\n\tprintln(int_str(rows[1][0]) + ':' + int_str(rows[1][1]))\n}\n")
+	out := global_decl_run_good(v3_bin, 'global_fixed_array_elements_from_call', "fn make_rows() [][2]int {\n\treturn [[1, 2]!, [3, 4]!]\n}\n\n__global rows = make_rows()\n\nfn main() {\n\tprintln(int_str(rows[0][0]) + ':' + int_str(rows[0][1]))\n\tprintln(int_str(rows[1][0]) + ':' + int_str(rows[1][1]))\n}\n")
 	assert out == '1:2\n3:4'
 }
 
@@ -234,7 +225,6 @@ fn main() {
 
 fn test_inferred_generic_atomic_globals_keep_concrete_types() {
 	v3_bin := global_decl_build_v3()
-	out := global_decl_run_good(v3_bin, 'inferred_generic_atomic_globals',
-		"import sync.stdatomic\n\n__global flag = stdatomic.new_atomic(false)\n__global number = stdatomic.new_atomic(7)\n\nfn main() {\n\tprintln(int_str(number.load()))\n\tprintln(flag.load())\n}\n")
+	out := global_decl_run_good(v3_bin, 'inferred_generic_atomic_globals', 'import sync.stdatomic\n\n__global flag = stdatomic.new_atomic(false)\n__global number = stdatomic.new_atomic(7)\n\nfn main() {\n\tprintln(int_str(number.load()))\n\tprintln(flag.load())\n}\n')
 	assert out == '7\nfalse'
 }

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -13609,3 +13609,78 @@ fn main() {
 	out := run_good_with_flags(v3_bin, 'array_map_aggregate_join_origins', '-ownership', source)
 	assert out == 'sourcesource'
 }
+
+fn test_nested_string_interpolation_restores_outer_scanner_state() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'nested_string_interpolation', "fn main() {\n\tvalue := 'ok'\n\tprintln('outer \${if value.len > 0 { 'inner \${value}' } else { 'empty' }} done')\n}\n")
+	assert out == 'outer inner ok done'
+}
+
+fn test_json_result_or_tail_keeps_if_expression_struct_type() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'json_result_or_if_struct', 'import x.json2
+
+struct Review {
+	id int
+}
+
+fn main() {
+	review := if true {
+		json2.decode[Review]("{\\"id\\":7}") or { Review{id: 1} }
+	} else {
+		Review{id: 2}
+	}
+	println(review.id)
+}
+')
+	assert out == '7'
+}
+
+fn test_unsafe_postfix_and_pointer_to_pointer_type_parse() {
+	v3_bin := build_v3_review_transform()
+	out := run_good(v3_bin, 'unsafe_postfix_pointer_to_pointer', 'struct Item {
+	value int
+}
+
+struct PointerState {
+mut:
+	list &&char
+}
+
+type RawHandle = voidptr
+
+fn (item &Item) read() int {
+	return item.value
+}
+
+fn main() {
+	item := &Item{value: 9}
+	state := PointerState{
+		list: unsafe { &&char(nil) }
+	}
+	handle := RawHandle(unsafe { nil })
+	println(unsafe { item }.read())
+	println(state.list == unsafe { &&char(nil) })
+	println(handle == RawHandle(unsafe { nil }))
+}
+')
+	assert out == '9\ntrue\ntrue'
+}
+
+fn test_export_wrapper_uses_declared_header_c_abi() {
+	v3_bin := build_v3_review_transform()
+	header := os.join_path(os.temp_dir(), 'v3_export_wrapper_c_abi.h')
+	os.write_file(header, 'extern int v3_exported_int(int value);\n') or { panic(err) }
+	out := run_good(v3_bin, 'export_wrapper_c_abi', '#include "${header}"
+
+@[export: "v3_exported_int"]
+fn exported_int(value int) int {
+	return value + 1
+}
+
+fn main() {
+	println(exported_int(6))
+}
+')
+	assert out == '7'
+}

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -793,8 +793,7 @@ fn gen_c_from_project_with_flags(v3_bin string, name string, flags string, files
 
 fn test_lifted_fn_literal_mut_param_interpolation_derefs_value() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'lifted_literal_mut_param_interpolation',
-		'struct Counter {\n\tvalue int\n}\n\nfn main() {\n\tmut counter := Counter{\n\t\tvalue: 7\n\t}\n\tf := fn (mut value Counter) {\n\t\tprintln("\${value.value}")\n\t}\n\tf(mut counter)\n}\n')
+	out := run_good(v3_bin, 'lifted_literal_mut_param_interpolation', 'struct Counter {\n\tvalue int\n}\n\nfn main() {\n\tmut counter := Counter{\n\t\tvalue: 7\n\t}\n\tf := fn (mut value Counter) {\n\t\tprintln("\${value.value}")\n\t}\n\tf(mut counter)\n}\n')
 	assert out == '7'
 }
 
@@ -986,8 +985,7 @@ fn main() {
 
 fn test_folded_string_constant_ifs_keep_branch_scopes() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'folded_string_constant_if_branch_scopes',
-		"fn main() {\n\tif 'left' == 'left' {\n\t\tx := 20\n\t\tprintln(int_str(x))\n\t}\n\tif 'right' == 'right' {\n\t\tx := 22\n\t\tprintln(int_str(x))\n\t}\n}\n")
+	out := run_good(v3_bin, 'folded_string_constant_if_branch_scopes', "fn main() {\n\tif 'left' == 'left' {\n\t\tx := 20\n\t\tprintln(int_str(x))\n\t}\n\tif 'right' == 'right' {\n\t\tx := 22\n\t\tprintln(int_str(x))\n\t}\n}\n")
 	assert out == '20\n22'
 }
 
@@ -1103,15 +1101,13 @@ fn main() {
 
 fn test_for_in_smartcast_interface_field_keeps_interface_element_type() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'for_in_smartcast_interface_field',
-		'interface Widget {\n\tid int\n}\n\nstruct Stack {\n\tid       int\n\tchildren []Widget\n}\n\nstruct Leaf {\n\tid int\n}\n\nfn total(w Widget) int {\n\tif w is Stack {\n\t\tmut value := w.id\n\t\tfor child in w.children {\n\t\t\tvalue += total(child)\n\t\t}\n\t\treturn value\n\t}\n\treturn w.id\n}\n\nfn main() {\n\tw := Widget(Stack{\n\t\tid: 1\n\t\tchildren: [Widget(Leaf{\n\t\t\tid: 2\n\t\t})]\n\t})\n\tprintln(int_str(total(w)))\n}\n')
+	out := run_good(v3_bin, 'for_in_smartcast_interface_field', 'interface Widget {\n\tid int\n}\n\nstruct Stack {\n\tid       int\n\tchildren []Widget\n}\n\nstruct Leaf {\n\tid int\n}\n\nfn total(w Widget) int {\n\tif w is Stack {\n\t\tmut value := w.id\n\t\tfor child in w.children {\n\t\t\tvalue += total(child)\n\t\t}\n\t\treturn value\n\t}\n\treturn w.id\n}\n\nfn main() {\n\tw := Widget(Stack{\n\t\tid: 1\n\t\tchildren: [Widget(Leaf{\n\t\t\tid: 2\n\t\t})]\n\t})\n\tprintln(int_str(total(w)))\n}\n')
 	assert out == '3'
 }
 
 fn test_interface_smartcast_rebuilds_richer_interface_fields() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'interface_smartcast_richer_fields',
-		'interface Base {\n\tx int\n}\n\ninterface Extended {\n\tBase\n\ty    int\n\tnext ?Extended\n}\n\nstruct Item {\n\tx    int\n\ty    int\n\tnext ?Extended\n}\n\nfn value(base Base) int {\n\tif base is Extended {\n\t\treturn base.x + base.y\n\t}\n\treturn 0\n}\n\nfn main() {\n\tprintln(int_str(value(Base(Item{\n\t\tx: 2\n\t\ty: 3\n\t}))))\n}\n')
+	out := run_good(v3_bin, 'interface_smartcast_richer_fields', 'interface Base {\n\tx int\n}\n\ninterface Extended {\n\tBase\n\ty    int\n\tnext ?Extended\n}\n\nstruct Item {\n\tx    int\n\ty    int\n\tnext ?Extended\n}\n\nfn value(base Base) int {\n\tif base is Extended {\n\t\treturn base.x + base.y\n\t}\n\treturn 0\n}\n\nfn main() {\n\tprintln(int_str(value(Base(Item{\n\t\tx: 2\n\t\ty: 3\n\t}))))\n}\n')
 	assert out == '5'
 }
 
@@ -1252,8 +1248,7 @@ fn test_imported_module_generic_function_value_prefers_local_declaration() {
 
 fn test_building_v_function_values_keep_plain_and_module_helpers() {
 	v3_bin := build_v3_review_transform()
-	out := run_good_project_with_flags(v3_bin, 'building_v_function_value_reachability',
-		'-building-v', {
+	out := run_good_project_with_flags(v3_bin, 'building_v_function_value_reachability', '-building-v', {
 		'v.mod':           "Module { name: 'building_v_function_value_reachability' }\n"
 		'worker/worker.v': 'module worker\n\nfn local_helper() int {\n\treturn 19\n}\n\nfn apply(callback fn () int) int {\n\treturn callback()\n}\n\npub fn local_value() int {\n\treturn apply(local_helper)\n}\n\npub fn selected_helper() int {\n\treturn 23\n}\n'
 		'main.v':          'module main\n\nimport worker\n\nfn apply(callback fn () int) int {\n\treturn callback()\n}\n\nfn main() {\n\tprintln(worker.local_value() + apply(worker.selected_helper))\n}\n'
@@ -1311,8 +1306,7 @@ fn test_optional_if_guard_prefers_local_type_over_imported_homonym() {
 
 fn test_fixed_array_alias_is_not_requalified_in_importing_module() {
 	v3_bin := build_v3_review_transform()
-	generated := gen_c_from_source(v3_bin, 'fixed_array_alias_import_context',
-		'import gg\nimport sokol.gfx\n\nfn main() {\n\t_ := gg.Color{}\n\t_ := gfx.ImageData{}\n}\n')
+	generated := gen_c_from_source(v3_bin, 'fixed_array_alias_import_context', 'import gg\nimport sokol.gfx\n\nfn main() {\n\t_ := gg.Color{}\n\t_ := gfx.ImageData{}\n}\n')
 	assert generated.contains('Array_fixed_struct_sg_range_16'), generated
 	assert !generated.contains('Array_fixed_gg__Range_16'), generated
 }
@@ -1329,8 +1323,7 @@ fn test_nested_string_array_literal_keeps_alias_element_type() {
 
 fn test_generic_array_retyping_is_scoped_to_the_lowered_literal() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'generic_array_retype_temp_scope',
-		"enum ChildSize {\n\tcompact\n}\n\nfn delimiters() [][]string {\n\treturn [['/*', '*/']]\n}\n\nfn child_sizes(len int) []ChildSize {\n\treturn [ChildSize.compact].repeat(len)\n}\n\nfn main() {\n\tvalues := delimiters()\n\tsizes := child_sizes(2)\n\tprintln(values[0][0])\n\tprintln(values[0][1])\n\tprintln(int_str(sizes.len))\n}\n")
+	out := run_good(v3_bin, 'generic_array_retype_temp_scope', "enum ChildSize {\n\tcompact\n}\n\nfn delimiters() [][]string {\n\treturn [['/*', '*/']]\n}\n\nfn child_sizes(len int) []ChildSize {\n\treturn [ChildSize.compact].repeat(len)\n}\n\nfn main() {\n\tvalues := delimiters()\n\tsizes := child_sizes(2)\n\tprintln(values[0][0])\n\tprintln(values[0][1])\n\tprintln(int_str(sizes.len))\n}\n")
 	assert out == '/*\n*/\n2'
 }
 
@@ -1347,18 +1340,14 @@ fn test_generic_specializations_keep_full_aliased_import_paths() {
 
 fn test_nested_inferred_fixed_array_literal_parses() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'nested_inferred_fixed_array_literal',
-		'fn main() {\n\tvalues := [..][..]int[[1, 2], [3, 4]]\n\tprintln(int_str(values[0][0] + values[0][1] + values[1][0] + values[1][1]))\n}\n')
+	out := run_good(v3_bin, 'nested_inferred_fixed_array_literal', 'fn main() {\n\tvalues := [..][..]int[[1, 2], [3, 4]]\n\tprintln(int_str(values[0][0] + values[0][1] + values[1][0] + values[1][1]))\n}\n')
 	assert out == '10'
-	run_bad(v3_bin, 'ragged_nested_inferred_fixed_array_literal',
-		'fn main() {\n\t_ := [..][..]int[[1], [2, 3]]\n}\n',
-		'inferred fixed-array literal rows must have the same size')
+	run_bad(v3_bin, 'ragged_nested_inferred_fixed_array_literal', 'fn main() {\n\t_ := [..][..]int[[1], [2, 3]]\n}\n', 'inferred fixed-array literal rows must have the same size')
 }
 
 fn test_shared_field_without_sync_import_compiles_and_locks() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'shared_field_without_sync_import',
-		'struct S {\nmut:\n\ta shared int\n}\n\nfn main() {\n\tmut s := S{}\n\tlock s.a {\n\t\ts.a = 7\n\t\tprintln(int_str(s.a))\n\t}\n}\n')
+	out := run_good(v3_bin, 'shared_field_without_sync_import', 'struct S {\nmut:\n\ta shared int\n}\n\nfn main() {\n\tmut s := S{}\n\tlock s.a {\n\t\ts.a = 7\n\t\tprintln(int_str(s.a))\n\t}\n}\n')
 	assert out == '7'
 }
 
@@ -1420,254 +1409,153 @@ fn main() {
 
 fn test_nested_shared_field_lock_allows_member_access() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'nested_shared_field_lock',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nfn main() {\n\tmut coordinator := Coordinator{}\n\tlock coordinator.state {\n\t\tcoordinator.state.value = 7\n\t}\n\tmut value := 0\n\trlock coordinator.state {\n\t\tvalue = coordinator.state.value\n\t}\n\tprintln(int_str(value))\n}\n')
+	out := run_good(v3_bin, 'nested_shared_field_lock', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nfn main() {\n\tmut coordinator := Coordinator{}\n\tlock coordinator.state {\n\t\tcoordinator.state.value = 7\n\t}\n\tmut value := 0\n\trlock coordinator.state {\n\t\tvalue = coordinator.state.value\n\t}\n\tprintln(int_str(value))\n}\n')
 	assert out == '7'
 }
 
 fn test_nested_shared_field_lock_rejects_base_reassignment() {
 	v3_bin := build_v3_review_transform()
-	run_bad(v3_bin, 'nested_shared_field_lock_base_reassignment',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut p := &first\n\tlock p.state {\n\t\tp = &second\n\t\tp.state.value = 7\n\t}\n}\n',
-		'cannot reassign `p` while it is used to locate locked shared value `p.state`')
-	run_bad(v3_bin, 'nested_shared_field_lock_index_reassignment',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\titems := [&first, &second]\n\tmut i := 0\n\tlock items[i].state {\n\t\ti = 1\n\t\titems[i].state.value = 7\n\t}\n}\n',
-		'cannot reassign `i` while it is used to locate locked shared value `items[i].state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_base_reassignment', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut p := &first\n\tlock p.state {\n\t\tp = &second\n\t\tp.state.value = 7\n\t}\n}\n', 'cannot reassign `p` while it is used to locate locked shared value `p.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_index_reassignment', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\titems := [&first, &second]\n\tmut i := 0\n\tlock items[i].state {\n\t\ti = 1\n\t\titems[i].state.value = 7\n\t}\n}\n', 'cannot reassign `i` while it is used to locate locked shared value `items[i].state`')
 }
 
 fn test_nested_shared_field_lock_rejects_aliased_index_mutation() {
 	v3_bin := build_v3_review_transform()
-	run_bad(v3_bin, 'nested_shared_field_lock_aliased_index_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut items := [&first, &second]\n\ti := 0\n\tlock items[i].state {\n\t\titems[0] = &second\n\t\titems[i].state.value = 7\n\t}\n}\n',
-		'may alias locked shared value `items[i].state`')
-	run_bad(v3_bin, 'nested_shared_field_lock_equivalent_literal_index_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut items := [&first]\n\tlock items[0].state {\n\t\titems[0x0] = &replacement\n\t\titems[0].state.value++\n\t}\n}\n',
-		'may alias locked shared value `items[0].state`')
-	out := run_good(v3_bin, 'nested_shared_field_lock_distinct_literal_index',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut items := [&first, &second]\n\tlock items[0].state {\n\t\titems[1] = &first\n\t\titems[0].state.value = 7\n\t\tprintln(int_str(items[0].state.value))\n\t}\n}\n')
+	run_bad(v3_bin, 'nested_shared_field_lock_aliased_index_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut items := [&first, &second]\n\ti := 0\n\tlock items[i].state {\n\t\titems[0] = &second\n\t\titems[i].state.value = 7\n\t}\n}\n', 'may alias locked shared value `items[i].state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_equivalent_literal_index_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut items := [&first]\n\tlock items[0].state {\n\t\titems[0x0] = &replacement\n\t\titems[0].state.value++\n\t}\n}\n', 'may alias locked shared value `items[0].state`')
+	out := run_good(v3_bin, 'nested_shared_field_lock_distinct_literal_index', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut items := [&first, &second]\n\tlock items[0].state {\n\t\titems[1] = &first\n\t\titems[0].state.value = 7\n\t\tprintln(int_str(items[0].state.value))\n\t}\n}\n')
 	assert out == '7'
 }
 
 fn test_nested_shared_field_lock_rejects_promoted_field_alias_mutation() {
 	v3_bin := build_v3_review_transform()
-	run_bad(v3_bin, 'nested_shared_field_lock_promoted_field_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator = unsafe { nil }\n}\n\nstruct Wrapper {\nmut:\n\tHolder\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut wrapper := Wrapper{}\n\twrapper.Holder.current = &first\n\tlock wrapper.current.state {\n\t\twrapper.Holder.current = &replacement\n\t\twrapper.current.state.value++\n\t}\n}\n',
-		'used to locate locked shared value `wrapper.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_promoted_field_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator = unsafe { nil }\n}\n\nstruct Wrapper {\nmut:\n\tHolder\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut wrapper := Wrapper{}\n\twrapper.Holder.current = &first\n\tlock wrapper.current.state {\n\t\twrapper.Holder.current = &replacement\n\t\twrapper.current.state.value++\n\t}\n}\n', 'used to locate locked shared value `wrapper.current.state`')
 }
 
 fn test_nested_shared_field_lock_rejects_pointer_alias_mutation() {
 	v3_bin := build_v3_review_transform()
-	run_bad(v3_bin, 'nested_shared_field_lock_cross_assignment_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\talias, unrelated = unrelated, alias\n\tlock holder.current.state {\n\t\tunrelated.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
-	run_bad(v3_bin, 'nested_shared_field_lock_pointer_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 7\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
-	run_bad(v3_bin, 'nested_shared_field_lock_address_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := &holder\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 7\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
-	run_bad(v3_bin, 'nested_shared_field_lock_call_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn passthrough(holder &Holder) &Holder {\n\treturn holder\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := passthrough(holder)\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 7\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
-	run_bad(v3_bin, 'nested_shared_field_lock_selector_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nstruct Box {\n\tholder &Holder\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tbox := Box{\n\t\tholder: holder\n\t}\n\tmut alias := box.holder\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 7\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
-	run_bad(v3_bin, 'nested_shared_field_lock_index_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tholders := [holder]\n\tmut alias := holders[0]\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 7\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
-	run_bad(v3_bin, 'nested_shared_field_lock_selector_base_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nstruct Box {\nmut:\n\tholder &Holder\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut box := Box{\n\t\tholder: holder\n\t}\n\tlock holder.current.state {\n\t\tbox.holder.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
-	run_bad(v3_bin, 'nested_shared_field_lock_index_base_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut holders := [holder]\n\tlock holder.current.state {\n\t\tholders[0].current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
-	run_bad(v3_bin, 'nested_shared_field_lock_parameter_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn mutate(mut holder &Holder, mut other &Holder) {\n\tmut replacement := Coordinator{}\n\tmut alias := other\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value = 7\n\t}\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut other := holder\n\tmutate(mut holder, mut other)\n}\n',
-		'may alias locked shared value `holder.current.state`')
-	run_bad(v3_bin, 'nested_shared_field_lock_if_expr_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn choose() bool {\n\treturn true\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := if choose() { holder } else { unrelated }\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 7\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
-	run_bad(v3_bin, 'nested_shared_field_lock_match_expr_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn choose() bool {\n\treturn true\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := match choose() {\n\t\ttrue { holder }\n\t\telse { unrelated }\n\t}\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 7\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
-	run_bad(v3_bin, 'nested_shared_field_lock_defer_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tdefer {\n\t\talias = unrelated\n\t}\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
-	run_bad(v3_bin, 'nested_shared_field_lock_mut_call_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn replace(mut holder &Holder, replacement &Coordinator) {\n\tholder.current = replacement\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tlock holder.current.state {\n\t\treplace(mut holder, &replacement)\n\t\tholder.current.state.value++\n\t}\n}\n',
-		'used to locate locked shared value `holder.current.state`')
-	run_bad(v3_bin, 'nested_shared_field_lock_mut_receiver_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn (mut holder Holder) replace(replacement &Coordinator) {\n\tholder.current = replacement\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tlock holder.current.state {\n\t\tholder.replace(&replacement)\n\t\tholder.current.state.value++\n\t}\n}\n',
-		'used to locate locked shared value `holder.current.state`')
-	run_bad(v3_bin, 'nested_shared_field_lock_mut_pointer_call_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn replace(mut current &Holder, replacement &Holder) {\n\tcurrent = replacement\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := &Holder{\n\t\tcurrent: &first\n\t}\n\treplace(mut holder, alias)\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
-	run_bad(v3_bin, 'nested_shared_field_lock_or_fallback_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn maybe() ?int {\n\treturn 1\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tmaybe() or {\n\t\talias = unrelated\n\t\t0\n\t}\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
-	run_bad(v3_bin, 'nested_shared_field_lock_select_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tch := chan int{cap: 1}\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tselect {\n\t\tch <- 1 {}\n\t\telse {\n\t\t\talias = unrelated\n\t\t}\n\t}\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
-	run_good(v3_bin, 'nested_shared_field_lock_skipped_short_circuit_mut_call',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn maybe_replace(mut current &Holder, replacement &Holder) bool {\n\tcurrent = replacement\n\treturn true\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := &Holder{\n\t\tcurrent: &first\n\t}\n\tif false && maybe_replace(mut alias, holder) {}\n\tskipped := true || maybe_replace(mut alias, holder)\n\tassert skipped\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n')
-	run_bad(v3_bin, 'nested_shared_field_lock_conditional_pointer_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn choose() bool {\n\treturn false\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tif choose() {\n\t\talias = unrelated\n\t}\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 7\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
-	run_bad(v3_bin, 'nested_shared_field_lock_match_pointer_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn choose() bool {\n\treturn false\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tmatch choose() {\n\t\ttrue { alias = unrelated }\n\t\telse {}\n\t}\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 7\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
-	run_bad(v3_bin, 'nested_shared_field_lock_loop_pointer_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn choose() bool {\n\treturn false\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tfor choose() {\n\t\talias = unrelated\n\t}\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 7\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
-	run_bad(v3_bin, 'nested_shared_field_lock_for_in_pointer_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tvalues := []int{}\n\tfor _ in values {\n\t\talias = unrelated\n\t}\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 7\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
-	out := run_good(v3_bin, 'nested_shared_field_lock_rebound_pointer_alias',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\talias = unrelated\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 7\n\t\tprintln(int_str(holder.current.state.value))\n\t}\n}\n')
+	run_bad(v3_bin, 'nested_shared_field_lock_cross_assignment_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\talias, unrelated = unrelated, alias\n\tlock holder.current.state {\n\t\tunrelated.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_pointer_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 7\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_address_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := &holder\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 7\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_call_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn passthrough(holder &Holder) &Holder {\n\treturn holder\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := passthrough(holder)\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 7\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_selector_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nstruct Box {\n\tholder &Holder\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tbox := Box{\n\t\tholder: holder\n\t}\n\tmut alias := box.holder\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 7\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_index_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tholders := [holder]\n\tmut alias := holders[0]\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 7\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_selector_base_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nstruct Box {\nmut:\n\tholder &Holder\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut box := Box{\n\t\tholder: holder\n\t}\n\tlock holder.current.state {\n\t\tbox.holder.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_index_base_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut holders := [holder]\n\tlock holder.current.state {\n\t\tholders[0].current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_parameter_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn mutate(mut holder &Holder, mut other &Holder) {\n\tmut replacement := Coordinator{}\n\tmut alias := other\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value = 7\n\t}\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut other := holder\n\tmutate(mut holder, mut other)\n}\n', 'may alias locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_if_expr_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn choose() bool {\n\treturn true\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := if choose() { holder } else { unrelated }\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 7\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_match_expr_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn choose() bool {\n\treturn true\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := match choose() {\n\t\ttrue { holder }\n\t\telse { unrelated }\n\t}\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 7\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_defer_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tdefer {\n\t\talias = unrelated\n\t}\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_mut_call_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn replace(mut holder &Holder, replacement &Coordinator) {\n\tholder.current = replacement\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tlock holder.current.state {\n\t\treplace(mut holder, &replacement)\n\t\tholder.current.state.value++\n\t}\n}\n', 'used to locate locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_mut_receiver_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn (mut holder Holder) replace(replacement &Coordinator) {\n\tholder.current = replacement\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tlock holder.current.state {\n\t\tholder.replace(&replacement)\n\t\tholder.current.state.value++\n\t}\n}\n', 'used to locate locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_mut_pointer_call_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn replace(mut current &Holder, replacement &Holder) {\n\tcurrent = replacement\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := &Holder{\n\t\tcurrent: &first\n\t}\n\treplace(mut holder, alias)\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_or_fallback_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn maybe() ?int {\n\treturn 1\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tmaybe() or {\n\t\talias = unrelated\n\t\t0\n\t}\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_select_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tch := chan int{cap: 1}\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tselect {\n\t\tch <- 1 {}\n\t\telse {\n\t\t\talias = unrelated\n\t\t}\n\t}\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
+	run_good(v3_bin, 'nested_shared_field_lock_skipped_short_circuit_mut_call', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn maybe_replace(mut current &Holder, replacement &Holder) bool {\n\tcurrent = replacement\n\treturn true\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := &Holder{\n\t\tcurrent: &first\n\t}\n\tif false && maybe_replace(mut alias, holder) {}\n\tskipped := true || maybe_replace(mut alias, holder)\n\tassert skipped\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n')
+	run_bad(v3_bin, 'nested_shared_field_lock_conditional_pointer_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn choose() bool {\n\treturn false\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tif choose() {\n\t\talias = unrelated\n\t}\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 7\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_match_pointer_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn choose() bool {\n\treturn false\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tmatch choose() {\n\t\ttrue { alias = unrelated }\n\t\telse {}\n\t}\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 7\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_loop_pointer_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn choose() bool {\n\treturn false\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tfor choose() {\n\t\talias = unrelated\n\t}\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 7\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_for_in_pointer_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tvalues := []int{}\n\tfor _ in values {\n\t\talias = unrelated\n\t}\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 7\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
+	out := run_good(v3_bin, 'nested_shared_field_lock_rebound_pointer_alias', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\talias = unrelated\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 7\n\t\tprintln(int_str(holder.current.state.value))\n\t}\n}\n')
 	assert out == '7'
-	address_out := run_good(v3_bin, 'nested_shared_field_lock_distinct_address_alias',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := &unrelated\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 11\n\t\tprintln(int_str(holder.current.state.value))\n\t}\n}\n')
+	address_out := run_good(v3_bin, 'nested_shared_field_lock_distinct_address_alias', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := &unrelated\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 11\n\t\tprintln(int_str(holder.current.state.value))\n\t}\n}\n')
 	assert address_out == '11'
-	call_rebound_out := run_good(v3_bin, 'nested_shared_field_lock_rebound_call_alias',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn passthrough(holder &Holder) &Holder {\n\treturn holder\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := passthrough(holder)\n\talias = unrelated\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 12\n\t\tprintln(int_str(holder.current.state.value))\n\t}\n}\n')
+	call_rebound_out := run_good(v3_bin, 'nested_shared_field_lock_rebound_call_alias', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn passthrough(holder &Holder) &Holder {\n\treturn holder\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := passthrough(holder)\n\talias = unrelated\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 12\n\t\tprintln(int_str(holder.current.state.value))\n\t}\n}\n')
 	assert call_rebound_out == '12'
-	param_rebound_out := run_good(v3_bin, 'nested_shared_field_lock_rebound_parameter_alias',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn mutate(mut holder &Holder, mut other &Holder) {\n\tmut replacement := Coordinator{}\n\tmut unrelated := &Holder{\n\t\tcurrent: holder.current\n\t}\n\tmut alias := other\n\talias = unrelated\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value = 13\n\t\tprintln(int_str(holder.current.state.value))\n\t}\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut other := holder\n\tmutate(mut holder, mut other)\n}\n')
+	param_rebound_out := run_good(v3_bin, 'nested_shared_field_lock_rebound_parameter_alias', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn mutate(mut holder &Holder, mut other &Holder) {\n\tmut replacement := Coordinator{}\n\tmut unrelated := &Holder{\n\t\tcurrent: holder.current\n\t}\n\tmut alias := other\n\talias = unrelated\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value = 13\n\t\tprintln(int_str(holder.current.state.value))\n\t}\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut other := holder\n\tmutate(mut holder, mut other)\n}\n')
 	assert param_rebound_out == '13'
-	defer_out := run_good(v3_bin, 'nested_shared_field_lock_defer_rebinds_after_lock',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := unrelated\n\tdefer {\n\t\talias = holder\n\t}\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value = 14\n\t\tprintln(int_str(holder.current.state.value))\n\t}\n}\n')
+	defer_out := run_good(v3_bin, 'nested_shared_field_lock_defer_rebinds_after_lock', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := unrelated\n\tdefer {\n\t\talias = holder\n\t}\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value = 14\n\t\tprintln(int_str(holder.current.state.value))\n\t}\n}\n')
 	assert defer_out == '14'
-	conditional_out := run_good(v3_bin, 'nested_shared_field_lock_rebound_pointer_alias_all_paths',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn choose() bool {\n\treturn false\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tif choose() {\n\t\talias = unrelated\n\t} else {\n\t\talias = unrelated\n\t}\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 8\n\t\tprintln(int_str(holder.current.state.value))\n\t}\n}\n')
+	conditional_out := run_good(v3_bin, 'nested_shared_field_lock_rebound_pointer_alias_all_paths', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn choose() bool {\n\treturn false\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tif choose() {\n\t\talias = unrelated\n\t} else {\n\t\talias = unrelated\n\t}\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 8\n\t\tprintln(int_str(holder.current.state.value))\n\t}\n}\n')
 	assert conditional_out == '8'
-	match_out := run_good(v3_bin, 'nested_shared_field_lock_match_rebound_pointer_alias_all_paths',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn choose() bool {\n\treturn false\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tmatch choose() {\n\t\ttrue { alias = unrelated }\n\t\telse { alias = unrelated }\n\t}\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 9\n\t\tprintln(int_str(holder.current.state.value))\n\t}\n}\n')
+	match_out := run_good(v3_bin, 'nested_shared_field_lock_match_rebound_pointer_alias_all_paths', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn choose() bool {\n\treturn false\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tmatch choose() {\n\t\ttrue { alias = unrelated }\n\t\telse { alias = unrelated }\n\t}\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 9\n\t\tprintln(int_str(holder.current.state.value))\n\t}\n}\n')
 	assert match_out == '9'
-	loop_out := run_good(v3_bin, 'nested_shared_field_lock_loop_rebound_pointer_alias_all_exits',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tfor {\n\t\talias = unrelated\n\t\tbreak\n\t}\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 10\n\t\tprintln(int_str(holder.current.state.value))\n\t}\n}\n')
+	loop_out := run_good(v3_bin, 'nested_shared_field_lock_loop_rebound_pointer_alias_all_exits', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut second := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tfor {\n\t\talias = unrelated\n\t\tbreak\n\t}\n\tlock holder.current.state {\n\t\talias.current = &second\n\t\tholder.current.state.value = 10\n\t\tprintln(int_str(holder.current.state.value))\n\t}\n}\n')
 	assert loop_out == '10'
 }
 
 fn test_nested_shared_field_lock_preserves_continue_pointer_aliases() {
 	v3_bin := build_v3_review_transform()
-	run_bad(v3_bin, 'nested_shared_field_lock_continue_pointer_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn choose() bool {\n\treturn true\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := unrelated\n\tfor i := 0; i < 1; i++ {\n\t\tif choose() {\n\t\t\talias = holder\n\t\t\tcontinue\n\t\t}\n\t\talias = unrelated\n\t}\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_continue_pointer_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn choose() bool {\n\treturn true\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := unrelated\n\tfor i := 0; i < 1; i++ {\n\t\tif choose() {\n\t\t\talias = holder\n\t\t\tcontinue\n\t\t}\n\t\talias = unrelated\n\t}\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
 }
 
 fn test_nested_shared_field_lock_rechecks_pointer_aliases_in_loop_post() {
 	v3_bin := build_v3_review_transform()
-	run_bad(v3_bin, 'nested_shared_field_lock_loop_post_pointer_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut candidate := unrelated\n\tmut alias := unrelated\n\tmut i := 0\n\tfor ; i < 1; i, alias = i + 1, candidate {\n\t\tcandidate = holder\n\t}\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_loop_post_pointer_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut candidate := unrelated\n\tmut alias := unrelated\n\tmut i := 0\n\tfor ; i < 1; i, alias = i + 1, candidate {\n\t\tcandidate = holder\n\t}\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
 }
 
 fn test_nested_shared_field_lock_tracks_select_receive_pointer_alias() {
 	v3_bin := build_v3_review_transform()
-	run_bad(v3_bin, 'nested_shared_field_lock_select_receive_pointer_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tholders := chan &Holder{cap: 1}\n\tholders <- holder\n\tmut alias := unrelated\n\tselect {\n\t\talias = <-holders {}\n\t\telse {}\n\t}\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_select_receive_pointer_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tholders := chan &Holder{cap: 1}\n\tholders <- holder\n\tmut alias := unrelated\n\tselect {\n\t\talias = <-holders {}\n\t\telse {}\n\t}\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
 }
 
 fn test_nested_shared_field_lock_treats_pointer_iteration_binding_as_alias() {
 	v3_bin := build_v3_review_transform()
-	run_bad(v3_bin, 'nested_shared_field_lock_pointer_iteration_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut holders := [holder]\n\tfor mut alias in holders {\n\t\tlock holder.current.state {\n\t\t\talias.current = &replacement\n\t\t\tholder.current.state.value++\n\t\t}\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_pointer_iteration_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut holders := [holder]\n\tfor mut alias in holders {\n\t\tlock holder.current.state {\n\t\t\talias.current = &replacement\n\t\t\tholder.current.state.value++\n\t\t}\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
 }
 
 fn test_nested_shared_field_lock_treats_lambda_pointer_parameters_as_aliases() {
 	v3_bin := build_v3_review_transform()
-	run_bad(v3_bin, 'nested_shared_field_lock_lambda_parameter_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn apply(callback fn (&Holder, &Holder) int, locked &Holder, other &Holder) {\n\t_ := callback(locked, other)\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tapply(|mut locked, mut other| if true {\n\t\tmut replacement := Coordinator{}\n\t\tlock locked.current.state {\n\t\t\tother.current = &replacement\n\t\t\tlocked.current.state.value++\n\t\t}\n\t\t0\n\t} else {\n\t\t0\n\t}, holder, alias)\n}\n',
-		'may alias locked shared value `locked.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_lambda_parameter_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn apply(callback fn (&Holder, &Holder) int, locked &Holder, other &Holder) {\n\t_ := callback(locked, other)\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tapply(|mut locked, mut other| if true {\n\t\tmut replacement := Coordinator{}\n\t\tlock locked.current.state {\n\t\t\tother.current = &replacement\n\t\t\tlocked.current.state.value++\n\t\t}\n\t\t0\n\t} else {\n\t\t0\n\t}, holder, alias)\n}\n', 'may alias locked shared value `locked.current.state`')
 }
 
 fn test_nested_shared_field_lock_preserves_explicit_capture_pointer_aliases() {
 	v3_bin := build_v3_review_transform()
-	run_bad(v3_bin, 'nested_shared_field_lock_explicit_capture_pointer_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tcallback := fn [mut holder, mut alias, replacement] () {\n\t\tlock holder.current.state {\n\t\t\talias.current = &replacement\n\t\t\tholder.current.state.value++\n\t\t}\n\t}\n\tcallback()\n}\n',
-		'may alias locked shared value `holder.current.state`')
-	out := run_good(v3_bin, 'nested_shared_field_lock_distinct_explicit_capture_pointer',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tcallback := fn [mut holder, mut unrelated, replacement] () {\n\t\tlock holder.current.state {\n\t\t\tunrelated.current = &replacement\n\t\t\tholder.current.state.value = 31\n\t\t\tprintln(int_str(holder.current.state.value))\n\t\t}\n\t}\n\tcallback()\n}\n')
+	run_bad(v3_bin, 'nested_shared_field_lock_explicit_capture_pointer_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tcallback := fn [mut holder, mut alias, replacement] () {\n\t\tlock holder.current.state {\n\t\t\talias.current = &replacement\n\t\t\tholder.current.state.value++\n\t\t}\n\t}\n\tcallback()\n}\n', 'may alias locked shared value `holder.current.state`')
+	out := run_good(v3_bin, 'nested_shared_field_lock_distinct_explicit_capture_pointer', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tcallback := fn [mut holder, mut unrelated, replacement] () {\n\t\tlock holder.current.state {\n\t\t\tunrelated.current = &replacement\n\t\t\tholder.current.state.value = 31\n\t\t\tprintln(int_str(holder.current.state.value))\n\t\t}\n\t}\n\tcallback()\n}\n')
 	assert out == '31'
 }
 
 fn test_nested_shared_field_lock_treats_if_guard_pointer_binding_as_alias() {
 	v3_bin := build_v3_review_transform()
-	run_bad(v3_bin, 'nested_shared_field_lock_if_guard_pointer_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn maybe_holder(holder &Holder) ?&Holder {\n\treturn holder\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tif mut alias := maybe_holder(holder) {\n\t\tlock holder.current.state {\n\t\t\talias.current = &replacement\n\t\t\tholder.current.state.value++\n\t\t}\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_if_guard_pointer_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn maybe_holder(holder &Holder) ?&Holder {\n\treturn holder\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tif mut alias := maybe_holder(holder) {\n\t\tlock holder.current.state {\n\t\t\talias.current = &replacement\n\t\t\tholder.current.state.value++\n\t\t}\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
 }
 
 fn test_nested_shared_field_lock_merges_pointer_aliases_at_goto_target() {
 	v3_bin := build_v3_review_transform()
-	run_bad(v3_bin, 'nested_shared_field_lock_goto_pointer_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tunsafe {\n\t\tgoto locked\n\t}\n\talias = unrelated\n\tlocked:\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
-	run_bad(v3_bin, 'nested_shared_field_lock_backward_goto_pointer_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := unrelated\n\tlocked:\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value++\n\t}\n\talias = holder\n\tunsafe {\n\t\tgoto locked\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_goto_pointer_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := holder\n\tunsafe {\n\t\tgoto locked\n\t}\n\talias = unrelated\n\tlocked:\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_backward_goto_pointer_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := unrelated\n\tlocked:\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value++\n\t}\n\talias = holder\n\tunsafe {\n\t\tgoto locked\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
 }
 
 fn test_nested_shared_field_lock_tracks_indirect_pointer_writes() {
 	v3_bin := build_v3_review_transform()
-	run_bad(v3_bin, 'nested_shared_field_lock_indirect_pointer_write',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut slot := &holder\n\tlock holder.current.state {\n\t\tunsafe {\n\t\t\t*slot = unrelated\n\t\t}\n\t\tholder.current.state.value++\n\t}\n\t_ = replacement\n}\n',
-		'may alias locked shared value `holder.current.state`')
-	run_bad(v3_bin, 'nested_shared_field_lock_prior_indirect_pointer_write',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := unrelated\n\tmut slot := &alias\n\tunsafe {\n\t\t*slot = holder\n\t}\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
-	out := run_good(v3_bin, 'nested_shared_field_lock_distinct_indirect_pointer_write',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut slot := &unrelated\n\tlock holder.current.state {\n\t\tunsafe {\n\t\t\t*slot = &Holder{\n\t\t\t\tcurrent: &replacement\n\t\t\t}\n\t\t}\n\t\tholder.current.state.value = 23\n\t\tprintln(int_str(holder.current.state.value))\n\t}\n}\n')
+	run_bad(v3_bin, 'nested_shared_field_lock_indirect_pointer_write', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut slot := &holder\n\tlock holder.current.state {\n\t\tunsafe {\n\t\t\t*slot = unrelated\n\t\t}\n\t\tholder.current.state.value++\n\t}\n\t_ = replacement\n}\n', 'may alias locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_prior_indirect_pointer_write', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := unrelated\n\tmut slot := &alias\n\tunsafe {\n\t\t*slot = holder\n\t}\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
+	out := run_good(v3_bin, 'nested_shared_field_lock_distinct_indirect_pointer_write', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut slot := &unrelated\n\tlock holder.current.state {\n\t\tunsafe {\n\t\t\t*slot = &Holder{\n\t\t\t\tcurrent: &replacement\n\t\t\t}\n\t\t}\n\t\tholder.current.state.value = 23\n\t\tprintln(int_str(holder.current.state.value))\n\t}\n}\n')
 	assert out == '23'
 }
 
 fn test_nested_shared_field_lock_preserves_labelled_loop_exit_pointer_aliases() {
 	v3_bin := build_v3_review_transform()
-	run_bad(v3_bin, 'nested_shared_field_lock_labelled_break_pointer_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := unrelated\n\touter: for {\n\t\tfor {\n\t\t\talias = holder\n\t\t\tbreak outer\n\t\t}\n\t\talias = unrelated\n\t}\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
-	run_bad(v3_bin, 'nested_shared_field_lock_labelled_continue_pointer_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := unrelated\n\touter: for i := 0; i < 1; i++ {\n\t\tfor {\n\t\t\talias = holder\n\t\t\tcontinue outer\n\t\t}\n\t\talias = unrelated\n\t}\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n',
-		'may alias locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_labelled_break_pointer_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := unrelated\n\touter: for {\n\t\tfor {\n\t\t\talias = holder\n\t\t\tbreak outer\n\t\t}\n\t\talias = unrelated\n\t}\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_labelled_continue_pointer_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\nfn main() {\n\tmut first := Coordinator{}\n\tmut replacement := Coordinator{}\n\tmut holder := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut unrelated := &Holder{\n\t\tcurrent: &first\n\t}\n\tmut alias := unrelated\n\touter: for i := 0; i < 1; i++ {\n\t\tfor {\n\t\t\talias = holder\n\t\t\tcontinue outer\n\t\t}\n\t\talias = unrelated\n\t}\n\tlock holder.current.state {\n\t\talias.current = &replacement\n\t\tholder.current.state.value++\n\t}\n}\n', 'may alias locked shared value `holder.current.state`')
 }
 
 fn test_nested_shared_field_lock_rejects_global_parameter_alias_mutation() {
 	v3_bin := build_v3_review_transform()
-	run_bad(v3_bin, 'nested_shared_field_lock_global_parameter_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\n__global (\n\tglobal_coordinator = Coordinator{}\n\tglobal_holder = &Holder{\n\t\tcurrent: &global_coordinator\n\t}\n)\n\nfn mutate(mut alias &Holder) {\n\tmut replacement := Coordinator{}\n\tlock global_holder.current.state {\n\t\talias.current = &replacement\n\t\tglobal_holder.current.state.value++\n\t}\n}\n\nfn main() {\n\tmutate(mut global_holder)\n}\n',
-		'may alias locked shared value `global_holder.current.state`')
-	out := run_good(v3_bin, 'nested_shared_field_lock_rebound_global_parameter',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\n__global (\n\tglobal_coordinator = Coordinator{}\n\tglobal_holder = &Holder{\n\t\tcurrent: &global_coordinator\n\t}\n)\n\nfn mutate(mut alias &Holder) {\n\tmut replacement := Coordinator{}\n\tmut local_holder := &Holder{\n\t\tcurrent: &replacement\n\t}\n\talias = local_holder\n\tlock global_holder.current.state {\n\t\talias.current = &replacement\n\t\tglobal_holder.current.state.value = 19\n\t\tprintln(int_str(global_holder.current.state.value))\n\t}\n}\n\nfn main() {\n\tmut incoming := global_holder\n\tmutate(mut incoming)\n}\n')
+	run_bad(v3_bin, 'nested_shared_field_lock_global_parameter_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\n__global (\n\tglobal_coordinator = Coordinator{}\n\tglobal_holder = &Holder{\n\t\tcurrent: &global_coordinator\n\t}\n)\n\nfn mutate(mut alias &Holder) {\n\tmut replacement := Coordinator{}\n\tlock global_holder.current.state {\n\t\talias.current = &replacement\n\t\tglobal_holder.current.state.value++\n\t}\n}\n\nfn main() {\n\tmutate(mut global_holder)\n}\n', 'may alias locked shared value `global_holder.current.state`')
+	out := run_good(v3_bin, 'nested_shared_field_lock_rebound_global_parameter', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\n__global (\n\tglobal_coordinator = Coordinator{}\n\tglobal_holder = &Holder{\n\t\tcurrent: &global_coordinator\n\t}\n)\n\nfn mutate(mut alias &Holder) {\n\tmut replacement := Coordinator{}\n\tmut local_holder := &Holder{\n\t\tcurrent: &replacement\n\t}\n\talias = local_holder\n\tlock global_holder.current.state {\n\t\talias.current = &replacement\n\t\tglobal_holder.current.state.value = 19\n\t\tprintln(int_str(global_holder.current.state.value))\n\t}\n}\n\nfn main() {\n\tmut incoming := global_holder\n\tmutate(mut incoming)\n}\n')
 	assert out == '19'
 }
 
 fn test_nested_shared_field_lock_rejects_global_pointer_alias_mutation() {
 	v3_bin := build_v3_review_transform()
-	run_bad(v3_bin, 'nested_shared_field_lock_global_pointer_alias_mutation',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\n__global (\n\tglobal_coordinator = Coordinator{}\n\tglobal_holder = &Holder{\n\t\tcurrent: &global_coordinator\n\t}\n\tglobal_alias = &Holder{\n\t\tcurrent: &global_coordinator\n\t}\n)\n\nfn connect_globals() {\n\tglobal_alias = global_holder\n}\n\nfn main() {\n\tconnect_globals()\n\tmut replacement := Coordinator{}\n\tlock global_holder.current.state {\n\t\tglobal_alias.current = &replacement\n\t\tglobal_holder.current.state.value++\n\t}\n}\n',
-		'may alias locked shared value `global_holder.current.state`')
+	run_bad(v3_bin, 'nested_shared_field_lock_global_pointer_alias_mutation', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Holder {\nmut:\n\tcurrent &Coordinator\n}\n\n__global (\n\tglobal_coordinator = Coordinator{}\n\tglobal_holder = &Holder{\n\t\tcurrent: &global_coordinator\n\t}\n\tglobal_alias = &Holder{\n\t\tcurrent: &global_coordinator\n\t}\n)\n\nfn connect_globals() {\n\tglobal_alias = global_holder\n}\n\nfn main() {\n\tconnect_globals()\n\tmut replacement := Coordinator{}\n\tlock global_holder.current.state {\n\t\tglobal_alias.current = &replacement\n\t\tglobal_holder.current.state.value++\n\t}\n}\n', 'may alias locked shared value `global_holder.current.state`')
 }
 
 fn test_nested_shared_field_lock_rejects_call_base() {
 	v3_bin := build_v3_review_transform()
-	run_bad(v3_bin, 'nested_shared_field_lock_call_base',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nfn pick() &Coordinator {\n\treturn &Coordinator{}\n}\n\nfn main() {\n\tlock pick().state {\n\t\tpick().state.value = 7\n\t}\n}\n',
-		'selector bases and indices must be stable expressions')
+	run_bad(v3_bin, 'nested_shared_field_lock_call_base', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nfn pick() &Coordinator {\n\treturn &Coordinator{}\n}\n\nfn main() {\n\tlock pick().state {\n\t\tpick().state.value = 7\n\t}\n}\n', 'selector bases and indices must be stable expressions')
 }
 
 fn test_nested_shared_field_lock_rejects_overloaded_index() {
 	v3_bin := build_v3_review_transform()
-	run_bad(v3_bin, 'nested_shared_field_lock_overloaded_index',
-		'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Registry {\n\tentries []&Coordinator\n}\n\nfn (registry Registry) [] (key int) &Coordinator {\n\treturn registry.entries[key]\n}\n\nfn main() {\n\tmut coordinator := Coordinator{}\n\tmut registry := Registry{\n\t\tentries: [&coordinator]\n\t}\n\tkey := 0\n\tlock registry[key].state {\n\t\tregistry[key].state.value = 7\n\t}\n}\n',
-		'selector bases and indices must be stable expressions')
+	run_bad(v3_bin, 'nested_shared_field_lock_overloaded_index', 'struct State {\nmut:\n\tvalue int\n}\n\nstruct Coordinator {\n\tstate shared State\n}\n\nstruct Registry {\n\tentries []&Coordinator\n}\n\nfn (registry Registry) [] (key int) &Coordinator {\n\treturn registry.entries[key]\n}\n\nfn main() {\n\tmut coordinator := Coordinator{}\n\tmut registry := Registry{\n\t\tentries: [&coordinator]\n\t}\n\tkey := 0\n\tlock registry[key].state {\n\t\tregistry[key].state.value = 7\n\t}\n}\n', 'selector bases and indices must be stable expressions')
 }
 
 fn test_reassigned_nil_pointer_can_be_dereferenced() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'reassigned_nil_pointer',
-		'fn main() {\n\tmut pointer := &int(unsafe { nil })\n\tmut value := 7\n\tpointer = &value\n\tprintln(int_str(*pointer))\n}\n')
+	out := run_good(v3_bin, 'reassigned_nil_pointer', 'fn main() {\n\tmut pointer := &int(unsafe { nil })\n\tmut value := 7\n\tpointer = &value\n\tprintln(int_str(*pointer))\n}\n')
 	assert out == '7'
 }
 
@@ -1683,30 +1571,21 @@ fn test_imported_shared_field_without_sync_import_compiles_and_locks() {
 
 fn test_reject_dynamic_arrays_for_fixed_array_expectations() {
 	v3_bin := build_v3_review_transform()
-	run_bad(v3_bin, 'bad_fixed_array_literal_len',
-		'fn take3(a [3]int) int {\n\treturn a[0]\n}\nfn main() {\n\t_ := take3([1, 2])\n}\n',
-		'cannot use')
-	run_bad(v3_bin, 'bad_dynamic_array_for_fixed_array',
-		'fn take3(a [3]int) int {\n\treturn a[0]\n}\nfn main() {\n\txs := [1, 2, 3]\n\t_ := take3(xs)\n}\n',
-		'cannot use')
-	out := run_good(v3_bin, 'good_exact_fixed_array_literal',
-		'fn take3(a [3]int) int {\n\treturn a[0] + a[1] + a[2]\n}\nfn main() {\n\tprintln(int_str(take3([1, 2, 3])))\n}\n')
+	run_bad(v3_bin, 'bad_fixed_array_literal_len', 'fn take3(a [3]int) int {\n\treturn a[0]\n}\nfn main() {\n\t_ := take3([1, 2])\n}\n', 'cannot use')
+	run_bad(v3_bin, 'bad_dynamic_array_for_fixed_array', 'fn take3(a [3]int) int {\n\treturn a[0]\n}\nfn main() {\n\txs := [1, 2, 3]\n\t_ := take3(xs)\n}\n', 'cannot use')
+	out := run_good(v3_bin, 'good_exact_fixed_array_literal', 'fn take3(a [3]int) int {\n\treturn a[0] + a[1] + a[2]\n}\nfn main() {\n\tprintln(int_str(take3([1, 2, 3])))\n}\n')
 	assert out == '6'
-	indexed := run_good(v3_bin, 'good_fixed_array_init_index',
-		'fn main() {\n\ta := [4]int{init: index * index}\n\tprintln(int_str(a[0]) + "," + int_str(a[1]) + "," + int_str(a[2]) + "," + int_str(a[3]))\n}\n')
+	indexed := run_good(v3_bin, 'good_fixed_array_init_index', 'fn main() {\n\ta := [4]int{init: index * index}\n\tprintln(int_str(a[0]) + "," + int_str(a[1]) + "," + int_str(a[2]) + "," + int_str(a[3]))\n}\n')
 	assert indexed == '0,1,4,9'
-	const_indexed := run_good(v3_bin, 'good_fixed_array_const_init_index',
-		'const n = 4\n\nfn main() {\n\ta := [n]int{init: index * index}\n\tprintln(int_str(a[0]) + "," + int_str(a[1]) + "," + int_str(a[2]) + "," + int_str(a[3]))\n}\n')
+	const_indexed := run_good(v3_bin, 'good_fixed_array_const_init_index', 'const n = 4\n\nfn main() {\n\ta := [n]int{init: index * index}\n\tprintln(int_str(a[0]) + "," + int_str(a[1]) + "," + int_str(a[2]) + "," + int_str(a[3]))\n}\n')
 	assert const_indexed == '0,1,4,9'
-	arg_indexed := run_good(v3_bin, 'good_fixed_array_arg_init_index',
-		'fn take(a [4]int) int {\n\treturn a[0] + a[1] + a[2] + a[3]\n}\n\nfn main() {\n\tprintln(int_str(take([4]int{init: index * index})))\n}\n')
+	arg_indexed := run_good(v3_bin, 'good_fixed_array_arg_init_index', 'fn take(a [4]int) int {\n\treturn a[0] + a[1] + a[2] + a[3]\n}\n\nfn main() {\n\tprintln(int_str(take([4]int{init: index * index})))\n}\n')
 	assert arg_indexed == '14'
 }
 
 fn test_array_equality_uses_semantic_element_comparison() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'semantic_array_equality',
-		"struct Child {\n\tlabel string\n}\n\nstruct Item {\n\tname string\n\tparts []string\n\tnested [][]string\n\tchildren []Child\n}\n\nfn join(a string, b string) string {\n\treturn a + b\n}\n\nfn main() {\n\tleft := [Item{\n\t\tname: 'hi'.clone()\n\t\tparts: ['ab'.clone()]\n\t\tnested: [[join('n', 'est')]]\n\t\tchildren: [Child{\n\t\t\tlabel: 'kid'.clone()\n\t\t}]\n\t}]\n\tright := [Item{\n\t\tname: join('h', 'i')\n\t\tparts: [join('a', 'b')]\n\t\tnested: [['nest'.clone()]]\n\t\tchildren: [Child{\n\t\t\tlabel: join('k', 'id')\n\t\t}]\n\t}]\n\tmaps_left := [{\n\t\t'k': 'value'.clone()\n\t}]\n\tmaps_right := [{\n\t\t'k': join('val', 'ue')\n\t}]\n\tnested_left := [[join('y', 'o')]]\n\tnested_right := [['yo'.clone()]]\n\tchild_map_left := {\n\t\t'items': [Child{\n\t\t\tlabel: 'mapkid'.clone()\n\t\t}]\n\t}\n\tchild_map_right := {\n\t\t'items': [Child{\n\t\t\tlabel: join('map', 'kid')\n\t\t}]\n\t}\n\tneedle := Item{\n\t\tname: join('h', 'i')\n\t\tparts: [join('a', 'b')]\n\t\tnested: [['nest'.clone()]]\n\t\tchildren: [Child{\n\t\t\tlabel: join('k', 'id')\n\t\t}]\n\t}\n\tprintln(left == right)\n\tprintln(left.equals(right))\n\tprintln(maps_left == maps_right)\n\tprintln(nested_left == nested_right)\n\tprintln(child_map_left == child_map_right)\n\tprintln(needle in left)\n\tprintln(int_str(left.index(needle)))\n}\n")
+	out := run_good(v3_bin, 'semantic_array_equality', "struct Child {\n\tlabel string\n}\n\nstruct Item {\n\tname string\n\tparts []string\n\tnested [][]string\n\tchildren []Child\n}\n\nfn join(a string, b string) string {\n\treturn a + b\n}\n\nfn main() {\n\tleft := [Item{\n\t\tname: 'hi'.clone()\n\t\tparts: ['ab'.clone()]\n\t\tnested: [[join('n', 'est')]]\n\t\tchildren: [Child{\n\t\t\tlabel: 'kid'.clone()\n\t\t}]\n\t}]\n\tright := [Item{\n\t\tname: join('h', 'i')\n\t\tparts: [join('a', 'b')]\n\t\tnested: [['nest'.clone()]]\n\t\tchildren: [Child{\n\t\t\tlabel: join('k', 'id')\n\t\t}]\n\t}]\n\tmaps_left := [{\n\t\t'k': 'value'.clone()\n\t}]\n\tmaps_right := [{\n\t\t'k': join('val', 'ue')\n\t}]\n\tnested_left := [[join('y', 'o')]]\n\tnested_right := [['yo'.clone()]]\n\tchild_map_left := {\n\t\t'items': [Child{\n\t\t\tlabel: 'mapkid'.clone()\n\t\t}]\n\t}\n\tchild_map_right := {\n\t\t'items': [Child{\n\t\t\tlabel: join('map', 'kid')\n\t\t}]\n\t}\n\tneedle := Item{\n\t\tname: join('h', 'i')\n\t\tparts: [join('a', 'b')]\n\t\tnested: [['nest'.clone()]]\n\t\tchildren: [Child{\n\t\t\tlabel: join('k', 'id')\n\t\t}]\n\t}\n\tprintln(left == right)\n\tprintln(left.equals(right))\n\tprintln(maps_left == maps_right)\n\tprintln(nested_left == nested_right)\n\tprintln(child_map_left == child_map_right)\n\tprintln(needle in left)\n\tprintln(int_str(left.index(needle)))\n}\n")
 	assert out == 'true\ntrue\ntrue\ntrue\ntrue\ntrue\n0'
 }
 
@@ -1752,15 +1631,13 @@ fn main() {
 
 fn test_array_map_fn_value_uses_callback_return_type() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'array_map_fn_value_return_type',
-		"fn main() {\n\ti_to_str := fn (i int) string {\n\t\treturn int_str(i)\n\t}\n\ta := [1, 2, 3].map(i_to_str)\n\tassert a == ['1', '2', '3']\n\tprintln(a[0] + a[1] + a[2])\n}\n")
+	out := run_good(v3_bin, 'array_map_fn_value_return_type', "fn main() {\n\ti_to_str := fn (i int) string {\n\t\treturn int_str(i)\n\t}\n\ta := [1, 2, 3].map(i_to_str)\n\tassert a == ['1', '2', '3']\n\tprintln(a[0] + a[1] + a[2])\n}\n")
 	assert out == '123'
 }
 
 fn test_const_array_allows_newline_separators_with_line_comments() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'const_array_line_comments',
-		'const xs = [\n\t1\n\t// one\n\t2\n\t// two\n\t3\n]\n\nfn main() {\n\tprintln(int_str(xs.len))\n\tprintln(int_str(xs[1]))\n}\n')
+	out := run_good(v3_bin, 'const_array_line_comments', 'const xs = [\n\t1\n\t// one\n\t2\n\t// two\n\t3\n]\n\nfn main() {\n\tprintln(int_str(xs.len))\n\tprintln(int_str(xs[1]))\n}\n')
 	assert out == '3\n2'
 }
 
@@ -1816,8 +1693,7 @@ fn test_mut_pointer_capture_is_not_over_dereferenced() {
 	// genuine `&S` local: its rvalue uses must not be over-dereferenced, so a call that
 	// expects the pointer still receives it (regression for gating the pointer-value
 	// rvalue/lvalue flags on `capture_by_ref` instead of every `capture_mut`).
-	out := run_good(v3_bin, 'mut_pointer_capture',
-		'struct S {\n\tn int\n}\n\nfn takes_ptr(p &S) int {\n\treturn p.n\n}\n\nfn call(cb fn ()) {\n\tcb()\n}\n\nfn main() {\n\tmut p := &S{\n\t\tn: 5\n\t}\n\tcall(fn [mut p] () {\n\t\tprintln(int_str(takes_ptr(p)))\n\t})\n}\n')
+	out := run_good(v3_bin, 'mut_pointer_capture', 'struct S {\n\tn int\n}\n\nfn takes_ptr(p &S) int {\n\treturn p.n\n}\n\nfn call(cb fn ()) {\n\tcb()\n}\n\nfn main() {\n\tmut p := &S{\n\t\tn: 5\n\t}\n\tcall(fn [mut p] () {\n\t\tprintln(int_str(takes_ptr(p)))\n\t})\n}\n')
 	assert out == '5'
 }
 
@@ -2433,8 +2309,7 @@ fn main() {
 	println(int_str(total))
 }
 '
-	c_source := gen_c_from_source(v3_bin, 'local_dynamic_callback_array_index_assign_hot_loop_c',
-		source)
+	c_source := gen_c_from_source(v3_bin, 'local_dynamic_callback_array_index_assign_hot_loop_c', source)
 	assert c_source.contains('closure__closure_try_destroy(__field_closure_'), c_source
 	assert c_source.contains('.receiver = counter'), c_source
 	out := run_good(v3_bin, 'local_dynamic_callback_array_index_assign_hot_loop', source)
@@ -2533,8 +2408,7 @@ fn main() {
 	println(int_str(total))
 }
 '
-	c_source := gen_c_from_source(v3_bin, 'local_callback_fixed_array_initializer_hot_loop_c',
-		source)
+	c_source := gen_c_from_source(v3_bin, 'local_callback_fixed_array_initializer_hot_loop_c', source)
 	assert c_source.contains('closure__closure_try_destroy(__array_closure_'), c_source
 	out := run_good(v3_bin, 'local_callback_fixed_array_initializer_hot_loop', source)
 	assert out == '1250025000'
@@ -2722,8 +2596,7 @@ fn main() {
 	println(int_str(total))
 }
 '
-	c_source := gen_c_from_source(v3_bin, 'local_dynamic_callback_map_index_assign_hot_loop_c',
-		source)
+	c_source := gen_c_from_source(v3_bin, 'local_dynamic_callback_map_index_assign_hot_loop_c', source)
 	assert c_source.contains('closure__closure_try_destroy(__map_val_'), c_source
 	out := run_good(v3_bin, 'local_dynamic_callback_map_index_assign_hot_loop', source)
 	assert out == '1250025000'
@@ -3040,8 +2913,7 @@ fn test_immediately_invoked_closure_keeps_aliased_integer_capture_address_alive(
 	println(int_str(unsafe { *p + 1 }))
 }
 '
-	c_source := gen_c_from_source(v3_bin, 'immediate_closure_aliased_integer_capture_address_c',
-		source)
+	c_source := gen_c_from_source(v3_bin, 'immediate_closure_aliased_integer_capture_address_c', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	deref_pos := main_body.index('*p') or { -1 }
 	destroy_pos := main_body.index('closure__closure_try_destroy(__immediate_closure_') or { -1 }
@@ -3412,8 +3284,7 @@ fn test_arm64_backend_rejects_defer_results_before_ssa() {
 fn main() {
 	println(int_str(f()))
 }
-',
-		'`$res()` is not supported by the V3 arm64 backend')
+', '`\$res()` is not supported by the V3 arm64 backend')
 }
 
 fn test_eval_backend_rejects_active_defer_results() {
@@ -3428,8 +3299,7 @@ fn test_eval_backend_rejects_active_defer_results() {
 fn main() {
 	println(int_str(f()))
 }
-',
-		'`$res()` is not supported by the V3 eval backend')
+', '`\$res()` is not supported by the V3 eval backend')
 }
 
 fn test_wasm_backend_rejects_defer_results_before_codegen() {
@@ -3444,8 +3314,7 @@ fn test_wasm_backend_rejects_defer_results_before_codegen() {
 fn main() {
 	println(int_str(f()))
 }
-',
-		'`$res()` is not supported by the V3 wasm backend')
+', '`\$res()` is not supported by the V3 wasm backend')
 }
 
 fn test_thread_handle_equality_uses_platform_comparison() {
@@ -3562,8 +3431,7 @@ fn (mut counter Counter) next() int {
 	return counter.value
 }
 '
-	run_bad(v3_bin, 'mut_method_value_stack_receiver_direct', source +
-		'fn make() fn () int {
+	run_bad(v3_bin, 'mut_method_value_stack_receiver_direct', source + 'fn make() fn () int {
 	mut counter := Counter{}
 	return counter.next
 }
@@ -3571,10 +3439,8 @@ fn (mut counter Counter) next() int {
 fn main() {
 	_ = make()
 }
-',
-		'mutable local receiver cannot escape')
-	run_bad(v3_bin, 'mut_method_value_stack_receiver_alias', source +
-		'fn make() fn () int {
+', 'mutable local receiver cannot escape')
+	run_bad(v3_bin, 'mut_method_value_stack_receiver_alias', source + 'fn make() fn () int {
 	mut counter := Counter{}
 	callback := counter.next
 	return callback
@@ -3583,10 +3449,8 @@ fn main() {
 fn main() {
 	_ = make()
 }
-',
-		'mutable local receiver cannot escape')
-	in_scope := run_good(v3_bin, 'mut_method_value_in_scope_borrows_receiver', source +
-		'fn main() {
+', 'mutable local receiver cannot escape')
+	in_scope := run_good(v3_bin, 'mut_method_value_in_scope_borrows_receiver', source + 'fn main() {
 	mut counter := Counter{}
 	callback := counter.next
 	println(int_str(callback()))
@@ -4021,8 +3885,7 @@ const counter = Counter{}
 fn main() {
 	counter.increment()
 }
-',
-		'cannot modify constant `counter`')
+', 'cannot modify constant `counter`')
 }
 
 fn test_mut_value_capture_in_call_under_selector_base() {
@@ -4030,8 +3893,7 @@ fn test_mut_value_capture_in_call_under_selector_base() {
 	// A `[mut s]` value capture used as a call argument nested inside a selector base
 	// (`wrap(s).s.n`) must still be lowered to its value; the selector-base deref
 	// suppression applies only to the direct receiver ident, not to nested expressions.
-	out := run_good(v3_bin, 'mut_capture_selector_base',
-		'struct S {\n\tn int\n}\n\nstruct Box {\n\ts S\n}\n\nfn wrap(s S) Box {\n\treturn Box{\n\t\ts: s\n\t}\n}\n\nfn call(cb fn ()) {\n\tcb()\n}\n\nfn main() {\n\tmut s := S{\n\t\tn: 7\n\t}\n\tcall(fn [mut s] () {\n\t\tprintln(int_str(wrap(s).s.n))\n\t})\n}\n')
+	out := run_good(v3_bin, 'mut_capture_selector_base', 'struct S {\n\tn int\n}\n\nstruct Box {\n\ts S\n}\n\nfn wrap(s S) Box {\n\treturn Box{\n\t\ts: s\n\t}\n}\n\nfn call(cb fn ()) {\n\tcb()\n}\n\nfn main() {\n\tmut s := S{\n\t\tn: 7\n\t}\n\tcall(fn [mut s] () {\n\t\tprintln(int_str(wrap(s).s.n))\n\t})\n}\n')
 	assert out == '7'
 }
 
@@ -4041,8 +3903,7 @@ fn test_mut_value_capture_parenthesized_selector_receiver() {
 	// (`(s).n`) is still the direct selector receiver and must keep the suppression so
 	// the selector emits arrow access. Otherwise the inner `s` is auto-dereferenced to
 	// `*s` while the selector still emits `->`, producing an invalid `(*s)->n`.
-	out := run_good(v3_bin, 'mut_capture_paren_selector_base',
-		'struct S {\n\tn int\n}\n\nfn call(cb fn ()) {\n\tcb()\n}\n\nfn main() {\n\tmut s := S{\n\t\tn: 7\n\t}\n\tcall(fn [mut s] () {\n\t\tprintln(int_str((s).n))\n\t})\n}\n')
+	out := run_good(v3_bin, 'mut_capture_paren_selector_base', 'struct S {\n\tn int\n}\n\nfn call(cb fn ()) {\n\tcb()\n}\n\nfn main() {\n\tmut s := S{\n\t\tn: 7\n\t}\n\tcall(fn [mut s] () {\n\t\tprintln(int_str((s).n))\n\t})\n}\n')
 	assert out == '7'
 }
 
@@ -4053,8 +3914,7 @@ fn test_heap_escaping_amp_alias_keeps_heap_pointer() {
 	// auto-dereferenced to `*s`. Over-dereferencing here initializes `p`'s `&S` decl from
 	// an `S` value (a stale stack copy), reviving the escape/stale-mutation bug the heap
 	// move avoids. A later `s = S{n: 2}` must be observable through the returned pointer.
-	out := run_good(v3_bin, 'heap_escaping_amp_alias',
-		'struct S {\n\tn int\n}\n\nfn leak() &S {\n\tmut s := S{\n\t\tn: 1\n\t}\n\tp := &s\n\ts = S{\n\t\tn: 2\n\t}\n\treturn p\n}\n\nfn main() {\n\tp := leak()\n\tprintln(int_str(p.n))\n}\n')
+	out := run_good(v3_bin, 'heap_escaping_amp_alias', 'struct S {\n\tn int\n}\n\nfn leak() &S {\n\tmut s := S{\n\t\tn: 1\n\t}\n\tp := &s\n\ts = S{\n\t\tn: 2\n\t}\n\treturn p\n}\n\nfn main() {\n\tp := leak()\n\tprintln(int_str(p.n))\n}\n')
 	assert out == '2'
 }
 
@@ -4165,11 +4025,9 @@ fn main() {
 
 fn test_heap_escaping_amp_reassignment_moves_current_source() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'heap_escaping_amp_reassign_source',
-		'fn make() &int {\n\tmut a := 10\n\tmut b := 20\n\tmut p := &a\n\tp = &b\n\treturn p\n}\n\nfn main() {\n\tprintln(int_str(*make()))\n}\n')
+	out := run_good(v3_bin, 'heap_escaping_amp_reassign_source', 'fn make() &int {\n\tmut a := 10\n\tmut b := 20\n\tmut p := &a\n\tp = &b\n\treturn p\n}\n\nfn main() {\n\tprintln(int_str(*make()))\n}\n')
 	assert out == '20'
-	c_source := gen_c_from_source(v3_bin, 'heap_escaping_amp_reassign_source_c',
-		'fn make() &int {\n\tmut a := 10\n\tmut b := 20\n\tmut p := &a\n\tp = &b\n\treturn p\n}\n\nfn main() {\n\t_ := make()\n}\n')
+	c_source := gen_c_from_source(v3_bin, 'heap_escaping_amp_reassign_source_c', 'fn make() &int {\n\tmut a := 10\n\tmut b := 20\n\tmut p := &a\n\tp = &b\n\treturn p\n}\n\nfn main() {\n\t_ := make()\n}\n')
 	body := c_fn_body(c_source, 'int* make(void) {')
 	assert body.contains('int* b ='), body
 	assert !body.contains('p = &b;'), body
@@ -4203,8 +4061,7 @@ fn main() {
 	println(int_str(cache["entry"].item.value))
 }
 '
-	c_source := gen_c_from_source(v3_bin, 'map_index_selector_write_retains_local_address_c',
-		source)
+	c_source := gen_c_from_source(v3_bin, 'map_index_selector_write_retains_local_address_c', source)
 	body := c_fn_body(c_source, 'map make_cache(void) {')
 	assert body.contains('memdup'), body
 	out := run_good(v3_bin, 'map_index_selector_write_retains_local_address', source)
@@ -4213,8 +4070,7 @@ fn main() {
 
 fn test_return_address_of_pointer_backed_field_preserves_identity() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'return_pointer_backed_field_address',
-		'struct Node[T] {\nmut:\n\tvalue T\n}\n\nstruct List[T] {\nmut:\n\ttail &Node[T] = unsafe { nil }\n}\n\nfn (list &List[T]) last() &T {\n\treturn &list.tail.value\n}\n\nfn main() {\n\tmut node := &Node[int]{\n\t\tvalue: 1\n\t}\n\tlist := List[int]{\n\t\ttail: node\n\t}\n\tmut last := list.last()\n\tunsafe {\n\t\t*last = 9\n\t}\n\tprintln(int_str(node.value))\n}\n')
+	out := run_good(v3_bin, 'return_pointer_backed_field_address', 'struct Node[T] {\nmut:\n\tvalue T\n}\n\nstruct List[T] {\nmut:\n\ttail &Node[T] = unsafe { nil }\n}\n\nfn (list &List[T]) last() &T {\n\treturn &list.tail.value\n}\n\nfn main() {\n\tmut node := &Node[int]{\n\t\tvalue: 1\n\t}\n\tlist := List[int]{\n\t\ttail: node\n\t}\n\tmut last := list.last()\n\tunsafe {\n\t\t*last = 9\n\t}\n\tprintln(int_str(node.value))\n}\n')
 	assert out == '9'
 }
 
@@ -4230,8 +4086,7 @@ fn test_imported_result_array_return_or_preserves_success_value() {
 
 fn test_result_multi_return_match_branch_unwraps_payload_type() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'result_multi_return_match_branch_unwrap',
-		"enum Kind {\n\tleft\n\tright\n}\n\nfn left_pair() !(int, string) {\n\treturn 1, 'left'\n}\n\nfn right_pair() !(int, string) {\n\treturn 2, 'right'\n}\n\nfn choose(kind Kind) !(int, string) {\n\treturn match kind {\n\t\t.left {\n\t\t\tleft_pair()!\n\t\t}\n\t\t.right {\n\t\t\tright_pair()!\n\t\t}\n\t}\n}\n\nfn main() {\n\tn, label := choose(.right)!\n\tprintln(int_str(n) + ':' + label)\n}\n")
+	out := run_good(v3_bin, 'result_multi_return_match_branch_unwrap', "enum Kind {\n\tleft\n\tright\n}\n\nfn left_pair() !(int, string) {\n\treturn 1, 'left'\n}\n\nfn right_pair() !(int, string) {\n\treturn 2, 'right'\n}\n\nfn choose(kind Kind) !(int, string) {\n\treturn match kind {\n\t\t.left {\n\t\t\tleft_pair()!\n\t\t}\n\t\t.right {\n\t\t\tright_pair()!\n\t\t}\n\t}\n}\n\nfn main() {\n\tn, label := choose(.right)!\n\tprintln(int_str(n) + ':' + label)\n}\n")
 	assert out == '2:right'
 }
 
@@ -4247,8 +4102,7 @@ fn test_result_multi_return_match_branch_unwraps_imported_payload_type() {
 
 fn test_string_to_owned_compiles_under_ownership_cgen() {
 	v3_bin := build_v3_review_transform_ownership()
-	out := run_good_with_flags(v3_bin, 'string_to_owned_ownership_cgen', '-ownership',
-		"fn main() {\n\tname := 'owned'.to_owned()\n\tcopy := name.to_owned()\n\tprintln(copy)\n}\n")
+	out := run_good_with_flags(v3_bin, 'string_to_owned_ownership_cgen', '-ownership', "fn main() {\n\tname := 'owned'.to_owned()\n\tcopy := name.to_owned()\n\tprintln(copy)\n}\n")
 	assert out == 'owned'
 }
 
@@ -4362,15 +4216,13 @@ fn main() {
 	assert c_source.contains('closure__closure_create_with_data_and_drop'), c_source
 	assert c_source.contains('string__free(&((*ctx).text));'), c_source
 	assert c_source.contains('array__free(&((*ctx).values));'), c_source
-	out := run_good_with_flags(v3_bin, 'owned_fn_literal_capture_context', '-ownership -gc none',
-		source)
+	out := run_good_with_flags(v3_bin, 'owned_fn_literal_capture_context', '-ownership -gc none', source)
 	assert out == '95'
 }
 
 fn test_generic_interface_method_body_marks_log_debug_dispatch() {
 	v3_bin := build_v3_review_transform_ownership()
-	out := run_good_with_flags(v3_bin, 'generic_interface_log_debug_dispatch', '-ownership',
-		"import log\n\ninterface Sink {\n\tbinary_data()\n}\n\nstruct Box[T] {}\n\nfn (mut b Box[T]) binary_data() {\n\t_ = b\n\tlog.debug('hidden')\n}\n\nstruct Runner {}\n\nfn (mut r Runner) run(mut s Sink) {\n\t_ = r\n\ts.binary_data()\n}\n\nstruct Worker {\nmut:\n\trunner Runner\n}\n\nfn main() {\n\tmut worker := Worker{\n\t\trunner: Runner{}\n\t}\n\tmut b := Box[int]{}\n\tworker.runner.run(mut b)\n\tprintln('ok')\n}\n")
+	out := run_good_with_flags(v3_bin, 'generic_interface_log_debug_dispatch', '-ownership', "import log\n\ninterface Sink {\n\tbinary_data()\n}\n\nstruct Box[T] {}\n\nfn (mut b Box[T]) binary_data() {\n\t_ = b\n\tlog.debug('hidden')\n}\n\nstruct Runner {}\n\nfn (mut r Runner) run(mut s Sink) {\n\t_ = r\n\ts.binary_data()\n}\n\nstruct Worker {\nmut:\n\trunner Runner\n}\n\nfn main() {\n\tmut worker := Worker{\n\t\trunner: Runner{}\n\t}\n\tmut b := Box[int]{}\n\tworker.runner.run(mut b)\n\tprintln('ok')\n}\n")
 	assert out == 'ok'
 }
 
@@ -4425,8 +4277,7 @@ fn main() {
 
 fn test_generic_interface_implementer_result_uses_dispatch_abi() {
 	v3_bin := build_v3_review_transform_ownership()
-	out := run_good_with_flags(v3_bin, 'generic_interface_implementer_result_dispatch',
-		'-ownership', 'interface Writer {
+	out := run_good_with_flags(v3_bin, 'generic_interface_implementer_result_dispatch', '-ownership', 'interface Writer {
 mut:
 	write(buf []u8) !int
 }
@@ -4491,13 +4342,10 @@ fn main() {
 fn test_array_literal_separator_handling() {
 	v3_bin := build_v3_review_transform()
 	// Comma-, newline-, and blank-line-separated element lists parse with the expected length.
-	out := run_good(v3_bin, 'array_literal_separators',
-		'const nl = [\n\t1\n\t2\n\t3\n]\nconst blank = [\n\t4\n\n\t5\n]\n\nfn main() {\n\tcommas := [6, 7, 8]\n\tprintln(int_str(nl.len) + ":" + int_str(blank.len) + ":" + int_str(commas.len))\n}\n')
+	out := run_good(v3_bin, 'array_literal_separators', 'const nl = [\n\t1\n\t2\n\t3\n]\nconst blank = [\n\t4\n\n\t5\n]\n\nfn main() {\n\tcommas := [6, 7, 8]\n\tprintln(int_str(nl.len) + ":" + int_str(blank.len) + ":" + int_str(commas.len))\n}\n')
 	assert out == '3:2:3'
-	run_bad(v3_bin, 'array_literal_missing_separator', 'fn main() {\n\t_ := [1 2]\n}\n',
-		'unexpected token `2`, expecting `]`')
-	run_bad(v3_bin, 'array_literal_doubled_comma', 'fn main() {\n\t_ := [1,,2]\n}\n',
-		'unexpected token `,`, expecting `]`')
+	run_bad(v3_bin, 'array_literal_missing_separator', 'fn main() {\n\t_ := [1 2]\n}\n', 'unexpected token `2`, expecting `]`')
+	run_bad(v3_bin, 'array_literal_doubled_comma', 'fn main() {\n\t_ := [1,,2]\n}\n', 'unexpected token `,`, expecting `]`')
 }
 
 fn test_container_wrapped_import_alias_type_resolves() {
@@ -4513,57 +4361,49 @@ fn test_container_wrapped_import_alias_type_resolves() {
 
 fn test_nested_map_equality_uses_declared_value_type() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'nested_map_semantic_equality',
-		"struct Item {\n\tname string\n\tparts []string\n}\n\nstruct Holder {\n\titems map[string][]Item\n}\n\nfn join(a string, b string) string {\n\treturn a + b\n}\n\nfn main() {\n\tmut left_map := map[string][]Item{}\n\tleft_map['items'] = [Item{\n\t\tname: 'ab'.clone()\n\t\tparts: ['xy'.clone()]\n\t}]\n\tmut right_map := map[string][]Item{}\n\tright_map['items'] = [Item{\n\t\tname: join('a', 'b')\n\t\tparts: [join('x', 'y')]\n\t}]\n\tleft_arr := [left_map]\n\tright_arr := [right_map]\n\tleft_holder := Holder{\n\t\titems: left_map\n\t}\n\tright_holder := Holder{\n\t\titems: right_map\n\t}\n\tprintln(left_arr == right_arr)\n\tprintln(left_holder == right_holder)\n}\n")
+	out := run_good(v3_bin, 'nested_map_semantic_equality', "struct Item {\n\tname string\n\tparts []string\n}\n\nstruct Holder {\n\titems map[string][]Item\n}\n\nfn join(a string, b string) string {\n\treturn a + b\n}\n\nfn main() {\n\tmut left_map := map[string][]Item{}\n\tleft_map['items'] = [Item{\n\t\tname: 'ab'.clone()\n\t\tparts: ['xy'.clone()]\n\t}]\n\tmut right_map := map[string][]Item{}\n\tright_map['items'] = [Item{\n\t\tname: join('a', 'b')\n\t\tparts: [join('x', 'y')]\n\t}]\n\tleft_arr := [left_map]\n\tright_arr := [right_map]\n\tleft_holder := Holder{\n\t\titems: left_map\n\t}\n\tright_holder := Holder{\n\t\titems: right_map\n\t}\n\tprintln(left_arr == right_arr)\n\tprintln(left_holder == right_holder)\n}\n")
 	assert out == 'true\ntrue'
 }
 
 fn test_pointer_array_equality_uses_pointer_identity() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'pointer_array_equality',
-		'struct Node {\n\tvalue int\n}\n\nfn main() {\n\tleft_node := Node{\n\t\tvalue: 5\n\t}\n\tright_node := Node{\n\t\tvalue: 5\n\t}\n\tleft_ptr := &left_node\n\tright_ptr := &right_node\n\tleft := [left_ptr]\n\tright := [right_ptr]\n\tsame := [left_ptr]\n\tprintln(left == right)\n\tprintln(left != right)\n\tprintln(left == same)\n\tprintln(right_ptr in left)\n\tprintln(int_str(left.index(right_ptr)))\n}\n')
+	out := run_good(v3_bin, 'pointer_array_equality', 'struct Node {\n\tvalue int\n}\n\nfn main() {\n\tleft_node := Node{\n\t\tvalue: 5\n\t}\n\tright_node := Node{\n\t\tvalue: 5\n\t}\n\tleft_ptr := &left_node\n\tright_ptr := &right_node\n\tleft := [left_ptr]\n\tright := [right_ptr]\n\tsame := [left_ptr]\n\tprintln(left == right)\n\tprintln(left != right)\n\tprintln(left == same)\n\tprintln(right_ptr in left)\n\tprintln(int_str(left.index(right_ptr)))\n}\n')
 	assert out == 'false\ntrue\ntrue\nfalse\n-1'
 }
 
 fn test_struct_pointer_equality_is_semantic() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'struct_pointer_semantic_equality',
-		"struct Person {\n\tname string\n\ttags []string\n}\n\nfn main() {\n\tleft := &Person{\n\t\tname: 'abc'.clone()\n\t\ttags: ['x'.clone()]\n\t}\n\tright := &Person{\n\t\tname: ('a' + 'bc')\n\t\ttags: [('x' + '')]\n\t}\n\tsame := left\n\tprintln(left == right)\n\tprintln(left != right)\n\tprintln(left == same)\n}\n")
+	out := run_good(v3_bin, 'struct_pointer_semantic_equality', "struct Person {\n\tname string\n\ttags []string\n}\n\nfn main() {\n\tleft := &Person{\n\t\tname: 'abc'.clone()\n\t\ttags: ['x'.clone()]\n\t}\n\tright := &Person{\n\t\tname: ('a' + 'bc')\n\t\ttags: [('x' + '')]\n\t}\n\tsame := left\n\tprintln(left == right)\n\tprintln(left != right)\n\tprintln(left == same)\n}\n")
 	assert out == 'true\nfalse\ntrue'
 }
 
 fn test_multilevel_struct_pointer_equality_uses_pointer_identity() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'multilevel_struct_pointer_identity_equality',
-		"struct Person {\n\tname string\n}\n\nfn main() {\n\tmut left := &Person{\n\t\tname: 'same'\n\t}\n\tmut right := &Person{\n\t\tname: 'same'\n\t}\n\tleft_slot := &left\n\tright_slot := &right\n\tsame_slot := left_slot\n\tprintln(left_slot == right_slot)\n\tprintln(left_slot != right_slot)\n\tprintln(left_slot == same_slot)\n\tprintln(*left_slot == *right_slot)\n}\n")
+	out := run_good(v3_bin, 'multilevel_struct_pointer_identity_equality', "struct Person {\n\tname string\n}\n\nfn main() {\n\tmut left := &Person{\n\t\tname: 'same'\n\t}\n\tmut right := &Person{\n\t\tname: 'same'\n\t}\n\tleft_slot := &left\n\tright_slot := &right\n\tsame_slot := left_slot\n\tprintln(left_slot == right_slot)\n\tprintln(left_slot != right_slot)\n\tprintln(left_slot == same_slot)\n\tprintln(*left_slot == *right_slot)\n}\n")
 	assert out == 'false\ntrue\ntrue\ntrue'
 }
 
 fn test_struct_equality_with_interface_field_compiles() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'struct_eq_interface_field',
-		"interface Thing {\n\tvalue() int\n}\n\nstruct Item {\n\tn int\n}\n\nfn (i Item) value() int {\n\treturn i.n\n}\n\nstruct Box {\n\tthing Thing\n\tlabel string\n}\n\nfn main() {\n\titem := Item{\n\t\tn: 7\n\t}\n\tleft := Box{\n\t\tthing: item\n\t\tlabel: 'same'\n\t}\n\tright := left\n\tprintln(left == right)\n}\n")
+	out := run_good(v3_bin, 'struct_eq_interface_field', "interface Thing {\n\tvalue() int\n}\n\nstruct Item {\n\tn int\n}\n\nfn (i Item) value() int {\n\treturn i.n\n}\n\nstruct Box {\n\tthing Thing\n\tlabel string\n}\n\nfn main() {\n\titem := Item{\n\t\tn: 7\n\t}\n\tleft := Box{\n\t\tthing: item\n\t\tlabel: 'same'\n\t}\n\tright := left\n\tprintln(left == right)\n}\n")
 	assert out == 'true'
 }
 
 fn test_array_pointer_equality_uses_pointer_identity() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'array_pointer_equality',
-		'fn main() {\n\tleft := [1, 2]\n\tright := [1, 2]\n\tleft_ptr := &left\n\tright_ptr := &right\n\tsame_ptr := left_ptr\n\tprintln(left_ptr == right_ptr)\n\tprintln(left_ptr != right_ptr)\n\tprintln(left_ptr == same_ptr)\n\tprintln(*left_ptr == *right_ptr)\n}\n')
+	out := run_good(v3_bin, 'array_pointer_equality', 'fn main() {\n\tleft := [1, 2]\n\tright := [1, 2]\n\tleft_ptr := &left\n\tright_ptr := &right\n\tsame_ptr := left_ptr\n\tprintln(left_ptr == right_ptr)\n\tprintln(left_ptr != right_ptr)\n\tprintln(left_ptr == same_ptr)\n\tprintln(*left_ptr == *right_ptr)\n}\n')
 	assert out == 'false\ntrue\ntrue\ntrue'
 }
 
 fn test_pointer_u8_array_bytestr_stays_in_cgen() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'pointer_u8_array_bytestr',
-		'fn show(data &[]u8) string {\n\treturn data.bytestr()\n}\n\nfn main() {\n\tbytes := [u8(104), u8(105)]\n\tprintln(show(&bytes))\n}\n')
+	out := run_good(v3_bin, 'pointer_u8_array_bytestr', 'fn show(data &[]u8) string {\n\treturn data.bytestr()\n}\n\nfn main() {\n\tbytes := [u8(104), u8(105)]\n\tprintln(show(&bytes))\n}\n')
 	assert out == 'hi'
 }
 
 fn test_map_pointer_equality_uses_pointer_identity() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'map_pointer_equality',
-		"fn main() {\n\tleft := {\n\t\t'x': 1\n\t}\n\tright := {\n\t\t'x': 1\n\t}\n\tleft_ptr := &left\n\tright_ptr := &right\n\tsame_ptr := left_ptr\n\tprintln(left_ptr == right_ptr)\n\tprintln(left_ptr != right_ptr)\n\tprintln(left_ptr == same_ptr)\n\tprintln(*left_ptr == *right_ptr)\n}\n")
+	out := run_good(v3_bin, 'map_pointer_equality', "fn main() {\n\tleft := {\n\t\t'x': 1\n\t}\n\tright := {\n\t\t'x': 1\n\t}\n\tleft_ptr := &left\n\tright_ptr := &right\n\tsame_ptr := left_ptr\n\tprintln(left_ptr == right_ptr)\n\tprintln(left_ptr != right_ptr)\n\tprintln(left_ptr == same_ptr)\n\tprintln(*left_ptr == *right_ptr)\n}\n")
 	assert out == 'false\ntrue\ntrue\ntrue'
 }
 
@@ -4579,8 +4419,7 @@ fn test_cyclic_interface_default_does_not_deref_nil_global() {
 
 fn test_fixed_array_values_compare_semantically() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'fixed_array_semantic_equality',
-		"fn join(a string, b string) string {\n\treturn a + b\n}\n\nfn main() {\n\tleft := [[1]string{init: 'ab'.clone()}]\n\tright := [[1]string{init: join('a', 'b')}]\n\tmut map_left := map[string][1]string{}\n\tmap_left['k'] = [1]string{init: 'cd'.clone()}\n\tmut map_right := map[string][1]string{}\n\tmap_right['k'] = [1]string{init: join('c', 'd')}\n\tmut ints_left := map[string][2]i64{}\n\tints_left['k'] = [i64(1), i64(0)]!\n\tmut ints_right := map[string][2]i64{}\n\tints_right['k'] = [i64(2), i64(0)]!\n\tprintln(left == right)\n\tprintln(left.equals(right))\n\tprintln(map_left == map_right)\n\tprintln(ints_left == ints_right)\n}\n")
+	out := run_good(v3_bin, 'fixed_array_semantic_equality', "fn join(a string, b string) string {\n\treturn a + b\n}\n\nfn main() {\n\tleft := [[1]string{init: 'ab'.clone()}]\n\tright := [[1]string{init: join('a', 'b')}]\n\tmut map_left := map[string][1]string{}\n\tmap_left['k'] = [1]string{init: 'cd'.clone()}\n\tmut map_right := map[string][1]string{}\n\tmap_right['k'] = [1]string{init: join('c', 'd')}\n\tmut ints_left := map[string][2]i64{}\n\tints_left['k'] = [i64(1), i64(0)]!\n\tmut ints_right := map[string][2]i64{}\n\tints_right['k'] = [i64(2), i64(0)]!\n\tprintln(left == right)\n\tprintln(left.equals(right))\n\tprintln(map_left == map_right)\n\tprintln(ints_left == ints_right)\n}\n")
 	assert out == 'true\ntrue\ntrue\nfalse'
 }
 
@@ -4595,36 +4434,31 @@ fn test_const_length_fixed_array_map_values_compare_semantically() {
 
 fn test_interface_array_repeat_evaluates_receiver_once() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'interface_repeat_side_effects',
-		'interface Thing {\n\tvalue() int\n}\n\nstruct Item {\n\tn int\n}\n\nfn (i Item) value() int {\n\treturn i.n\n}\n\n__global calls int\n\nfn make_item() Thing {\n\tcalls++\n\treturn Item{\n\t\tn: calls\n\t}\n}\n\nfn main() {\n\titems := [make_item()].repeat(3)\n\tprintln(int_str(calls))\n\tprintln(int_str(items[0].value() + items[1].value() + items[2].value()))\n}\n')
+	out := run_good(v3_bin, 'interface_repeat_side_effects', 'interface Thing {\n\tvalue() int\n}\n\nstruct Item {\n\tn int\n}\n\nfn (i Item) value() int {\n\treturn i.n\n}\n\n__global calls int\n\nfn make_item() Thing {\n\tcalls++\n\treturn Item{\n\t\tn: calls\n\t}\n}\n\nfn main() {\n\titems := [make_item()].repeat(3)\n\tprintln(int_str(calls))\n\tprintln(int_str(items[0].value() + items[1].value() + items[2].value()))\n}\n')
 	assert out == '1\n3'
 }
 
 fn test_negative_is_return_smartcasts_following_statements() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'negative_is_return_smartcast',
-		'struct MapKind {\n\tkey_type int\n\tvalue_type int\n}\nstruct OtherKind {}\ntype Kind = MapKind | OtherKind\n\nfn passthrough(k Kind) Kind {\n\treturn k\n}\n\nfn score(k Kind) int {\n\tclean := passthrough(k)\n\tif clean !is MapKind {\n\t\treturn 0\n\t}\n\treturn clean.key_type + clean.value_type\n}\n\nfn main() {\n\tprintln(int_str(score(Kind(MapKind{\n\t\tkey_type: 2\n\t\tvalue_type: 5\n\t}))))\n\tprintln(int_str(score(Kind(OtherKind{}))))\n}\n')
+	out := run_good(v3_bin, 'negative_is_return_smartcast', 'struct MapKind {\n\tkey_type int\n\tvalue_type int\n}\nstruct OtherKind {}\ntype Kind = MapKind | OtherKind\n\nfn passthrough(k Kind) Kind {\n\treturn k\n}\n\nfn score(k Kind) int {\n\tclean := passthrough(k)\n\tif clean !is MapKind {\n\t\treturn 0\n\t}\n\treturn clean.key_type + clean.value_type\n}\n\nfn main() {\n\tprintln(int_str(score(Kind(MapKind{\n\t\tkey_type: 2\n\t\tvalue_type: 5\n\t}))))\n\tprintln(int_str(score(Kind(OtherKind{}))))\n}\n')
 	assert out == '7\n0'
 }
 
 fn test_if_expr_smartcast_selector_decl_does_not_smartcast_local() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'if_expr_selector_decl_smartcast_local',
-		'struct Cat {\n\tage int\n}\nstruct Dog {\n\ttricks int\n}\ntype Animal = Cat | Dog\n\nstruct Ident {\n\tobj Animal\n}\n\nfn has_age(cat Cat) bool {\n\treturn cat.age == 3\n}\n\nfn main() {\n\tleft := Ident{\n\t\tobj: Animal(Cat{\n\t\t\tage: 2\n\t\t})\n\t}\n\tmut obj := if left.obj is Cat {\n\t\tleft.obj\n\t} else {\n\t\tCat{}\n\t}\n\tif true {\n\t\tobj = Cat{\n\t\t\tage: 3\n\t\t}\n\t}\n\tprintln(has_age(obj))\n}\n')
+	out := run_good(v3_bin, 'if_expr_selector_decl_smartcast_local', 'struct Cat {\n\tage int\n}\nstruct Dog {\n\ttricks int\n}\ntype Animal = Cat | Dog\n\nstruct Ident {\n\tobj Animal\n}\n\nfn has_age(cat Cat) bool {\n\treturn cat.age == 3\n}\n\nfn main() {\n\tleft := Ident{\n\t\tobj: Animal(Cat{\n\t\t\tage: 2\n\t\t})\n\t}\n\tmut obj := if left.obj is Cat {\n\t\tleft.obj\n\t} else {\n\t\tCat{}\n\t}\n\tif true {\n\t\tobj = Cat{\n\t\t\tage: 3\n\t\t}\n\t}\n\tprintln(has_age(obj))\n}\n')
 	assert out == 'true'
 }
 
 fn test_comptime_type_conditions_handle_logical_ops() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'comptime_type_condition_logical_ops',
-		"fn classify[T](x T) int {\n\t_ := x\n\t\$if T !is string && T !is \$int && T !is []u8 {\n\t\treturn 1\n\t} \$else {\n\t\treturn 2\n\t}\n\treturn 0\n}\n\nfn grouped[T](x T) int {\n\t_ := x\n\t\$if (T is int || T is string) && T is bool {\n\t\treturn 1\n\t} \$else {\n\t\treturn 2\n\t}\n\treturn 0\n}\n\nfn main() {\n\tprintln(int_str(classify('abc')))\n\tprintln(int_str(classify(3)))\n\tprintln(int_str(classify([u8(1)])))\n\tprintln(int_str(classify(1.5)))\n\tprintln(int_str(grouped(3)))\n\tprintln(int_str(grouped('abc')))\n}\n")
+	out := run_good(v3_bin, 'comptime_type_condition_logical_ops', "fn classify[T](x T) int {\n\t_ := x\n\t\$if T !is string && T !is \$int && T !is []u8 {\n\t\treturn 1\n\t} \$else {\n\t\treturn 2\n\t}\n\treturn 0\n}\n\nfn grouped[T](x T) int {\n\t_ := x\n\t\$if (T is int || T is string) && T is bool {\n\t\treturn 1\n\t} \$else {\n\t\treturn 2\n\t}\n\treturn 0\n}\n\nfn main() {\n\tprintln(int_str(classify('abc')))\n\tprintln(int_str(classify(3)))\n\tprintln(int_str(classify([u8(1)])))\n\tprintln(int_str(classify(1.5)))\n\tprintln(int_str(grouped(3)))\n\tprintln(int_str(grouped('abc')))\n}\n")
 	assert out == '2\n2\n2\n1\n2\n2'
 }
 
 fn test_comptime_type_conditions_keep_prefix_types_compact() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'comptime_type_condition_prefix_types',
-		'struct Foo {}\n\nfn main() {\n\t\$if ?int is ?int {\n\t\tprintln("opt")\n\t} \$else {\n\t\tprintln("badopt")\n\t}\n\t\$if !Foo is !Foo {\n\t\tprintln("res")\n\t} \$else {\n\t\tprintln("badres")\n\t}\n}\n')
+	out := run_good(v3_bin, 'comptime_type_condition_prefix_types', 'struct Foo {}\n\nfn main() {\n\t\$if ?int is ?int {\n\t\tprintln("opt")\n\t} \$else {\n\t\tprintln("badopt")\n\t}\n\t\$if !Foo is !Foo {\n\t\tprintln("res")\n\t} \$else {\n\t\tprintln("badres")\n\t}\n}\n')
 	assert out == 'opt\nres'
 }
 
@@ -4641,7 +4475,7 @@ fn test_imported_generic_indirections_conditions_keep_integer_literals() {
 	v3_bin := build_v3_review_transform()
 	out := run_good_project(v3_bin, 'generic_indirections_integer_literals', {
 		'v.mod':         "Module { name: 'generic_indirections_integer_literals' }\n"
-		'probe/probe.v': 'module probe\n\npub fn depth[T](value T) int {\n\t_ = value\n\t$if T.indirections == 0 {\n\t\treturn 0\n\t} $else $if T.indirections == 1 {\n\t\treturn 1\n\t}\n\treturn 2\n}\n'
+		'probe/probe.v': 'module probe\n\npub fn depth[T](value T) int {\n\t_ = value\n\t\$if T.indirections == 0 {\n\t\treturn 0\n\t} \$else \$if T.indirections == 1 {\n\t\treturn 1\n\t}\n\treturn 2\n}\n'
 		'main.v':        'module main\n\nimport probe\n\nfn main() {\n\tn := 7\n\tprintln(int_str(probe.depth(n)))\n\tprintln(int_str(probe.depth(&n)))\n}\n'
 	}, 'main.v')
 	assert out == '0\n1'
@@ -4649,15 +4483,13 @@ fn test_imported_generic_indirections_conditions_keep_integer_literals() {
 
 fn test_nested_comptime_field_names_do_not_replace_each_other() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'nested_comptime_field_name_prefixes',
-		'struct Embedded {\n\tn int\n}\n\nstruct Item {\n\tEmbedded\n\tname string\n}\n\nfn normal_fields[T]() int {\n\tmut count := 0\n\t$for field in T.fields {\n\t\t$if field.is_embed {\n\t\t\t$for reserved_field in T.fields {\n\t\t\t\t$if !reserved_field.is_embed {\n\t\t\t\t\tcount++\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n\treturn count\n}\n\nfn main() {\n\tprintln(int_str(normal_fields[Item]()))\n}\n')
+	out := run_good(v3_bin, 'nested_comptime_field_name_prefixes', 'struct Embedded {\n\tn int\n}\n\nstruct Item {\n\tEmbedded\n\tname string\n}\n\nfn normal_fields[T]() int {\n\tmut count := 0\n\t\$for field in T.fields {\n\t\t\$if field.is_embed {\n\t\t\t\$for reserved_field in T.fields {\n\t\t\t\t\$if !reserved_field.is_embed {\n\t\t\t\t\tcount++\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n\treturn count\n}\n\nfn main() {\n\tprintln(int_str(normal_fields[Item]()))\n}\n')
 	assert out == '1'
 }
 
 fn test_struct_equality_compares_pointer_fields_as_pointers() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'struct_eq_pointer_field',
-		'struct Node {\n\tvalue int\n\tnext &Node\n}\n\nfn main() {\n\tleft := Node{\n\t\tvalue: 7\n\t\tnext: unsafe { nil }\n\t}\n\tright := Node{\n\t\tvalue: 7\n\t\tnext: unsafe { nil }\n\t}\n\tprintln([left] == [right])\n}\n')
+	out := run_good(v3_bin, 'struct_eq_pointer_field', 'struct Node {\n\tvalue int\n\tnext &Node\n}\n\nfn main() {\n\tleft := Node{\n\t\tvalue: 7\n\t\tnext: unsafe { nil }\n\t}\n\tright := Node{\n\t\tvalue: 7\n\t\tnext: unsafe { nil }\n\t}\n\tprintln([left] == [right])\n}\n')
 	assert out == 'true'
 }
 
@@ -4669,13 +4501,11 @@ fn test_single_module_test_file_skips_premodule_attributes() {
 	os.write_file(os.join_path(root, 'v.mod'), 'Module { name: "premodule_attr_module_test" }\n') or {
 		panic(err)
 	}
-	os.write_file(os.join_path(root, 'tar', 'reader.v'),
-		'module tar /* implementation module */\n\nfn reader_value() string {\n\treturn "reader"\n}\n') or {
+	os.write_file(os.join_path(root, 'tar', 'reader.v'), 'module tar /* implementation module */\n\nfn reader_value() string {\n\treturn "reader"\n}\n') or {
 		panic(err)
 	}
 	test_file := os.join_path(root, 'tar', 'reader_test.v')
-	os.write_file(test_file,
-		'@[has_globals]\n/* block comment before module */\nmodule tar // test module\n\nfn test_reader_value() {\n\tprintln(reader_value())\n}\n') or {
+	os.write_file(test_file, '@[has_globals]\n/* block comment before module */\nmodule tar // test module\n\nfn test_reader_value() {\n\tprintln(reader_value())\n}\n') or {
 		panic(err)
 	}
 	bin_path := os.join_path(root, 'reader_test_bin')
@@ -4701,85 +4531,73 @@ fn test_delete_last_empty_array_panics_before_tail_clear() {
 
 fn test_delete_last_preserves_shared_slice_buffer() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'delete_last_preserves_shared_slice_buffer',
-		"fn main() {\n\tmut a := [1, 2, 3, 4]\n\tb := unsafe { a[..a.len] }\n\told_data := a.data\n\ta.delete_last()\n\tassert a == [1, 2, 3]\n\tassert b == [1, 2, 3, 4]\n\tassert a.data != old_data\n\tprintln('ok')\n}\n")
+	out := run_good(v3_bin, 'delete_last_preserves_shared_slice_buffer', "fn main() {\n\tmut a := [1, 2, 3, 4]\n\tb := unsafe { a[..a.len] }\n\told_data := a.data\n\ta.delete_last()\n\tassert a == [1, 2, 3]\n\tassert b == [1, 2, 3, 4]\n\tassert a.data != old_data\n\tprintln('ok')\n}\n")
 	assert out == 'ok'
 }
 
 fn test_slice_element_assignment_writes_through() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'slice_element_assignment_writes_through',
-		"fn main() {\n\tmut a := [1, 2, 3, 4]\n\tmut s := unsafe { a[1..3] }\n\ts[0] = 42\n\ts[1] += 5\n\tassert a == [1, 42, 8, 4]\n\tassert s == [42, 8]\n\tprintln('ok')\n}\n")
+	out := run_good(v3_bin, 'slice_element_assignment_writes_through', "fn main() {\n\tmut a := [1, 2, 3, 4]\n\tmut s := unsafe { a[1..3] }\n\ts[0] = 42\n\ts[1] += 5\n\tassert a == [1, 42, 8, 4]\n\tassert s == [42, 8]\n\tprintln('ok')\n}\n")
 	assert out == 'ok'
 }
 
 fn test_string_pointer_comparisons_keep_pointer_semantics() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'string_pointer_comparison',
-		"fn main() {\n\tleft := 'same'.clone()\n\tright := 'same'.clone()\n\tpleft := &left\n\tpright := &right\n\tprintln(pleft == pright)\n\tprintln(pleft != pright)\n\tprintln(*pleft == *pright)\n}\n")
+	out := run_good(v3_bin, 'string_pointer_comparison', "fn main() {\n\tleft := 'same'.clone()\n\tright := 'same'.clone()\n\tpleft := &left\n\tpright := &right\n\tprintln(pleft == pright)\n\tprintln(pleft != pright)\n\tprintln(*pleft == *pright)\n}\n")
 	assert out == 'false\ntrue\ntrue'
 }
 
 fn test_map_keys_and_values_lower_to_runtime_methods() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'map_keys_values_lowering',
-		"fn make_lookup() map[string]int {\n\treturn {\n\t\t'one': 1\n\t\t'two': 2\n\t}\n}\n\nfn main() {\n\tlookup := make_lookup()\n\tkeys := lookup.keys()\n\tvalues := make_lookup().values()\n\tmut total := 0\n\tfor value in values {\n\t\ttotal += value\n\t}\n\tsingle := {\n\t\t'only': 9\n\t}\n\tprintln(int_str(keys.len))\n\tprintln(int_str(values.len))\n\tprintln(int_str(total))\n\tprintln(int_str(single.keys().len))\n\tprintln(single.keys()[0])\n\tprintln(int_str(single.values().len))\n\tprintln(int_str(single.values()[0]))\n}\n")
+	out := run_good(v3_bin, 'map_keys_values_lowering', "fn make_lookup() map[string]int {\n\treturn {\n\t\t'one': 1\n\t\t'two': 2\n\t}\n}\n\nfn main() {\n\tlookup := make_lookup()\n\tkeys := lookup.keys()\n\tvalues := make_lookup().values()\n\tmut total := 0\n\tfor value in values {\n\t\ttotal += value\n\t}\n\tsingle := {\n\t\t'only': 9\n\t}\n\tprintln(int_str(keys.len))\n\tprintln(int_str(values.len))\n\tprintln(int_str(total))\n\tprintln(int_str(single.keys().len))\n\tprintln(single.keys()[0])\n\tprintln(int_str(single.values().len))\n\tprintln(int_str(single.values()[0]))\n}\n")
 	assert out == '2\n2\n3\n1\nonly\n1\n9'
 }
 
 fn test_map_str_preserves_signed_wide_entries() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'map_str_signed_wide_entries',
-		"fn main() {\n\tvalue_map := {\n\t\t'x': i64(5000000000)\n\t}\n\tkey_map := {\n\t\ti64(-5000000000): 'x'\n\t}\n\tprintln(value_map.str())\n\tprintln(key_map.str())\n}\n")
+	out := run_good(v3_bin, 'map_str_signed_wide_entries', "fn main() {\n\tvalue_map := {\n\t\t'x': i64(5000000000)\n\t}\n\tkey_map := {\n\t\ti64(-5000000000): 'x'\n\t}\n\tprintln(value_map.str())\n\tprintln(key_map.str())\n}\n")
 	assert out == "{'x': 5000000000}\n{-5000000000: 'x'}"
 }
 
 fn test_map_str_normalizes_alias_key_and_value_types() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'map_str_alias_kinds',
-		"type ID = int\n\ntype Amount = f64\n\nfn main() {\n\tids := {\n\t\tID(23): 'id'\n\t}\n\tamounts := {\n\t\t'price': Amount(1.25)\n\t}\n\tprintln('\${ids}')\n\tprintln('\${amounts}')\n}\n")
+	out := run_good(v3_bin, 'map_str_alias_kinds', "type ID = int\n\ntype Amount = f64\n\nfn main() {\n\tids := {\n\t\tID(23): 'id'\n\t}\n\tamounts := {\n\t\t'price': Amount(1.25)\n\t}\n\tprintln('\${ids}')\n\tprintln('\${amounts}')\n}\n")
 	assert out == "{23: 'id'}\n{'price': 1.25}"
 }
 
 fn test_chained_array_alias_stringification_uses_outer_alias_only() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'chained_array_alias_str',
-		"type A = []int\n\ntype B = A\n\nfn main() {\n\tvalue := B([1, 2])\n\tprintln('\${value}')\n}\n")
+	out := run_good(v3_bin, 'chained_array_alias_str', "type A = []int\n\ntype B = A\n\nfn main() {\n\tvalue := B([1, 2])\n\tprintln('\${value}')\n}\n")
 	assert out == 'B([1, 2])'
 }
 
 fn test_alias_pointer_receiver_str_gets_addressable_value() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'alias_pointer_receiver_str',
-		"type Number = int\n\nfn (n &Number) str() string {\n\treturn 'number:' + int_str(int(*n))\n}\n\nstruct Point {\n\tx int\n}\n\ntype NamedPoint = Point\n\nfn (p &NamedPoint) str() string {\n\treturn 'point:' + int_str(p.x)\n}\n\nfn main() {\n\tn := Number(7)\n\tp := NamedPoint(Point{\n\t\tx: 9\n\t})\n\tprintln('\${n}')\n\tprintln('\${Number(8)}')\n\tprintln('\${p}')\n\tprintln('\${NamedPoint(Point{x: 10})}')\n}\n")
+	out := run_good(v3_bin, 'alias_pointer_receiver_str', "type Number = int\n\nfn (n &Number) str() string {\n\treturn 'number:' + int_str(int(*n))\n}\n\nstruct Point {\n\tx int\n}\n\ntype NamedPoint = Point\n\nfn (p &NamedPoint) str() string {\n\treturn 'point:' + int_str(p.x)\n}\n\nfn main() {\n\tn := Number(7)\n\tp := NamedPoint(Point{\n\t\tx: 9\n\t})\n\tprintln('\${n}')\n\tprintln('\${Number(8)}')\n\tprintln('\${p}')\n\tprintln('\${NamedPoint(Point{x: 10})}')\n}\n")
 	assert out == 'number:7\nnumber:8\npoint:9\npoint:10'
 }
 
 fn test_mut_map_param_interpolation_preserves_pointer() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'mut_map_param_interpolation',
-		"type Scores = map[string]int\n\nfn show(mut m map[string]int) {\n\tprintln('\${m}')\n}\n\nfn show_alias(mut m Scores) {\n\tprintln('\${m}')\n}\n\nfn main() {\n\tmut m := map[string]int{}\n\tm['x'] = 3\n\tshow(mut m)\n\tmut scores := Scores(map[string]int{})\n\tscores['y'] = 4\n\tshow_alias(mut scores)\n}\n")
+	out := run_good(v3_bin, 'mut_map_param_interpolation', "type Scores = map[string]int\n\nfn show(mut m map[string]int) {\n\tprintln('\${m}')\n}\n\nfn show_alias(mut m Scores) {\n\tprintln('\${m}')\n}\n\nfn main() {\n\tmut m := map[string]int{}\n\tm['x'] = 3\n\tshow(mut m)\n\tmut scores := Scores(map[string]int{})\n\tscores['y'] = 4\n\tshow_alias(mut scores)\n}\n")
 	assert out == "{'x': 3}\n{'y': 4}"
 }
 
 fn test_map_literal_stringification_evaluates_entries_once() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'map_literal_str_side_effects',
-		"__global key_calls int\n__global val_calls int\n\nfn next_key() string {\n\tkey_calls++\n\treturn 'k' + int_str(key_calls)\n}\n\nfn next_val() int {\n\tval_calls++\n\treturn val_calls * 10\n}\n\nfn main() {\n\tprintln({\n\t\tnext_key(): next_val()\n\t})\n\tprintln(int_str(key_calls) + ',' + int_str(val_calls))\n}\n")
+	out := run_good(v3_bin, 'map_literal_str_side_effects', "__global key_calls int\n__global val_calls int\n\nfn next_key() string {\n\tkey_calls++\n\treturn 'k' + int_str(key_calls)\n}\n\nfn next_val() int {\n\tval_calls++\n\treturn val_calls * 10\n}\n\nfn main() {\n\tprintln({\n\t\tnext_key(): next_val()\n\t})\n\tprintln(int_str(key_calls) + ',' + int_str(val_calls))\n}\n")
 	assert out == "{'k1': 10}\n1,1"
 }
 
 fn test_map_literal_declaration_evaluates_entries_once() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'map_literal_decl_side_effects',
-		"__global key_calls int\n__global val_calls int\n\nfn next_key() string {\n\tkey_calls++\n\treturn 'key'\n}\n\nfn next_val() int {\n\tval_calls++\n\treturn val_calls * 10\n}\n\nfn main() {\n\tvalues := {\n\t\tnext_key(): next_val()\n\t}\n\tprintln(int_str(values['key']))\n\tprintln(int_str(key_calls) + ',' + int_str(val_calls))\n}\n")
+	out := run_good(v3_bin, 'map_literal_decl_side_effects', "__global key_calls int\n__global val_calls int\n\nfn next_key() string {\n\tkey_calls++\n\treturn 'key'\n}\n\nfn next_val() int {\n\tval_calls++\n\treturn val_calls * 10\n}\n\nfn main() {\n\tvalues := {\n\t\tnext_key(): next_val()\n\t}\n\tprintln(int_str(values['key']))\n\tprintln(int_str(key_calls) + ',' + int_str(val_calls))\n}\n")
 	assert out == '10\n1,1'
 }
 
 fn test_fn_literal_preserves_mut_param_string_interpolation() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'fn_literal_mut_param_interp',
-		"struct Counter {\n\tvalue int\n}\n\nfn show(mut counter Counter) {\n\t_ := fn () {}\n\tprintln('\${counter.value}')\n}\n\nfn main() {\n\tmut counter := Counter{\n\t\tvalue: 42\n\t}\n\tshow(mut counter)\n}\n")
+	out := run_good(v3_bin, 'fn_literal_mut_param_interp', "struct Counter {\n\tvalue int\n}\n\nfn show(mut counter Counter) {\n\t_ := fn () {}\n\tprintln('\${counter.value}')\n}\n\nfn main() {\n\tmut counter := Counter{\n\t\tvalue: 42\n\t}\n\tshow(mut counter)\n}\n")
 	assert out == '42'
 }
 
@@ -4794,29 +4612,25 @@ fn test_shadowed_minmaxof_calls_are_not_rewritten() {
 
 fn test_runes_iterator_index_is_loop_scoped() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'runes_iterator_index_scope',
-		"fn main() {\n\tfor i, r in 'ab'.runes_iterator() {\n\t\t_ := r\n\t\tprintln(int_str(i))\n\t}\n\ti := 9\n\tprintln(int_str(i))\n}\n")
+	out := run_good(v3_bin, 'runes_iterator_index_scope', "fn main() {\n\tfor i, r in 'ab'.runes_iterator() {\n\t\t_ := r\n\t\tprintln(int_str(i))\n\t}\n\ti := 9\n\tprintln(int_str(i))\n}\n")
 	assert out == '0\n1\n9'
 }
 
 fn test_array_last_index_uses_element_width() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'array_last_index_element_width',
-		'fn main() {\n\twide := [i64(1), i64(5000000000), i64(2), i64(5000000000)]\n\tfloats := [1.25, 2.5, 1.25]\n\tflags := [true, false, true]\n\tprintln(int_str(wide.last_index(i64(5000000000))))\n\tprintln(int_str(floats.last_index(1.25)))\n\tprintln(int_str(flags.last_index(true)))\n}\n')
+	out := run_good(v3_bin, 'array_last_index_element_width', 'fn main() {\n\twide := [i64(1), i64(5000000000), i64(2), i64(5000000000)]\n\tfloats := [1.25, 2.5, 1.25]\n\tflags := [true, false, true]\n\tprintln(int_str(wide.last_index(i64(5000000000))))\n\tprintln(int_str(floats.last_index(1.25)))\n\tprintln(int_str(flags.last_index(true)))\n}\n')
 	assert out == '3\n2\n2'
 }
 
 fn test_array_last_index_uses_semantic_element_comparison() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'array_last_index_semantic_equality',
-		"struct Item {\n\tname string\n\tparts []string\n}\n\nfn join(a string, b string) string {\n\treturn a + b\n}\n\nfn main() {\n\tnested := [['ab'.clone()], [join('x', 'y')], [join('a', 'b')]]\n\tnested_needle := ['ab'.clone()]\n\titems := [Item{\n\t\tname: 'ab'.clone()\n\t\tparts: ['xy'.clone()]\n\t}, Item{\n\t\tname: join('a', 'b')\n\t\tparts: [join('x', 'y')]\n\t}]\n\tneedle := Item{\n\t\tname: 'ab'.clone()\n\t\tparts: ['xy'.clone()]\n\t}\n\tprintln(int_str(nested.last_index(nested_needle)))\n\tprintln(int_str(items.last_index(needle)))\n}\n")
+	out := run_good(v3_bin, 'array_last_index_semantic_equality', "struct Item {\n\tname string\n\tparts []string\n}\n\nfn join(a string, b string) string {\n\treturn a + b\n}\n\nfn main() {\n\tnested := [['ab'.clone()], [join('x', 'y')], [join('a', 'b')]]\n\tnested_needle := ['ab'.clone()]\n\titems := [Item{\n\t\tname: 'ab'.clone()\n\t\tparts: ['xy'.clone()]\n\t}, Item{\n\t\tname: join('a', 'b')\n\t\tparts: [join('x', 'y')]\n\t}]\n\tneedle := Item{\n\t\tname: 'ab'.clone()\n\t\tparts: ['xy'.clone()]\n\t}\n\tprintln(int_str(nested.last_index(nested_needle)))\n\tprintln(int_str(items.last_index(needle)))\n}\n")
 	assert out == '2\n1'
 }
 
 fn test_generic_string_literal_matching_typeof_marker_is_preserved() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'generic_marker_string_literal',
-		"fn marker_and_type[T](value T) string {\n\tmarker := '__v3_generic_type_name:T'\n\treturn marker + '|' + typeof(value).name\n}\n\nfn main() {\n\tprintln(marker_and_type(7))\n}\n")
+	out := run_good(v3_bin, 'generic_marker_string_literal', "fn marker_and_type[T](value T) string {\n\tmarker := '__v3_generic_type_name:T'\n\treturn marker + '|' + typeof(value).name\n}\n\nfn main() {\n\tprintln(marker_and_type(7))\n}\n")
 	assert out == '__v3_generic_type_name:T|int'
 }
 
@@ -5313,50 +5127,43 @@ fn main() {
 
 fn test_optional_string_equality_uses_payload_equality() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'optional_string_semantic_equality',
-		"fn maybe_text(ok bool) ?string {\n\tif !ok {\n\t\treturn none\n\t}\n\tprefix := 'a'.clone()\n\treturn prefix + 'b'\n}\n\nfn main() {\n\tleft := maybe_text(true)\n\tright := maybe_text(true)\n\tmissing_left := maybe_text(false)\n\tmissing_right := maybe_text(false)\n\tprintln(left == right)\n\tprintln(left != right)\n\tprintln(left == missing_left)\n\tprintln(missing_left == missing_right)\n\tprintln(missing_left != missing_right)\n}\n")
+	out := run_good(v3_bin, 'optional_string_semantic_equality', "fn maybe_text(ok bool) ?string {\n\tif !ok {\n\t\treturn none\n\t}\n\tprefix := 'a'.clone()\n\treturn prefix + 'b'\n}\n\nfn main() {\n\tleft := maybe_text(true)\n\tright := maybe_text(true)\n\tmissing_left := maybe_text(false)\n\tmissing_right := maybe_text(false)\n\tprintln(left == right)\n\tprintln(left != right)\n\tprintln(left == missing_left)\n\tprintln(missing_left == missing_right)\n\tprintln(missing_left != missing_right)\n}\n")
 	assert out == 'true\nfalse\nfalse\ntrue\nfalse'
 }
 
 fn test_optional_nested_array_equality_guards_payload_work() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'optional_nested_array_guarded_equality',
-		"fn maybe_nested(ok bool) ?[][]string {\n\tif !ok {\n\t\treturn none\n\t}\n\treturn [['a'.clone()], ['b'.clone()]]\n}\n\nfn main() {\n\tleft := maybe_nested(true)\n\tright := maybe_nested(true)\n\tmissing_left := maybe_nested(false)\n\tmissing_right := maybe_nested(false)\n\tprintln(left == right)\n\tprintln(left != right)\n\tprintln(left == missing_left)\n\tprintln(missing_left == missing_right)\n\tprintln(missing_left != missing_right)\n}\n")
+	out := run_good(v3_bin, 'optional_nested_array_guarded_equality', "fn maybe_nested(ok bool) ?[][]string {\n\tif !ok {\n\t\treturn none\n\t}\n\treturn [['a'.clone()], ['b'.clone()]]\n}\n\nfn main() {\n\tleft := maybe_nested(true)\n\tright := maybe_nested(true)\n\tmissing_left := maybe_nested(false)\n\tmissing_right := maybe_nested(false)\n\tprintln(left == right)\n\tprintln(left != right)\n\tprintln(left == missing_left)\n\tprintln(missing_left == missing_right)\n\tprintln(missing_left != missing_right)\n}\n")
 	assert out == 'true\nfalse\nfalse\ntrue\nfalse'
 }
 
 fn test_optional_assignment_invalidates_payload_smartcast() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'optional_assignment_invalidates_payload_smartcast',
-		'fn main() {\n\tmut value := ?int(none)\n\tvalue = 1\n\tvalue = none\n\tresolved := value or { 42 }\n\tprintln(int_str(resolved))\n}\n')
+	out := run_good(v3_bin, 'optional_assignment_invalidates_payload_smartcast', 'fn main() {\n\tmut value := ?int(none)\n\tvalue = 1\n\tvalue = none\n\tresolved := value or { 42 }\n\tprintln(int_str(resolved))\n}\n')
 	assert out == '42'
 }
 
 fn test_optional_variant_to_optional_sum_cast_preserves_wrapper() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'optional_variant_to_optional_sum_cast',
-		"struct Cat {}\n\nstruct Dog {\n\tname string\n}\n\ntype Animal = Cat | Dog\n\nfn maybe_dog(ok bool) ?Dog {\n\tif !ok {\n\t\treturn none\n\t}\n\treturn Dog{\n\t\tname: 'Rex'\n\t}\n}\n\nfn show(ok bool) string {\n\tmaybe_animal := ?Animal(maybe_dog(ok))\n\tanimal := maybe_animal or { return 'missing' }\n\tif animal is Dog {\n\t\treturn animal.name\n\t}\n\treturn 'cat'\n}\n\nfn main() {\n\tprintln(show(true))\n\tprintln(show(false))\n}\n")
+	out := run_good(v3_bin, 'optional_variant_to_optional_sum_cast', "struct Cat {}\n\nstruct Dog {\n\tname string\n}\n\ntype Animal = Cat | Dog\n\nfn maybe_dog(ok bool) ?Dog {\n\tif !ok {\n\t\treturn none\n\t}\n\treturn Dog{\n\t\tname: 'Rex'\n\t}\n}\n\nfn show(ok bool) string {\n\tmaybe_animal := ?Animal(maybe_dog(ok))\n\tanimal := maybe_animal or { return 'missing' }\n\tif animal is Dog {\n\t\treturn animal.name\n\t}\n\treturn 'cat'\n}\n\nfn main() {\n\tprintln(show(true))\n\tprintln(show(false))\n}\n")
 	assert out == 'Rex\nmissing'
 }
 
 fn test_wrapped_plus_minus_continuations_consume_auto_semicolon() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'wrapped_plus_minus_continuation',
-		'fn add(total int, delta int) int {\n\treturn total\n\t\t+ delta\n}\n\nfn sub(total int, delta int) int {\n\treturn total\n\t\t- delta\n}\n\nfn main() {\n\tprintln(int_str(add(3, 4)))\n\tprintln(int_str(sub(9, 2)))\n}\n')
+	out := run_good(v3_bin, 'wrapped_plus_minus_continuation', 'fn add(total int, delta int) int {\n\treturn total\n\t\t+ delta\n}\n\nfn sub(total int, delta int) int {\n\treturn total\n\t\t- delta\n}\n\nfn main() {\n\tprintln(int_str(add(3, 4)))\n\tprintln(int_str(sub(9, 2)))\n}\n')
 	assert out == '7\n7'
 }
 
 fn test_gated_optional_array_index_materializes_base_before_wrap() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'gated_optional_array_index_base_order',
-		"fn get_arr(ok bool) ?[]int {\n\tprintln('get')\n\tif !ok {\n\t\treturn none\n\t}\n\treturn [3, 7, 11]\n}\n\nfn main() {\n\tprintln(int_str(get_arr(true)#[-1] or { 40 }))\n\tprintln(int_str(get_arr(true)#[9] or { 41 }))\n\tprintln(int_str(get_arr(false)#[-1] or { 42 }))\n}\n")
+	out := run_good(v3_bin, 'gated_optional_array_index_base_order', "fn get_arr(ok bool) ?[]int {\n\tprintln('get')\n\tif !ok {\n\t\treturn none\n\t}\n\treturn [3, 7, 11]\n}\n\nfn main() {\n\tprintln(int_str(get_arr(true)#[-1] or { 40 }))\n\tprintln(int_str(get_arr(true)#[9] or { 41 }))\n\tprintln(int_str(get_arr(false)#[-1] or { 42 }))\n}\n")
 	assert out == 'get\n11\nget\n41\nget\n42'
 }
 
 fn test_normalized_option_result_fixed_array_names_keep_outer_wrapper() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'normalized_option_result_fixed_array',
-		"struct Foo {\n\tn int\n}\n\nfn opt_values(ok bool) ?[2]int {\n\tif !ok {\n\t\treturn none\n\t}\n\treturn [1, 2]!\n}\n\nfn res_values(ok bool) ![2]Foo {\n\tif !ok {\n\t\treturn error('x')\n\t}\n\treturn [Foo{\n\t\tn: 3\n\t}, Foo{\n\t\tn: 4\n\t}]!\n}\n\nfn main() {\n\ta := opt_values(true) or { [0, 0]! }\n\tb := res_values(true) or { [Foo{\n\t\tn: 0\n\t}, Foo{\n\t\tn: 0\n\t}]! }\n\tmissing_a := opt_values(false) or { [5, 6]! }\n\tmissing_b := res_values(false) or { [Foo{\n\t\tn: 7\n\t}, Foo{\n\t\tn: 8\n\t}]! }\n\tprintln(int_str(a[0] + a[1] + b[0].n + b[1].n))\n\tprintln(int_str(missing_a[0] + missing_a[1] + missing_b[0].n + missing_b[1].n))\n}\n")
+	out := run_good(v3_bin, 'normalized_option_result_fixed_array', "struct Foo {\n\tn int\n}\n\nfn opt_values(ok bool) ?[2]int {\n\tif !ok {\n\t\treturn none\n\t}\n\treturn [1, 2]!\n}\n\nfn res_values(ok bool) ![2]Foo {\n\tif !ok {\n\t\treturn error('x')\n\t}\n\treturn [Foo{\n\t\tn: 3\n\t}, Foo{\n\t\tn: 4\n\t}]!\n}\n\nfn main() {\n\ta := opt_values(true) or { [0, 0]! }\n\tb := res_values(true) or { [Foo{\n\t\tn: 0\n\t}, Foo{\n\t\tn: 0\n\t}]! }\n\tmissing_a := opt_values(false) or { [5, 6]! }\n\tmissing_b := res_values(false) or { [Foo{\n\t\tn: 7\n\t}, Foo{\n\t\tn: 8\n\t}]! }\n\tprintln(int_str(a[0] + a[1] + b[0].n + b[1].n))\n\tprintln(int_str(missing_a[0] + missing_a[1] + missing_b[0].n + missing_b[1].n))\n}\n")
 	assert out == '10\n26'
 }
 
@@ -5374,22 +5181,19 @@ fn test_hierarchical_import_runtime_inits_before_importer_init() {
 
 fn test_lowered_generic_operator_call_records_specialization() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'lowered_generic_operator_call_records_specialization',
-		'struct Box[T] {\n\tv T\n}\n\nfn (a Box[T]) + (b Box[T]) Box[T] {\n\treturn Box[T]{\n\t\tv: a.v + b.v\n\t}\n}\n\nfn main() {\n\tleft := Box[int]{\n\t\tv: 2\n\t}\n\tright := Box[int]{\n\t\tv: 5\n\t}\n\tresult := left + right\n\tprintln(int_str(result.v))\n}\n')
+	out := run_good(v3_bin, 'lowered_generic_operator_call_records_specialization', 'struct Box[T] {\n\tv T\n}\n\nfn (a Box[T]) + (b Box[T]) Box[T] {\n\treturn Box[T]{\n\t\tv: a.v + b.v\n\t}\n}\n\nfn main() {\n\tleft := Box[int]{\n\t\tv: 2\n\t}\n\tright := Box[int]{\n\t\tv: 5\n\t}\n\tresult := left + right\n\tprintln(int_str(result.v))\n}\n')
 	assert out == '7'
 }
 
 fn test_late_inferred_generic_call_emits_specialization() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'late_inferred_generic_call_emits_specialization',
-		'fn make[T]() T {\n\treturn T(41)\n}\n\nfn use[T](value T) T {\n\treturn value + T(1)\n}\n\nfn main() {\n\tx := make[int]()\n\tprintln(int_str(use(x)))\n}\n')
+	out := run_good(v3_bin, 'late_inferred_generic_call_emits_specialization', 'fn make[T]() T {\n\treturn T(41)\n}\n\nfn use[T](value T) T {\n\treturn value + T(1)\n}\n\nfn main() {\n\tx := make[int]()\n\tprintln(int_str(use(x)))\n}\n')
 	assert out == '42'
 }
 
 fn test_late_reachable_body_generic_call_emits_specialization() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'late_reachable_body_generic_call_emits_specialization',
-		'fn identity[T](value T) T {\n\treturn value\n}\n\nfn late_helper() int {\n\treturn identity[int](42)\n}\n\nfn outer[T]() int {\n\treturn late_helper()\n}\n\nfn main() {\n\tprintln(int_str(outer[int]()))\n}\n')
+	out := run_good(v3_bin, 'late_reachable_body_generic_call_emits_specialization', 'fn identity[T](value T) T {\n\treturn value\n}\n\nfn late_helper() int {\n\treturn identity[int](42)\n}\n\nfn outer[T]() int {\n\treturn late_helper()\n}\n\nfn main() {\n\tprintln(int_str(outer[int]()))\n}\n')
 	assert out == '42'
 }
 
@@ -5411,12 +5215,9 @@ fn test_vmodroot_c_flag_preserves_project_path_with_spaces() {
 		os.rmdir_all(root) or {}
 	}
 	write_project_file(root, 'v.mod', "Module { name: 'flag_pseudo_path' }\n")
-	write_project_file(root, 'main.v',
-		'module main\n\n#flag -I @VMODROOT/include -D FEATURE\n#insert "flag_value.c"\n\nfn C.flag_value() int\n\nfn main() {\n\tprintln(int_str(C.flag_value()))\n}\n')
-	write_project_file(root, 'include/flag_value.c',
-		'#include <flag_value.h>\n\nstatic inline int flag_value(void) {\n\treturn flag_value_inner();\n}\n')
-	write_project_file(root, 'include/flag_value.h',
-		'static inline int flag_value_inner(void) {\n\treturn 57;\n}\n')
+	write_project_file(root, 'main.v', 'module main\n\n#flag -I @VMODROOT/include -D FEATURE\n#insert "flag_value.c"\n\nfn C.flag_value() int\n\nfn main() {\n\tprintln(int_str(C.flag_value()))\n}\n')
+	write_project_file(root, 'include/flag_value.c', '#include <flag_value.h>\n\nstatic inline int flag_value(void) {\n\treturn flag_value_inner();\n}\n')
+	write_project_file(root, 'include/flag_value.h', 'static inline int flag_value_inner(void) {\n\treturn 57;\n}\n')
 	bin := os.join_path(os.temp_dir(), 'v3_flag_pseudo_path')
 	compile :=
 		os.execute('${os.quoted_path(v3_bin)} ${os.quoted_path(os.join_path(root, 'main.v'))} -b c -o ${os.quoted_path(bin)}')
@@ -5452,8 +5253,7 @@ fn test_imported_header_tree_uses_real_stdint_with_inttypes() {
 	outer_path := os.join_path(os.temp_dir(), outer_name)
 	inner_path := os.join_path(os.temp_dir(), inner_name)
 	os.write_file(outer_path, '#import "${inner_name}"\n') or { panic(err) }
-	os.write_file(inner_path,
-		'#include <inttypes.h>\n#include <stdint.h>\ntypedef uint64_t ImportedWord;\n') or {
+	os.write_file(inner_path, '#include <inttypes.h>\n#include <stdint.h>\ntypedef uint64_t ImportedWord;\n') or {
 		panic(err)
 	}
 	defer {
@@ -5471,8 +5271,7 @@ fn main() {}
 
 fn test_statement_array_append_consumes_rhs_expression() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'statement_array_append_rhs_expression',
-		'fn main() {\n\tmut value := u32(0x123)\n\tmut values := []u32{}\n\tvalues << value & 0xff\n\tprintln(int_str(int(values[0])))\n}\n')
+	out := run_good(v3_bin, 'statement_array_append_rhs_expression', 'fn main() {\n\tmut value := u32(0x123)\n\tmut values := []u32{}\n\tvalues << value & 0xff\n\tprintln(int_str(int(values[0])))\n}\n')
 	assert out == '35'
 }
 
@@ -5550,8 +5349,7 @@ fn main() {
 
 fn test_optional_map_append_evaluates_key_before_rhs() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'optional_map_append_evaluation_order',
-		'struct State {\nmut:\n\tkey   string\n\ttrace string\n}\n\nfn select_key(key string, mut state State) string {\n\tstate.trace += "key"\n\treturn key\n}\n\nfn next_value(mut state State) ?int {\n\tstate.trace += "rhs"\n\tstate.key = "changed"\n\treturn 7\n}\n\nfn main() {\n\tmut state := State{\n\t\tkey: "original"\n\t}\n\tmut values := map[string][]int{}\n\tvalues[select_key(state.key, mut state)] << next_value(mut state) or { return }\n\tprintln(state.trace)\n\tprintln(int_str(values["original"][0]))\n\tprintln("changed" in values)\n}\n')
+	out := run_good(v3_bin, 'optional_map_append_evaluation_order', 'struct State {\nmut:\n\tkey   string\n\ttrace string\n}\n\nfn select_key(key string, mut state State) string {\n\tstate.trace += "key"\n\treturn key\n}\n\nfn next_value(mut state State) ?int {\n\tstate.trace += "rhs"\n\tstate.key = "changed"\n\treturn 7\n}\n\nfn main() {\n\tmut state := State{\n\t\tkey: "original"\n\t}\n\tmut values := map[string][]int{}\n\tvalues[select_key(state.key, mut state)] << next_value(mut state) or { return }\n\tprintln(state.trace)\n\tprintln(int_str(values["original"][0]))\n\tprintln("changed" in values)\n}\n')
 	assert out == 'keyrhs\n7\nfalse'
 }
 
@@ -5600,8 +5398,7 @@ fn main() {
 
 fn test_json2_skipped_pointer_field_does_not_specialize_decoder() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'json2_skipped_pointer_field',
-		'import gg\nimport x.json2\n\nstruct Config {\n\tcontext &gg.Context @[skip]\n\tname string\n}\n\nfn main() {\n\tconfig := json2.decode[Config]("{\\"name\\":\\"ok\\"}") or { panic(err) }\n\tprintln(config.name)\n}\n')
+	out := run_good(v3_bin, 'json2_skipped_pointer_field', 'import gg\nimport x.json2\n\nstruct Config {\n\tcontext &gg.Context @[skip]\n\tname string\n}\n\nfn main() {\n\tconfig := json2.decode[Config]("{\\"name\\":\\"ok\\"}") or { panic(err) }\n\tprintln(config.name)\n}\n')
 	assert out == 'ok'
 }
 
@@ -5610,7 +5407,7 @@ fn test_comptime_field_generic_calls_keep_resolved_field_types() {
 	out := run_good_project(v3_bin, 'comptime_field_resolved_types', {
 		'v.mod':         "Module { name: 'comptime_field_resolved_types' }\n"
 		'model/model.v': 'module model\n\npub enum KeyCode {\n\tenter\n}\n\npub type Callback = fn (int)\n\n@[typedef]\npub struct C.model_event {\npub:\n\tkey KeyCode\n\tcb Callback\n}\n\npub type Event = C.model_event\n'
-		'codec/codec.v': 'module codec\n\npub fn visit[T](mut value T) {\n\t$for field in T.fields {\n\t\ttouch(mut value.$(field.name))\n\t}\n}\n\nfn touch[T](mut value T) {\n\t_ = value\n}\n'
+		'codec/codec.v': 'module codec\n\npub fn visit[T](mut value T) {\n\t\$for field in T.fields {\n\t\ttouch(mut value.\$(field.name))\n\t}\n}\n\nfn touch[T](mut value T) {\n\t_ = value\n}\n'
 		'main.v':        'module main\n\nimport codec\nimport model\n\nfn main() {\n\tmut event := model.Event{}\n\tcodec.visit(mut event)\n\tprintln(int_str(int(event.key)))\n}\n'
 	}, 'main.v')
 	assert out == '0'
@@ -5653,7 +5450,7 @@ fn test_comptime_pointer_field_generic_local_uses_call_return_type() {
 	out := run_good_project(v3_bin, 'comptime_pointer_field_call_return_type', {
 		'v.mod':         "Module { name: 'comptime_pointer_field_call_return_type' }\n"
 		'model/model.v': 'module model\n\npub struct App {\npub mut:\n\tvalue int\n}\n\npub struct Context {\npub mut:\n\tapp &App\n}\n'
-		'codec/codec.v': 'module codec\n\npub fn fill[T](mut value T) {\n\t$for field in T.fields {\n\t\t$if field.indirections == 1 {\n\t\t\tmut decoded_ptr := create_ptr(value.$(field.name))\n\t\t\tdecoded_ptr.value = 42\n\t\t\tvalue.$(field.name) = decoded_ptr\n\t\t}\n\t}\n}\n\nfn create_ptr[T](_ &T) &T {\n\treturn &T{}\n}\n'
+		'codec/codec.v': 'module codec\n\npub fn fill[T](mut value T) {\n\t\$for field in T.fields {\n\t\t\$if field.indirections == 1 {\n\t\t\tmut decoded_ptr := create_ptr(value.\$(field.name))\n\t\t\tdecoded_ptr.value = 42\n\t\t\tvalue.\$(field.name) = decoded_ptr\n\t\t}\n\t}\n}\n\nfn create_ptr[T](_ &T) &T {\n\treturn &T{}\n}\n'
 		'main.v':        'module main\n\nimport codec\nimport model\n\nfn main() {\n\tmut context := model.Context{\n\t\tapp: &model.App{}\n\t}\n\tcodec.fill(mut context)\n\tprintln(context.app.value)\n}\n'
 	}, 'main.v')
 	assert out == '42'
@@ -5681,8 +5478,7 @@ fn test_imported_struct_defaults_keep_declaring_module_constants() {
 
 fn test_json2_c_alias_fields_keep_declaring_module_types() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'json2_c_alias_field_types',
-		'import sokol.sapp\nimport x.json2\n\nfn main() {\n\tevent := json2.decode[sapp.Event]("{}") or { sapp.Event{} }\n\tprintln(int_str(int(event.frame_count)))\n}\n')
+	out := run_good(v3_bin, 'json2_c_alias_field_types', 'import sokol.sapp\nimport x.json2\n\nfn main() {\n\tevent := json2.decode[sapp.Event]("{}") or { sapp.Event{} }\n\tprintln(int_str(int(event.frame_count)))\n}\n')
 	assert out == '0'
 }
 
@@ -5700,8 +5496,7 @@ fn test_json2_reflected_fields_keep_independent_decoder_specializations() {
 	v3_bin := build_v3_review_transform()
 	src_file := os.join_path(os.temp_dir(), 'v3_json2_reflected_independent_field_decoders.v')
 	c_file := os.join_path(os.temp_dir(), 'v3_json2_reflected_independent_field_decoders.c')
-	os.write_file(src_file,
-		'import x.json2\n\nstruct Result {\n\tvalue int\n}\n\nstruct Weather {\n\tlang string\n\tresult Result\n}\n\nfn main() {\n\t_ := json2.decode[Weather](r\'{"lang":"en","result":{"value":42}}\')!\n}\n') or {
+	os.write_file(src_file, 'import x.json2\n\nstruct Result {\n\tvalue int\n}\n\nstruct Weather {\n\tlang string\n\tresult Result\n}\n\nfn main() {\n\t_ := json2.decode[Weather](r\'{"lang":"en","result":{"value":42}}\')!\n}\n') or {
 		panic(err)
 	}
 	compile := os.execute('${v3_bin} -nocache ${src_file} -b c -o ${c_file}')
@@ -5791,36 +5586,31 @@ fn main() {
 
 fn test_json2_encode_keeps_independent_array_element_specializations() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'json2_independent_array_element_specializations',
-		'import x.json2\n\nstruct Event {\n\tvalue int\n}\n\nstruct Payload {\n\tflags [][]bool\n\tevents []Event\n}\n\nfn main() {\n\tpayload := Payload{\n\t\tflags: [[true]]\n\t\tevents: [Event{\n\t\t\tvalue: 42\n\t\t}]\n\t}\n\tencoded := json2.encode(payload)\n\tprintln(json2.decode[Payload](encoded)!.events[0].value)\n}\n')
+	out := run_good(v3_bin, 'json2_independent_array_element_specializations', 'import x.json2\n\nstruct Event {\n\tvalue int\n}\n\nstruct Payload {\n\tflags [][]bool\n\tevents []Event\n}\n\nfn main() {\n\tpayload := Payload{\n\t\tflags: [[true]]\n\t\tevents: [Event{\n\t\t\tvalue: 42\n\t\t}]\n\t}\n\tencoded := json2.encode(payload)\n\tprintln(json2.decode[Payload](encoded)!.events[0].value)\n}\n')
 	assert out == '42'
 }
 
 fn test_json2_encode_array_keeps_main_type_with_imported_homonym() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'json2_array_main_type_imported_homonym',
-		'import gg\nimport x.json2\n\nstruct Event {\n\tvalue int\n}\n\nfn main() {\n\t_ = json2.encode([gg.Event{}])\n\tencoded := json2.encode([Event{\n\t\tvalue: 42\n\t}])\n\tprintln(encoded)\n}\n')
+	out := run_good(v3_bin, 'json2_array_main_type_imported_homonym', 'import gg\nimport x.json2\n\nstruct Event {\n\tvalue int\n}\n\nfn main() {\n\t_ = json2.encode([gg.Event{}])\n\tencoded := json2.encode([Event{\n\t\tvalue: 42\n\t}])\n\tprintln(encoded)\n}\n')
 	assert out.contains('"value":42')
 }
 
 fn test_json2_decode_keeps_main_type_with_imported_homonym() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'json2_decode_main_type_imported_homonym',
-		'import gg\nimport x.json2\n\nstruct Event {\n\tvalue int\n}\n\nfn main() {\n\t_ = json2.decode[gg.Event]("{}") or { gg.Event{} }\n\tevent := json2.decode[Event](r\'{"value":42}\')!\n\tprintln(event.value)\n}\n')
+	out := run_good(v3_bin, 'json2_decode_main_type_imported_homonym', 'import gg\nimport x.json2\n\nstruct Event {\n\tvalue int\n}\n\nfn main() {\n\t_ = json2.decode[gg.Event]("{}") or { gg.Event{} }\n\tevent := json2.decode[Event](r\'{"value":42}\')!\n\tprintln(event.value)\n}\n')
 	assert out == '42'
 }
 
 fn test_json2_encode_shared_struct_field_uses_locked_value_type() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'json2_shared_struct_field_value',
-		'import x.json2\n\nstruct State {\n\tvalue int\n}\n\nstruct Client {\n\tstate shared State\n}\n\nfn main() {\n\tclient := Client{}\n\tprintln(json2.encode(client))\n}\n')
+	out := run_good(v3_bin, 'json2_shared_struct_field_value', 'import x.json2\n\nstruct State {\n\tvalue int\n}\n\nstruct Client {\n\tstate shared State\n}\n\nfn main() {\n\tclient := Client{}\n\tprintln(json2.encode(client))\n}\n')
 	assert out == '{"state":{"value":0}}'
 }
 
 fn test_json2_decode_any_map_keeps_sum_value_type() {
 	v3_bin := build_v3_review_transform()
-	out := run_good(v3_bin, 'json2_any_map_value',
-		'import x.json2\n\nfn main() {\n\tvalues := json2.decode[map[string]json2.Any](r\'{"ok":true}\')!\n\tprintln(values["ok"] or { json2.Any(false) })\n}\n')
+	out := run_good(v3_bin, 'json2_any_map_value', 'import x.json2\n\nfn main() {\n\tvalues := json2.decode[map[string]json2.Any](r\'{"ok":true}\')!\n\tprintln(values["ok"] or { json2.Any(false) })\n}\n')
 	assert out == 'true'
 }
 
@@ -6039,8 +5829,7 @@ fn main() {
 	println(lengths)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_transient_address_drop_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_transient_address_drop_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	source_drop_pos := main_body.index('array__free(&(') or { -1 }
 	result_move_pos := main_body.index('Array lengths = ') or { -1 }
@@ -6074,12 +5863,10 @@ fn main() {
 	println(items[0] == items[1])
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_implicit_reference_receiver_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_implicit_reference_receiver_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	assert !main_body.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_implicit_reference_receiver', '-ownership',
-		source)
+	out := run_good_with_flags(v3_bin, 'array_map_implicit_reference_receiver', '-ownership', source)
 	assert out == '1\n2\nfalse'
 }
 
@@ -6106,8 +5893,7 @@ fn main() {
 	println(boxes[0].value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_generic_pointer_result_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_generic_pointer_result_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	assert !main_body.contains('array__free(&(__map_source_'), main_body
 	out := run_good_with_flags(v3_bin, 'array_map_generic_pointer_result', '-ownership', source)
@@ -6139,8 +5925,7 @@ fn main() {
 	}
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_generic_sum_pointer_result_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_generic_sum_pointer_result_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	assert !main_body.contains('array__free(&(__map_source_'), main_body
 	out := run_good_with_flags(v3_bin, 'array_map_generic_sum_pointer_result', '-ownership', source)
@@ -6172,8 +5957,7 @@ fn main() {
 	println(selected[0].text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_wrapped_pointer_results_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_wrapped_pointer_results_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	assert !main_body.contains('array__free(&(__map_source_'), main_body
 	out := run_good_with_flags(v3_bin, 'array_map_wrapped_pointer_results', '-ownership', source)
@@ -6197,8 +5981,7 @@ fn main() {
 	println(values[0].text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_dump_pointer_result_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_dump_pointer_result_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	assert !main_body.contains('array__free(&(__map_source_'), main_body
 }
@@ -6233,8 +6016,7 @@ fn main() {
 	println(values[0].text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_local_pointer_alias_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_local_pointer_alias_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -6274,8 +6056,7 @@ fn main() {
 	println(values[0].text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_conditional_pointer_alias_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_conditional_pointer_alias_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -6316,8 +6097,7 @@ fn main() {
 	println(values[0].text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_branch_local_pointer_alias_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_branch_local_pointer_alias_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -6361,8 +6141,7 @@ fn main() {
 	println(selected[0].text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_shadowed_nested_alias_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_shadowed_nested_alias_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	source_drop_pos := main_body.index('array__free(&(') or { -1 }
 	result_move_pos := main_body.index('Array selected = ') or { -1 }
@@ -6416,13 +6195,11 @@ fn main() {
 	println(indexed[0].text)
 }
 '
-	selected_c := gen_c_from_source_with_flags(v3_bin,
-		'array_map_local_aggregate_selector_alias_c', '-ownership', source)
+	selected_c := gen_c_from_source_with_flags(v3_bin, 'array_map_local_aggregate_selector_alias_c', '-ownership', source)
 	main_body := c_fn_body(selected_c, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_local_aggregate_selector_alias', '-ownership',
-		source)
+	out := run_good_with_flags(v3_bin, 'array_map_local_aggregate_selector_alias', '-ownership', source)
 	assert out == 'source\nsource'
 }
 
@@ -6479,8 +6256,7 @@ fn main() {
 	println(indexed[0].text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_nested_selector_write_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_nested_selector_write_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -6525,8 +6301,7 @@ fn main() {
 	println(selected[0].text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_direct_selector_write_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_direct_selector_write_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -6564,8 +6339,7 @@ fn main() {
 	println(selected[0].text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_direct_index_write_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_direct_index_write_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -6615,8 +6389,7 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_dyn_index_write_c', '-ownership',
-		source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_dyn_index_write_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -6697,13 +6470,11 @@ fn main() {
 	println(index_saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_projected_aggregate_origins_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_projected_aggregate_origins_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_projected_aggregate_origins', '-ownership',
-		source)
+	out := run_good_with_flags(v3_bin, 'array_map_projected_aggregate_origins', '-ownership', source)
 	assert out == '0\nsource\n0\nsource'
 }
 
@@ -6753,8 +6524,7 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_forward_goto_origin_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_forward_goto_origin_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -6812,8 +6582,7 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_helper_goto_origin_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_helper_goto_origin_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -6862,13 +6631,11 @@ fn main() {
 	println(selected[0].text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_nested_local_selector_chain_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_nested_local_selector_chain_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_nested_local_selector_chain', '-ownership',
-		source)
+	out := run_good_with_flags(v3_bin, 'array_map_nested_local_selector_chain', '-ownership', source)
 	assert out == 'source'
 }
 
@@ -6916,8 +6683,7 @@ fn main() {
 	println(selected[0].text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_nested_selector_write_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_nested_selector_write_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -6968,8 +6734,7 @@ fn main() {
 	println(selected[0].value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutating_method_write_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutating_method_write_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -7020,8 +6785,7 @@ fn main() {
 	println(selected[0].value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutating_function_write_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutating_function_write_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -7070,13 +6834,11 @@ fn main() {
 	println(selected[0].text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutating_method_selector_result_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutating_method_selector_result_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_mutating_method_selector_result', '-ownership',
-		source)
+	out := run_good_with_flags(v3_bin, 'array_map_mutating_method_selector_result', '-ownership', source)
 	assert out == 'source'
 }
 
@@ -7115,13 +6877,11 @@ fn main() {
 	println(selected[0].text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutating_function_index_result_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutating_function_index_result_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_mutating_function_index_result', '-ownership',
-		source)
+	out := run_good_with_flags(v3_bin, 'array_map_mutating_function_index_result', '-ownership', source)
 	assert out == 'source'
 }
 
@@ -7172,8 +6932,7 @@ fn main() {
 	println(selected[0].value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_nested_mutating_call_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_nested_mutating_call_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -7225,8 +6984,7 @@ fn main() {
 	println(selected[0].value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutator_local_alias_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutator_local_alias_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -7279,8 +7037,7 @@ fn main() {
 	println(selected[0].value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutator_alias_overwrite_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutator_alias_overwrite_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	source_drop_pos := main_body.index('array__free(&(') or { -1 }
 	result_move_pos := main_body.index('Array selected = ') or { -1 }
@@ -7330,8 +7087,7 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_external_mutator_escape_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_external_mutator_escape_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -7366,8 +7122,7 @@ fn main() {
 	println(saved[0].text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_external_append_escape_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_external_append_escape_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -7413,8 +7168,7 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_external_pointer_alias_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_external_pointer_alias_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -7467,13 +7221,11 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin,
-		'array_map_external_pointer_in_local_aggregate_c', '-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_external_pointer_in_local_aggregate_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_external_pointer_in_local_aggregate',
-		'-ownership', source)
+	out := run_good_with_flags(v3_bin, 'array_map_external_pointer_in_local_aggregate', '-ownership', source)
 	assert out == '0\nsource'
 }
 
@@ -7561,13 +7313,11 @@ fn main() {
 	println(saved_match.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin,
-		'array_map_conditional_local_aggregate_initializers_c', '-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_conditional_local_aggregate_initializers_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_conditional_local_aggregate_initializers',
-		'-ownership', source)
+	out := run_good_with_flags(v3_bin, 'array_map_conditional_local_aggregate_initializers', '-ownership', source)
 	assert out == '0\nsource\n0\nsource'
 }
 
@@ -7645,13 +7395,11 @@ fn main() {
 	println(saved_overridden.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_struct_update_pointer_origins_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_struct_update_pointer_origins_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert compact_main.count('array__free(&(__map_source_') == 1, main_body
-	out := run_good_with_flags(v3_bin, 'array_map_struct_update_pointer_origins', '-ownership',
-		source)
+	out := run_good_with_flags(v3_bin, 'array_map_struct_update_pointer_origins', '-ownership', source)
 	assert out == '0\nsource\n0\nexternal'
 }
 
@@ -7716,8 +7464,7 @@ fn main() {
 	println(selected_match[0])
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin,
-		'array_map_local_conditional_pointer_initializers_c', '-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_local_conditional_pointer_initializers_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	if_result_pos := compact_main.index('Arrayselected_if=') or { -1 }
@@ -7733,8 +7480,7 @@ fn main() {
 	}
 	assert if_source_drop_pos >= 0 && if_source_drop_pos < if_result_pos, main_body
 	assert match_source_drop_pos > if_result_pos && match_source_drop_pos < match_result_pos, main_body
-	out := run_good_with_flags(v3_bin, 'array_map_local_conditional_pointer_initializers',
-		'-ownership', source)
+	out := run_good_with_flags(v3_bin, 'array_map_local_conditional_pointer_initializers', '-ownership', source)
 	assert out == '0\n0'
 }
 
@@ -7790,13 +7536,11 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_external_pointer_in_call_result_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_external_pointer_in_call_result_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_external_pointer_in_call_result', '-ownership',
-		source)
+	out := run_good_with_flags(v3_bin, 'array_map_external_pointer_in_call_result', '-ownership', source)
 	assert out == '0\nsource'
 }
 
@@ -7855,13 +7599,11 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_call_result_per_field_origin_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_call_result_per_field_origin_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_call_result_per_field_origin', '-ownership',
-		source)
+	out := run_good_with_flags(v3_bin, 'array_map_call_result_per_field_origin', '-ownership', source)
 	assert out == '0\nexternal'
 }
 
@@ -7920,8 +7662,7 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_global_pointer_call_result_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_global_pointer_call_result_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -7976,8 +7717,7 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mut_call_pointer_origin_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mut_call_pointer_origin_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -8075,13 +7815,11 @@ fn main() {
 	println(direct_saved.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin,
-		'array_map_nested_call_and_dereference_pointer_origin_c', '-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_nested_call_and_dereference_pointer_origin_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_nested_call_and_dereference_pointer_origin',
-		'-ownership', source)
+	out := run_good_with_flags(v3_bin, 'array_map_nested_call_and_dereference_pointer_origin', '-ownership', source)
 	assert out == '0\nsource\n0\n0\nsource'
 }
 
@@ -8140,8 +7878,7 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_call_argument_snapshot_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_call_argument_snapshot_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -8207,13 +7944,11 @@ fn main() {
 }
 '
 	}
-	callback_c_source := gen_c_from_project_with_flags(v3_bin, 'array_map_callback_alias_scope_c',
-		'-ownership', files, 'main.v')
+	callback_c_source := gen_c_from_project_with_flags(v3_bin, 'array_map_callback_alias_scope_c', '-ownership', files, 'main.v')
 	callback_main_body := c_fn_body(callback_c_source, 'int main(int argc, char** argv) {')
 	compact_callback_main := callback_main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_callback_main.contains('array__free(&(__map_source_'), callback_main_body
-	callback_out := run_good_project_with_flags(v3_bin, 'array_map_callback_alias_scope',
-		'-ownership', files, 'main.v')
+	callback_out := run_good_project_with_flags(v3_bin, 'array_map_callback_alias_scope', '-ownership', files, 'main.v')
 	assert callback_out == '0\nsource'
 }
 
@@ -8268,13 +8003,11 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_earlier_argument_target_effect_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_earlier_argument_target_effect_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_earlier_argument_target_effect', '-ownership',
-		source)
+	out := run_good_with_flags(v3_bin, 'array_map_earlier_argument_target_effect', '-ownership', source)
 	assert out == '0\nsource'
 }
 
@@ -8330,13 +8063,11 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_expression_child_origin_effect_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_expression_child_origin_effect_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_expression_child_origin_effect', '-ownership',
-		source)
+	out := run_good_with_flags(v3_bin, 'array_map_expression_child_origin_effect', '-ownership', source)
 	assert out == '0\nsource'
 }
 
@@ -8389,13 +8120,11 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_decl_initializer_pointer_origin_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_decl_initializer_pointer_origin_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_decl_initializer_pointer_origin', '-ownership',
-		source)
+	out := run_good_with_flags(v3_bin, 'array_map_decl_initializer_pointer_origin', '-ownership', source)
 	assert out == '0\nsource'
 }
 
@@ -8449,13 +8178,11 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_assignment_rhs_pointer_origin_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_assignment_rhs_pointer_origin_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_assignment_rhs_pointer_origin', '-ownership',
-		source)
+	out := run_good_with_flags(v3_bin, 'array_map_assignment_rhs_pointer_origin', '-ownership', source)
 	assert out == '0\nsource'
 }
 
@@ -8503,13 +8230,11 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_multi_assign_pointer_origin_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_multi_assign_pointer_origin_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_multi_assign_pointer_origin', '-ownership',
-		source)
+	out := run_good_with_flags(v3_bin, 'array_map_multi_assign_pointer_origin', '-ownership', source)
 	assert out == '0\nsource'
 }
 
@@ -8561,8 +8286,7 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_multi_assign_rhs_effects_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_multi_assign_rhs_effects_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -8618,13 +8342,11 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_condition_pointer_alias_update_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_condition_pointer_alias_update_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_condition_pointer_alias_update', '-ownership',
-		source)
+	out := run_good_with_flags(v3_bin, 'array_map_condition_pointer_alias_update', '-ownership', source)
 	assert out == '0\nsource'
 }
 
@@ -8677,13 +8399,11 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin,
-		'array_map_nested_condition_pointer_alias_update_c', '-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_nested_condition_pointer_alias_update_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_nested_condition_pointer_alias_update',
-		'-ownership', source)
+	out := run_good_with_flags(v3_bin, 'array_map_nested_condition_pointer_alias_update', '-ownership', source)
 	assert out == '0\nsource'
 }
 
@@ -8735,13 +8455,11 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin,
-		'array_map_infix_operand_pointer_alias_update_c', '-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_infix_operand_pointer_alias_update_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_infix_operand_pointer_alias_update',
-		'-ownership', source)
+	out := run_good_with_flags(v3_bin, 'array_map_infix_operand_pointer_alias_update', '-ownership', source)
 	assert out == '0\nsource'
 }
 
@@ -8794,13 +8512,11 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin,
-		'array_map_match_subject_pointer_alias_update_c', '-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_match_subject_pointer_alias_update_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_match_subject_pointer_alias_update',
-		'-ownership', source)
+	out := run_good_with_flags(v3_bin, 'array_map_match_subject_pointer_alias_update', '-ownership', source)
 	assert out == '0\nsource'
 }
 
@@ -8839,8 +8555,7 @@ fn main() {
 	println(retained.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_global_call_sink_c', '-ownership',
-		source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_global_call_sink_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -8901,13 +8616,11 @@ fn main() {
 }
 '
 	}
-	c_source := gen_c_from_project_with_flags(v3_bin, 'array_map_global_wrapper_sink_c',
-		'-ownership', files, 'main.v')
+	c_source := gen_c_from_project_with_flags(v3_bin, 'array_map_global_wrapper_sink_c', '-ownership', files, 'main.v')
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_project_with_flags(v3_bin, 'array_map_global_wrapper_sink', '-ownership',
-		files, 'main.v')
+	out := run_good_project_with_flags(v3_bin, 'array_map_global_wrapper_sink', '-ownership', files, 'main.v')
 	assert out == '0\nsource'
 }
 
@@ -8967,13 +8680,11 @@ fn main() {
 }
 '
 	}
-	c_source := gen_c_from_project_with_flags(v3_bin, 'array_map_callback_wrapper_sink_c',
-		'-ownership', files, 'main.v')
+	c_source := gen_c_from_project_with_flags(v3_bin, 'array_map_callback_wrapper_sink_c', '-ownership', files, 'main.v')
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_project_with_flags(v3_bin, 'array_map_callback_wrapper_sink', '-ownership',
-		files, 'main.v')
+	out := run_good_project_with_flags(v3_bin, 'array_map_callback_wrapper_sink', '-ownership', files, 'main.v')
 	assert out == '0\nsource'
 }
 
@@ -9030,13 +8741,11 @@ fn main() {
 }
 '
 	}
-	c_source := gen_c_from_project_with_flags(v3_bin,
-		'array_map_forwarded_callback_wrapper_sink_c', '-ownership', files, 'main.v')
+	c_source := gen_c_from_project_with_flags(v3_bin, 'array_map_forwarded_callback_wrapper_sink_c', '-ownership', files, 'main.v')
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_project_with_flags(v3_bin, 'array_map_forwarded_callback_wrapper_sink',
-		'-ownership', files, 'main.v')
+	out := run_good_project_with_flags(v3_bin, 'array_map_forwarded_callback_wrapper_sink', '-ownership', files, 'main.v')
 	assert out == '0\nsource'
 }
 
@@ -9095,13 +8804,11 @@ fn main() {
 }
 '
 	}
-	c_source := gen_c_from_project_with_flags(v3_bin, 'array_map_aliased_callback_wrapper_sink_c',
-		'-ownership', files, 'main.v')
+	c_source := gen_c_from_project_with_flags(v3_bin, 'array_map_aliased_callback_wrapper_sink_c', '-ownership', files, 'main.v')
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_project_with_flags(v3_bin, 'array_map_aliased_callback_wrapper_sink',
-		'-ownership', files, 'main.v')
+	out := run_good_project_with_flags(v3_bin, 'array_map_aliased_callback_wrapper_sink', '-ownership', files, 'main.v')
 	assert out == '0\nsource'
 }
 
@@ -9167,13 +8874,11 @@ fn main() {
 }
 '
 	}
-	c_source := gen_c_from_project_with_flags(v3_bin, 'array_map_helper_rebound_callback_alias_c',
-		'-ownership', files, 'main.v')
+	c_source := gen_c_from_project_with_flags(v3_bin, 'array_map_helper_rebound_callback_alias_c', '-ownership', files, 'main.v')
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_project_with_flags(v3_bin, 'array_map_helper_rebound_callback_alias',
-		'-ownership', files, 'main.v')
+	out := run_good_project_with_flags(v3_bin, 'array_map_helper_rebound_callback_alias', '-ownership', files, 'main.v')
 	assert out == '0\nsource'
 }
 
@@ -9235,8 +8940,7 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_nested_helper_rebind_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_nested_helper_rebind_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -9290,13 +8994,11 @@ fn main() {
 	println(target.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_explicit_deref_helper_storage_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_explicit_deref_helper_storage_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_explicit_deref_helper_storage', '-ownership',
-		source)
+	out := run_good_with_flags(v3_bin, 'array_map_explicit_deref_helper_storage', '-ownership', source)
 	assert out == '0\nsource'
 }
 
@@ -9360,13 +9062,11 @@ fn main() {
 }
 '
 	}
-	c_source := gen_c_from_project_with_flags(v3_bin, 'array_map_conditional_callback_alias_c',
-		'-ownership', files, 'main.v')
+	c_source := gen_c_from_project_with_flags(v3_bin, 'array_map_conditional_callback_alias_c', '-ownership', files, 'main.v')
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_project_with_flags(v3_bin, 'array_map_conditional_callback_alias',
-		'-ownership', files, 'main.v')
+	out := run_good_project_with_flags(v3_bin, 'array_map_conditional_callback_alias', '-ownership', files, 'main.v')
 	assert out == '0\nsource'
 }
 
@@ -9487,13 +9187,11 @@ fn main() {
 }
 '
 	}
-	c_source := gen_c_from_project_with_flags(v3_bin, 'array_map_branch_callback_alias_c',
-		'-ownership', files, 'main.v')
+	c_source := gen_c_from_project_with_flags(v3_bin, 'array_map_branch_callback_alias_c', '-ownership', files, 'main.v')
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_project_with_flags(v3_bin, 'array_map_branch_callback_alias', '-ownership',
-		files, 'main.v')
+	out := run_good_project_with_flags(v3_bin, 'array_map_branch_callback_alias', '-ownership', files, 'main.v')
 	assert out == '0\nsource\n0\nsource\n0\nsource\n0\nsource'
 }
 
@@ -9554,13 +9252,11 @@ fn main() {
 }
 '
 	}
-	c_source := gen_c_from_project_with_flags(v3_bin, 'array_map_nested_callback_wrapper_sink_c',
-		'-ownership', files, 'main.v')
+	c_source := gen_c_from_project_with_flags(v3_bin, 'array_map_nested_callback_wrapper_sink_c', '-ownership', files, 'main.v')
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_project_with_flags(v3_bin, 'array_map_nested_callback_wrapper_sink',
-		'-ownership', files, 'main.v')
+	out := run_good_project_with_flags(v3_bin, 'array_map_nested_callback_wrapper_sink', '-ownership', files, 'main.v')
 	assert out == '0\nsource'
 }
 
@@ -9603,8 +9299,7 @@ fn main() {
 	println(retained.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_indirect_call_sink_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_indirect_call_sink_c', '-ownership', source)
 	map_body := c_fn_body(c_source, 'Array main__map_with(')
 	compact_map := map_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_map.contains('array__free(&(__map_source_'), map_body
@@ -9656,13 +9351,11 @@ fn main() {
 }
 '
 	}
-	c_source := gen_c_from_project_with_flags(v3_bin, 'array_map_external_c_call_sink_c',
-		'-ownership', files, 'main.v')
+	c_source := gen_c_from_project_with_flags(v3_bin, 'array_map_external_c_call_sink_c', '-ownership', files, 'main.v')
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_project_with_flags(v3_bin, 'array_map_external_c_call_sink', '-ownership',
-		files, 'main.v')
+	out := run_good_project_with_flags(v3_bin, 'array_map_external_c_call_sink', '-ownership', files, 'main.v')
 	assert out == '0\nsource'
 }
 
@@ -9710,8 +9403,7 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_deferred_exit_origin_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_deferred_exit_origin_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -9766,8 +9458,7 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_return_before_late_defer_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_return_before_late_defer_c', '-ownership', source)
 	map_body := c_fn_body(c_source, 'Array map_or_return(main__PointerBox* saved, bool early) {')
 	compact_map := map_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert compact_map.contains('array__free(&(__map_source_'), map_body
@@ -9828,13 +9519,11 @@ fn main() {
 		'break':    source
 		'continue': source.replace('\t\t\t\t\tbreak\n', '\t\t\t\t\tcontinue\n')
 	} {
-		c_source := gen_c_from_source_with_flags(v3_bin,
-			'array_map_${exit_kind}_before_late_defer_c', '-ownership', exit_source)
+		c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_${exit_kind}_before_late_defer_c', '-ownership', exit_source)
 		main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 		compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 		assert compact_main.contains('array__free(&(__map_source_'), main_body
-		out := run_good_with_flags(v3_bin, 'array_map_${exit_kind}_before_late_defer',
-			'-ownership', exit_source)
+		out := run_good_with_flags(v3_bin, 'array_map_${exit_kind}_before_late_defer', '-ownership', exit_source)
 		assert out == '0\nexternal'
 	}
 }
@@ -9868,8 +9557,7 @@ fn main() {
 	println(item.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_return_element_address_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_return_element_address_c', '-ownership', source)
 	first_body := c_fn_body(c_source, 'main__Item* main__first_item(void) {')
 	compact_first := first_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_first.contains('array__free(&(__map_source_'), first_body
@@ -9917,13 +9605,11 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_external_pointer_in_local_map_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_external_pointer_in_local_map_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_external_pointer_in_local_map', '-ownership',
-		source)
+	out := run_good_with_flags(v3_bin, 'array_map_external_pointer_in_local_map', '-ownership', source)
 	assert out == '0\nsource'
 }
 
@@ -9967,8 +9653,7 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_dynamic_local_array_index_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_dynamic_local_array_index_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -10017,8 +9702,7 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_delimiter_map_key_c', '-ownership',
-		source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_delimiter_map_key_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -10070,13 +9754,11 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin,
-		'array_map_dynamic_assignment_replaces_exact_origin_c', '-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_dynamic_assignment_replaces_exact_origin_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_dynamic_assignment_replaces_exact_origin',
-		'-ownership', source)
+	out := run_good_with_flags(v3_bin, 'array_map_dynamic_assignment_replaces_exact_origin', '-ownership', source)
 	assert out == '0\nsource'
 }
 
@@ -10118,13 +9800,11 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin,
-		'array_map_repeated_local_array_initializer_c', '-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_repeated_local_array_initializer_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_repeated_local_array_initializer', '-ownership',
-		source)
+	out := run_good_with_flags(v3_bin, 'array_map_repeated_local_array_initializer', '-ownership', source)
 	assert out == '0\nsource'
 }
 
@@ -10177,8 +9857,7 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_select_pointer_origins_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_select_pointer_origins_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -10235,13 +9914,11 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_select_in_arm_pointer_rebind_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_select_in_arm_pointer_rebind_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_select_in_arm_pointer_rebind', '-ownership',
-		source)
+	out := run_good_with_flags(v3_bin, 'array_map_select_in_arm_pointer_rebind', '-ownership', source)
 	assert out == '0\nsource'
 }
 
@@ -10293,8 +9970,7 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_loop_break_pointer_origins_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_loop_break_pointer_origins_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -10350,13 +10026,11 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin,
-		'array_map_labeled_outer_loop_pointer_origin_c', '-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_labeled_outer_loop_pointer_origin_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_labeled_outer_loop_pointer_origin', '-ownership',
-		source)
+	out := run_good_with_flags(v3_bin, 'array_map_labeled_outer_loop_pointer_origin', '-ownership', source)
 	assert out == '0\nsource'
 }
 
@@ -10409,14 +10083,12 @@ fn main() {
 	println(selected[0])
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin,
-		'array_map_unrelated_local_aggregate_pointer_c', '-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_unrelated_local_aggregate_pointer_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	source_drop_pos := main_body.index('array__free(&(') or { -1 }
 	result_move_pos := main_body.index('Array selected = ') or { -1 }
 	assert source_drop_pos >= 0 && source_drop_pos < result_move_pos, main_body
-	out := run_good_with_flags(v3_bin, 'array_map_unrelated_local_aggregate_pointer', '-ownership',
-		source)
+	out := run_good_with_flags(v3_bin, 'array_map_unrelated_local_aggregate_pointer', '-ownership', source)
 	assert out == '0'
 }
 
@@ -10465,53 +10137,42 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin,
-		'array_map_conditional_external_pointer_alias_c', '-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_conditional_external_pointer_alias_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_conditional_external_pointer_alias',
-		'-ownership', source)
+	out := run_good_with_flags(v3_bin, 'array_map_conditional_external_pointer_alias', '-ownership', source)
 	assert out == '0\nsource'
 
-	match_source := source.replace('if flag {\n\t\t\t\talias = &saved\n\t\t\t}',
-		'match flag {\n\t\t\t\ttrue { alias = &saved }\n\t\t\t\telse {}\n\t\t\t}')
+	match_source := source.replace('if flag {\n\t\t\t\talias = &saved\n\t\t\t}', 'match flag {\n\t\t\t\ttrue { alias = &saved }\n\t\t\t\telse {}\n\t\t\t}')
 	assert match_source != source
-	match_c_source := gen_c_from_source_with_flags(v3_bin,
-		'array_map_match_external_pointer_alias_c', '-ownership', match_source)
+	match_c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_match_external_pointer_alias_c', '-ownership', match_source)
 	match_main_body := c_fn_body(match_c_source, 'int main(int argc, char** argv) {')
 	compact_match_main := match_main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_match_main.contains('array__free(&(__map_source_'), match_main_body
-	match_out := run_good_with_flags(v3_bin, 'array_map_match_external_pointer_alias',
-		'-ownership', match_source)
+	match_out := run_good_with_flags(v3_bin, 'array_map_match_external_pointer_alias', '-ownership', match_source)
 	assert match_out == '0\nsource'
 
-	loop_source := source.replace('if flag {\n\t\t\t\talias = &saved\n\t\t\t}',
-		'for flag {\n\t\t\t\talias = &saved\n\t\t\t\tbreak\n\t\t\t}')
+	loop_source := source.replace('if flag {\n\t\t\t\talias = &saved\n\t\t\t}', 'for flag {\n\t\t\t\talias = &saved\n\t\t\t\tbreak\n\t\t\t}')
 	assert loop_source != source
-	loop_c_source := gen_c_from_source_with_flags(v3_bin,
-		'array_map_loop_external_pointer_alias_c', '-ownership', loop_source)
+	loop_c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_loop_external_pointer_alias_c', '-ownership', loop_source)
 	loop_main_body := c_fn_body(loop_c_source, 'int main(int argc, char** argv) {')
 	compact_loop_main := loop_main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_loop_main.contains('array__free(&(__map_source_'), loop_main_body
-	loop_out := run_good_with_flags(v3_bin, 'array_map_loop_external_pointer_alias', '-ownership',
-		loop_source)
+	loop_out := run_good_with_flags(v3_bin, 'array_map_loop_external_pointer_alias', '-ownership', loop_source)
 	assert loop_out == '0\nsource'
 
 	or_source := source.replace('fn make_items() []Item {', "fn may_fail() ! {
 	return error('failed')
 }
 
-fn make_items() []Item {").replace('if flag {\n\t\t\t\talias = &saved\n\t\t\t}',
-		'may_fail() or {\n\t\t\t\talias = &saved\n\t\t\t}')
+fn make_items() []Item {").replace('if flag {\n\t\t\t\talias = &saved\n\t\t\t}', 'may_fail() or {\n\t\t\t\talias = &saved\n\t\t\t}')
 	assert or_source != source
-	or_c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_or_external_pointer_alias_c',
-		'-ownership', or_source)
+	or_c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_or_external_pointer_alias_c', '-ownership', or_source)
 	or_main_body := c_fn_body(or_c_source, 'int main(int argc, char** argv) {')
 	compact_or_main := or_main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_or_main.contains('array__free(&(__map_source_'), or_main_body
-	or_out := run_good_with_flags(v3_bin, 'array_map_or_external_pointer_alias', '-ownership',
-		or_source)
+	or_out := run_good_with_flags(v3_bin, 'array_map_or_external_pointer_alias', '-ownership', or_source)
 	assert or_out == '0\nsource'
 }
 
@@ -10559,24 +10220,20 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source_true := gen_c_from_source_with_flags(v3_bin,
-		'array_map_comptime_external_pointer_alias_true_c', '-ownership', source_true)
+	c_source_true := gen_c_from_source_with_flags(v3_bin, 'array_map_comptime_external_pointer_alias_true_c', '-ownership', source_true)
 	main_body_true := c_fn_body(c_source_true, 'int main(int argc, char** argv) {')
 	compact_main_true := main_body_true.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main_true.contains('array__free(&(__map_source_'), main_body_true
-	out_true := run_good_with_flags(v3_bin, 'array_map_comptime_external_pointer_alias_true',
-		'-ownership', source_true)
+	out_true := run_good_with_flags(v3_bin, 'array_map_comptime_external_pointer_alias_true', '-ownership', source_true)
 	assert out_true == '0\nsource'
 
 	source_false := source_true.replace('\$if true {', '\$if false {')
-	c_source_false := gen_c_from_source_with_flags(v3_bin,
-		'array_map_comptime_external_pointer_alias_false_c', '-ownership', source_false)
+	c_source_false := gen_c_from_source_with_flags(v3_bin, 'array_map_comptime_external_pointer_alias_false_c', '-ownership', source_false)
 	main_body_false := c_fn_body(c_source_false, 'int main(int argc, char** argv) {')
 	source_drop_pos := main_body_false.index('array__free(&(') or { -1 }
 	result_move_pos := main_body_false.index('Array selected = ') or { -1 }
 	assert source_drop_pos >= 0 && source_drop_pos < result_move_pos, main_body_false
-	out_false := run_good_with_flags(v3_bin, 'array_map_comptime_external_pointer_alias_false',
-		'-ownership', source_false)
+	out_false := run_good_with_flags(v3_bin, 'array_map_comptime_external_pointer_alias_false', '-ownership', source_false)
 	assert out_false == '0\nexternal'
 }
 
@@ -10627,8 +10284,7 @@ fn main() {
 	apply(store)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_indirect_mutator_c', '-ownership',
-		source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_indirect_mutator_c', '-ownership', source)
 	apply_body := c_fn_body(c_source, 'void main__apply(main__Setter setter) {')
 	compact_apply := apply_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_apply.contains('array__free(&(__map_source_'), apply_body
@@ -10664,8 +10320,7 @@ fn main() {
 	println(retained.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_channel_pointer_sink_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_channel_pointer_sink_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -10702,8 +10357,7 @@ fn main() {
 	println(retained.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_local_channel_alias_sink_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_local_channel_alias_sink_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -10746,8 +10400,7 @@ fn main() {
 	println(<-saved)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_spawn_pointer_sink_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_spawn_pointer_sink_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -10791,8 +10444,7 @@ fn main() {
 	println(<-saved)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_spawn_pointer_receiver_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_spawn_pointer_receiver_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -10842,14 +10494,12 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin,
-		'array_map_external_pointer_alias_overwrite_c', '-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_external_pointer_alias_overwrite_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	source_drop_pos := main_body.index('array__free(&(') or { -1 }
 	result_move_pos := main_body.index('Array selected = ') or { -1 }
 	assert source_drop_pos >= 0 && source_drop_pos < result_move_pos, main_body
-	out := run_good_with_flags(v3_bin, 'array_map_external_pointer_alias_overwrite', '-ownership',
-		source)
+	out := run_good_with_flags(v3_bin, 'array_map_external_pointer_alias_overwrite', '-ownership', source)
 	assert out == '0\nexternal'
 }
 
@@ -10896,8 +10546,7 @@ fn main() {
 	println(selected[0].value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutator_storage_overwrite_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutator_storage_overwrite_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	source_drop_pos := main_body.index('array__free(&(') or { -1 }
 	result_move_pos := main_body.index('Array selected = ') or { -1 }
@@ -10905,42 +10554,32 @@ fn main() {
 	out := run_good_with_flags(v3_bin, 'array_map_mutator_storage_overwrite', '-ownership', source)
 	assert out == 'external'
 
-	early_return_source := source.replace('box.value = value\n\tbox.value = replacement',
-		'box.value = value\n\tif true {\n\t\treturn\n\t}\n\tbox.value = replacement')
+	early_return_source := source.replace('box.value = value\n\tbox.value = replacement', 'box.value = value\n\tif true {\n\t\treturn\n\t}\n\tbox.value = replacement')
 	assert early_return_source != source
-	early_return_c_source := gen_c_from_source_with_flags(v3_bin,
-		'array_map_mutator_storage_early_return_c', '-ownership', early_return_source)
+	early_return_c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutator_storage_early_return_c', '-ownership', early_return_source)
 	early_return_main_body := c_fn_body(early_return_c_source, 'int main(int argc, char** argv) {')
 	compact_early_return_main :=
 		early_return_main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_early_return_main.contains('array__free(&(__map_source_'), early_return_main_body
 
-	early_return_out := run_good_with_flags(v3_bin, 'array_map_mutator_storage_early_return',
-		'-ownership', early_return_source)
+	early_return_out := run_good_with_flags(v3_bin, 'array_map_mutator_storage_early_return', '-ownership', early_return_source)
 	assert early_return_out == 'source'
 
-	delegated_source := source.replace('fn (mut box PointerBox) set_then_reset(value &Item, replacement &Item) {\n\tbox.value = value',
-		'fn (mut box PointerBox) store(value &Item) {\n\tbox.value = value\n}\n\nfn (mut box PointerBox) set_then_reset(value &Item, replacement &Item) {\n\tbox.store(value)')
+	delegated_source := source.replace('fn (mut box PointerBox) set_then_reset(value &Item, replacement &Item) {\n\tbox.value = value', 'fn (mut box PointerBox) store(value &Item) {\n\tbox.value = value\n}\n\nfn (mut box PointerBox) set_then_reset(value &Item, replacement &Item) {\n\tbox.store(value)')
 	assert delegated_source != source
-	delegated_c_source := gen_c_from_source_with_flags(v3_bin,
-		'array_map_delegated_mutator_storage_overwrite_c', '-ownership', delegated_source)
+	delegated_c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_delegated_mutator_storage_overwrite_c', '-ownership', delegated_source)
 	delegated_main_body := c_fn_body(delegated_c_source, 'int main(int argc, char** argv) {')
 	delegated_source_drop_pos := delegated_main_body.index('array__free(&(') or { -1 }
 	delegated_result_move_pos := delegated_main_body.index('Array selected = ') or { -1 }
 	assert delegated_source_drop_pos >= 0 && delegated_source_drop_pos < delegated_result_move_pos, delegated_main_body
 
-	delegated_out := run_good_with_flags(v3_bin, 'array_map_delegated_mutator_storage_overwrite',
-		'-ownership', delegated_source)
+	delegated_out := run_good_with_flags(v3_bin, 'array_map_delegated_mutator_storage_overwrite', '-ownership', delegated_source)
 	assert delegated_out == 'external'
 
-	reverse_delegated_source := source.replace('fn (mut box PointerBox) set_then_reset(value &Item, replacement &Item) {\n\tbox.value = value\n\tbox.value = replacement',
-		'fn store(mut box PointerBox, value &Item) {\n\tbox.value = value\n}\n\nfn (mut box PointerBox) set_then_reset(value &Item, replacement &Item) {\n\tbox.value = value\n\tstore(mut box, replacement)')
+	reverse_delegated_source := source.replace('fn (mut box PointerBox) set_then_reset(value &Item, replacement &Item) {\n\tbox.value = value\n\tbox.value = replacement', 'fn store(mut box PointerBox, value &Item) {\n\tbox.value = value\n}\n\nfn (mut box PointerBox) set_then_reset(value &Item, replacement &Item) {\n\tbox.value = value\n\tstore(mut box, replacement)')
 	assert reverse_delegated_source != source
-	reverse_delegated_c_source := gen_c_from_source_with_flags(v3_bin,
-		'array_map_reverse_delegated_mutator_storage_overwrite_c', '-ownership',
-		reverse_delegated_source)
-	reverse_delegated_main_body := c_fn_body(reverse_delegated_c_source,
-		'int main(int argc, char** argv) {')
+	reverse_delegated_c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_reverse_delegated_mutator_storage_overwrite_c', '-ownership', reverse_delegated_source)
+	reverse_delegated_main_body := c_fn_body(reverse_delegated_c_source, 'int main(int argc, char** argv) {')
 	reverse_delegated_source_drop_pos := reverse_delegated_main_body.index('array__free(&(') or {
 		-1
 	}
@@ -10950,87 +10589,63 @@ fn main() {
 	assert reverse_delegated_source_drop_pos >= 0
 		&& reverse_delegated_source_drop_pos < reverse_delegated_result_move_pos, reverse_delegated_main_body
 
-	reverse_delegated_out := run_good_with_flags(v3_bin,
-		'array_map_reverse_delegated_mutator_storage_overwrite', '-ownership',
-		reverse_delegated_source)
+	reverse_delegated_out := run_good_with_flags(v3_bin, 'array_map_reverse_delegated_mutator_storage_overwrite', '-ownership', reverse_delegated_source)
 	assert reverse_delegated_out == 'external'
 
-	loop_source := source.replace('box.value = value\n\tbox.value = replacement',
-		'for {\n\t\tbox.value = value\n\t\tif true {\n\t\t\tbreak\n\t\t}\n\t\tbox.value = replacement\n\t\tbreak\n\t}')
+	loop_source := source.replace('box.value = value\n\tbox.value = replacement', 'for {\n\t\tbox.value = value\n\t\tif true {\n\t\t\tbreak\n\t\t}\n\t\tbox.value = replacement\n\t\tbreak\n\t}')
 	assert loop_source != source
-	loop_c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutator_storage_loop_break_c',
-		'-ownership', loop_source)
+	loop_c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutator_storage_loop_break_c', '-ownership', loop_source)
 	loop_main_body := c_fn_body(loop_c_source, 'int main(int argc, char** argv) {')
 	compact_loop_main := loop_main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_loop_main.contains('array__free(&(__map_source_'), loop_main_body
-	loop_out := run_good_with_flags(v3_bin, 'array_map_mutator_storage_loop_break', '-ownership',
-		loop_source)
+	loop_out := run_good_with_flags(v3_bin, 'array_map_mutator_storage_loop_break', '-ownership', loop_source)
 	assert loop_out == 'source'
 
-	deferred_source := source.replace('box.value = value\n\tbox.value = replacement',
-		'defer {\n\t\tbox.value = value\n\t}\n\tbox.value = replacement')
+	deferred_source := source.replace('box.value = value\n\tbox.value = replacement', 'defer {\n\t\tbox.value = value\n\t}\n\tbox.value = replacement')
 	assert deferred_source != source
-	deferred_c_source := gen_c_from_source_with_flags(v3_bin,
-		'array_map_mutator_storage_deferred_c', '-ownership', deferred_source)
+	deferred_c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutator_storage_deferred_c', '-ownership', deferred_source)
 	deferred_main_body := c_fn_body(deferred_c_source, 'int main(int argc, char** argv) {')
 	compact_deferred_main := deferred_main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_deferred_main.contains('array__free(&(__map_source_'), deferred_main_body
-	deferred_out := run_good_with_flags(v3_bin, 'array_map_mutator_storage_deferred', '-ownership',
-		deferred_source)
+	deferred_out := run_good_with_flags(v3_bin, 'array_map_mutator_storage_deferred', '-ownership', deferred_source)
 	assert deferred_out == 'source'
 
-	deferred_exit_alias_source := source.replace('box.value = value\n\tbox.value = replacement',
-		'mut alias := unsafe { value }\n\tdefer {\n\t\tbox.value = alias\n\t}\n\tif true {\n\t\treturn\n\t}\n\talias = unsafe { replacement }')
+	deferred_exit_alias_source := source.replace('box.value = value\n\tbox.value = replacement', 'mut alias := unsafe { value }\n\tdefer {\n\t\tbox.value = alias\n\t}\n\tif true {\n\t\treturn\n\t}\n\talias = unsafe { replacement }')
 	assert deferred_exit_alias_source != source
-	deferred_exit_alias_c_source := gen_c_from_source_with_flags(v3_bin,
-		'array_map_mutator_storage_deferred_exit_alias_c', '-ownership', deferred_exit_alias_source)
-	deferred_exit_alias_main := c_fn_body(deferred_exit_alias_c_source,
-		'int main(int argc, char** argv) {')
+	deferred_exit_alias_c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutator_storage_deferred_exit_alias_c', '-ownership', deferred_exit_alias_source)
+	deferred_exit_alias_main := c_fn_body(deferred_exit_alias_c_source, 'int main(int argc, char** argv) {')
 	compact_deferred_exit_alias_main :=
 		deferred_exit_alias_main.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_deferred_exit_alias_main.contains('array__free(&(__map_source_'), deferred_exit_alias_main
-	deferred_exit_alias_out := run_good_with_flags(v3_bin,
-		'array_map_mutator_storage_deferred_exit_alias', '-ownership', deferred_exit_alias_source)
+	deferred_exit_alias_out := run_good_with_flags(v3_bin, 'array_map_mutator_storage_deferred_exit_alias', '-ownership', deferred_exit_alias_source)
 	assert deferred_exit_alias_out == 'source'
 
-	nested_deferred_exit_alias_source := source.replace('box.value = value\n\tbox.value = replacement',
-		'if true {\n\t\tmut local := PointerBox{\n\t\t\tvalue: unsafe { replacement }\n\t\t}\n\t\tmut alias := &local\n\t\tdefer {\n\t\t\talias.value = value\n\t\t}\n\t\talias = &box\n\t}')
+	nested_deferred_exit_alias_source := source.replace('box.value = value\n\tbox.value = replacement', 'if true {\n\t\tmut local := PointerBox{\n\t\t\tvalue: unsafe { replacement }\n\t\t}\n\t\tmut alias := &local\n\t\tdefer {\n\t\t\talias.value = value\n\t\t}\n\t\talias = &box\n\t}')
 	assert nested_deferred_exit_alias_source != source
-	nested_deferred_exit_alias_c_source := gen_c_from_source_with_flags(v3_bin,
-		'array_map_mutator_storage_nested_deferred_exit_alias_c', '-ownership',
-		nested_deferred_exit_alias_source)
-	nested_deferred_exit_alias_main := c_fn_body(nested_deferred_exit_alias_c_source,
-		'int main(int argc, char** argv) {')
+	nested_deferred_exit_alias_c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutator_storage_nested_deferred_exit_alias_c', '-ownership', nested_deferred_exit_alias_source)
+	nested_deferred_exit_alias_main := c_fn_body(nested_deferred_exit_alias_c_source, 'int main(int argc, char** argv) {')
 	compact_nested_deferred_exit_alias_main :=
 		nested_deferred_exit_alias_main.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_nested_deferred_exit_alias_main.contains('array__free(&(__map_source_'), nested_deferred_exit_alias_main
-	nested_deferred_exit_alias_out := run_good_with_flags(v3_bin,
-		'array_map_mutator_storage_nested_deferred_exit_alias', '-ownership',
-		nested_deferred_exit_alias_source)
+	nested_deferred_exit_alias_out := run_good_with_flags(v3_bin, 'array_map_mutator_storage_nested_deferred_exit_alias', '-ownership', nested_deferred_exit_alias_source)
 	assert nested_deferred_exit_alias_out == 'source'
 
-	late_defer_source := source.replace('box.value = value\n\tbox.value = replacement',
-		'box.value = value\n\tif value.text.len > 0 {\n\t\treturn\n\t}\n\tdefer {\n\t\tbox.value = replacement\n\t}')
+	late_defer_source := source.replace('box.value = value\n\tbox.value = replacement', 'box.value = value\n\tif value.text.len > 0 {\n\t\treturn\n\t}\n\tdefer {\n\t\tbox.value = replacement\n\t}')
 	assert late_defer_source != source
-	late_defer_c_source := gen_c_from_source_with_flags(v3_bin,
-		'array_map_mutator_storage_late_defer_c', '-ownership', late_defer_source)
+	late_defer_c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutator_storage_late_defer_c', '-ownership', late_defer_source)
 	late_defer_main := c_fn_body(late_defer_c_source, 'int main(int argc, char** argv) {')
 	compact_late_defer_main := late_defer_main.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_late_defer_main.contains('array__free(&(__map_source_'), late_defer_main
-	late_defer_out := run_good_with_flags(v3_bin, 'array_map_mutator_storage_late_defer',
-		'-ownership', late_defer_source)
+	late_defer_out := run_good_with_flags(v3_bin, 'array_map_mutator_storage_late_defer', '-ownership', late_defer_source)
 	assert late_defer_out == 'source'
 
-	select_source := source.replace('box.value = value\n\tbox.value = replacement',
-		'signal := chan bool{cap: 1}\n\tsignal <- true\n\tselect {\n\t\t<-signal {\n\t\t\tbox.value = value\n\t\t}\n\t\telse {\n\t\t\tbox.value = replacement\n\t\t}\n\t}')
+	select_source := source.replace('box.value = value\n\tbox.value = replacement', 'signal := chan bool{cap: 1}\n\tsignal <- true\n\tselect {\n\t\t<-signal {\n\t\t\tbox.value = value\n\t\t}\n\t\telse {\n\t\t\tbox.value = replacement\n\t\t}\n\t}')
 	assert select_source != source
-	select_c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutator_storage_select_c',
-		'-ownership', select_source)
+	select_c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutator_storage_select_c', '-ownership', select_source)
 	select_main_body := c_fn_body(select_c_source, 'int main(int argc, char** argv) {')
 	compact_select_main := select_main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_select_main.contains('array__free(&(__map_source_'), select_main_body
-	select_out := run_good_with_flags(v3_bin, 'array_map_mutator_storage_select', '-ownership',
-		select_source)
+	select_out := run_good_with_flags(v3_bin, 'array_map_mutator_storage_select', '-ownership', select_source)
 	assert select_out == 'source'
 
 	direct_exit_source := 'struct Item {
@@ -11082,8 +10697,7 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	direct_exit_out := run_good_with_flags(v3_bin, 'array_map_deferred_direct_exit_alias',
-		'-ownership', direct_exit_source)
+	direct_exit_out := run_good_with_flags(v3_bin, 'array_map_deferred_direct_exit_alias', '-ownership', direct_exit_source)
 	assert direct_exit_out == '7\nsource'
 }
 
@@ -11140,12 +10754,10 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_return_expr_deferred_origin_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_return_expr_deferred_origin_c', '-ownership', source)
 	compact_c := c_source.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_c.contains('array__free(&(__map_source_'), c_source
-	out := run_good_with_flags(v3_bin, 'array_map_return_expr_deferred_origin', '-ownership',
-		source)
+	out := run_good_with_flags(v3_bin, 'array_map_return_expr_deferred_origin', '-ownership', source)
 	assert out == '7\nsource'
 }
 
@@ -11200,8 +10812,7 @@ fn main() {
 	println(selected[0].value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutator_or_success_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutator_or_success_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -11252,25 +10863,21 @@ fn main() {
 	println(selected[0].value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutator_target_alias_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutator_target_alias_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
 	out := run_good_with_flags(v3_bin, 'array_map_mutator_target_alias', '-ownership', source)
 	assert out == 'source'
 
-	aggregate_source := source.replace('mut pbox := &box\n\tpbox.value = value',
-		'tmp := PointerBox{\n\t\tvalue: unsafe { value }\n\t}\n\tbox.value = tmp.value')
+	aggregate_source := source.replace('mut pbox := &box\n\tpbox.value = value', 'tmp := PointerBox{\n\t\tvalue: unsafe { value }\n\t}\n\tbox.value = tmp.value')
 	assert aggregate_source != source
-	aggregate_c_source := gen_c_from_source_with_flags(v3_bin,
-		'array_map_mutator_aggregate_source_c', '-ownership', aggregate_source)
+	aggregate_c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_mutator_aggregate_source_c', '-ownership', aggregate_source)
 	aggregate_main_body := c_fn_body(aggregate_c_source, 'int main(int argc, char** argv) {')
 	compact_aggregate_main :=
 		aggregate_main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_aggregate_main.contains('array__free(&(__map_source_'), aggregate_main_body
-	aggregate_out := run_good_with_flags(v3_bin, 'array_map_mutator_aggregate_source',
-		'-ownership', aggregate_source)
+	aggregate_out := run_good_with_flags(v3_bin, 'array_map_mutator_aggregate_source', '-ownership', aggregate_source)
 	assert aggregate_out == 'source'
 }
 
@@ -11352,8 +10959,7 @@ fn main() {
 	println(indexed[0].values[0].text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_all_mutator_targets_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_all_mutator_targets_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -11407,24 +11013,20 @@ fn main() {
 	println(selected[0].value.text)
 }
 '
-	c_source_true := gen_c_from_source_with_flags(v3_bin, 'array_map_comptime_mutator_true_c',
-		'-ownership', source_true)
+	c_source_true := gen_c_from_source_with_flags(v3_bin, 'array_map_comptime_mutator_true_c', '-ownership', source_true)
 	main_body_true := c_fn_body(c_source_true, 'int main(int argc, char** argv) {')
 	compact_main_true := main_body_true.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main_true.contains('array__free(&(__map_source_'), main_body_true
-	out_true := run_good_with_flags(v3_bin, 'array_map_comptime_mutator_true', '-ownership',
-		source_true)
+	out_true := run_good_with_flags(v3_bin, 'array_map_comptime_mutator_true', '-ownership', source_true)
 	assert out_true == 'source'
 
 	source_false := source_true.replace('\$if true {', '\$if false {')
-	c_source_false := gen_c_from_source_with_flags(v3_bin, 'array_map_comptime_mutator_false_c',
-		'-ownership', source_false)
+	c_source_false := gen_c_from_source_with_flags(v3_bin, 'array_map_comptime_mutator_false_c', '-ownership', source_false)
 	main_body_false := c_fn_body(c_source_false, 'int main(int argc, char** argv) {')
 	source_drop_pos := main_body_false.index('array__free(&(') or { -1 }
 	result_move_pos := main_body_false.index('Array selected = ') or { -1 }
 	assert source_drop_pos >= 0 && source_drop_pos < result_move_pos, main_body_false
-	out_false := run_good_with_flags(v3_bin, 'array_map_comptime_mutator_false', '-ownership',
-		source_false)
+	out_false := run_good_with_flags(v3_bin, 'array_map_comptime_mutator_false', '-ownership', source_false)
 	assert out_false == 'external'
 }
 
@@ -11452,8 +11054,7 @@ fn main() {
 	println(selected[0].text)
 }
 '
-	c_source_true := gen_c_from_source_with_flags(v3_bin, 'array_map_comptime_if_true_c',
-		'-ownership', source_true)
+	c_source_true := gen_c_from_source_with_flags(v3_bin, 'array_map_comptime_if_true_c', '-ownership', source_true)
 	main_body_true := c_fn_body(c_source_true, 'int main(int argc, char** argv) {')
 	compact_main_true := main_body_true.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main_true.contains('array__free(&(__map_source_'), main_body_true
@@ -11461,14 +11062,12 @@ fn main() {
 	assert out_true == 'source'
 
 	source_false := source_true.replace('\$if true {', '\$if false {')
-	c_source_false := gen_c_from_source_with_flags(v3_bin, 'array_map_comptime_if_false_c',
-		'-ownership', source_false)
+	c_source_false := gen_c_from_source_with_flags(v3_bin, 'array_map_comptime_if_false_c', '-ownership', source_false)
 	main_body_false := c_fn_body(c_source_false, 'int main(int argc, char** argv) {')
 	source_drop_pos := main_body_false.index('array__free(&(') or { -1 }
 	result_move_pos := main_body_false.index('Array selected = ') or { -1 }
 	assert source_drop_pos >= 0 && source_drop_pos < result_move_pos, main_body_false
-	out_false := run_good_with_flags(v3_bin, 'array_map_comptime_if_false', '-ownership',
-		source_false)
+	out_false := run_good_with_flags(v3_bin, 'array_map_comptime_if_false', '-ownership', source_false)
 	assert out_false == 'external'
 }
 
@@ -11514,14 +11113,12 @@ fn main() {
 	println(selected[0].value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_transient_mutating_method_arg_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_transient_mutating_method_arg_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	source_drop_pos := main_body.index('array__free(&(') or { -1 }
 	result_move_pos := main_body.index('Array selected = ') or { -1 }
 	assert source_drop_pos >= 0 && source_drop_pos < result_move_pos, main_body
-	out := run_good_with_flags(v3_bin, 'array_map_transient_mutating_method_arg', '-ownership',
-		source)
+	out := run_good_with_flags(v3_bin, 'array_map_transient_mutating_method_arg', '-ownership', source)
 	assert out == 'external'
 }
 
@@ -11575,8 +11172,7 @@ fn main() {
 	println(selected[0].run())
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_returned_closure_capture_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_returned_closure_capture_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -11624,8 +11220,7 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_invoked_closure_capture_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_invoked_closure_capture_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -11665,14 +11260,12 @@ fn main() {
 	println(selected[0].text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_projected_passthrough_parameter_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_projected_passthrough_parameter_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	source_drop_pos := main_body.index('array__free(&(') or { -1 }
 	result_move_pos := main_body.index('Array selected = ') or { -1 }
 	assert source_drop_pos >= 0 && source_drop_pos < result_move_pos, main_body
-	out := run_good_with_flags(v3_bin, 'array_map_projected_passthrough_parameter', '-ownership',
-		source)
+	out := run_good_with_flags(v3_bin, 'array_map_projected_passthrough_parameter', '-ownership', source)
 	assert out == 'external'
 }
 
@@ -11709,8 +11302,7 @@ fn main() {
 	println(selected[0].text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_nested_alias_overwrite_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_nested_alias_overwrite_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	source_drop_pos := main_body.index('array__free(&(') or { -1 }
 	result_move_pos := main_body.index('Array selected = ') or { -1 }
@@ -11746,8 +11338,7 @@ fn main() {
 	println(values[0].text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_assoc_pointer_result_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_assoc_pointer_result_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	assert !main_body.contains('array__free(&(__map_source_'), main_body
 	out := run_good_with_flags(v3_bin, 'array_map_assoc_pointer_result', '-ownership', source)
@@ -11788,8 +11379,7 @@ fn main() {
 	println(selected[0].text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_helper_external_field_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_helper_external_field_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	source_drop_pos := main_body.index('array__free(&(') or { -1 }
 	result_move_pos := main_body.index('Array selected = ') or { -1 }
@@ -11923,8 +11513,7 @@ fn main() {
 	println(*results[0].external)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_unrelated_pointer_result_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_unrelated_pointer_result_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	source_drop_pos := main_body.index('array__free(&(') or { -1 }
 	result_move_pos := main_body.index('Array results = ') or { -1 }
@@ -11953,8 +11542,7 @@ fn main() {
 	println(selected[0].text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_selected_external_pointer_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_selected_external_pointer_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	source_drop_pos := main_body.index('array__free(&(') or { -1 }
 	result_move_pos := main_body.index('Array selected = ') or { -1 }
@@ -12654,8 +12242,7 @@ fn main() {
 
 fn test_building_v_keeps_valid_match_and_filtered_array_expression_types() {
 	v3_bin := build_v3_review_transform()
-	out := run_good_with_flags(v3_bin, 'building_v_valid_expression_types',
-		'-building-v -d valid_exprs', 'struct NumberInfo {
+	out := run_good_with_flags(v3_bin, 'building_v_valid_expression_types', '-building-v -d valid_exprs', 'struct NumberInfo {
 	values []int
 }
 
@@ -12930,13 +12517,11 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_loop_carried_pointer_origin_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_loop_carried_pointer_origin_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_loop_carried_pointer_origin', '-ownership',
-		source)
+	out := run_good_with_flags(v3_bin, 'array_map_loop_carried_pointer_origin', '-ownership', source)
 	assert out == '0\nsource'
 }
 
@@ -12988,8 +12573,7 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_loop_carried_helper_origin_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_loop_carried_helper_origin_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -13049,13 +12633,11 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin,
-		'array_map_conditional_continue_helper_origin_c', '-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_conditional_continue_helper_origin_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_conditional_continue_helper_origin',
-		'-ownership', source)
+	out := run_good_with_flags(v3_bin, 'array_map_conditional_continue_helper_origin', '-ownership', source)
 	assert out == '0\nsource'
 }
 
@@ -13109,8 +12691,7 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_break_helper_origin_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_break_helper_origin_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -13166,14 +12747,12 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin,
-		'array_map_labeled_continue_inner_fixed_point_c', '-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_labeled_continue_inner_fixed_point_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	source_drop_pos := main_body.index('array__free(&(') or { -1 }
 	result_move_pos := main_body.index('Array selected = ') or { -1 }
 	assert source_drop_pos >= 0 && source_drop_pos < result_move_pos, main_body
-	out := run_good_with_flags(v3_bin, 'array_map_labeled_continue_inner_fixed_point',
-		'-ownership', source)
+	out := run_good_with_flags(v3_bin, 'array_map_labeled_continue_inner_fixed_point', '-ownership', source)
 	assert out == '0\nexternal'
 }
 
@@ -13209,8 +12788,7 @@ fn main() {
 	println(saved[0].text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_external_slice_backing_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_external_slice_backing_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -13375,15 +12953,13 @@ fn test_test_command_skips_incompatible_single_file() {
 	assert result.output.contains('SKIP ${test_src}'), result.output
 
 	backend_test_src := os.join_path(test_dir, 'v3_incompatible_backend_test.js.v')
-	os.write_file(backend_test_src,
-		'module main\n\nfn test_never_checked() {\n\tmissing_symbol()\n}\n') or { panic(err) }
+	os.write_file(backend_test_src, 'module main\n\nfn test_never_checked() {\n\tmissing_symbol()\n}\n') or { panic(err) }
 	backend_result := os.execute('${v3_bin} -nocache test ${backend_test_src}')
 	assert backend_result.exit_code == 0, backend_result.output
 	assert backend_result.output.contains('SKIP ${backend_test_src}'), backend_result.output
 
 	compatible_test_src := os.join_path(test_dir, 'v3_compatible_backend_test.c.v')
-	os.write_file(compatible_test_src,
-		"module main\n\nfn test_test_command_skips_incompatible_single_file() {\n\tprintln('compatible backend test')\n}\n") or {
+	os.write_file(compatible_test_src, "module main\n\nfn test_test_command_skips_incompatible_single_file() {\n\tprintln('compatible backend test')\n}\n") or {
 		panic(err)
 	}
 	compatible_result := os.execute('${v3_bin} -nocache test ${compatible_test_src}')
@@ -13395,8 +12971,7 @@ fn test_test_command_skips_incompatible_single_file() {
 fn test_test_command_honors_vtest_build_constraint() {
 	v3_bin := build_v3_review_transform()
 	test_src := os.join_path(os.temp_dir(), 'v3_constrained_test.v')
-	os.write_file(test_src,
-		'// vtest build: windows\nmodule main\n\nfn test_never_checked() {\n\tmissing_symbol()\n}\n') or {
+	os.write_file(test_src, '// vtest build: windows\nmodule main\n\nfn test_never_checked() {\n\tmissing_symbol()\n}\n') or {
 		panic(err)
 	}
 	result := os.execute('${v3_bin} -nocache -os linux test ${test_src}')
@@ -13470,8 +13045,7 @@ fn main() {
 	println(saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_c_for_pointer_origin_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_c_for_pointer_origin_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body
@@ -13528,13 +13102,11 @@ fn main() {
 	println(selected[0])
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin,
-		'array_map_c_for_continue_post_pointer_origin_c', '-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_c_for_continue_post_pointer_origin_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert compact_main.contains('array__free(&(__map_source_'), main_body
-	out := run_good_with_flags(v3_bin, 'array_map_c_for_continue_post_pointer_origin',
-		'-ownership', source)
+	out := run_good_with_flags(v3_bin, 'array_map_c_for_continue_post_pointer_origin', '-ownership', source)
 	assert out == '0'
 }
 
@@ -13601,8 +13173,7 @@ fn main() {
 	println(comptime_saved.value.text)
 }
 '
-	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_aggregate_join_origins_c',
-		'-ownership', source)
+	c_source := gen_c_from_source_with_flags(v3_bin, 'array_map_aggregate_join_origins_c', '-ownership', source)
 	main_body := c_fn_body(c_source, 'int main(int argc, char** argv) {')
 	compact_main := main_body.replace(' ', '').replace('\t', '').replace('\n', '')
 	assert !compact_main.contains('array__free(&(__map_source_'), main_body

--- a/vlib/v3/transform/if.v
+++ b/vlib/v3/transform/if.v
@@ -62,8 +62,7 @@ fn (mut t Transformer) try_expand_if_guard(_id flat.NodeId, node flat.Node) ?[]f
 	if !t.is_optional_type_name(t.node_type(rhs_expr)) {
 		rhs_node := t.a.nodes[int(rhs_expr)]
 		if rhs_node.kind == .selector && rhs_node.children_count > 0 {
-			rhs_expr = t.make_selector_op(t.a.child(&rhs_node, 0), rhs_node.value, rhs_type,
-				rhs_node.op)
+			rhs_expr = t.make_selector_op(t.a.child(&rhs_node, 0), rhs_node.value, rhs_type, rhs_node.op)
 		} else {
 			t.set_node_typ(int(rhs_expr), rhs_type)
 		}
@@ -88,8 +87,7 @@ fn (mut t Transformer) try_expand_if_guard(_id flat.NodeId, node flat.Node) ?[]f
 		}
 	}
 	if value_decls.len == 0 && lhs.value != '_' && value_type != 'void' {
-		value_decls << t.make_decl_assign_typed(lhs.value, t.make_selector(t.make_ident(tmp_name),
-			'value', value_type), value_type)
+		value_decls << t.make_decl_assign_typed(lhs.value, t.make_selector(t.make_ident(tmp_name), 'value', value_type), value_type)
 	}
 
 	then_id := t.a.child(&node, 1)
@@ -146,8 +144,7 @@ fn (mut t Transformer) expand_channel_receive_if_guard(node flat.Node, lhs_name 
 	channel_expr := t.transform_expr(info.channel_id)
 	mut prelude := []flat.NodeId{}
 	t.drain_pending(mut prelude)
-	prelude << t.make_decl_assign_typed(val_name, t.zero_value_for_type(info.value_type),
-		info.value_type)
+	prelude << t.make_decl_assign_typed(val_name, t.zero_value_for_type(info.value_type), info.value_type)
 	mut channel_source := channel_expr
 	if info.needs_deref {
 		channel_source = t.make_prefix(.mul, channel_source)
@@ -304,8 +301,7 @@ fn (mut t Transformer) expand_map_index_if_guard(node flat.Node, lhs_name string
 	mut prelude := []flat.NodeId{}
 	t.drain_pending(mut prelude)
 	prelude << t.make_decl_assign_typed(key_name, key_expr, info.key_storage_type)
-	prelude << t.make_decl_assign_typed(ptr_name, t.make_map_get_check_expr(map_expr,
-		info.base_type, key_name), 'voidptr')
+	prelude << t.make_decl_assign_typed(ptr_name, t.make_map_get_check_expr(map_expr, info.base_type, key_name), 'voidptr')
 
 	ptr_ident := t.make_ident(ptr_name)
 	found_cond := t.make_infix(.ne, ptr_ident, t.a.add(.nil_literal))
@@ -318,8 +314,7 @@ fn (mut t Transformer) expand_map_index_if_guard(node flat.Node, lhs_name string
 	// `&${info.value_type}` and, when the value type is unresolved, emit an invalid
 	// `void __discard = *(void*)ptr`.
 	if lhs_name != '_' {
-		ptr_value := t.make_prefix(.mul, t.make_cast('&${info.value_type}', t.make_ident(ptr_name),
-			'&${info.value_type}'))
+		ptr_value := t.make_prefix(.mul, t.make_cast('&${info.value_type}', t.make_ident(ptr_name), '&${info.value_type}'))
 		t.set_var_type(lhs_name, info.value_type)
 		then_children << t.make_decl_assign_typed(lhs_name, ptr_value, info.value_type)
 	}
@@ -364,8 +359,7 @@ fn (mut t Transformer) expand_array_index_if_guard(node flat.Node, lhs_name stri
 
 	idx_ident := t.make_ident(index_name)
 	lower_ok := t.make_infix(.ge, idx_ident, t.make_int_literal(0))
-	upper_ok := t.make_infix(.lt, t.make_ident(index_name),
-		t.array_index_len_expr(info, array_expr))
+	upper_ok := t.make_infix(.lt, t.make_ident(index_name), t.array_index_len_expr(info, array_expr))
 	found_cond := t.make_infix(.logical_and, lower_ok, upper_ok)
 
 	then_id := t.a.child(&node, 1)
@@ -378,8 +372,7 @@ fn (mut t Transformer) expand_array_index_if_guard(node flat.Node, lhs_name stri
 		guard_value_type = t.optional_base_type(t.qualify_optional_type(info.value_type))
 		opt_name := t.new_temp('arr_opt')
 		value_expr = t.make_selector(t.make_ident(opt_name), 'value', guard_value_type)
-		then_children << t.make_decl_assign_typed(opt_name, t.make_index(array_expr,
-			t.make_ident(index_name), info.value_type), info.value_type)
+		then_children << t.make_decl_assign_typed(opt_name, t.make_index(array_expr, t.make_ident(index_name), info.value_type), info.value_type)
 	}
 	then_children << t.make_decl_assign_typed(lhs_name, value_expr, guard_value_type)
 	t.set_var_type(lhs_name, guard_value_type)
@@ -523,8 +516,7 @@ fn (mut t Transformer) try_expand_if_expr_value_for_type(id flat.NodeId, node fl
 	t.pending_stmts.clear()
 
 	mut prelude := []flat.NodeId{}
-	prelude << t.make_decl_assign_typed(tmp_name, t.zero_value_for_type(actual_result_type),
-		actual_result_type)
+	prelude << t.make_decl_assign_typed(tmp_name, t.zero_value_for_type(actual_result_type), actual_result_type)
 	for stmt in t.build_if_value_chain(id, tmp_name, actual_result_type) {
 		prelude << stmt
 	}
@@ -716,8 +708,8 @@ fn (t &Transformer) smartcast_contexts_from_is_exprs(infos []IsExprInfo) []Smart
 	mut result := []SmartcastContext{cap: infos.len}
 	for info in infos {
 		result << SmartcastContext{
-			expr_name:     info.expr_name
-			variant_name:  info.variant_name
+			expr_name: info.expr_name
+			variant_name: info.variant_name
 			sum_type_name: info.sum_type_name
 		}
 	}
@@ -737,8 +729,7 @@ fn (t &Transformer) stmt_value_type_with_smartcasts(id flat.NodeId, contexts []S
 		}
 		.expr_stmt {
 			if node.children_count > 0 {
-				return t.node_type_with_smartcasts(t.a.child(&node, node.children_count - 1),
-					contexts)
+				return t.node_type_with_smartcasts(t.a.child(&node, node.children_count - 1), contexts)
 			}
 			return ''
 		}
@@ -817,14 +808,11 @@ fn (t &Transformer) node_type_with_smartcasts(id flat.NodeId, contexts []Smartca
 			base_key := t.expr_key(base_id)
 			if base_key.len > 0 {
 				if sc := t.find_smartcast_in_context(base_key, contexts) {
-					variant_type := t.qualify_variant(t.trim_pointer_type(sc.variant_name),
-						sc.sum_type_name)
+					variant_type := t.qualify_variant(t.trim_pointer_type(sc.variant_name), sc.sum_type_name)
 					if ftyp := t.lookup_struct_field_type(variant_type, node.value) {
 						return ftyp
 					}
-					if ftyp := t.lookup_struct_field_type(t.trim_pointer_type(sc.variant_name),
-						node.value)
-					{
+					if ftyp := t.lookup_struct_field_type(t.trim_pointer_type(sc.variant_name), node.value) {
 						return ftyp
 					}
 				}
@@ -1020,12 +1008,10 @@ fn (mut t Transformer) build_if_value_guard_chain(if_node flat.Node, target_name
 		return none
 	}
 	if info := t.map_index_info(rhs_id) {
-		return t.build_map_index_if_value_guard_chain(if_node, lhs.value, info, target_name,
-			target_type)
+		return t.build_map_index_if_value_guard_chain(if_node, lhs.value, info, target_name, target_type)
 	}
 	if info := t.array_index_info(rhs_id) {
-		return t.build_array_index_if_value_guard_chain(if_node, lhs.value, info, target_name,
-			target_type)
+		return t.build_array_index_if_value_guard_chain(if_node, lhs.value, info, target_name, target_type)
 	}
 	mut rhs_type := t.optional_result_expr_type_name(rhs_id)
 	if !t.is_optional_type_name(rhs_type) {
@@ -1063,14 +1049,12 @@ fn (mut t Transformer) build_if_value_guard_chain(if_node flat.Node, target_name
 		}
 	}
 	if value_decls.len == 0 {
-		value_decls << t.make_decl_assign_typed(lhs.value, t.make_selector(t.make_ident(tmp_name),
-			'value', value_type), value_type)
+		value_decls << t.make_decl_assign_typed(lhs.value, t.make_selector(t.make_ident(tmp_name), 'value', value_type), value_type)
 		t.set_var_type(lhs.value, value_type)
 	}
 	then_id := t.a.child(&if_node, 1)
 	then_block0 := t.if_value_branch_block(then_id, target_name, target_type)
-	mut then_children := []flat.NodeId{cap: int(t.a.nodes[int(then_block0)].children_count) +
-		value_decls.len}
+	mut then_children := []flat.NodeId{cap: int(t.a.nodes[int(then_block0)].children_count) + value_decls.len}
 	then_children << value_decls
 	then_children << t.a.children_of(&t.a.nodes[int(then_block0)])
 	then_block := t.make_block_prefix_scope_drops(then_children)
@@ -1107,16 +1091,14 @@ fn (mut t Transformer) build_map_index_if_value_guard_chain(if_node flat.Node, l
 	mut result := []flat.NodeId{}
 	t.drain_pending(mut result)
 	result << t.make_decl_assign_typed(key_name, key_expr, info.key_storage_type)
-	result << t.make_decl_assign_typed(ptr_name, t.make_map_get_check_expr(map_expr,
-		info.base_type, key_name), 'voidptr')
+	result << t.make_decl_assign_typed(ptr_name, t.make_map_get_check_expr(map_expr, info.base_type, key_name), 'voidptr')
 	ptr_ident := t.make_ident(ptr_name)
 	found_cond := t.make_infix(.ne, ptr_ident, t.a.add(.nil_literal))
 
 	saved_var_types := t.var_types.clone()
 	mut then_children := []flat.NodeId{}
 	if lhs_name != '_' {
-		ptr_value := t.make_prefix(.mul, t.make_cast('&${info.value_type}', t.make_ident(ptr_name),
-			'&${info.value_type}'))
+		ptr_value := t.make_prefix(.mul, t.make_cast('&${info.value_type}', t.make_ident(ptr_name), '&${info.value_type}'))
 		then_children << t.make_decl_assign_typed(lhs_name, ptr_value, info.value_type)
 		t.set_var_type(lhs_name, info.value_type)
 	}
@@ -1150,8 +1132,7 @@ fn (mut t Transformer) build_array_index_if_value_guard_chain(if_node flat.Node,
 	result << t.make_decl_assign_typed(index_name, index_expr, 'int')
 	idx_ident := t.make_ident(index_name)
 	lower_ok := t.make_infix(.ge, idx_ident, t.make_int_literal(0))
-	upper_ok := t.make_infix(.lt, t.make_ident(index_name),
-		t.array_index_len_expr(info, array_expr))
+	upper_ok := t.make_infix(.lt, t.make_ident(index_name), t.array_index_len_expr(info, array_expr))
 	found_cond := t.make_infix(.logical_and, lower_ok, upper_ok)
 
 	saved_var_types := t.var_types.clone()
@@ -1164,16 +1145,14 @@ fn (mut t Transformer) build_array_index_if_value_guard_chain(if_node flat.Node,
 		if t.is_optional_type_name(info.value_type) {
 			value_type = t.optional_base_type(t.qualify_optional_type(info.value_type))
 			opt_name = t.new_temp('arr_opt')
-			opt_decl = t.make_decl_assign_typed(opt_name, t.make_index(array_expr,
-				t.make_ident(index_name), info.value_type), info.value_type)
+			opt_decl = t.make_decl_assign_typed(opt_name, t.make_index(array_expr, t.make_ident(index_name), info.value_type), info.value_type)
 			value = t.make_selector(t.make_ident(opt_name), 'value', value_type)
 		}
 		then_children << t.make_decl_assign_typed(lhs_name, value, value_type)
 		t.set_var_type(lhs_name, value_type)
 	} else if t.is_optional_type_name(info.value_type) {
 		opt_name = t.new_temp('arr_opt')
-		opt_decl = t.make_decl_assign_typed(opt_name, t.make_index(array_expr,
-			t.make_ident(index_name), info.value_type), info.value_type)
+		opt_decl = t.make_decl_assign_typed(opt_name, t.make_index(array_expr, t.make_ident(index_name), info.value_type), info.value_type)
 	}
 	then_id := t.a.child(&if_node, 1)
 	then_block0 := t.if_value_branch_block(then_id, target_name, target_type)
@@ -1495,13 +1474,13 @@ fn (mut t Transformer) transform_if_guard_condition(node flat.Node) flat.NodeId 
 		t.a.children << child
 	}
 	return t.a.add_node(flat.Node{
-		kind:           .decl_assign
-		op:             node.op
+		kind: .decl_assign
+		op: node.op
 		children_start: start
 		children_count: flat.child_count(new_children.len)
-		pos:            node.pos
-		value:          node.value
-		typ:            node.typ
+		pos: node.pos
+		value: node.value
+		typ: node.typ
 	})
 }
 
@@ -1604,11 +1583,11 @@ fn (mut t Transformer) transform_plain_if_branches(id flat.NodeId, node flat.Nod
 		if_start := t.a.children.len
 		t.a.children << new_children
 		t.a.add_node(flat.Node{
-			kind:           .if_expr
+			kind: .if_expr
 			children_start: if_start
 			children_count: flat.child_count(child_count)
-			typ:            node.typ
-			pos:            node.pos
+			typ: node.typ
+			pos: node.pos
 		})
 	}
 	for pending in cond_pending {
@@ -1694,11 +1673,11 @@ fn (mut t Transformer) transform_if_branches_with_smartcast(id flat.NodeId, node
 		if_start := t.a.children.len
 		t.a.children << new_children
 		t.a.add_node(flat.Node{
-			kind:           .if_expr
+			kind: .if_expr
 			children_start: if_start
 			children_count: flat.child_count(child_count)
-			typ:            node.typ
-			pos:            node.pos
+			typ: node.typ
+			pos: node.pos
 		})
 	}
 	for pending in cond_pending {
@@ -1869,15 +1848,15 @@ fn (t &Transformer) collect_is_exprs(cond_id flat.NodeId, mut result []IsExprInf
 			stn := t.sum_type_for_is_expr(expr_type, cond.value)
 			if stn.len > 0 {
 				result << IsExprInfo{
-					expr_name:     ek
-					variant_name:  cond.value
+					expr_name: ek
+					variant_name: cond.value
 					sum_type_name: stn
 				}
 			} else {
 				if t.is_interface_type_name(expr_type) {
 					result << IsExprInfo{
-						expr_name:     ek
-						variant_name:  cond.value
+						expr_name: ek
+						variant_name: cond.value
 						sum_type_name: expr_type
 					}
 				}
@@ -1937,8 +1916,8 @@ fn (t &Transformer) option_none_cmp_info(cond flat.Node) ?IsExprInfo {
 		return none
 	}
 	return IsExprInfo{
-		expr_name:     ek
-		variant_name:  base
+		expr_name: ek
+		variant_name: base
 		sum_type_name: option_unwrap_marker
 	}
 }
@@ -1966,8 +1945,8 @@ fn (t &Transformer) extract_else_branch_smartcasts(cond_id flat.NodeId) []IsExpr
 				if stn.len > 0 {
 					return [
 						IsExprInfo{
-							expr_name:     ek
-							variant_name:  inner.value
+							expr_name: ek
+							variant_name: inner.value
 							sum_type_name: stn
 						},
 					]
@@ -2010,8 +1989,8 @@ fn (t &Transformer) extract_is_expr(cond_id flat.NodeId) IsExprInfo {
 		if ek.len > 0 && cond.value.len > 0 {
 			expr_type := t.original_expr_type(expr_id)
 			return IsExprInfo{
-				expr_name:     ek
-				variant_name:  cond.value
+				expr_name: ek
+				variant_name: cond.value
 				sum_type_name: t.sum_type_for_is_expr(expr_type, cond.value)
 			}
 		}

--- a/vlib/v3/transform/if.v
+++ b/vlib/v3/transform/if.v
@@ -658,6 +658,10 @@ fn (t &Transformer) if_expr_branch_type_overrides(branch_typ string, stale_typ s
 	if stale_typ in ['array', 'map', 'unknown'] {
 		return true
 	}
+	if stale_typ == 'int' && (branch_typ in t.structs
+		|| '${t.cur_module}.${branch_typ}' in t.structs) {
+		return true
+	}
 	if t.is_optional_type_name(stale_typ) && !t.is_optional_type_name(branch_typ) {
 		stale_payload := t.optional_base_type(stale_typ)
 		return t.normalize_type_alias(stale_payload) == t.normalize_type_alias(branch_typ)
@@ -760,6 +764,22 @@ fn (t &Transformer) node_type_with_smartcasts(id flat.NodeId, contexts []Smartca
 	}
 	node := t.a.nodes[int(id)]
 	match node.kind {
+		.or_expr {
+			if node.children_count > 0 {
+				source_id := t.a.child(&node, 0)
+				source_node := t.a.nodes[int(source_id)]
+				source_type := t.json_decode_or_expr_type(source_id, source_node) or {
+					t.node_type_with_smartcasts(source_id, contexts)
+				}
+				if t.is_optional_type_name(source_type) {
+					value_type := t.optional_base_type(source_type)
+					if value_type.len > 0 && value_type !in ['unknown', 'void'] {
+						return value_type
+					}
+				}
+			}
+			return t.node_type(id)
+		}
 		.call {
 			if node.children_count > 0 {
 				callee := t.a.child_node(&node, 0)

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -157,7 +157,10 @@ fn (mut t Transformer) monomorphize_pass() []string {
 	mut interface_impl_cache := map[string]bool{}
 	// Generic cloning is recursive. Reuse one stack-shaped child-id buffer instead
 	// of allocating a temporary array for every cloned AST node.
-	t.generic_clone_children.ensure_cap(t.a.nodes.len)
+	// Its live length is bounded by the active generic subtree, not by the whole
+	// program; let exceptional deep trees grow it instead of reserving millions
+	// of entries up front.
+	t.generic_clone_children.ensure_cap(65536)
 	struct_decls := t.collect_generic_struct_decls()
 	t.monomorph_profile('mono driver struct decls: ${time.ticks() - debug_started} ms')
 	t.materialize_generic_sum_types(false)
@@ -3758,8 +3761,8 @@ fn (mut t Transformer) emit_generic_fn_specialization(decl GenericFnDecl, args [
 		concrete_error_count = t.tc.errors.len
 		t.tc.check_concrete_fn_semantics(int(clone_id), decl.file, decl.module)
 	}
-	t.transform_specialized_fn_body(clone_id, decl.module, decl.file, generic_params,
-		concrete_args, decl.node.value, validate_return)
+	t.transform_specialized_fn_body(clone_id, specialization_nodes_start, decl.module, decl.file,
+		generic_params, concrete_args, decl.node.value, validate_return)
 	was_boxed_types_frozen := t.interface_boxed_types_frozen
 	t.interface_boxed_types_frozen = false
 	t.collect_lowered_interface_boxed_types_range(specialization_nodes_start, t.a.nodes.len)
@@ -3779,7 +3782,7 @@ fn (mut t Transformer) emit_generic_fn_specialization(decl GenericFnDecl, args [
 	return clone_id
 }
 
-fn (mut t Transformer) transform_specialized_fn_body(clone_id flat.NodeId, module_name string, file_name string, params []string, args []string, source_name string, validate_return bool) {
+fn (mut t Transformer) transform_specialized_fn_body(clone_id flat.NodeId, specialization_nodes_start int, module_name string, file_name string, params []string, args []string, source_name string, validate_return bool) {
 	if int(clone_id) < 0 || int(clone_id) >= t.a.nodes.len {
 		return
 	}
@@ -3807,7 +3810,14 @@ fn (mut t Transformer) transform_specialized_fn_body(clone_id flat.NodeId, modul
 	old_validating_specialization := t.validating_generic_spec
 	t.in_monomorphize_scan = false
 	t.validating_generic_spec = true
+	old_node_type_memo := t.node_type_memo
+	t.node_type_memo = &NodeTypeMemo{}
+	if t.memo_node_types {
+		t.begin_node_type_memo(specialization_nodes_start, t.a.nodes.len - 1)
+	}
 	t.transform_fn_body(int(clone_id))
+	t.end_node_type_memo()
+	t.node_type_memo = old_node_type_memo
 	if validate_return {
 		t.validate_specialized_fn_return(clone_id, source_name)
 	}
@@ -7431,14 +7441,25 @@ fn (t &Transformer) local_concrete_fn_shadows_generic(name string, module_name s
 			return false
 		}
 	}
-	if qname in t.fn_ret_types || name in t.fn_ret_types {
+	if qname in t.fn_ret_types {
 		return true
 	}
 	if isnil(t.tc) {
+		return name in t.fn_ret_types
+	}
+	if qname in t.tc.fn_param_types || qname in t.tc.fn_ret_types {
+		return true
+	}
+	if name !in t.fn_ret_types && name !in t.tc.fn_param_types && name !in t.tc.fn_ret_types {
 		return false
 	}
-	return qname in t.tc.fn_param_types || qname in t.tc.fn_ret_types || name in t.tc.fn_param_types
-		|| name in t.tc.fn_ret_types
+	decl_module := t.tc.fn_type_modules[name] or { '' }
+	source_module := if t.cur_fn_source_module.len > 0 {
+		t.cur_fn_source_module
+	} else {
+		module_name
+	}
+	return generic_decl_module_matches_call_module(decl_module, source_module)
 }
 
 fn generic_decl_module_matches_call_module(decl_module string, call_module string) bool {
@@ -12434,6 +12455,11 @@ fn (t &Transformer) lock_colliding_main_generic_type_text(typ string, module_nam
 }
 
 fn (t &Transformer) type_short_name_has_non_main_owner(name string) bool {
+	if t.non_main_type_index_ready {
+		return t.non_main_type_short_names[name]
+	}
+	// Small fixture transformers can call this helper before prepare_with_pre_scans().
+	// Production transforms use the prebuilt O(1) index above.
 	for candidate, info in t.structs {
 		owner := if info.module.len > 0 { info.module } else { candidate.all_before_last('.') }
 		if candidate.contains('.') && candidate.all_after_last('.') == name

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -130,6 +130,8 @@ mut:
 	embedded_fields               map[string][]FieldInfo
 	struct_short_name_index       map[string]string
 	struct_short_name_index_ready bool
+	non_main_type_short_names     map[string]bool
+	non_main_type_index_ready     bool
 	unique_fields                 map[string]string
 	alias_methods                 map[string]string
 	globals                       map[string]string
@@ -168,6 +170,8 @@ mut:
 	cur_file                        string
 	cur_module                      string
 	cur_fn_name                     string
+	cur_fn_source_file              string
+	cur_fn_source_module            string
 	cur_fn_receiver_name            string
 	cur_fn_ret_type                 string
 	cur_fn_is_generic               bool
@@ -1125,20 +1129,20 @@ pub fn reserve_parallel_transform_cache_ast(mut a flat.FlatAst, skip_generics bo
 fn reserve_parallel_transform_ast_with_cache_mode(mut a flat.FlatAst, skip_generics bool, cache_mode bool) {
 	// The shared-base parallel path partitions this headroom between workers.
 	// Generic lowering needs more headroom than self-host transform because worker
-	// regions cannot grow while their disposable arenas are active.
-	// Self-host growth currently lands at ~1.87x nodes / ~2.24x children of the
-	// parsed size, and the per-chunk cost-proportional slices amplify any local
-	// growth-per-cost outlier, so the 2x / 7:3 factors used to sit within a few
-	// percent of a loud nogrow overflow — one added source file could trip them.
+	// regions cannot grow while their disposable arenas are active. The shared path
+	// admits at most half of this pool's estimated growth, leaving the other half for
+	// uneven per-chunk expansion without retaining a 3x/4x slab for large programs.
+	// Per-chunk cost-proportional slices amplify local growth outliers, so the
+	// capacities still stay well above the observed whole-program growth.
 	nodes_factor_num, nodes_factor_den := if skip_generics {
 		if cache_mode { 5, 2 } else { 9, 4 }
 	} else {
-		3, 1
+		9, 4
 	}
 	children_factor_num, children_factor_den := if skip_generics {
 		if cache_mode { 3, 1 } else { 8, 3 }
 	} else {
-		4, 1
+		3, 1
 	}
 	nodes_cap := a.nodes.len * nodes_factor_num / nodes_factor_den
 	children_cap := a.children.len * children_factor_num / children_factor_den
@@ -1483,7 +1487,10 @@ pub fn monomorphize_with_used_checked_config_scoped_cached(mut a flat.FlatAst, t
 			remaining_match_log_end, base_node_count)
 		late_log_start = t.used_fns_log.len
 		t.monomorph_profile('mono wrapper late matches: ${time.ticks() - debug_started} ms')
-		if t.used_fn_count() == used_after_pass {
+		// Late-body transformation requests concrete generic work immediately. If
+		// reachability grew but queued no specialization, another whole-AST pass
+		// cannot materialize anything new.
+		if t.used_fn_count() == used_after_pass || t.pending_generic_fn_specs.len == 0 {
 			break
 		}
 	}
@@ -1686,6 +1693,7 @@ fn (mut t Transformer) prepare() {
 	t.rebuild_embedded_fields_index()
 	t.prepare_runtime_type_indexes()
 	t.rebuild_struct_short_name_index()
+	t.rebuild_non_main_type_short_names()
 	if !t.defer_pre_scan_indexes {
 		t.collect_multi_return_fn_ret_types()
 	}
@@ -1982,6 +1990,27 @@ fn (mut t Transformer) rebuild_struct_short_name_index() {
 		}
 	}
 	t.struct_short_name_index_ready = true
+}
+
+fn (mut t Transformer) rebuild_non_main_type_short_names() {
+	t.non_main_type_short_names = map[string]bool{}
+	for candidate, info in t.structs {
+		owner := if info.module.len > 0 { info.module } else { candidate.all_before_last('.') }
+		if candidate.contains('.') && owner !in ['', 'main', 'builtin'] {
+			t.non_main_type_short_names[candidate.all_after_last('.')] = true
+		}
+	}
+	for candidate, _ in t.sum_types {
+		if candidate.contains('.') && candidate.all_before_last('.') !in ['', 'main', 'builtin'] {
+			t.non_main_type_short_names[candidate.all_after_last('.')] = true
+		}
+	}
+	for candidate, _ in t.enum_types {
+		if candidate.contains('.') && candidate.all_before_last('.') !in ['', 'main', 'builtin'] {
+			t.non_main_type_short_names[candidate.all_after_last('.')] = true
+		}
+	}
+	t.non_main_type_index_ready = true
 }
 
 // base_write_allowed reports whether an in-place write to node slot `idx` is
@@ -3750,6 +3779,8 @@ fn (t &Transformer) fork_worker_config(ast &flat.FlatAst, wtc &types.TypeChecker
 	w.cur_file = ''
 	w.cur_module = ''
 	w.cur_fn_name = ''
+	w.cur_fn_source_file = ''
+	w.cur_fn_source_module = ''
 	w.cur_fn_ret_type = ''
 	w.in_call_callee = false
 	w.in_const_init = false
@@ -3863,6 +3894,8 @@ fn (t &Transformer) fork_program_view(ast &flat.FlatAst, wtc &types.TypeChecker,
 		embedded_fields:                 t.embedded_fields
 		struct_short_name_index:         t.struct_short_name_index
 		struct_short_name_index_ready:   t.struct_short_name_index_ready
+		non_main_type_short_names:       t.non_main_type_short_names
+		non_main_type_index_ready:       t.non_main_type_index_ready
 		unique_fields:                   t.unique_fields
 		alias_methods:                   t.alias_methods
 		globals:                         t.globals
@@ -8597,6 +8630,10 @@ fn (mut t Transformer) transform_fn_body(fn_idx int) {
 		t.transformed_fns[fn_idx] = true
 	}
 	t.cur_fn_name = fn_node.value
+	old_source_file := t.cur_fn_source_file
+	old_source_module := t.cur_fn_source_module
+	t.cur_fn_source_file = t.node_file_or(fn_idx, t.cur_file)
+	t.cur_fn_source_module = t.node_module_or(fn_idx, t.cur_module)
 	old_receiver_name := t.cur_fn_receiver_name
 	t.cur_fn_receiver_name = ''
 	old_is_generic := t.cur_fn_is_generic
@@ -8779,6 +8816,8 @@ fn (mut t Transformer) transform_fn_body(fn_idx int) {
 	t.cur_fn_is_generic = old_is_generic
 	t.cur_fn_manualfree = old_manualfree
 	t.cur_fn_receiver_name = old_receiver_name
+	t.cur_fn_source_file = old_source_file
+	t.cur_fn_source_module = old_source_module
 	t.temp_counter = outer_temp_counter
 }
 
@@ -23772,6 +23811,19 @@ fn (t &Transformer) expr_value_type(id flat.NodeId) string {
 		return ''
 	}
 	node := t.a.nodes[int(id)]
+	if node.kind == .or_expr && node.children_count > 0 {
+		source_id := t.a.child(&node, 0)
+		source_node := t.a.nodes[int(source_id)]
+		source_type := t.json_decode_or_expr_type(source_id, source_node) or {
+			t.node_type(source_id)
+		}
+		if t.is_optional_type_name(source_type) {
+			value_type := t.optional_base_type(source_type)
+			if value_type.len > 0 && value_type !in ['unknown', 'void'] {
+				return value_type
+			}
+		}
+	}
 	if node.kind == .call {
 		if ret := t.ierror_call_return_type(node) {
 			return ret

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -15,15 +15,11 @@ import v3.workers
 
 const min_parallel_transform_items = 256
 const max_parallel_transform_jobs = 7
-// Shared-base (clone-free) transform: workers share the master arrays and
-// append into pre-partitioned capacity regions, so extra threads cost no
-// clone memory; cap by core count only.
-const max_shared_transform_jobs = 18
-// Shared regions are cheap views over the same AST. Keep two chunks per lane so
-// the persistent queue can absorb heterogeneous-core and scheduler stragglers;
-// the caller consumes two synchronous chunks while each pool worker consumes
-// two queued chunks.
-const shared_transform_chunks_per_job = 2
+// Shared-base workers share the AST but retain private checker and transform
+// scratch. Eight lanes keep large user builds below the ordinary memory ceiling.
+const max_shared_transform_jobs = 8
+// One chunk per lane bounds the number of private worker views kept until merge.
+const shared_transform_chunks_per_job = 1
 // Normal function lowering needs part of the shared append pool too. Limit
 // expansion estimates to the other half before assigning fixed worker regions.
 const shared_expansion_pool_divisor = 2
@@ -32,7 +28,7 @@ const max_parallel_monomorph_jobs = 18
 const scoped_transform_batches = 16
 const scoped_transform_max_batch_items = 2048
 const scoped_monomorph_batch_specs = 512
-const scoped_monomorph_node_threshold = 500_000
+const scoped_monomorph_node_threshold = 1_000_000
 
 $if !windows {
 	// RegionRelocateArgs is one worker region's in-place id-relocation job: the
@@ -1104,13 +1100,7 @@ fn (mut t Transformer) run_parallel_monomorphize_specs(specs []PendingGenericFnS
 			view.specialized_fn_modules = map[int]string{}
 			view.specialized_fn_files = map[int]string{}
 			mut wtc := t.tc.fork_for_parallel_transform(view)
-			wtc.fn_ret_types = t.tc.fn_ret_types.clone()
-			wtc.fn_param_types = t.tc.fn_param_types.clone()
-			wtc.fn_variadic = t.tc.fn_variadic.clone()
-			wtc.specialized_generic_fns = t.tc.specialized_generic_fns.clone()
-			wtc.fn_type_modules = t.tc.fn_type_modules.clone()
-			wtc.fn_type_files = t.tc.fn_type_files.clone()
-			wtc.transform_signature_maps_shared = false
+			wtc.ensure_private_transform_signatures()
 			mut w := t.fork_worker(view, wtc)
 			w.global_temp_counter = node_starts[ci]
 			w.fn_ret_types = t.fn_ret_types.clone()
@@ -1136,6 +1126,8 @@ fn (mut t Transformer) run_parallel_monomorphize_specs(specs []PendingGenericFnS
 		// signature base. This algorithm moves and mutates those maps, so detach
 		// once before taking ownership of their storage.
 		t.ensure_private_signature_maps()
+		mut master_tc := unsafe { &types.TypeChecker(voidptr(t.tc)) }
+		master_tc.ensure_private_transform_signatures()
 		mut shared_fn_ret_types := t.fn_ret_types.move()
 		mut shared_receiver_index := t.receiver_method_suffix_index.move()
 		t.parallel_monomorph_scan_nodes = []int{}
@@ -1328,6 +1320,11 @@ fn (mut t Transformer) run_scoped_monomorphize_specs(specs []PendingGenericFnSpe
 	// Workers treat declaration parameter metadata as immutable. Build the lazy
 	// index in the parent arena before a scoped worker can grow its backing map.
 	t.prepare_parallel_call_param_types()
+	// A scoped transformer can itself be a fork whose signature tables still
+	// point at its parent's read-only base. Detach before pre-registering the
+	// batch, rather than mutating storage another worker may be reading.
+	t.ensure_private_signature_maps()
+	t.tc.ensure_private_transform_signatures()
 	t.tc.freeze_type_cache_for_forks()
 	defer {
 		t.tc.unfreeze_type_cache_after_forks()
@@ -1357,14 +1354,7 @@ fn (mut t Transformer) run_scoped_monomorphize_specs(specs []PendingGenericFnSpe
 			t.a.children.cap)
 		wast.specialized_fn_nodes = map[int]bool{}
 		mut wtc := t.tc.fork_for_parallel_transform(wast)
-		wtc.fn_ret_types = t.tc.fn_ret_types.clone()
-		wtc.fn_param_types = t.tc.fn_param_types.clone()
-		wtc.fn_variadic = t.tc.fn_variadic.clone()
-		wtc.specialized_generic_fns = t.tc.specialized_generic_fns.clone()
-		wtc.fn_type_modules = t.tc.fn_type_modules.clone()
-		wtc.fn_type_files = t.tc.fn_type_files.clone()
-		wtc.receiver_method_suffix_index = t.tc.receiver_method_suffix_index.clone()
-		wtc.transform_signature_maps_shared = false
+		wtc.ensure_private_transform_signatures()
 		mut w := t.fork_worker(wast, wtc)
 		w.fn_ret_types = t.fn_ret_types.clone()
 		w.receiver_method_suffix_index = t.receiver_method_suffix_index.clone()
@@ -1480,9 +1470,9 @@ fn monomorph_job_limit(available_jobs int, node_count int, configured_jobs int) 
 		return int_min(available_jobs, configured_jobs)
 	}
 	// Each helper retains a forked checker and its disposable specialization arena
-	// until the final publication barrier. Two workers keep large applications under
-	// the normal memory budget; smaller programs retain the lower-latency four-way path.
-	return int_min(available_jobs, if node_count >= 500_000 { 2 } else { 4 })
+	// until the final publication barrier. Three workers keep large applications well
+	// below the normal memory limit; smaller programs retain the lower-latency four-way path.
+	return int_min(available_jobs, if node_count >= 500_000 { 3 } else { 4 })
 }
 
 // monomorph_regions_can_merge_in_place reports whether sequential leftward

--- a/vlib/v3/transform/transform_parallel_test.v
+++ b/vlib/v3/transform/transform_parallel_test.v
@@ -15,7 +15,7 @@ fn test_monomorph_job_count_does_not_start_empty_workers() {
 fn test_monomorph_job_limit_caps_large_programs() {
 	$if !v3_no_parallel ? {
 		assert monomorph_job_limit(12, 499_999, 0) == 4
-		assert monomorph_job_limit(12, 500_000, 0) == 2
+		assert monomorph_job_limit(12, 500_000, 0) == 3
 		assert monomorph_job_limit(1, 500_000, 0) == 1
 		assert monomorph_job_limit(12, 500_000, 6) == 6
 		assert monomorph_job_limit(4, 500_000, 8) == 4

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -330,9 +330,9 @@ mut:
 
 fn new_visible_mutation_cache() &VisibleMutationCache {
 	return &VisibleMutationCache{
-		decls:          map[string]VisibleMutationFnDecl{}
-		decl_misses:    map[string]bool{}
-		results:        map[u64]bool{}
+		decls: map[string]VisibleMutationFnDecl{}
+		decl_misses: map[string]bool{}
+		results: map[u64]bool{}
 		rebind_results: map[u64]bool{}
 	}
 }
@@ -559,46 +559,46 @@ fn new_function_check_context() FunctionCheckContext {
 
 fn clone_function_check_context(src FunctionCheckContext) FunctionCheckContext {
 	return FunctionCheckContext{
-		method_value_locals:                      src.method_value_locals.clone()
-		method_value_local_owners:                clone_scope_binding_owner_map(src.method_value_local_owners)
-		method_value_local_depth:                 src.method_value_local_depth.clone()
-		method_value_stack_mut_owners:            src.method_value_stack_mut_owners.clone()
-		fn_value_variadic_locals:                 src.fn_value_variadic_locals.clone()
-		fn_value_variadic_local_owners:           src.fn_value_variadic_local_owners.clone()
-		fn_value_variadic_local_depth:            src.fn_value_variadic_local_depth.clone()
-		capturing_fn_literal_locals:              src.capturing_fn_literal_locals.clone()
-		capturing_fn_literal_local_owners:        src.capturing_fn_literal_local_owners.clone()
-		capturing_fn_literal_local_depth:         src.capturing_fn_literal_local_depth.clone()
-		node_id:                                  src.node_id
+		method_value_locals: src.method_value_locals.clone()
+		method_value_local_owners: clone_scope_binding_owner_map(src.method_value_local_owners)
+		method_value_local_depth: src.method_value_local_depth.clone()
+		method_value_stack_mut_owners: src.method_value_stack_mut_owners.clone()
+		fn_value_variadic_locals: src.fn_value_variadic_locals.clone()
+		fn_value_variadic_local_owners: src.fn_value_variadic_local_owners.clone()
+		fn_value_variadic_local_depth: src.fn_value_variadic_local_depth.clone()
+		capturing_fn_literal_locals: src.capturing_fn_literal_locals.clone()
+		capturing_fn_literal_local_owners: src.capturing_fn_literal_local_owners.clone()
+		capturing_fn_literal_local_depth: src.capturing_fn_literal_local_depth.clone()
+		node_id: src.node_id
 		concrete_generic_receiver_specialization: src.concrete_generic_receiver_specialization
-		mut_param_base_types:                     src.mut_param_base_types.clone()
-		mut_param_owners:                         src.mut_param_owners.clone()
-		mut_local_owners:                         src.mut_local_owners.clone()
-		closure_copy_owners:                      src.closure_copy_owners.clone()
-		shared_owners:                            src.shared_owners.clone()
-		shared_array_owners:                      src.shared_array_owners.clone()
-		locked_shared_names:                      src.locked_shared_names.clone()
-		locked_shared_modes:                      src.locked_shared_modes.clone()
-		locked_shared_base_names:                 src.locked_shared_base_names.clone()
-		pointer_binding_value_keys:               clone_pointer_binding_value_keys(src.pointer_binding_value_keys)
-		immutable_reference_aliases:              src.immutable_reference_aliases.clone()
-		unsafe_reference_alias_owners:            src.unsafe_reference_alias_owners.clone()
-		unsafe_alias_break_states:                clone_unsafe_alias_break_states(src.unsafe_alias_break_states)
-		pointer_alias_break_states:               clone_pointer_alias_loop_states(src.pointer_alias_break_states)
-		pointer_alias_continue_states:            clone_pointer_alias_loop_states(src.pointer_alias_continue_states)
-		pointer_alias_goto_states:                clone_pointer_alias_goto_states(src.pointer_alias_goto_states)
-		pointer_alias_backward_goto_targets:      src.pointer_alias_backward_goto_targets.clone()
-		closure_forbidden_captures:               src.closure_forbidden_captures.clone()
-		local_decl_rhs_by_name:                   src.local_decl_rhs_by_name.clone()
-		local_decl_rhs_indexed:                   src.local_decl_rhs_indexed
-		bool_condition_exprs:                     src.bool_condition_exprs.clone()
-		has_goto_nodes:                           src.has_goto_nodes
-		closure_scope:                            src.closure_scope
-		lambda_no_captures:                       src.lambda_no_captures
-		generic_params:                           src.generic_params.clone()
-		return_type:                              src.return_type
-		undefined_variable_context_depth:         src.undefined_variable_context_depth
-		continue_after_unknown_ident:             src.continue_after_unknown_ident
+		mut_param_base_types: src.mut_param_base_types.clone()
+		mut_param_owners: src.mut_param_owners.clone()
+		mut_local_owners: src.mut_local_owners.clone()
+		closure_copy_owners: src.closure_copy_owners.clone()
+		shared_owners: src.shared_owners.clone()
+		shared_array_owners: src.shared_array_owners.clone()
+		locked_shared_names: src.locked_shared_names.clone()
+		locked_shared_modes: src.locked_shared_modes.clone()
+		locked_shared_base_names: src.locked_shared_base_names.clone()
+		pointer_binding_value_keys: clone_pointer_binding_value_keys(src.pointer_binding_value_keys)
+		immutable_reference_aliases: src.immutable_reference_aliases.clone()
+		unsafe_reference_alias_owners: src.unsafe_reference_alias_owners.clone()
+		unsafe_alias_break_states: clone_unsafe_alias_break_states(src.unsafe_alias_break_states)
+		pointer_alias_break_states: clone_pointer_alias_loop_states(src.pointer_alias_break_states)
+		pointer_alias_continue_states: clone_pointer_alias_loop_states(src.pointer_alias_continue_states)
+		pointer_alias_goto_states: clone_pointer_alias_goto_states(src.pointer_alias_goto_states)
+		pointer_alias_backward_goto_targets: src.pointer_alias_backward_goto_targets.clone()
+		closure_forbidden_captures: src.closure_forbidden_captures.clone()
+		local_decl_rhs_by_name: src.local_decl_rhs_by_name.clone()
+		local_decl_rhs_indexed: src.local_decl_rhs_indexed
+		bool_condition_exprs: src.bool_condition_exprs.clone()
+		has_goto_nodes: src.has_goto_nodes
+		closure_scope: src.closure_scope
+		lambda_no_captures: src.lambda_no_captures
+		generic_params: src.generic_params.clone()
+		return_type: src.return_type
+		undefined_variable_context_depth: src.undefined_variable_context_depth
+		continue_after_unknown_ident: src.continue_after_unknown_ident
 	}
 }
 
@@ -697,7 +697,7 @@ pub mut:
 	source_no_body_fn_suffixes       map[string]bool
 	unsafe_fns                       map[string]bool
 	unsafe_c_fns                     map[string]bool
-	fn_ret_type_texts                map[string]string   // generic struct method key -> original return type text (e.g. `Box[T].clone` -> `Box[T]`)
+	fn_ret_type_texts                map[string]string // generic struct method key -> original return type text (e.g. `Box[T].clone` -> `Box[T]`)
 	fn_param_type_texts              map[string][]string // generic struct method key -> original param type texts (receiver first)
 	fn_type_files                    map[string]string
 	fn_type_modules                  map[string]string
@@ -883,10 +883,10 @@ pub mut:
 	// sorted node ids so collect_top_level_idx_fast can merge them without
 	// rescanning every gap between parser-recorded declarations.
 	synthetic_top_level_type_ids  []int
-	expected_expr_id              int  = -1
+	expected_expr_id              int = -1
 	expected_expr_type            Type = Type(void_)
 	cur_fn_ret_type               Type = Type(void_)
-	channel_send_or_expr_id       int  = -1
+	channel_send_or_expr_id       int = -1
 	smartcasts                    map[string]Type
 	ownership                     &OwnershipState = unsafe { nil }
 	ownership_return_item_by_name map[string]int
@@ -929,12 +929,12 @@ mut:
 	// Includes method-value aliases and binding-owner maps; all backing maps are
 	// replaced together at every function/worker boundary.
 	fn_context               FunctionCheckContext
-	type_cache               &TypeCache               = unsafe { nil }
-	pre_transform_type_cache &TypeCache               = unsafe { nil }
+	type_cache               &TypeCache = unsafe { nil }
+	pre_transform_type_cache &TypeCache = unsafe { nil }
 	resolution_type_views    &ResolutionTypeViewCache = unsafe { nil }
-	visible_mutation_cache   &VisibleMutationCache    = unsafe { nil }
-	type_interner            &TypeInterner            = unsafe { nil }
-	symbols                  &SymbolInterner          = unsafe { nil }
+	visible_mutation_cache   &VisibleMutationCache = unsafe { nil }
+	type_interner            &TypeInterner = unsafe { nil }
+	symbols                  &SymbolInterner = unsafe { nil }
 	// direct_parent_ids maps a parsed node to the first AST node that references
 	// it as a child. It is immutable during semantic checking and shared by
 	// checker workers. Transformed or appended nodes use the scan fallback in
@@ -996,151 +996,151 @@ pub fn TypeChecker.new(a &flat.FlatAst) TypeChecker {
 	type_interner := new_type_interner()
 	symbols := new_symbol_interner()
 	return TypeChecker{
-		a:                                     a
-		raw_type_equality:                     os.getenv('V3_NO_RAW_TYPE_EQUALITY') == ''
-		fast_parse_recent:                     os.getenv('V3_NO_FAST_PARSE_RECENT') == ''
-		fast_type_text_refs:                   os.getenv('V3_NO_TYPE_TEXT_REFS') == ''
-		fast_c_type_recent:                    os.getenv('V3_NO_FAST_C_TYPE_RECENT') == ''
-		memo_call_info:                        os.getenv('V3_NO_CALL_INFO_MEMO') == ''
-		method_suffix_prescreen:               os.getenv('V3_NO_METHOD_SUFFIX_PRESCREEN') == ''
-		prefix_param_scan:                     os.getenv('V3_NO_PREFIX_PARAM_SCAN') == ''
-		fn_ret_types:                          map[string]Type{}
-		fn_param_types:                        map[string][]Type{}
-		c_fn_module_ret_types:                 map[string]Type{}
-		c_fn_module_param_types:               map[string][]Type{}
-		c_fn_module_variadic:                  map[string]bool{}
-		c_fn_abi_variadic_prefixes:            map[string]int{}
-		fn_shared_params:                      map[string][]bool{}
-		mut_receiver_methods:                  map[string]bool{}
-		source_no_body_fns:                    map[string]bool{}
-		source_no_body_fn_suffixes:            map[string]bool{}
-		unsafe_fns:                            map[string]bool{}
-		unsafe_c_fns:                          map[string]bool{}
-		fn_ret_type_texts:                     map[string]string{}
-		fn_param_type_texts:                   map[string][]string{}
-		fn_type_files:                         map[string]string{}
-		fn_type_modules:                       map[string]string{}
-		fn_generic_params:                     map[string][]string{}
-		specialized_generic_fns:               map[string]bool{}
-		fn_variadic:                           map[string]bool{}
-		c_variadic_fns:                        map[string]bool{}
-		fn_implicit_veb_ctx:                   map[string]bool{}
-		receiver_method_suffix_index:          map[string]string{}
-		generic_receiver_method_index:         map[string][]string{}
-		structs:                               map[string][]StructField{}
-		struct_modules:                        map[string]string{}
-		struct_files:                          map[string]string{}
-		soa_structs:                           map[string]bool{}
-		declared_type_scope_keys:              map[string]bool{}
-		concrete_type_scope_keys:              map[string]bool{}
-		struct_error_embeds_shadow_builtin:    map[string]bool{}
-		struct_generic_params:                 map[string][]string{}
-		struct_implements:                     map[string][]string{}
-		struct_shared_fields:                  map[string]bool{}
-		struct_shared_element_fields:          map[string]bool{}
-		struct_field_c_abi_fns:                map[string]string{}
-		generic_method_value_info:             map[string]CallInfo{}
-		params_structs:                        map[string]bool{}
-		c_typedef_structs:                     map[string]bool{}
-		unions:                                map[string]bool{}
-		type_aliases:                          map[string]string{}
-		type_alias_modules:                    map[string]string{}
-		type_alias_generic_params:             map[string][]string{}
-		type_alias_c_abi_fns:                  map[string]string{}
-		sum_types:                             map[string][]string{}
-		sum_generic_params:                    map[string][]string{}
-		enum_names:                            map[string]bool{}
-		enum_fields:                           map[string][]string{}
-		flag_enums:                            map[string]bool{}
-		interface_names:                       map[string]bool{}
-		interface_generic_params:              map[string][]string{}
-		interface_fields:                      map[string][]StructField{}
-		interface_embeds:                      map[string][]string{}
-		interface_abstract_methods:            map[string][]string{}
-		interface_impl_name_snapshots:         map[string][]string{}
+		a: a
+		raw_type_equality: os.getenv('V3_NO_RAW_TYPE_EQUALITY') == ''
+		fast_parse_recent: os.getenv('V3_NO_FAST_PARSE_RECENT') == ''
+		fast_type_text_refs: os.getenv('V3_NO_TYPE_TEXT_REFS') == ''
+		fast_c_type_recent: os.getenv('V3_NO_FAST_C_TYPE_RECENT') == ''
+		memo_call_info: os.getenv('V3_NO_CALL_INFO_MEMO') == ''
+		method_suffix_prescreen: os.getenv('V3_NO_METHOD_SUFFIX_PRESCREEN') == ''
+		prefix_param_scan: os.getenv('V3_NO_PREFIX_PARAM_SCAN') == ''
+		fn_ret_types: map[string]Type{}
+		fn_param_types: map[string][]Type{}
+		c_fn_module_ret_types: map[string]Type{}
+		c_fn_module_param_types: map[string][]Type{}
+		c_fn_module_variadic: map[string]bool{}
+		c_fn_abi_variadic_prefixes: map[string]int{}
+		fn_shared_params: map[string][]bool{}
+		mut_receiver_methods: map[string]bool{}
+		source_no_body_fns: map[string]bool{}
+		source_no_body_fn_suffixes: map[string]bool{}
+		unsafe_fns: map[string]bool{}
+		unsafe_c_fns: map[string]bool{}
+		fn_ret_type_texts: map[string]string{}
+		fn_param_type_texts: map[string][]string{}
+		fn_type_files: map[string]string{}
+		fn_type_modules: map[string]string{}
+		fn_generic_params: map[string][]string{}
+		specialized_generic_fns: map[string]bool{}
+		fn_variadic: map[string]bool{}
+		c_variadic_fns: map[string]bool{}
+		fn_implicit_veb_ctx: map[string]bool{}
+		receiver_method_suffix_index: map[string]string{}
+		generic_receiver_method_index: map[string][]string{}
+		structs: map[string][]StructField{}
+		struct_modules: map[string]string{}
+		struct_files: map[string]string{}
+		soa_structs: map[string]bool{}
+		declared_type_scope_keys: map[string]bool{}
+		concrete_type_scope_keys: map[string]bool{}
+		struct_error_embeds_shadow_builtin: map[string]bool{}
+		struct_generic_params: map[string][]string{}
+		struct_implements: map[string][]string{}
+		struct_shared_fields: map[string]bool{}
+		struct_shared_element_fields: map[string]bool{}
+		struct_field_c_abi_fns: map[string]string{}
+		generic_method_value_info: map[string]CallInfo{}
+		params_structs: map[string]bool{}
+		c_typedef_structs: map[string]bool{}
+		unions: map[string]bool{}
+		type_aliases: map[string]string{}
+		type_alias_modules: map[string]string{}
+		type_alias_generic_params: map[string][]string{}
+		type_alias_c_abi_fns: map[string]string{}
+		sum_types: map[string][]string{}
+		sum_generic_params: map[string][]string{}
+		enum_names: map[string]bool{}
+		enum_fields: map[string][]string{}
+		flag_enums: map[string]bool{}
+		interface_names: map[string]bool{}
+		interface_generic_params: map[string][]string{}
+		interface_fields: map[string][]StructField{}
+		interface_embeds: map[string][]string{}
+		interface_abstract_methods: map[string][]string{}
+		interface_impl_name_snapshots: map[string][]string{}
 		interface_impl_candidates_at_snapshot: map[string]bool{}
-		interface_impl_candidates_at_index:    map[string]bool{}
-		interface_method_names_index:          map[string][]string{}
-		interface_abstract_index:              map[string][]string{}
-		interface_field_list_index:            map[string][]StructField{}
-		interface_impl_indexes:                map[string]&InterfaceImplIndex{}
-		c_globals:                             map[string]Type{}
-		global_names:                          map[string]bool{}
-		shared_global_names:                   map[string]bool{}
-		const_types:                           map[string]Type{}
-		const_exprs:                           map[string]flat.NodeId{}
-		const_modules:                         map[string]string{}
-		const_files:                           map[string]string{}
-		const_suffixes:                        map[string]string{}
-		declaration_visibility:                map[string]DeclarationVisibility{}
-		imports:                               map[string]string{}
-		file_imports:                          map[string]string{}
-		file_selective_imports:                map[string][]string{}
-		file_imports_by_file:                  map[string]&FileImportInfo{}
-		file_modules:                          map[string]string{}
-		translated_files:                      map[string]bool{}
-		has_globals_files:                     map[string]bool{}
-		deprecated_symbols:                    map[string]DeprecationInfo{}
-		file_scope:                            fs
-		cur_scope:                             fs
+		interface_impl_candidates_at_index: map[string]bool{}
+		interface_method_names_index: map[string][]string{}
+		interface_abstract_index: map[string][]string{}
+		interface_field_list_index: map[string][]StructField{}
+		interface_impl_indexes: map[string]&InterfaceImplIndex{}
+		c_globals: map[string]Type{}
+		global_names: map[string]bool{}
+		shared_global_names: map[string]bool{}
+		const_types: map[string]Type{}
+		const_exprs: map[string]flat.NodeId{}
+		const_modules: map[string]string{}
+		const_files: map[string]string{}
+		const_suffixes: map[string]string{}
+		declaration_visibility: map[string]DeclarationVisibility{}
+		imports: map[string]string{}
+		file_imports: map[string]string{}
+		file_selective_imports: map[string][]string{}
+		file_imports_by_file: map[string]&FileImportInfo{}
+		file_modules: map[string]string{}
+		translated_files: map[string]bool{}
+		has_globals_files: map[string]bool{}
+		deprecated_symbols: map[string]DeprecationInfo{}
+		file_scope: fs
+		cur_scope: fs
 		// The node-indexed cache arrays start empty: collect() sizes them via
 		// reset_node_caches (allocating them here too paid for everything
 		// twice), and extend_node_caches grows them on demand for any checker
 		// used without a collect() call.
-		resolved_call_names:                     []string{}
-		resolved_call_set:                       []bool{}
-		resolved_fn_value_names:                 []string{}
-		resolved_fn_value_set:                   []bool{}
-		statement_nodes:                         []bool{}
-		method_values_by_fn:                     map[int][]string{}
-		method_value_locals:                     map[string]bool{}
-		method_value_local_depth:                map[string]int{}
-		capturing_fn_literal_locals:             map[string]bool{}
-		capturing_fn_literal_local_depth:        map[string]int{}
+		resolved_call_names: []string{}
+		resolved_call_set: []bool{}
+		resolved_fn_value_names: []string{}
+		resolved_fn_value_set: []bool{}
+		statement_nodes: []bool{}
+		method_values_by_fn: map[int][]string{}
+		method_value_locals: map[string]bool{}
+		method_value_local_depth: map[string]int{}
+		capturing_fn_literal_locals: map[string]bool{}
+		capturing_fn_literal_local_depth: map[string]int{}
 		capturing_fn_literal_return_unsupported: map[string]bool{}
-		cur_fn_mut_param_base_types:             map[string]Type{}
-		cur_fn_mut_param_binding_owners:         map[string]ScopeBindingOwner{}
-		cur_fn_mut_local_binding_owners:         map[string]ScopeBindingOwner{}
-		cur_fn_shared_binding_owners:            map[string]ScopeBindingOwner{}
-		expr_type_values:                        []Type{}
-		expr_type_set:                           []bool{}
-		lexical_smartcast_misses:                []bool{}
-		checking_nodes:                          []bool{}
-		sparse_resolved_call_names:              map[int]string{}
-		sparse_resolved_fn_values:               map[int]string{}
-		sparse_statement_nodes:                  map[int]bool{}
-		sparse_expr_type_values:                 map[int]Type{}
-		sparse_checking_nodes:                   map[int]bool{}
-		diagnostic_files:                        map[string]bool{}
-		multiple_module_import_lines:            map[u64]bool{}
-		source_texts_by_file:                    map[string]string{}
-		selected_file_called_fns:                map[string]bool{}
-		smartcasts:                              map[string]Type{}
-		type_cache:                              &TypeCache{
-			parse_entries:              map[u64]ParseTypeCacheEntry{}
-			c_entries:                  map[TypeId]string{}
-			struct_field_entries:       map[string]Type{}
-			struct_field_misses:        map[string]bool{}
-			ierror_compat_entries:      map[string]int{}
+		cur_fn_mut_param_base_types: map[string]Type{}
+		cur_fn_mut_param_binding_owners: map[string]ScopeBindingOwner{}
+		cur_fn_mut_local_binding_owners: map[string]ScopeBindingOwner{}
+		cur_fn_shared_binding_owners: map[string]ScopeBindingOwner{}
+		expr_type_values: []Type{}
+		expr_type_set: []bool{}
+		lexical_smartcast_misses: []bool{}
+		checking_nodes: []bool{}
+		sparse_resolved_call_names: map[int]string{}
+		sparse_resolved_fn_values: map[int]string{}
+		sparse_statement_nodes: map[int]bool{}
+		sparse_expr_type_values: map[int]Type{}
+		sparse_checking_nodes: map[int]bool{}
+		diagnostic_files: map[string]bool{}
+		multiple_module_import_lines: map[u64]bool{}
+		source_texts_by_file: map[string]string{}
+		selected_file_called_fns: map[string]bool{}
+		smartcasts: map[string]Type{}
+		type_cache: &TypeCache{
+			parse_entries: map[u64]ParseTypeCacheEntry{}
+			c_entries: map[TypeId]string{}
+			struct_field_entries: map[string]Type{}
+			struct_field_misses: map[string]bool{}
+			ierror_compat_entries: map[string]int{}
 			source_error_embed_entries: map[string]int{}
 		}
-		resolution_type_views:                   &ResolutionTypeViewCache{
+		resolution_type_views: &ResolutionTypeViewCache{
 			by_file: map[string]&TypeChecker{}
 		}
-		visible_mutation_cache:                  new_visible_mutation_cache()
-		type_interner:                           type_interner
-		symbols:                                 symbols
-		enclosing_generic_params_by_node:        map[int][]string{}
-		declaration_attributes:                  map[int][]string{}
-		type_declaration_ids:                    map[string][]int{}
-		strings_builder_bindings:                map[string]bool{}
-		static_associated_fn_keys:               map[string]bool{}
-		declaration_param_mutability:            map[string][]bool{}
-		strict_map_index_files:                  map[string]bool{}
-		fn_decl_short_name_ids:                  map[string]int{}
-		file_import_alias_paths:                 map[string]string{}
-		file_import_suffix_paths:                map[string]string{}
-		struct_embed_receivers:                  map[string][]string{}
+		visible_mutation_cache: new_visible_mutation_cache()
+		type_interner: type_interner
+		symbols: symbols
+		enclosing_generic_params_by_node: map[int][]string{}
+		declaration_attributes: map[int][]string{}
+		type_declaration_ids: map[string][]int{}
+		strings_builder_bindings: map[string]bool{}
+		static_associated_fn_keys: map[string]bool{}
+		declaration_param_mutability: map[string][]bool{}
+		strict_map_index_files: map[string]bool{}
+		fn_decl_short_name_ids: map[string]int{}
+		file_import_alias_paths: map[string]string{}
+		file_import_suffix_paths: map[string]string{}
+		struct_embed_receivers: map[string][]string{}
 	}
 }
 
@@ -1153,175 +1153,175 @@ pub fn TypeChecker.new(a &flat.FlatAst) TypeChecker {
 fn (tc &TypeChecker) fork_program_view(ast &flat.FlatAst, direct_dependencies_by_fn map[int][]SymbolId) TypeChecker {
 	fs := new_scope(tc.file_scope)
 	return TypeChecker{
-		a:                                  ast
-		compiler_vroot:                     tc.compiler_vroot
-		raw_type_equality:                  tc.raw_type_equality
-		fast_parse_recent:                  tc.fast_parse_recent
-		fast_type_text_refs:                tc.fast_type_text_refs
-		fast_c_type_recent:                 tc.fast_c_type_recent
-		memo_call_info:                     tc.memo_call_info
-		method_suffix_prescreen:            tc.method_suffix_prescreen
-		prefix_param_scan:                  tc.prefix_param_scan
-		building_v_fast:                    tc.building_v_fast
-		valid_diagnostic_fast:              tc.valid_diagnostic_fast
-		valid_resolution_fast:              tc.valid_resolution_fast
-		enable_globals:                     tc.enable_globals
-		fn_ret_types:                       tc.fn_ret_types
-		fn_param_types:                     tc.fn_param_types
-		c_fn_module_ret_types:              tc.c_fn_module_ret_types
-		c_fn_module_param_types:            tc.c_fn_module_param_types
-		c_fn_module_variadic:               tc.c_fn_module_variadic
-		c_fn_abi_variadic_prefixes:         tc.c_fn_abi_variadic_prefixes
-		fn_shared_params:                   tc.fn_shared_params
-		mut_receiver_methods:               tc.mut_receiver_methods
-		source_no_body_fns:                 tc.source_no_body_fns
-		source_no_body_fn_suffixes:         tc.source_no_body_fn_suffixes
-		unsafe_fns:                         tc.unsafe_fns
-		unsafe_c_fns:                       tc.unsafe_c_fns
-		fn_ret_type_texts:                  tc.fn_ret_type_texts
-		fn_param_type_texts:                tc.fn_param_type_texts
-		fn_type_files:                      tc.fn_type_files
-		fn_type_modules:                    tc.fn_type_modules
-		fn_generic_params:                  tc.fn_generic_params
-		transform_signature_names_log:      []string{}
-		specialized_generic_fns:            tc.specialized_generic_fns
-		fn_variadic:                        tc.fn_variadic
-		c_variadic_fns:                     tc.c_variadic_fns
-		fn_implicit_veb_ctx:                tc.fn_implicit_veb_ctx
-		receiver_method_suffix_index:       tc.receiver_method_suffix_index
-		generic_receiver_method_index:      tc.generic_receiver_method_index
-		structs:                            tc.structs
-		struct_modules:                     tc.struct_modules
-		struct_files:                       tc.struct_files
-		declared_type_scope_keys:           tc.declared_type_scope_keys
-		concrete_type_scope_keys:           tc.concrete_type_scope_keys
+		a: ast
+		compiler_vroot: tc.compiler_vroot
+		raw_type_equality: tc.raw_type_equality
+		fast_parse_recent: tc.fast_parse_recent
+		fast_type_text_refs: tc.fast_type_text_refs
+		fast_c_type_recent: tc.fast_c_type_recent
+		memo_call_info: tc.memo_call_info
+		method_suffix_prescreen: tc.method_suffix_prescreen
+		prefix_param_scan: tc.prefix_param_scan
+		building_v_fast: tc.building_v_fast
+		valid_diagnostic_fast: tc.valid_diagnostic_fast
+		valid_resolution_fast: tc.valid_resolution_fast
+		enable_globals: tc.enable_globals
+		fn_ret_types: tc.fn_ret_types
+		fn_param_types: tc.fn_param_types
+		c_fn_module_ret_types: tc.c_fn_module_ret_types
+		c_fn_module_param_types: tc.c_fn_module_param_types
+		c_fn_module_variadic: tc.c_fn_module_variadic
+		c_fn_abi_variadic_prefixes: tc.c_fn_abi_variadic_prefixes
+		fn_shared_params: tc.fn_shared_params
+		mut_receiver_methods: tc.mut_receiver_methods
+		source_no_body_fns: tc.source_no_body_fns
+		source_no_body_fn_suffixes: tc.source_no_body_fn_suffixes
+		unsafe_fns: tc.unsafe_fns
+		unsafe_c_fns: tc.unsafe_c_fns
+		fn_ret_type_texts: tc.fn_ret_type_texts
+		fn_param_type_texts: tc.fn_param_type_texts
+		fn_type_files: tc.fn_type_files
+		fn_type_modules: tc.fn_type_modules
+		fn_generic_params: tc.fn_generic_params
+		transform_signature_names_log: []string{}
+		specialized_generic_fns: tc.specialized_generic_fns
+		fn_variadic: tc.fn_variadic
+		c_variadic_fns: tc.c_variadic_fns
+		fn_implicit_veb_ctx: tc.fn_implicit_veb_ctx
+		receiver_method_suffix_index: tc.receiver_method_suffix_index
+		generic_receiver_method_index: tc.generic_receiver_method_index
+		structs: tc.structs
+		struct_modules: tc.struct_modules
+		struct_files: tc.struct_files
+		declared_type_scope_keys: tc.declared_type_scope_keys
+		concrete_type_scope_keys: tc.concrete_type_scope_keys
 		struct_error_embeds_shadow_builtin: tc.struct_error_embeds_shadow_builtin
-		struct_generic_params:              tc.struct_generic_params
-		struct_implements:                  tc.struct_implements
-		struct_shared_fields:               tc.struct_shared_fields
-		struct_shared_element_fields:       tc.struct_shared_element_fields
-		struct_field_c_abi_fns:             tc.struct_field_c_abi_fns
-		generic_method_value_info:          tc.generic_method_value_info
-		params_structs:                     tc.params_structs
-		c_typedef_structs:                  tc.c_typedef_structs
-		unions:                             tc.unions
-		type_aliases:                       tc.type_aliases
-		type_alias_modules:                 tc.type_alias_modules
-		type_alias_generic_params:          tc.type_alias_generic_params
-		type_alias_c_abi_fns:               tc.type_alias_c_abi_fns
-		sum_types:                          tc.sum_types
-		sum_generic_params:                 tc.sum_generic_params
-		enum_names:                         tc.enum_names
-		enum_fields:                        tc.enum_fields
-		flag_enums:                         tc.flag_enums
-		interface_names:                    tc.interface_names
-		interface_generic_params:           tc.interface_generic_params
-		interface_fields:                   tc.interface_fields
-		interface_embeds:                   tc.interface_embeds
-		interface_abstract_methods:         tc.interface_abstract_methods
+		struct_generic_params: tc.struct_generic_params
+		struct_implements: tc.struct_implements
+		struct_shared_fields: tc.struct_shared_fields
+		struct_shared_element_fields: tc.struct_shared_element_fields
+		struct_field_c_abi_fns: tc.struct_field_c_abi_fns
+		generic_method_value_info: tc.generic_method_value_info
+		params_structs: tc.params_structs
+		c_typedef_structs: tc.c_typedef_structs
+		unions: tc.unions
+		type_aliases: tc.type_aliases
+		type_alias_modules: tc.type_alias_modules
+		type_alias_generic_params: tc.type_alias_generic_params
+		type_alias_c_abi_fns: tc.type_alias_c_abi_fns
+		sum_types: tc.sum_types
+		sum_generic_params: tc.sum_generic_params
+		enum_names: tc.enum_names
+		enum_fields: tc.enum_fields
+		flag_enums: tc.flag_enums
+		interface_names: tc.interface_names
+		interface_generic_params: tc.interface_generic_params
+		interface_fields: tc.interface_fields
+		interface_embeds: tc.interface_embeds
+		interface_abstract_methods: tc.interface_abstract_methods
 		interface_impl_candidates_at_index: tc.interface_impl_candidates_at_index
-		interface_method_names_index:       tc.interface_method_names_index
-		interface_abstract_index:           tc.interface_abstract_index
-		interface_field_list_index:         tc.interface_field_list_index
-		interface_impl_indexes:             tc.interface_impl_indexes
-		interface_query_indexes_ready:      tc.interface_query_indexes_ready
-		c_globals:                          tc.c_globals
-		global_names:                       tc.global_names
-		shared_global_names:                tc.shared_global_names
-		const_types:                        tc.const_types
-		const_exprs:                        tc.const_exprs
-		const_modules:                      tc.const_modules
-		const_files:                        tc.const_files
-		const_suffixes:                     tc.const_suffixes
-		declaration_visibility:             tc.declaration_visibility
-		imports:                            tc.imports
-		file_imports:                       tc.file_imports
-		file_selective_imports:             tc.file_selective_imports
-		file_imports_by_file:               tc.file_imports_by_file
-		file_modules:                       tc.file_modules
-		translated_files:                   tc.translated_files
-		has_globals_files:                  tc.has_globals_files
-		deprecated_symbols:                 tc.deprecated_symbols
-		file_scope:                         fs
-		cur_scope:                          fs
-		scope_pool:                         []&Scope{}
-		has_builtins:                       tc.has_builtins
-		cur_module:                         tc.cur_module
-		cur_file:                           tc.cur_file
-		resolution_type_mode:               tc.resolution_type_mode
-		trust_checked_expr_types:           tc.trust_checked_expr_types
-		errors:                             []TypeError{}
-		notices:                            []TypeError{}
-		resolved_call_names:                tc.resolved_call_names
-		resolved_call_set:                  tc.resolved_call_set
-		resolved_fn_value_names:            tc.resolved_fn_value_names
-		resolved_fn_value_set:              tc.resolved_fn_value_set
-		statement_nodes:                    tc.statement_nodes
-		direct_dependencies_by_fn:          direct_dependencies_by_fn
-		method_values_by_fn:                tc.method_values_by_fn
-		cur_comptime_variant_loop_vars:     tc.cur_comptime_variant_loop_vars
-		expr_type_values:                   tc.expr_type_values
-		expr_type_set:                      tc.expr_type_set
-		lexical_smartcast_misses:           tc.lexical_smartcast_misses
-		checking_nodes:                     tc.checking_nodes
-		sparse_resolved_call_names:         map[int]string{}
-		sparse_resolved_fn_values:          map[int]string{}
-		sparse_statement_nodes:             map[int]bool{}
-		sparse_expr_type_values:            map[int]Type{}
-		sparse_checking_nodes:              map[int]bool{}
-		diagnose_unknown_calls:             tc.diagnose_unknown_calls
-		reject_unlowered_map_mutation:      tc.reject_unlowered_map_mutation
-		reject_unsupported_generics:        tc.reject_unsupported_generics
-		checker_fixture_mode:               tc.checker_fixture_mode
-		autofree_mode:                      tc.autofree_mode
-		no_main:                            tc.no_main
-		warns_are_errors:                   tc.warns_are_errors
-		notes_are_errors:                   tc.notes_are_errors
-		is_prod:                            tc.is_prod
-		suppress_dump_output:               tc.suppress_dump_output
-		diagnostic_files:                   tc.diagnostic_files
-		multiple_module_import_lines:       tc.multiple_module_import_lines
-		source_texts_by_file:               tc.source_texts_by_file
-		ct_update_pos:                      tc.ct_update_pos
-		ct_update_indexed:                  tc.ct_update_indexed
-		has_spawn_expr:                     tc.has_spawn_expr
-		inactive_top_level_node_ids:        tc.inactive_top_level_node_ids
-		selected_file_called_fns:           tc.selected_file_called_fns
-		selected_file_worklist:             tc.selected_file_worklist
-		defer_ierror_gating:                tc.defer_ierror_gating
-		pending_ierror_errors:              []PendingIerrorError{}
-		top_level_idx:                      tc.top_level_idx
-		top_level_idx_nodes_len:            tc.top_level_idx_nodes_len
-		synthetic_top_level_type_ids:       tc.synthetic_top_level_type_ids
-		direct_parent_ids:                  tc.direct_parent_ids
-		rewritten_parent_ids:               tc.rewritten_parent_ids
-		value_used_nodes:                   tc.value_used_nodes
-		direct_parent_index_trusted:        tc.direct_parent_index_trusted
-		has_goto_nodes:                     tc.has_goto_nodes
-		declaration_attributes:             tc.declaration_attributes
-		type_declaration_ids:               tc.type_declaration_ids
-		strings_builder_bindings:           tc.strings_builder_bindings
-		static_associated_fn_keys:          tc.static_associated_fn_keys
-		declaration_param_mutability:       tc.declaration_param_mutability
-		strict_map_index_files:             tc.strict_map_index_files
-		fn_decl_short_name_ids:             tc.fn_decl_short_name_ids
-		file_import_alias_paths:            tc.file_import_alias_paths
-		file_import_suffix_paths:           tc.file_import_suffix_paths
-		struct_embed_receivers:             tc.struct_embed_receivers
-		enclosing_generic_params_by_node:   tc.enclosing_generic_params_by_node
-		enclosing_generic_param_masks:      tc.enclosing_generic_param_masks
-		expected_expr_id:                   -1
-		expected_expr_type:                 Type(void_)
-		smartcasts:                         tc.smartcasts
-		ownership:                          tc.ownership
-		selfhost:                           tc.selfhost
-		fn_context:                         new_function_check_context()
-		resolution_type_views:              &ResolutionTypeViewCache{
+		interface_method_names_index: tc.interface_method_names_index
+		interface_abstract_index: tc.interface_abstract_index
+		interface_field_list_index: tc.interface_field_list_index
+		interface_impl_indexes: tc.interface_impl_indexes
+		interface_query_indexes_ready: tc.interface_query_indexes_ready
+		c_globals: tc.c_globals
+		global_names: tc.global_names
+		shared_global_names: tc.shared_global_names
+		const_types: tc.const_types
+		const_exprs: tc.const_exprs
+		const_modules: tc.const_modules
+		const_files: tc.const_files
+		const_suffixes: tc.const_suffixes
+		declaration_visibility: tc.declaration_visibility
+		imports: tc.imports
+		file_imports: tc.file_imports
+		file_selective_imports: tc.file_selective_imports
+		file_imports_by_file: tc.file_imports_by_file
+		file_modules: tc.file_modules
+		translated_files: tc.translated_files
+		has_globals_files: tc.has_globals_files
+		deprecated_symbols: tc.deprecated_symbols
+		file_scope: fs
+		cur_scope: fs
+		scope_pool: []&Scope{}
+		has_builtins: tc.has_builtins
+		cur_module: tc.cur_module
+		cur_file: tc.cur_file
+		resolution_type_mode: tc.resolution_type_mode
+		trust_checked_expr_types: tc.trust_checked_expr_types
+		errors: []TypeError{}
+		notices: []TypeError{}
+		resolved_call_names: tc.resolved_call_names
+		resolved_call_set: tc.resolved_call_set
+		resolved_fn_value_names: tc.resolved_fn_value_names
+		resolved_fn_value_set: tc.resolved_fn_value_set
+		statement_nodes: tc.statement_nodes
+		direct_dependencies_by_fn: direct_dependencies_by_fn
+		method_values_by_fn: tc.method_values_by_fn
+		cur_comptime_variant_loop_vars: tc.cur_comptime_variant_loop_vars
+		expr_type_values: tc.expr_type_values
+		expr_type_set: tc.expr_type_set
+		lexical_smartcast_misses: tc.lexical_smartcast_misses
+		checking_nodes: tc.checking_nodes
+		sparse_resolved_call_names: map[int]string{}
+		sparse_resolved_fn_values: map[int]string{}
+		sparse_statement_nodes: map[int]bool{}
+		sparse_expr_type_values: map[int]Type{}
+		sparse_checking_nodes: map[int]bool{}
+		diagnose_unknown_calls: tc.diagnose_unknown_calls
+		reject_unlowered_map_mutation: tc.reject_unlowered_map_mutation
+		reject_unsupported_generics: tc.reject_unsupported_generics
+		checker_fixture_mode: tc.checker_fixture_mode
+		autofree_mode: tc.autofree_mode
+		no_main: tc.no_main
+		warns_are_errors: tc.warns_are_errors
+		notes_are_errors: tc.notes_are_errors
+		is_prod: tc.is_prod
+		suppress_dump_output: tc.suppress_dump_output
+		diagnostic_files: tc.diagnostic_files
+		multiple_module_import_lines: tc.multiple_module_import_lines
+		source_texts_by_file: tc.source_texts_by_file
+		ct_update_pos: tc.ct_update_pos
+		ct_update_indexed: tc.ct_update_indexed
+		has_spawn_expr: tc.has_spawn_expr
+		inactive_top_level_node_ids: tc.inactive_top_level_node_ids
+		selected_file_called_fns: tc.selected_file_called_fns
+		selected_file_worklist: tc.selected_file_worklist
+		defer_ierror_gating: tc.defer_ierror_gating
+		pending_ierror_errors: []PendingIerrorError{}
+		top_level_idx: tc.top_level_idx
+		top_level_idx_nodes_len: tc.top_level_idx_nodes_len
+		synthetic_top_level_type_ids: tc.synthetic_top_level_type_ids
+		direct_parent_ids: tc.direct_parent_ids
+		rewritten_parent_ids: tc.rewritten_parent_ids
+		value_used_nodes: tc.value_used_nodes
+		direct_parent_index_trusted: tc.direct_parent_index_trusted
+		has_goto_nodes: tc.has_goto_nodes
+		declaration_attributes: tc.declaration_attributes
+		type_declaration_ids: tc.type_declaration_ids
+		strings_builder_bindings: tc.strings_builder_bindings
+		static_associated_fn_keys: tc.static_associated_fn_keys
+		declaration_param_mutability: tc.declaration_param_mutability
+		strict_map_index_files: tc.strict_map_index_files
+		fn_decl_short_name_ids: tc.fn_decl_short_name_ids
+		file_import_alias_paths: tc.file_import_alias_paths
+		file_import_suffix_paths: tc.file_import_suffix_paths
+		struct_embed_receivers: tc.struct_embed_receivers
+		enclosing_generic_params_by_node: tc.enclosing_generic_params_by_node
+		enclosing_generic_param_masks: tc.enclosing_generic_param_masks
+		expected_expr_id: -1
+		expected_expr_type: Type(void_)
+		smartcasts: tc.smartcasts
+		ownership: tc.ownership
+		selfhost: tc.selfhost
+		fn_context: new_function_check_context()
+		resolution_type_views: &ResolutionTypeViewCache{
 			by_file: map[string]&TypeChecker{}
 		}
-		visible_mutation_cache:             tc.visible_mutation_cache
-		type_interner:                      tc.type_interner
-		symbols:                            tc.symbols
+		visible_mutation_cache: tc.visible_mutation_cache
+		type_interner: tc.type_interner
+		symbols: tc.symbols
 	}
 }
 
@@ -1436,21 +1436,21 @@ pub fn (tc &TypeChecker) fork_for_parallel_transform(ast &flat.FlatAst) &TypeChe
 		// When the master froze its warm cache behind an overlay (see
 		// freeze_type_cache_for_forks), every fork shares that frozen cache as
 		// its read-only base instead of re-deriving each memoized type.
-		base:                       if tc.type_cache != unsafe { nil } {
+		base: if tc.type_cache != unsafe { nil } {
 			tc.type_cache.base
 		} else {
 			&TypeCache(unsafe { nil })
 		}
-		parse_enabled:              if tc.type_cache != unsafe { nil } {
+		parse_enabled: if tc.type_cache != unsafe { nil } {
 			tc.type_cache.parse_enabled
 		} else {
 			false
 		}
-		parse_entries:              map[u64]ParseTypeCacheEntry{}
-		c_entries:                  map[TypeId]string{}
-		struct_field_entries:       map[string]Type{}
-		struct_field_misses:        map[string]bool{}
-		ierror_compat_entries:      map[string]int{}
+		parse_entries: map[u64]ParseTypeCacheEntry{}
+		c_entries: map[TypeId]string{}
+		struct_field_entries: map[string]Type{}
+		struct_field_misses: map[string]bool{}
+		ierror_compat_entries: map[string]int{}
 		source_error_embed_entries: map[string]int{}
 	}
 	return &forked
@@ -1599,7 +1599,7 @@ pub fn (mut tc TypeChecker) set_fresh_type_cache_based_on(src &TypeChecker, pars
 	}
 	tc.type_cache = &TypeCache{
 		parse_enabled: parse_enabled
-		base:          base
+		base: base
 	}
 	// C-generation workers can also use disposable arenas. Keep their TypeIds
 	// private instead of publishing arena-backed interner storage globally.
@@ -1665,12 +1665,12 @@ pub fn (mut tc TypeChecker) free_parallel_transform_caches() {
 		}
 	}
 	tc.type_cache = &TypeCache{
-		parse_enabled:              parse_enabled
-		parse_entries:              map[u64]ParseTypeCacheEntry{}
-		c_entries:                  map[TypeId]string{}
-		struct_field_entries:       map[string]Type{}
-		struct_field_misses:        map[string]bool{}
-		ierror_compat_entries:      map[string]int{}
+		parse_enabled: parse_enabled
+		parse_entries: map[u64]ParseTypeCacheEntry{}
+		c_entries: map[TypeId]string{}
+		struct_field_entries: map[string]Type{}
+		struct_field_misses: map[string]bool{}
+		ierror_compat_entries: map[string]int{}
 		source_error_embed_entries: map[string]int{}
 	}
 }
@@ -2191,7 +2191,7 @@ pub fn (mut tc TypeChecker) begin_sparse_transform_node_caches(base_nodes int) {
 		&& !isnil(tc.type_cache) {
 		tc.pre_transform_type_cache = tc.type_cache
 		tc.type_cache = &TypeCache{
-			base:          tc.pre_transform_type_cache
+			base: tc.pre_transform_type_cache
 			parse_enabled: tc.pre_transform_type_cache.parse_enabled
 		}
 	}
@@ -2294,11 +2294,11 @@ fn (mut tc TypeChecker) record_error(kind TypeErrorKind, msg string, node flat.N
 		return
 	}
 	tc.errors << TypeError{
-		msg:        msg
-		kind:       kind
-		node:       node
-		file:       tc.cur_file
-		node_kind:  if int(node) >= 0 && int(node) < tc.a.nodes.len {
+		msg: msg
+		kind: kind
+		node: node
+		file: tc.cur_file
+		node_kind: if int(node) >= 0 && int(node) < tc.a.nodes.len {
 			tc.a.nodes[int(node)].kind.str()
 		} else {
 			''
@@ -2308,8 +2308,8 @@ fn (mut tc TypeChecker) record_error(kind TypeErrorKind, msg string, node flat.N
 		} else {
 			''
 		}
-		node_pos:   tc.node_position_string(node)
-		pos:        tc.node_pos(node)
+		node_pos: tc.node_position_string(node)
+		pos: tc.node_pos(node)
 	}
 }
 
@@ -2327,11 +2327,11 @@ fn (tc &TypeChecker) make_type_error(kind TypeErrorKind, msg string, node flat.N
 
 fn (tc &TypeChecker) make_type_error_at(kind TypeErrorKind, msg string, node flat.NodeId, pos token.Pos) TypeError {
 	return TypeError{
-		msg:        msg.replace('[fn(', '[fn (')
-		kind:       kind
-		node:       node
-		file:       tc.cur_file
-		node_kind:  if int(node) >= 0 && int(node) < tc.a.nodes.len {
+		msg: msg.replace('[fn(', '[fn (')
+		kind: kind
+		node: node
+		file: tc.cur_file
+		node_kind: if int(node) >= 0 && int(node) < tc.a.nodes.len {
 			tc.a.nodes[int(node)].kind.str()
 		} else {
 			''
@@ -2341,8 +2341,8 @@ fn (tc &TypeChecker) make_type_error_at(kind TypeErrorKind, msg string, node fla
 		} else {
 			''
 		}
-		node_pos:   tc.node_position_string(node)
-		pos:        pos
+		node_pos: tc.node_position_string(node)
+		pos: pos
 	}
 }
 
@@ -2366,8 +2366,7 @@ fn (mut tc TypeChecker) record_error_severity_at(kind TypeErrorKind, msg string,
 
 // record_cgen_error_at records a post-transform validation error with cgen severity.
 pub fn (mut tc TypeChecker) record_cgen_error_at(msg string, node flat.NodeId, source_id flat.NodeId, marker string) {
-	tc.record_error_severity_at(.compile_error, msg, node, tc.propagation_operator_pos(source_id,
-		node, marker), 'cgen error:')
+	tc.record_error_severity_at(.compile_error, msg, node, tc.propagation_operator_pos(source_id, node, marker), 'cgen error:')
 }
 
 fn (mut tc TypeChecker) record_error_with_details_at(kind TypeErrorKind, msg string, node flat.NodeId, pos token.Pos, details []string) {
@@ -2413,7 +2412,7 @@ fn (mut tc TypeChecker) record_notice_with_details_at(kind TypeErrorKind, msg st
 		base := tc.make_type_error_at(kind, msg, node, pos)
 		tc.errors << TypeError{
 			...base
-			details:  details.clone()
+			details: details.clone()
 			severity: 'error:'
 		}
 		return
@@ -2484,10 +2483,10 @@ fn (mut tc TypeChecker) record_unsupported_generic(msg string, node flat.NodeId)
 		return
 	}
 	tc.errors << TypeError{
-		msg:  msg
+		msg: msg
 		kind: .unsupported_generic
 		node: node
-		pos:  tc.node_pos(node)
+		pos: tc.node_pos(node)
 	}
 }
 
@@ -2593,8 +2592,7 @@ fn (mut tc TypeChecker) collect_top_level_idx_fast(a &flat.FlatAst, inactive []b
 				&& tc.synthetic_top_level_type_ids[synthetic_pos] < decl_idx {
 				synthetic_idx := tc.synthetic_top_level_type_ids[synthetic_pos]
 				if synthetic_idx < trailing {
-					idx_module = tc.collect_index_child(a, synthetic_idx, idx_file, idx_module,
-						inactive)
+					idx_module = tc.collect_index_child(a, synthetic_idx, idx_file, idx_module, inactive)
 				}
 				synthetic_pos++
 			}
@@ -2646,9 +2644,7 @@ fn (mut tc TypeChecker) check_insert_directive(id flat.NodeId, node flat.Node, f
 		tc.cur_file = file
 		tc.cur_module = if module_name.len > 0 { module_name } else { 'main' }
 		flag := node.typ.trim_space()
-		tc.record_error_at(.compile_error,
-			'bad #flag `${flag}`: shell command substitution with backticks is not supported; use #pkgconfig or explicit flags instead',
-			id, node.pos)
+		tc.record_error_at(.compile_error, 'bad #flag `${flag}`: shell command substitution with backticks is not supported; use #pkgconfig or explicit flags instead', id, node.pos)
 		tc.cur_file = saved_file
 		tc.cur_module = saved_module
 		return
@@ -2674,9 +2670,7 @@ fn (mut tc TypeChecker) check_insert_directive(id flat.NodeId, node flat.Node, f
 	saved_module := tc.cur_module
 	tc.cur_file = file
 	tc.cur_module = if module_name.len > 0 { module_name } else { 'main' }
-	tc.record_error_at(.compile_error,
-		'The file ${raw_target}, needed for insertion by module `${tc.cur_module}`, does not exist.',
-		id, node.pos)
+	tc.record_error_at(.compile_error, 'The file ${raw_target}, needed for insertion by module `${tc.cur_module}`, does not exist.', id, node.pos)
 	tc.cur_file = saved_file
 	tc.cur_module = saved_module
 }
@@ -2758,16 +2752,14 @@ fn (mut tc TypeChecker) collect_index_child(a &flat.FlatAst, i int, idx_file str
 			}
 			tc.declared_type_scope_keys[scope_type_key(idx_file, idx_module, node.value)] = true
 			if node.generic_params().len == 0 {
-				tc.concrete_type_scope_keys[scope_type_key(idx_file, idx_module,
-					node.value.all_after_last('.'))] = true
+				tc.concrete_type_scope_keys[scope_type_key(idx_file, idx_module, node.value.all_after_last('.'))] = true
 			}
 			tc.top_level_idx << i
 		}
 		.type_decl, .interface_decl, .enum_decl {
 			tc.declared_type_scope_keys[scope_type_key(idx_file, idx_module, node.value)] = true
 			if node.kind != .enum_decl && node.generic_params().len == 0 {
-				tc.concrete_type_scope_keys[scope_type_key(idx_file, idx_module,
-					node.value.all_after_last('.'))] = true
+				tc.concrete_type_scope_keys[scope_type_key(idx_file, idx_module, node.value.all_after_last('.'))] = true
 			}
 			tc.top_level_idx << i
 		}
@@ -2779,8 +2771,7 @@ fn (mut tc TypeChecker) collect_index_child(a &flat.FlatAst, i int, idx_file str
 			// by node order; descend in child order (same ascending ids).
 			mut inner_module := idx_module
 			for ci in 0 .. node.children_count {
-				inner_module = tc.collect_index_child(a, int(a.child(&node, ci)), idx_file,
-					inner_module, inactive)
+				inner_module = tc.collect_index_child(a, int(a.child(&node, ci)), idx_file, inner_module, inactive)
 			}
 			return inner_module
 		}
@@ -2821,11 +2812,11 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 		tc.ownership_reset()
 	}
 	tc.type_cache = &TypeCache{
-		parse_entries:              map[u64]ParseTypeCacheEntry{}
-		c_entries:                  map[TypeId]string{}
-		struct_field_entries:       map[string]Type{}
-		struct_field_misses:        map[string]bool{}
-		ierror_compat_entries:      map[string]int{}
+		parse_entries: map[u64]ParseTypeCacheEntry{}
+		c_entries: map[TypeId]string{}
+		struct_field_entries: map[string]Type{}
+		struct_field_misses: map[string]bool{}
+		ierror_compat_entries: map[string]int{}
 		source_error_embed_entries: map[string]int{}
 	}
 	// One full declaration scan: build the top-level declaration index that every
@@ -2889,16 +2880,14 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 				}
 				tc.declared_type_scope_keys[scope_type_key(idx_file, idx_module, node.value)] = true
 				if node.generic_params().len == 0 {
-					tc.concrete_type_scope_keys[scope_type_key(idx_file, idx_module,
-						node.value.all_after_last('.'))] = true
+					tc.concrete_type_scope_keys[scope_type_key(idx_file, idx_module, node.value.all_after_last('.'))] = true
 				}
 				tc.top_level_idx << i
 			}
 			.type_decl, .interface_decl, .enum_decl {
 				tc.declared_type_scope_keys[scope_type_key(idx_file, idx_module, node.value)] = true
 				if node.kind != .enum_decl && node.generic_params().len == 0 {
-					tc.concrete_type_scope_keys[scope_type_key(idx_file, idx_module,
-						node.value.all_after_last('.'))] = true
+					tc.concrete_type_scope_keys[scope_type_key(idx_file, idx_module, node.value.all_after_last('.'))] = true
 				}
 				tc.top_level_idx << i
 			}
@@ -2939,8 +2928,7 @@ fn (mut tc TypeChecker) reserve_collect_maps() {
 			// These maps are populated from separate pool lanes, so reserving here
 			// avoids their otherwise serial rehash ladders without sharing writes.
 			tc.declaration_visibility.reserve(u32(tc.declaration_visibility.len) + decl_estimate * 2)
-			tc.receiver_method_suffix_index.reserve(u32(tc.receiver_method_suffix_index.len) +
-				decl_estimate * 3)
+			tc.receiver_method_suffix_index.reserve(u32(tc.receiver_method_suffix_index.len) + decl_estimate * 3)
 			if !isnil(tc.visible_mutation_cache) {
 				mut mutation_cache := tc.visible_mutation_cache
 				mutation_cache.decls.reserve(u32(mutation_cache.decls.len) + decl_estimate * 8)
@@ -2948,8 +2936,7 @@ fn (mut tc TypeChecker) reserve_collect_maps() {
 			if os.getenv('V3_NO_EXTENDED_COLLECT_RESERVES') == '' {
 				tc.fn_type_files.reserve(u32(tc.fn_type_files.len) + decl_estimate * 3)
 				tc.fn_type_modules.reserve(u32(tc.fn_type_modules.len) + decl_estimate * 3)
-				tc.type_cache.c_name_entries.reserve(u32(tc.type_cache.c_name_entries.len) +
-					decl_estimate * 3)
+				tc.type_cache.c_name_entries.reserve(u32(tc.type_cache.c_name_entries.len) + decl_estimate * 3)
 			}
 		}
 	}
@@ -2978,9 +2965,7 @@ fn (mut tc TypeChecker) check_alias_declaration_cycles() {
 		container := recursive_alias_container(name, node.typ)
 		if container.len > 0 {
 			tc.recursive_alias_names[name] = true
-			tc.errors << tc.make_type_error_at(.unknown_type,
-				'alias `${name}` forms a recursive cycle; recursive declarations of aliases are not allowed - the alias `${name}` is used in the ${container}',
-				flat.NodeId(index), node.pos)
+			tc.errors << tc.make_type_error_at(.unknown_type, 'alias `${name}` forms a recursive cycle; recursive declarations of aliases are not allowed - the alias `${name}` is used in the ${container}', flat.NodeId(index), node.pos)
 			continue
 		}
 		target := trimmed_space(node.typ)
@@ -2988,9 +2973,7 @@ fn (mut tc TypeChecker) check_alias_declaration_cycles() {
 			continue
 		}
 		tc.recursive_alias_names[name] = true
-		tc.errors << tc.make_type_error_at(.unknown_type,
-			'alias `${name}` forms a recursive cycle; alias `${name}` forms a cycle through `${target}`',
-			flat.NodeId(index), node.pos)
+		tc.errors << tc.make_type_error_at(.unknown_type, 'alias `${name}` forms a recursive cycle; alias `${name}` forms a cycle through `${target}`', flat.NodeId(index), node.pos)
 	}
 }
 
@@ -3083,8 +3066,8 @@ fn is_plain_type_symbol(type_text string) bool {
 fn (mut tc TypeChecker) register_declaration_visibility(node flat.Node) {
 	visibility := DeclarationVisibility{
 		module_name: tc.cur_module
-		kind:        node.kind
-		is_pub:      node.op == .arrow
+		kind: node.kind
+		is_pub: node.op == .arrow
 	}
 	match node.kind {
 		.fn_decl {
@@ -3117,8 +3100,8 @@ fn (mut tc TypeChecker) register_declaration_visibility(node flat.Node) {
 				name := qualify_decl_name_in_module(field.value, tc.cur_module)
 				tc.declaration_visibility[name] = DeclarationVisibility{
 					module_name: tc.cur_module
-					kind:        .global_decl
-					is_pub:      visibility.is_pub || field.op == .arrow
+					kind: .global_decl
+					is_pub: visibility.is_pub || field.op == .arrow
 				}
 			}
 		}
@@ -3306,7 +3289,7 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 	// The native backend does not yet preserve large aggregate arguments reliably
 	// through the parse-cache helpers. Parsing uncached keeps native self-hosts
 	// correct while the C-hosted compiler retains the full memoization path.
-	$if @BACKEND == 'arm64' {
+	$if 'c' == 'arm64' {
 		tc.type_cache.parse_enabled = false
 	} $else {
 		tc.type_cache.parse_enabled = true
@@ -3373,8 +3356,7 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 					tc.v_fn_semantic_names[node.value] = true
 				}
 				if fast_pass2_registration {
-					tc.register_visible_mutation_fn_decl_with_lowered(tl_idx, tc.cur_module, qname,
-						node.value, lowered_qname, lowered_source_name)
+					tc.register_visible_mutation_fn_decl_with_lowered(tl_idx, tc.cur_module, qname, node.value, lowered_qname, lowered_source_name)
 				} else {
 					tc.register_visible_mutation_fn_decl(tl_idx, tc.cur_module, qname, node.value)
 				}
@@ -3401,8 +3383,7 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 					} else {
 						shared_params
 					}
-					tc.register_fn_signature_owned(qname, lowered_qname, ret_type, owned_ptypes,
-						owned_shared_params, is_variadic, has_forwardable_ctx)
+					tc.register_fn_signature_owned(qname, lowered_qname, ret_type, owned_ptypes, owned_shared_params, is_variadic, has_forwardable_ctx)
 					if is_c_variadic {
 						tc.register_c_variadic_fn_with_lowered(qname, lowered_qname)
 					}
@@ -3413,21 +3394,18 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 					tc.register_fn_ret_type_text(lowered_qname, node.typ)
 					if tc.cur_module in ['', 'main', 'builtin'] && qname != node.value
 						&& node.value !in tc.fn_param_types {
-						tc.register_fn_signature_owned(node.value, lowered_source_name, ret_type,
-							owned_ptypes, owned_shared_params, is_variadic, has_forwardable_ctx)
+						tc.register_fn_signature_owned(node.value, lowered_source_name, ret_type, owned_ptypes, owned_shared_params, is_variadic, has_forwardable_ctx)
 						if is_c_variadic {
 							tc.register_c_variadic_fn_with_lowered(node.value, lowered_source_name)
 						}
 						if has_mut_receiver {
-							tc.register_mut_receiver_method_with_lowered(node.value,
-								lowered_source_name)
+							tc.register_mut_receiver_method_with_lowered(node.value, lowered_source_name)
 						}
 						tc.register_fn_ret_type_text(node.value, node.typ)
 						tc.register_fn_ret_type_text(lowered_source_name, node.typ)
 					}
 				} else {
-					tc.register_fn_signature(qname, ret_type, ptypes, shared_params, is_variadic,
-						has_forwardable_ctx)
+					tc.register_fn_signature(qname, ret_type, ptypes, shared_params, is_variadic, has_forwardable_ctx)
 					if is_c_variadic {
 						tc.register_c_variadic_fn(qname)
 					}
@@ -3438,8 +3416,7 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 					tc.register_fn_ret_type_text(tc.cached_c_name(qname), node.typ)
 					if tc.cur_module in ['', 'main', 'builtin'] && qname != node.value
 						&& node.value !in tc.fn_param_types {
-						tc.register_fn_signature(node.value, ret_type, ptypes, shared_params,
-							is_variadic, has_forwardable_ctx)
+						tc.register_fn_signature(node.value, ret_type, ptypes, shared_params, is_variadic, has_forwardable_ctx)
 						if is_c_variadic {
 							tc.register_c_variadic_fn(node.value)
 						}
@@ -3512,11 +3489,11 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 						shared_element_field_names << f.value
 					}
 					fields << StructField{
-						name:        f.value
-						typ:         typ
+						name: f.value
+						typ: typ
 						has_default: f.children_count > 0
-						is_embed:    field_is_embed
-						is_mut:      source_field_decl_is_mut(f)
+						is_embed: field_is_embed
+						is_mut: source_field_decl_is_mut(f)
 						is_volatile: source_field_decl_is_volatile(f)
 					}
 				}
@@ -3580,8 +3557,7 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 				tc.c_fn_module_variadic[module_key] = is_variadic
 				tc.unsafe_c_fns[module_key] = !node.is_mut
 				if node.value !in tc.v_fn_semantic_names {
-					tc.register_fn_signature(node.value, ret_type, ptypes, []bool{}, is_variadic,
-						false)
+					tc.register_fn_signature(node.value, ret_type, ptypes, []bool{}, is_variadic, false)
 				}
 				if is_variadic {
 					tc.c_fn_abi_variadic_prefixes[c_name] = if ptypes.len > 0 {
@@ -3592,8 +3568,7 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 					tc.register_c_variadic_fn(node.value)
 				}
 				if !node.value.starts_with('C.') {
-					tc.register_fn_signature('C.${node.value}', ret_type, ptypes, []bool{},
-						is_variadic, false)
+					tc.register_fn_signature('C.${node.value}', ret_type, ptypes, []bool{}, is_variadic, false)
 					if is_variadic {
 						tc.register_c_variadic_fn('C.${node.value}')
 					}
@@ -3653,8 +3628,7 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 							shared_params << param_type_text_is_shared(child.typ)
 							param_mutability << child.is_mut
 						}
-						tc.register_fn_name_alias(mname, ret_type, ptypes, shared_params,
-							is_variadic, false)
+						tc.register_fn_name_alias(mname, ret_type, ptypes, shared_params, is_variadic, false)
 						tc.declaration_param_mutability[mname] = param_mutability
 						if f.is_mut {
 							tc.register_mut_receiver_method(mname)
@@ -3667,8 +3641,8 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 					} else if f.typ.len > 0 {
 						mut fields := tc.interface_fields[iface_name] or { []StructField{} }
 						fields << StructField{
-							name:   f.value
-							typ:    tc.parse_type(f.typ)
+							name: f.value
+							typ: tc.parse_type(f.typ)
 							is_mut: f.is_mut
 						}
 						tc.interface_fields[iface_name] = fields
@@ -3868,9 +3842,9 @@ fn deprecation_info_from_attrs(name string, attrs []string) ?DeprecationInfo {
 		return none
 	}
 	return DeprecationInfo{
-		name:    name
+		name: name
 		message: message
-		after:   after
+		after: after
 	}
 }
 
@@ -3975,17 +3949,14 @@ fn (mut tc TypeChecker) check_c_struct_redeclarations(a &flat.FlatAst) {
 					if !c_struct_decl_signatures_compatible(existing_sig, c_struct_sig) {
 						existing_file := c_struct_decl_files[qname] or { '' }
 						existing_module := c_struct_decl_modules[qname] or { '' }
-						if !tc.c_struct_redeclaration_allowed(qname, existing_file, tc.cur_file,
-							existing_module, tc.cur_module) {
+						if !tc.c_struct_redeclaration_allowed(qname, existing_file, tc.cur_file, existing_module, tc.cur_module) {
 							node_id := flat.NodeId(node_idx)
 							keyword := if comma_attr_text_has(node.typ, 'union') {
 								'union'
 							} else {
 								'struct'
 							}
-							tc.record_error_unfiltered_at(.duplicate_decl,
-								'cannot redeclare C struct `${qname}`', node_id, tc.declaration_keyword_name_pos(node_id,
-								keyword))
+							tc.record_error_unfiltered_at(.duplicate_decl, 'cannot redeclare C struct `${qname}`', node_id, tc.declaration_keyword_name_pos(node_id, keyword))
 						}
 					}
 					existing_fields := c_struct_decl_signature_field_count(existing_sig)
@@ -4047,7 +4018,7 @@ fn (mut tc TypeChecker) check_c_fn_redeclarations(a &flat.FlatAst) {
 				}
 				signature := CFnDeclSignature{
 					return_type: tc.c_extern_abi_type(tc.parse_type(node.typ))
-					params:      params
+					params: params
 					is_variadic: is_variadic
 				}
 				if existing := signatures[name] {
@@ -4060,9 +4031,7 @@ fn (mut tc TypeChecker) check_c_fn_redeclarations(a &flat.FlatAst) {
 						&& !c_fn_decl_signatures_compatible(existing, signature) {
 						existing_pos := positions[name] or { '' }
 						location := if existing_pos.len > 0 { ' at ${existing_pos}' } else { '' }
-						tc.record_error_unfiltered(.duplicate_decl,
-							'C function `${name}` was already declared with a different signature in module `${existing_module}`${location}',
-							flat.NodeId(node_idx))
+						tc.record_error_unfiltered(.duplicate_decl, 'C function `${name}` was already declared with a different signature in module `${existing_module}`${location}', flat.NodeId(node_idx))
 					}
 				} else {
 					signatures[name] = signature
@@ -4147,7 +4116,7 @@ fn (tc &TypeChecker) c_struct_decl_is_vlib_winsize_shim(file string, module_name
 	normalized := file.replace('\\', '/')
 	return normalized.contains('/vlib/term/')
 		|| (normalized.contains('/v3_module_cache_')
-		&& normalized.all_after_last('/').starts_with('term_') && normalized.ends_with('.vh'))
+			&& normalized.all_after_last('/').starts_with('term_') && normalized.ends_with('.vh'))
 }
 
 fn (tc &TypeChecker) c_struct_decl_is_vlib_termios_shim(file string, module_name string) bool {
@@ -4338,7 +4307,7 @@ fn (tc &TypeChecker) syntactic_fixed_array_const_type(id flat.NodeId) ?Type {
 	}
 	return Type(ArrayFixed{
 		elem_type: elem_type
-		len:       int(literal.children_count)
+		len: int(literal.children_count)
 	})
 }
 
@@ -4733,8 +4702,7 @@ pub mut:
 // qualify_name consults, so the memo stays valid even in phases that can
 // still register types (e.g. anonymous structs during fn-body checking).
 fn (tc &TypeChecker) qualify_table_fingerprint() int {
-	return tc.structs.len + tc.type_aliases.len + tc.interface_names.len + tc.sum_types.len +
-		tc.enum_names.len + tc.flag_enums.len
+	return tc.structs.len + tc.type_aliases.len + tc.interface_names.len + tc.sum_types.len + tc.enum_names.len + tc.flag_enums.len
 }
 
 // ownership_time_spent_us reports the accumulated ownership-analysis time for
@@ -4914,8 +4882,7 @@ fn (tc &TypeChecker) qualify_sum_variant_name(name string, generic_params []stri
 	if clean.starts_with('[') {
 		bracket_end := find_matching_bracket(clean, 0)
 		if bracket_end < clean.len {
-			return clean[..bracket_end + 1] + tc.qualify_sum_variant_name(clean[bracket_end +
-				1..], generic_params)
+			return clean[..bracket_end + 1] + tc.qualify_sum_variant_name(clean[bracket_end + 1..], generic_params)
 		}
 	}
 	bracket := clean.index_u8(`[`)
@@ -4924,15 +4891,13 @@ fn (tc &TypeChecker) qualify_sum_variant_name(name string, generic_params []stri
 		if bracket_end < clean.len {
 			inner := trimmed_space(clean[bracket + 1..bracket_end])
 			if is_fixed_array_len_text(inner) || is_builtin_type_name(clean[..bracket]) {
-				return tc.qualify_sum_variant_name(clean[..bracket], generic_params) +
-					clean[bracket..]
+				return tc.qualify_sum_variant_name(clean[..bracket], generic_params) + clean[bracket..]
 			}
 			mut parts := []string{}
 			for part in split_params(inner) {
 				parts << tc.qualify_sum_variant_name(part, generic_params)
 			}
-			return tc.qualify_name(clean[..bracket]) + '[' + parts.join(', ') + ']' +
-				clean[bracket_end + 1..]
+			return tc.qualify_name(clean[..bracket]) + '[' + parts.join(', ') + ']' + clean[bracket_end + 1..]
 		}
 	}
 	return tc.qualify_name(clean)
@@ -5068,8 +5033,7 @@ fn (tc &TypeChecker) qualify_type_text_impl(typ string, resolution bool, generic
 	if clean.starts_with('[') {
 		bracket_end := find_matching_bracket(clean, 0)
 		if bracket_end < clean.len {
-			return clean[..bracket_end + 1] + tc.qualify_type_text_impl(clean[bracket_end +
-				1..], resolution, generic_params)
+			return clean[..bracket_end + 1] + tc.qualify_type_text_impl(clean[bracket_end + 1..], resolution, generic_params)
 		}
 	}
 	if clean.starts_with('(') && clean.ends_with(')') && clean.contains(',') {
@@ -5088,15 +5052,13 @@ fn (tc &TypeChecker) qualify_type_text_impl(typ string, resolution bool, generic
 		if bracket_end < clean.len {
 			inner := trimmed_space(clean[bracket + 1..bracket_end])
 			if is_fixed_array_len_text(inner) || is_builtin_type_name(clean[..bracket]) {
-				return tc.qualify_type_text_impl(clean[..bracket], resolution, generic_params) +
-					clean[bracket..]
+				return tc.qualify_type_text_impl(clean[..bracket], resolution, generic_params) + clean[bracket..]
 			}
 			mut parts := []string{}
 			for part in split_params(inner) {
 				parts << tc.qualify_type_text_impl(part, resolution, generic_params)
 			}
-			return tc.qualify_type_text_impl(clean[..bracket], resolution, generic_params) + '[' +
-				parts.join(', ') + ']' + clean[bracket_end + 1..]
+			return tc.qualify_type_text_impl(clean[..bracket], resolution, generic_params) + '[' + parts.join(', ') + ']' + clean[bracket_end + 1..]
 		}
 	}
 	if resolution && clean.contains('.') {
@@ -5147,15 +5109,13 @@ fn (tc &TypeChecker) qualify_fn_type_text(typ string, resolution bool, generic_p
 			clean_part := trimmed_space(part)
 			is_mut := clean_part.starts_with('mut ')
 			param_text := if is_mut { trimmed_space(clean_part[4..]) } else { clean_part }
-			qualified := tc.qualify_type_text_impl(normalize_fn_type_param_text(param_text),
-				resolution, generic_params)
+			qualified := tc.qualify_type_text_impl(normalize_fn_type_param_text(param_text), resolution, generic_params)
 			params << if is_mut { 'mut ${qualified}' } else { qualified }
 		}
 	}
 	ret_str := trimmed_space(typ[params_end + 1..])
 	if ret_str.len > 0 {
-		return 'fn(${params.join(', ')}) ${tc.qualify_type_text_impl(ret_str, resolution,
-			generic_params)}'
+		return 'fn(${params.join(', ')}) ${tc.qualify_type_text_impl(ret_str, resolution, generic_params)}'
 	}
 	return 'fn(${params.join(', ')})'
 }
@@ -5170,7 +5130,7 @@ fn (mut tc TypeChecker) file_import_info() &FileImportInfo {
 		return info
 	}
 	info := &FileImportInfo{
-		imports:           map[string]string{}
+		imports: map[string]string{}
 		selective_imports: map[string][]string{}
 	}
 	tc.file_imports_by_file[tc.cur_file] = info
@@ -5207,9 +5167,7 @@ fn (mut tc TypeChecker) check_import_diagnostics() {
 		module_base := module_path.all_after_last('.')
 		explicit_alias := tc.import_has_explicit_alias(node)
 		if missing_path := tc.a.missing_imports[idx] {
-			tc.record_error_severity_at(.unknown_ident,
-				'cannot import module "${missing_path}" (not found)', flat.NodeId(idx), node.pos,
-				'builder error:')
+			tc.record_error_severity_at(.unknown_ident, 'cannot import module "${missing_path}" (not found)', flat.NodeId(idx), node.pos, 'builder error:')
 		}
 		tc.check_import_source_syntax(flat.NodeId(idx), node)
 		if tc.selective_import_has_missing_value_symbol(node, module_path)
@@ -5219,19 +5177,13 @@ fn (mut tc TypeChecker) check_import_diagnostics() {
 		tc.check_selective_const_imports(node, module_path)
 		tc.check_selective_type_imports(node, module_path)
 		if declaration_seen_in_file {
-			tc.record_error_at(.duplicate_decl,
-				'`import x` can only be declared at the beginning of the file', flat.NodeId(idx), token.new_span(node.pos.id,
-				node.pos.offset, node.pos.offset + 'import'.len))
+			tc.record_error_at(.duplicate_decl, '`import x` can only be declared at the beginning of the file', flat.NodeId(idx), token.new_span(node.pos.id, node.pos.offset, node.pos.offset + 'import'.len))
 		}
 		if explicit_alias && node.typ == module_base {
-			tc.record_error_at(.duplicate_decl,
-				'import alias `${module_path} as ${node.typ}` is redundant', flat.NodeId(idx),
-				tc.import_alias_pos(node))
+			tc.record_error_at(.duplicate_decl, 'import alias `${module_path} as ${node.typ}` is redundant', flat.NodeId(idx), tc.import_alias_pos(node))
 		}
 		if module_base == tc.cur_module {
-			tc.record_error_at(.duplicate_decl,
-				'cannot import `${module_path}` into a module with the same name',
-				flat.NodeId(idx), tc.import_module_path_pos(node))
+			tc.record_error_at(.duplicate_decl, 'cannot import `${module_path}` into a module with the same name', flat.NodeId(idx), tc.import_module_path_pos(node))
 		}
 		if node.typ == tc.cur_module {
 			alias_pos := if explicit_alias {
@@ -5239,22 +5191,16 @@ fn (mut tc TypeChecker) check_import_diagnostics() {
 			} else {
 				tc.import_module_basename_pos(node)
 			}
-			tc.record_error_at(.duplicate_decl,
-				'cannot import `${module_path}` as `${node.typ}` into a module with the same name',
-				flat.NodeId(idx), alias_pos)
+			tc.record_error_at(.duplicate_decl, 'cannot import `${module_path}` as `${node.typ}` into a module with the same name', flat.NodeId(idx), alias_pos)
 		}
 		if module_path == 'json' && module_base != tc.cur_module {
-			tc.record_warning_at(.duplicate_decl,
-				'module `json` has been deprecated; `json` will be removed soon; use the pure V `json2` module instead',
-				flat.NodeId(idx), node.pos)
+			tc.record_warning_at(.duplicate_decl, 'module `json` has been deprecated; `json` will be removed soon; use the pure V `json2` module instead', flat.NodeId(idx), node.pos)
 		}
 		key := file_import_key(tc.cur_file, node.typ)
 		if first_pos := first_imports[key] {
 			first_line := tc.import_line_number(first_pos)
 			pos := tc.import_module_path_pos(node)
-			tc.record_error_at(.duplicate_decl,
-				'A module `${node.typ}` was already imported on line ${first_line}`.',
-				flat.NodeId(idx), pos)
+			tc.record_error_at(.duplicate_decl, 'A module `${node.typ}` was already imported on line ${first_line}`.', flat.NodeId(idx), pos)
 		} else {
 			first_imports[key] = node.pos
 		}
@@ -5346,9 +5292,7 @@ fn (mut tc TypeChecker) check_selective_const_imports(node flat.Node, module_pat
 			}
 		}
 		if is_const {
-			tc.record_error_at(.duplicate_decl,
-				'cannot selectively import constant `${child.value}` from `${module_path}`, import `${module_path}` and use `${module_path}.${child.value}` instead',
-				child_id, tc.node_value_diagnostic_pos(child_id))
+			tc.record_error_at(.duplicate_decl, 'cannot selectively import constant `${child.value}` from `${module_path}`, import `${module_path}` and use `${module_path}.${child.value}` instead', child_id, tc.node_value_diagnostic_pos(child_id))
 			continue
 		}
 		if child.value[0].is_capital() {
@@ -5363,13 +5307,9 @@ fn (mut tc TypeChecker) check_selective_const_imports(node flat.Node, module_pat
 			}
 		}
 		if symbol_name.len == 0 {
-			tc.record_error_at(.unknown_fn,
-				'module `${module_path}` has no constant or function `${child.value}`', child_id,
-				tc.node_value_diagnostic_pos(child_id))
+			tc.record_error_at(.unknown_fn, 'module `${module_path}` has no constant or function `${child.value}`', child_id, tc.node_value_diagnostic_pos(child_id))
 		} else if _ := tc.private_declaration(symbol_name) {
-			tc.record_error_at(.unknown_fn,
-				'module `${module_path}` function `${child.value}()` is private', child_id,
-				tc.node_value_diagnostic_pos(child_id))
+			tc.record_error_at(.unknown_fn, 'module `${module_path}` function `${child.value}()` is private', child_id, tc.node_value_diagnostic_pos(child_id))
 		}
 	}
 }
@@ -5390,13 +5330,9 @@ fn (mut tc TypeChecker) check_selective_type_imports(node flat.Node, module_path
 			}
 		}
 		if symbol_name.len == 0 {
-			tc.record_error_at(.unknown_type,
-				'module `${module_path}` has no type `${child.value}`', child_id,
-				tc.node_value_diagnostic_pos(child_id))
+			tc.record_error_at(.unknown_type, 'module `${module_path}` has no type `${child.value}`', child_id, tc.node_value_diagnostic_pos(child_id))
 		} else if _ := tc.private_declaration(symbol_name) {
-			tc.record_error_at(.unknown_type,
-				'module `${module_path}` type `${child.value}` is private', child_id,
-				tc.node_value_diagnostic_pos(child_id))
+			tc.record_error_at(.unknown_type, 'module `${module_path}` type `${child.value}` is private', child_id, tc.node_value_diagnostic_pos(child_id))
 		}
 	}
 }
@@ -5420,8 +5356,7 @@ fn (mut tc TypeChecker) check_unused_import_diagnostics() {
 			continue
 		}
 		if tc.errors.any(it.file == tc.cur_file && it.kind == .unknown_ident
-			&& it.msg.starts_with('undefined variable') && it.node_value == node.typ)
-		{
+			&& it.msg.starts_with('undefined variable') && it.node_value == node.typ) {
 			continue
 		}
 		if tc.node_has_unused_import_warning(flat.NodeId(idx)) {
@@ -5441,9 +5376,7 @@ fn (mut tc TypeChecker) record_unused_import_warning(id flat.NodeId, node flat.N
 	} else {
 		'${node.typ} (${module_path})'
 	}
-	tc.record_warning_at(.unknown_ident,
-		"module '${display_name}' is imported but never used. Use `import ${display_name} as _`, to silence this warning, or just remove the unused import line",
-		id, tc.import_module_path_pos(node))
+	tc.record_warning_at(.unknown_ident, "module '${display_name}' is imported but never used. Use `import ${display_name} as _`, to silence this warning, or just remove the unused import line", id, tc.import_module_path_pos(node))
 }
 
 fn (tc &TypeChecker) node_has_unused_import_warning(id flat.NodeId) bool {
@@ -5483,8 +5416,7 @@ fn (mut tc TypeChecker) check_import_source_syntax(id flat.NodeId, node flat.Nod
 		}
 		end := import_source_ident_end(source, next)
 		if end > next {
-			tc.record_error_at(.duplicate_decl, '`import` statements must be a single line', id, token.new_span(node.pos.id,
-				next, end))
+			tc.record_error_at(.duplicate_decl, '`import` statements must be a single line', id, token.new_span(node.pos.id, next, end))
 		}
 		return
 	}
@@ -5502,8 +5434,7 @@ fn (mut tc TypeChecker) check_import_source_syntax(id flat.NodeId, node flat.Nod
 		return
 	}
 	if source[cursor] == `,` {
-		tc.record_error_at(.duplicate_decl, 'cannot import multiple modules at a time', id, token.new_span(node.pos.id,
-			cursor, cursor + 1))
+		tc.record_error_at(.duplicate_decl, 'cannot import multiple modules at a time', id, token.new_span(node.pos.id, cursor, cursor + 1))
 		return
 	}
 	if source[cursor] == `{` {
@@ -5515,8 +5446,7 @@ fn (mut tc TypeChecker) check_import_source_syntax(id flat.NodeId, node flat.Nod
 	}
 	if is_import_ident_byte(source[cursor]) {
 		end := import_source_ident_end(source, cursor)
-		tc.record_error_at(.duplicate_decl, 'cannot import multiple modules at a time', id, token.new_span(node.pos.id,
-			cursor, end))
+		tc.record_error_at(.duplicate_decl, 'cannot import multiple modules at a time', id, token.new_span(node.pos.id, cursor, end))
 	}
 }
 
@@ -5526,9 +5456,7 @@ fn (mut tc TypeChecker) check_selective_import_source_syntax(id flat.NodeId, nod
 		cursor++
 	}
 	if cursor < line_end && source[cursor] == `}` {
-		tc.record_error_at(.duplicate_decl,
-			'empty `${tc.import_module_path_text(node)}` import set, remove `{}`', id, token.new_span(node.pos.id,
-			cursor, cursor + 1))
+		tc.record_error_at(.duplicate_decl, 'empty `${tc.import_module_path_text(node)}` import set, remove `{}`', id, token.new_span(node.pos.id, cursor, cursor + 1))
 		return
 	}
 	mut close := -1
@@ -5543,14 +5471,11 @@ fn (mut tc TypeChecker) check_selective_import_source_syntax(id flat.NodeId, nod
 		for diagnostic_offset > open && source[diagnostic_offset] in [` `, `\t`, `\r`, `\n`] {
 			diagnostic_offset--
 		}
-		tc.record_error_at(.duplicate_decl, 'import syntax error, no closing `}`', id, token.new_span(node.pos.id,
-			diagnostic_offset, diagnostic_offset + 1))
+		tc.record_error_at(.duplicate_decl, 'import syntax error, no closing `}`', id, token.new_span(node.pos.id, diagnostic_offset, diagnostic_offset + 1))
 		return
 	}
 	if cursor < close && !is_import_ident_byte(source[cursor]) {
-		tc.record_error_at(.duplicate_decl,
-			'import syntax error, please specify a valid fn or type name', id, token.new_span(node.pos.id,
-			cursor, cursor + 1))
+		tc.record_error_at(.duplicate_decl, 'import syntax error, please specify a valid fn or type name', id, token.new_span(node.pos.id, cursor, cursor + 1))
 	}
 }
 
@@ -5659,8 +5584,7 @@ fn (mut tc TypeChecker) check_deprecated_byte_types() {
 		if pending_file.len == 0 || !node.pos.is_valid() {
 			continue
 		}
-		tc.check_deprecated_byte_types_in_file(flat.NodeId(idx), node.pos.id, pending_file,
-			identifier_offsets)
+		tc.check_deprecated_byte_types_in_file(flat.NodeId(idx), node.pos.id, pending_file, identifier_offsets)
 		pending_file = ''
 	}
 }
@@ -5723,8 +5647,7 @@ fn (mut tc TypeChecker) check_deprecated_byte_types_in_file(anchor flat.NodeId, 
 				end = close + 1
 			}
 		}
-		tc.errors << tc.make_type_error_at(.unknown_type, 'byte is deprecated, use u8 instead',
-			anchor, token.new_span(file_id, start, end))
+		tc.errors << tc.make_type_error_at(.unknown_type, 'byte is deprecated, use u8 instead', anchor, token.new_span(file_id, start, end))
 	}
 }
 
@@ -5879,8 +5802,7 @@ fn (mut tc TypeChecker) register_selective_imports(node flat.Node) {
 		if child.value in info.selective_imports {
 			tc.file_selective_imports[key] = []string{}
 			info.selective_imports[child.value] = []string{}
-			tc.record_error_unfiltered(.unknown_fn, 'ambiguous selective import `${child.value}`',
-				child_id)
+			tc.record_error_unfiltered(.unknown_fn, 'ambiguous selective import `${child.value}`', child_id)
 			continue
 		}
 		mut candidates := []string{}
@@ -5912,7 +5834,7 @@ struct ImportInfoCache {
 mut:
 	file     string
 	info     &FileImportInfo = unsafe { nil }
-	seen_len int             = -1
+	seen_len int = -1
 }
 
 fn (tc &TypeChecker) current_file_import_info() &FileImportInfo {
@@ -5956,8 +5878,7 @@ fn (tc &TypeChecker) resolve_selective_import_symbol(name string) ?string {
 				continue
 			}
 			for candidate in fallback_candidates {
-				if !tc.fn_signature_known(candidate) && candidate !in tc.fn_ret_types
-					&& candidate !in tc.fn_param_types {
+				if !tc.fn_signature_known(candidate) && candidate !in tc.fn_ret_types && candidate !in tc.fn_param_types {
 					continue
 				}
 				if resolved.len > 0 && resolved != candidate {
@@ -5990,8 +5911,7 @@ pub fn (tc &TypeChecker) resolve_any_selective_import_fn(name string) ?string {
 			continue
 		}
 		for candidate in candidates {
-			if !tc.fn_signature_known(candidate) && candidate !in tc.fn_ret_types
-				&& candidate !in tc.fn_param_types {
+			if !tc.fn_signature_known(candidate) && candidate !in tc.fn_ret_types && candidate !in tc.fn_param_types {
 				continue
 			}
 			if resolved.len > 0 && resolved != candidate {
@@ -6087,7 +6007,7 @@ fn (tc &TypeChecker) type_from_known_symbol(name string) ?Type {
 	}
 	if name in tc.flag_enums {
 		return Type(Enum{
-			name:    name
+			name: name
 			is_flag: true
 		})
 	}
@@ -6211,7 +6131,7 @@ fn (mut tc TypeChecker) register_mut_receiver_method(name string) {
 fn (mut tc TypeChecker) register_mut_receiver_method_with_lowered(name string, lowered_name string) {
 	if tc.defer_fn_ancillary {
 		tc.fn_mut_receiver_registrations << FnNamePairRegistration{
-			name:         name
+			name: name
 			lowered_name: lowered_name
 		}
 		return
@@ -6225,18 +6145,15 @@ fn (mut tc TypeChecker) register_mut_receiver_method_with_lowered(name string, l
 // register_fn_signature_owned installs aliases that may share immutable
 // master-owned signature arrays. lowered_name must be cached_c_name(name).
 fn (mut tc TypeChecker) register_fn_signature_owned(name string, lowered_name string, ret_type Type, params []Type, shared_params []bool, is_variadic bool, implicit_veb_ctx bool) {
-	tc.register_fn_name_alias_owned(name, ret_type, params, shared_params, is_variadic,
-		implicit_veb_ctx)
+	tc.register_fn_name_alias_owned(name, ret_type, params, shared_params, is_variadic, implicit_veb_ctx)
 	if lowered_name != name && !(name.starts_with('C.') && lowered_name in tc.v_fn_semantic_names) {
-		tc.register_fn_name_alias_owned(lowered_name, ret_type, params, shared_params, is_variadic,
-			implicit_veb_ctx)
+		tc.register_fn_name_alias_owned(lowered_name, ret_type, params, shared_params, is_variadic, implicit_veb_ctx)
 	}
 	if name.ends_with('.str') {
 		receiver := name.all_before_last('.')
 		legacy_name := '${receiver}_str'
 		if !legacy_name.contains('.') {
-			tc.register_fn_name_alias_owned(legacy_name, ret_type, params, shared_params,
-				is_variadic, implicit_veb_ctx)
+			tc.register_fn_name_alias_owned(legacy_name, ret_type, params, shared_params, is_variadic, implicit_veb_ctx)
 		}
 	}
 }
@@ -6246,15 +6163,13 @@ fn (mut tc TypeChecker) register_fn_signature(name string, ret_type Type, params
 	tc.register_fn_name_alias(name, ret_type, params, shared_params, is_variadic, implicit_veb_ctx)
 	lowered_name := tc.cached_c_name(name)
 	if lowered_name != name && !(name.starts_with('C.') && lowered_name in tc.v_fn_semantic_names) {
-		tc.register_fn_name_alias(lowered_name, ret_type, params, shared_params, is_variadic,
-			implicit_veb_ctx)
+		tc.register_fn_name_alias(lowered_name, ret_type, params, shared_params, is_variadic, implicit_veb_ctx)
 	}
 	if name.ends_with('.str') {
 		receiver := name.all_before_last('.')
 		legacy_name := '${receiver}_str'
 		if !legacy_name.contains('.') {
-			tc.register_fn_name_alias(legacy_name, ret_type, params, shared_params, is_variadic,
-				implicit_veb_ctx)
+			tc.register_fn_name_alias(legacy_name, ret_type, params, shared_params, is_variadic, implicit_veb_ctx)
 		}
 	}
 }
@@ -6267,8 +6182,7 @@ fn (mut tc TypeChecker) register_fn_name_alias(name string, ret_type Type, param
 	} else {
 		shared_params
 	}
-	tc.register_fn_name_alias_owned(name, ret_type, owned_params, owned_shared_params, is_variadic,
-		implicit_veb_ctx)
+	tc.register_fn_name_alias_owned(name, ret_type, owned_params, owned_shared_params, is_variadic, implicit_veb_ctx)
 }
 
 fn (mut tc TypeChecker) register_fn_name_alias_owned(name string, ret_type Type, params []Type, shared_params []bool, is_variadic bool, implicit_veb_ctx bool) {
@@ -6281,8 +6195,7 @@ fn (mut tc TypeChecker) register_fn_name_alias_owned(name string, ret_type Type,
 	// `failed to join compiler worker 0`).
 	if !name.starts_with('C.') {
 		if owner_module := tc.fn_type_modules[name] {
-			if owner_module != tc.cur_module && tc.cur_module !in ['', 'main', 'builtin']
-				&& !name.starts_with('${tc.cur_module}.') {
+			if owner_module != tc.cur_module && tc.cur_module !in ['', 'main', 'builtin'] && !name.starts_with('${tc.cur_module}.') {
 				return
 			}
 		}
@@ -6302,13 +6215,13 @@ fn (mut tc TypeChecker) register_fn_name_alias_owned(name string, ret_type Type,
 	}
 	if tc.defer_fn_ancillary {
 		tc.fn_ancillary_registrations << FnAncillaryRegistration{
-			name:             name
-			ret_type:         ret_type
-			shared_params:    shared_params
-			is_variadic:      is_variadic
+			name: name
+			ret_type: ret_type
+			shared_params: shared_params
+			is_variadic: is_variadic
 			implicit_veb_ctx: implicit_veb_ctx
-			file:             tc.cur_file
-			write_file:       write_file
+			file: tc.cur_file
+			write_file: write_file
 		}
 	} else {
 		tc.fn_ret_types[name] = ret_type
@@ -6392,8 +6305,7 @@ fn (mut tc TypeChecker) add_receiver_method_suffix_index(name string) {
 	if name.contains('.') {
 		bracket := receiver.index_u8(`[`)
 		if bracket > 0 {
-			tc.set_receiver_method_suffix_index('${receiver[..bracket]}.${name.all_after_last('.')}',
-				name)
+			tc.set_receiver_method_suffix_index('${receiver[..bracket]}.${name.all_after_last('.')}', name)
 		}
 	}
 	for i in 0 .. name.len {
@@ -6430,7 +6342,7 @@ fn (mut tc TypeChecker) register_c_variadic_fn_with_lowered(name string, lowered
 	}
 	if tc.defer_fn_ancillary {
 		tc.fn_c_variadic_registrations << FnNamePairRegistration{
-			name:         name
+			name: name
 			lowered_name: lowered_name
 		}
 		return
@@ -6692,10 +6604,10 @@ pub fn (mut tc TypeChecker) diagnose_unused_private_declarations(used_fns map[st
 			}
 			cand_idx := candidates.len
 			candidates << UnusedDeclCandidate{
-				is_fn:   true
-				name:    node.value
-				qname:   qname
-				file:    tc.cur_file
+				is_fn: true
+				name: node.value
+				qname: qname
+				file: tc.cur_file
 				node_id: flat.NodeId(idx)
 			}
 			fn_keys[node.value] << cand_idx
@@ -6721,11 +6633,11 @@ pub fn (mut tc TypeChecker) diagnose_unused_private_declarations(used_fns map[st
 			}
 			cand_idx := candidates.len
 			candidates << UnusedDeclCandidate{
-				is_fn:    false
-				name:     field.value
-				qname:    qname
-				file:     tc.cur_file
-				node_id:  field_id
+				is_fn: false
+				name: field.value
+				qname: qname
+				file: tc.cur_file
+				node_id: field_id
 				position: field.pos
 			}
 			const_keys[field.value] << cand_idx
@@ -6758,11 +6670,9 @@ pub fn (mut tc TypeChecker) diagnose_unused_private_declarations(used_fns map[st
 		}
 		tc.cur_file = cand.file
 		if cand.is_fn {
-			tc.record_notice_at(.unknown_ident, 'unused function: `${cand.name}`', cand.node_id,
-				tc.node_value_diagnostic_pos(cand.node_id))
+			tc.record_notice_at(.unknown_ident, 'unused function: `${cand.name}`', cand.node_id, tc.node_value_diagnostic_pos(cand.node_id))
 		} else {
-			tc.record_notice_at(.unknown_ident, 'unused constant: `${cand.name}`', cand.node_id,
-				cand.position)
+			tc.record_notice_at(.unknown_ident, 'unused constant: `${cand.name}`', cand.node_id, cand.position)
 		}
 	}
 	tc.cur_file = walk_end_file
@@ -6841,9 +6751,7 @@ pub fn (mut tc TypeChecker) check_main_module_requirement(is_shared bool) {
 	} else {
 		node.pos.offset
 	}
-	tc.record_error_at(.duplicate_decl,
-		'project must include a `main` module or be a shared library (compile with `v -shared`)',
-		first_module_id, token.new_span(node.pos.id, line_start, line_start + 1))
+	tc.record_error_at(.duplicate_decl, 'project must include a `main` module or be a shared library (compile with `v -shared`)', first_module_id, token.new_span(node.pos.id, line_start, line_start + 1))
 }
 
 fn (tc &TypeChecker) should_annotate_fn(node flat.Node, used_fns map[string]bool) bool {
@@ -6937,9 +6845,9 @@ fn (mut tc TypeChecker) annotate_node(id flat.NodeId) {
 					base_type := tc.resolve_type(base_id)
 					if type_contains_unknown(base_type)
 						|| ((base_type is OptionType || base_type is ResultType)
-						&& node.value !in ['ok', 'value', 'err'])
+							&& node.value !in ['ok', 'value', 'err'])
 						|| (tc.fn_context.generic_params.len > 0 && (base_type is OptionType
-						|| base_type is ResultType)) {
+							|| base_type is ResultType)) {
 						tc.annotate_node(base_id)
 						continue
 					}
@@ -7261,8 +7169,7 @@ fn (tc &TypeChecker) expr_is_value_tail_of(root_id flat.NodeId, target_id flat.N
 				&& tc.expr_is_value_tail_of(tc.a.child(&node, node.children_count - 1), target_id)
 		}
 		.or_expr {
-			return node.children_count >= 2 && node.value !in ['!', '?']
-				&& tc.expr_is_value_tail_of(tc.a.child(&node, 1), target_id)
+			return node.children_count >= 2 && node.value !in ['!', '?'] && tc.expr_is_value_tail_of(tc.a.child(&node, 1), target_id)
 		}
 		.if_expr, .match_stmt {
 			for i in 1 .. node.children_count {
@@ -7343,8 +7250,7 @@ fn (mut tc TypeChecker) annotate_call_expected_exprs(id flat.NodeId, node flat.N
 	}
 	collapsed := if field_init_args > 0 { 1 } else { 0 }
 	recv_extra := if info.has_receiver { 1 } else { 0 }
-	mut actual_count := node.children_count - 1 - info.arg_offset - field_init_args + collapsed +
-		recv_extra
+	mut actual_count := node.children_count - 1 - info.arg_offset - field_init_args + collapsed + recv_extra
 	for i in 1 + info.arg_offset .. node.children_count {
 		arg_id := tc.call_arg_value(tc.a.child(&node, i))
 		arg_type := tc.cached_expr_type(arg_id) or { tc.resolve_type(arg_id) }
@@ -7364,8 +7270,7 @@ fn (mut tc TypeChecker) annotate_call_expected_exprs(id flat.NodeId, node flat.N
 			continue
 		}
 		arg_shift := if ctx_omitted { ctx_count } else { 0 }
-		param_idx := i - 1 - info.arg_offset + (if info.has_receiver { 1 } else { 0 }) + arg_shift +
-			expanded_arg_offset
+		param_idx := i - 1 - info.arg_offset + (if info.has_receiver { 1 } else { 0 }) + arg_shift + expanded_arg_offset
 		if info.is_c_variadic && param_idx >= c_variadic_fixed_param_count(info) {
 			continue
 		}
@@ -7530,8 +7435,7 @@ fn (mut tc TypeChecker) annotate_for_in(_id flat.NodeId, node flat.Node) {
 		} else {
 			container := tc.a.nodes[int(container_id)]
 			if container.kind == .range {
-				tc.insert_loop_var(key_id, tc.range_loop_var_type(tc.a.child(&container, 0), tc.a.child(&container,
-					1)))
+				tc.insert_loop_var(key_id, tc.range_loop_var_type(tc.a.child(&container, 0), tc.a.child(&container, 1)))
 			} else {
 				// Annotation also walks deferred generic branches such as
 				// `$if T is $array { for value in data { ... } }`. The source template's
@@ -7635,11 +7539,11 @@ pub fn (tc &TypeChecker) iterator_for_in_next_call_info(typ Type) ?CallInfo {
 	}
 	if name == 'RunesIterator' || name == 'builtin.RunesIterator' {
 		return CallInfo{
-			name:         'RunesIterator.next'
-			params:       tarr1(Type(Pointer{
+			name: 'RunesIterator.next'
+			params: tarr1(Type(Pointer{
 				base_type: clean
 			}))
-			return_type:  Type(OptionType{
+			return_type: Type(OptionType{
 				base_type: Type(rune_)
 			})
 			has_receiver: true
@@ -7694,7 +7598,7 @@ fn (tc &TypeChecker) specialize_generic_interface_method(type_name string, info 
 	}
 	return CallInfo{
 		...info
-		params:      specialized_params
+		params: specialized_params
 		return_type: tc.substitute_generic_type_values(info.return_type, concrete_types, params)
 	}
 }
@@ -7736,16 +7640,16 @@ fn (tc &TypeChecker) specialized_index_overload_call_info(type_name string, meth
 		return info
 	}
 	return CallInfo{
-		name:                 concrete
-		params:               info.params.clone()
-		shared_params:        info.shared_params.clone()
-		return_type:          info.return_type
-		has_receiver:         info.has_receiver
-		is_variadic:          info.is_variadic
-		is_c_variadic:        info.is_c_variadic
-		params_known:         info.params_known
+		name: concrete
+		params: info.params.clone()
+		shared_params: info.shared_params.clone()
+		return_type: info.return_type
+		has_receiver: info.has_receiver
+		is_variadic: info.is_variadic
+		is_c_variadic: info.is_c_variadic
+		params_known: info.params_known
 		has_implicit_veb_ctx: info.has_implicit_veb_ctx
-		arg_offset:           info.arg_offset
+		arg_offset: info.arg_offset
 	}
 }
 
@@ -8005,9 +7909,7 @@ fn (tc &TypeChecker) node_calls_fn_that_may_store_globally(id flat.NodeId, calle
 		if node.children_count > 0 {
 			callee := tc.a.child_node(&node, 0)
 			if callee.kind == .ident {
-				if tc.fn_may_store_globally(checker_qualified_fn_name(caller_mod, callee.value), mut
-					visiting)
-				{
+				if tc.fn_may_store_globally(checker_qualified_fn_name(caller_mod, callee.value), mut visiting) {
 					return true
 				}
 			}
@@ -8310,25 +8212,21 @@ fn (mut tc TypeChecker) generic_fn_value_matches_expected(key string, expected T
 	}
 	mut inferred := map[string]Type{}
 	for i in 0 .. actual_fn.params.len {
-		tc.infer_generic_type_value_from_type(actual_fn.params[i].name(), expected_fn.params[i],
-			generic_params, mut inferred)
+		tc.infer_generic_type_value_from_type(actual_fn.params[i].name(), expected_fn.params[i], generic_params, mut inferred)
 	}
-	tc.infer_generic_type_value_from_type(actual_fn.return_type.name(), expected_fn.return_type,
-		generic_params, mut inferred)
+	tc.infer_generic_type_value_from_type(actual_fn.return_type.name(), expected_fn.return_type, generic_params, mut inferred)
 	mut concrete_types := []Type{cap: generic_params.len}
 	for param in generic_params {
 		concrete_types << (inferred[param] or { return false })
 	}
 	mut specialized_params := []Type{cap: actual_fn.params.len}
 	for param in actual_fn.params {
-		specialized_params << tc.substitute_generic_type_values(param, concrete_types,
-			generic_params)
+		specialized_params << tc.substitute_generic_type_values(param, concrete_types, generic_params)
 	}
 	specialized := Type(FnType{
-		params:      specialized_params
-		params_mut:  actual_fn.params_mut.clone()
-		return_type: tc.substitute_generic_type_values(actual_fn.return_type, concrete_types,
-			generic_params)
+		params: specialized_params
+		params_mut: actual_fn.params_mut.clone()
+		return_type: tc.substitute_generic_type_values(actual_fn.return_type, concrete_types, generic_params)
 	})
 	return tc.fn_value_signature_compatible(specialized, expected)
 }
@@ -8495,20 +8393,16 @@ pub fn (mut tc TypeChecker) check_semantics() {
 				node_id := flat.NodeId(i)
 				tc.check_invalid_test_file_name(node_id, node)
 				if tc.should_check_source_name(node_id) && !snake_case_name_is_valid(node.value) {
-					tc.check_snake_case_name(node_id, node.value, 'module name', tc.declaration_keyword_name_pos(node_id,
-						'module'))
+					tc.check_snake_case_name(node_id, node.value, 'module name', tc.declaration_keyword_name_pos(node_id, 'module'))
 				}
 			}
 			.struct_decl {
 				node_id := flat.NodeId(i)
 				if comma_attr_text_has(node.typ, 'typedef') && !node.value.starts_with('C.') {
-					tc.record_error_at(.assignment_mismatch,
-						'`typedef` attribute can only be used with C structs', node_id, tc.declaration_keyword_name_pos(node_id,
-						'struct'))
+					tc.record_error_at(.assignment_mismatch, '`typedef` attribute can only be used with C structs', node_id, tc.declaration_keyword_name_pos(node_id, 'struct'))
 				}
 				if tc.should_check_source_name(node_id) && !pascal_case_name_is_valid(node.value) {
-					tc.check_pascal_case_name(node_id, node.value, 'struct name', tc.declaration_keyword_name_pos(node_id,
-						'struct'))
+					tc.check_pascal_case_name(node_id, node.value, 'struct name', tc.declaration_keyword_name_pos(node_id, 'struct'))
 				}
 				tc.check_decl_type_strings(flat.NodeId(i), node)
 				tc.check_struct_implements(flat.NodeId(i), node)
@@ -8519,8 +8413,7 @@ pub fn (mut tc TypeChecker) check_semantics() {
 				if node.kind == .interface_decl {
 					if tc.should_check_source_name(node_id)
 						&& !pascal_case_name_is_valid(node.value) {
-						tc.check_pascal_case_name(node_id, node.value, 'interface name',
-							tc.source_line_declaration_pos(node_id))
+						tc.check_pascal_case_name(node_id, node.value, 'interface name', tc.source_line_declaration_pos(node_id))
 					}
 					tc.check_interface_member_names(node)
 				} else {
@@ -8533,8 +8426,7 @@ pub fn (mut tc TypeChecker) check_semantics() {
 					}
 					if tc.should_check_source_name(node_id)
 						&& !pascal_case_name_is_valid(node.value) {
-						tc.check_pascal_case_name(node_id, node.value, type_kind, tc.declaration_keyword_name_pos(node_id,
-							'type'))
+						tc.check_pascal_case_name(node_id, node.value, type_kind, tc.declaration_keyword_name_pos(node_id, 'type'))
 					}
 					is_c_alias := node.value.starts_with('C.') && node.children_count == 0
 						&& split_sum_variant_texts(node.typ).len <= 1
@@ -8545,9 +8437,7 @@ pub fn (mut tc TypeChecker) check_semantics() {
 						} else {
 							'alias'
 						}
-						tc.record_error_at(.duplicate_decl,
-							'cannot register ${kind} `${node.value}`, another type with this name exists',
-							node_id, tc.declaration_keyword_name_pos(node_id, 'type'))
+						tc.record_error_at(.duplicate_decl, 'cannot register ${kind} `${node.value}`, another type with this name exists', node_id, tc.declaration_keyword_name_pos(node_id, 'type'))
 					}
 				}
 				tc.check_decl_type_strings(flat.NodeId(i), node)
@@ -8555,8 +8445,7 @@ pub fn (mut tc TypeChecker) check_semantics() {
 			.enum_decl {
 				node_id := flat.NodeId(i)
 				if tc.should_check_source_name(node_id) && !pascal_case_name_is_valid(node.value) {
-					tc.check_pascal_case_name(node_id, node.value, 'enum name', tc.declaration_keyword_name_pos(node_id,
-						'enum'))
+					tc.check_pascal_case_name(node_id, node.value, 'enum name', tc.declaration_keyword_name_pos(node_id, 'enum'))
 				}
 				tc.check_enum_backing_type(flat.NodeId(i), node)
 				tc.check_enum_field_values(flat.NodeId(i), node)
@@ -8566,8 +8455,7 @@ pub fn (mut tc TypeChecker) check_semantics() {
 			}
 			.global_decl {
 				if !tc.enable_globals && !tc.has_globals_files[tc.cur_file] {
-					tc.record_error_at(.duplicate_decl,
-						'use `v -enable-globals ...` to enable globals', flat.NodeId(i), node.pos)
+					tc.record_error_at(.duplicate_decl, 'use `v -enable-globals ...` to enable globals', flat.NodeId(i), node.pos)
 				}
 				tc.check_const_global_initializers(node)
 			}
@@ -8688,10 +8576,10 @@ fn (tc &TypeChecker) fn_declaration_group_key(node flat.Node) string {
 
 fn (mut tc TypeChecker) check_fn_decl_semantics_scoped(fn_idx int, range_lo int, file string, module_name string) {
 	item := CheckWorkItem{
-		fn_idx:   fn_idx
+		fn_idx: fn_idx
 		range_lo: range_lo
-		file:     file
-		module:   module_name
+		file: file
+		module: module_name
 	}
 	scope := check_worker_scope_begin(true)
 	mut scoped := tc.fork_for_parallel_check()
@@ -8744,8 +8632,7 @@ fn (mut tc TypeChecker) check_selective_builtin_import_diagnostics() {
 			child_id := tc.a.child(node, i)
 			child := tc.a.node(child_id)
 			if child.kind == .ident && is_builtin_type_name(child.value) {
-				tc.record_error_at(.unknown_type, 'cannot import or override builtin type',
-					child_id, tc.node_value_diagnostic_pos(child_id))
+				tc.record_error_at(.unknown_type, 'cannot import or override builtin type', child_id, tc.node_value_diagnostic_pos(child_id))
 			}
 		}
 	}
@@ -8780,8 +8667,7 @@ fn (mut tc TypeChecker) check_c_js_generic_declarations() {
 			} else {
 				tc.generic_declaration_head_pos(flat.NodeId(index))
 			}
-			tc.record_error_at(.unsupported_generic,
-				'${namespace} ${type_kind} cannot be declared as generic', flat.NodeId(index), pos)
+			tc.record_error_at(.unsupported_generic, '${namespace} ${type_kind} cannot be declared as generic', flat.NodeId(index), pos)
 		}
 	}
 }
@@ -8860,18 +8746,17 @@ fn (mut tc TypeChecker) check_duplicate_fn_declarations() {
 			continue
 		}
 		tc.errors << TypeError{
-			msg:        'redefinition of function `${display_name}`'
-			kind:       .duplicate_decl
-			node:       flat.empty_node
+			msg: 'redefinition of function `${display_name}`'
+			kind: .duplicate_decl
+			node: flat.empty_node
 			node_value: key
-			severity:   'builder error:'
+			severity: 'builder error:'
 		}
 		for index in indexes {
 			node_id := flat.NodeId(index)
 			node := tc.a.nodes[index]
 			pos := tc.fn_declaration_diagnostic_pos(node)
-			base := tc.make_type_error_at(.duplicate_decl,
-				tc.fn_declaration_source_signature(node, pos), node_id, pos)
+			base := tc.make_type_error_at(.duplicate_decl, tc.fn_declaration_source_signature(node, pos), node_id, pos)
 			tc.errors << TypeError{
 				...base
 				severity: 'conflicting declaration:'
@@ -8975,8 +8860,7 @@ fn (mut tc TypeChecker) validate_goto_boundary_nodes(id flat.NodeId, inside_unsa
 		}
 		if child.kind == .goto_stmt {
 			if !inside_unsafe && !tc.node_is_in_translated_file(child_id) {
-				tc.record_goto_diagnostic(child_id, true,
-					'`goto` requires `unsafe` (consider using labelled break/continue)')
+				tc.record_goto_diagnostic(child_id, true, '`goto` requires `unsafe` (consider using labelled break/continue)')
 			}
 			if child.value !in labels {
 				tc.record_goto_diagnostic(child_id, false, 'unknown label `${child.value}`')
@@ -9057,12 +8941,10 @@ fn (mut tc TypeChecker) check_str_method_signature(id flat.NodeId, node flat.Nod
 		}
 	}
 	if !unalias_type(tc.parse_type(node.typ)).is_string() {
-		tc.record_error_at(.return_mismatch, '.str() methods should return `string`', id,
-			tc.fn_declaration_diagnostic_pos(node))
+		tc.record_error_at(.return_mismatch, '.str() methods should return `string`', id, tc.fn_declaration_diagnostic_pos(node))
 	}
 	if explicit_params != 0 {
-		tc.record_error_at(.call_arg_mismatch, '.str() methods should have 0 arguments', id,
-			tc.fn_declaration_diagnostic_pos(node))
+		tc.record_error_at(.call_arg_mismatch, '.str() methods should have 0 arguments', id, tc.fn_declaration_diagnostic_pos(node))
 	}
 }
 
@@ -9098,18 +8980,14 @@ fn (mut tc TypeChecker) check_free_method_signature(id flat.NodeId, node flat.No
 			} else {
 				receiver_pos
 			}
-			tc.record_error_at(.call_arg_mismatch,
-				'`.free()` methods should be defined on either a `(mut x &${type_name})`, or a `(x &${type_name})` receiver',
-				id, pos)
+			tc.record_error_at(.call_arg_mismatch, '`.free()` methods should be defined on either a `(mut x &${type_name})`, or a `(x &${type_name})` receiver', id, pos)
 		}
 	}
 	if unalias_type(tc.parse_type(node.typ)) !is Void {
-		tc.record_error_at(.return_mismatch, '`.free()` methods should not have a return type', id,
-			tc.fn_return_type_diagnostic_pos(node))
+		tc.record_error_at(.return_mismatch, '`.free()` methods should not have a return type', id, tc.fn_return_type_diagnostic_pos(node))
 	}
 	if explicit_params != 0 {
-		tc.record_error_at(.call_arg_mismatch, '`.free()` methods should have 0 arguments', id,
-			tc.fn_declaration_diagnostic_pos(node))
+		tc.record_error_at(.call_arg_mismatch, '`.free()` methods should have 0 arguments', id, tc.fn_declaration_diagnostic_pos(node))
 	}
 }
 
@@ -9154,8 +9032,7 @@ fn (mut tc TypeChecker) check_invalid_test_file_name(id flat.NodeId, node flat.N
 	if !base.starts_with('test_') || base.ends_with('_test.v') {
 		return
 	}
-	tc.record_error_with_details_at(.unknown_type, 'invalid test file name `${base}`', id,
-		tc.source_line_declaration_pos(id), [
+	tc.record_error_with_details_at(.unknown_type, 'invalid test file name `${base}`', id, tc.source_line_declaration_pos(id), [
 		'Test files should have names ending with `_test.v`.',
 	])
 }
@@ -9168,13 +9045,10 @@ fn (mut tc TypeChecker) check_snake_case_name(id flat.NodeId, name string, ident
 		return
 	}
 	if name.len > 1 && (name[0] == `_` || name.contains('._')) {
-		tc.record_error_at(.duplicate_decl, '${identifier} `${name}` cannot start with `_`', id,
-			pos)
+		tc.record_error_at(.duplicate_decl, '${identifier} `${name}` cannot start with `_`', id, pos)
 	}
 	if util.contains_capital(name) {
-		tc.record_error_at(.duplicate_decl,
-			'${identifier} `${name}` cannot contain uppercase letters, use snake_case instead', id,
-			pos)
+		tc.record_error_at(.duplicate_decl, '${identifier} `${name}` cannot contain uppercase letters, use snake_case instead', id, pos)
 	}
 }
 
@@ -9189,8 +9063,7 @@ fn (mut tc TypeChecker) check_pascal_case_name(id flat.NodeId, name string, iden
 	}
 	short_name := name.all_after_last('.')
 	if short_name.len > 0 && !short_name[0].is_capital() {
-		tc.record_error_at(.duplicate_decl,
-			'${identifier} `${name}` must begin with capital letter', id, pos)
+		tc.record_error_at(.duplicate_decl, '${identifier} `${name}` must begin with capital letter', id, pos)
 	}
 }
 
@@ -9203,8 +9076,7 @@ fn (mut tc TypeChecker) check_fn_declaration_name(id flat.NodeId, node flat.Node
 	tc.check_imported_module_prefix(id, node.value, 'fn')
 	name := node.value.all_after_last('.')
 	if !node.value.contains('.') && tc.cur_module in ['', 'main'] && is_builtin_type_name(name) {
-		tc.record_error_at(.duplicate_decl, 'top level declaration cannot shadow builtin type', id,
-			tc.fn_declaration_diagnostic_pos(node))
+		tc.record_error_at(.duplicate_decl, 'top level declaration cannot shadow builtin type', id, tc.fn_declaration_diagnostic_pos(node))
 	}
 	// V1 treats os and strconv like builtin modules. Their long-standing private
 	// implementation methods intentionally use a leading underscore.
@@ -9250,9 +9122,7 @@ fn (mut tc TypeChecker) check_fn_if_attribute_return(id flat.NodeId, node flat.N
 		}
 		if line.starts_with('@[if ') && line.ends_with(']') {
 			condition := line[5..line.len - 1].trim_space()
-			tc.record_error_at(.return_mismatch,
-				'only functions that do NOT return values can have `@[if ${condition}]` tags', id,
-				header_pos)
+			tc.record_error_at(.return_mismatch, 'only functions that do NOT return values can have `@[if ${condition}]` tags', id, header_pos)
 		}
 		return
 	}
@@ -9265,8 +9135,7 @@ fn (mut tc TypeChecker) check_main_fn_signature(id flat.NodeId, node flat.Node) 
 	for i in 0 .. node.children_count {
 		child := tc.a.child_node(&node, i)
 		if child.kind == .param {
-			tc.record_error_at(.return_mismatch, 'function `main` cannot have arguments', id,
-				tc.fn_header_declaration_pos(id))
+			tc.record_error_at(.return_mismatch, 'function `main` cannot have arguments', id, tc.fn_header_declaration_pos(id))
 			break
 		}
 		if tc.prefix_param_scan {
@@ -9274,12 +9143,10 @@ fn (mut tc TypeChecker) check_main_fn_signature(id flat.NodeId, node flat.Node) 
 		}
 	}
 	if tc.parse_type(node.typ) !is Void {
-		tc.record_error_at(.return_mismatch, 'function `main` cannot return values', id,
-			tc.fn_header_declaration_pos(id))
+		tc.record_error_at(.return_mismatch, 'function `main` cannot return values', id, tc.fn_header_declaration_pos(id))
 	}
 	if node.kind == .c_fn_decl {
-		tc.record_error_at(.return_mismatch, 'function `main` must declare a body', id,
-			tc.fn_header_declaration_pos(id))
+		tc.record_error_at(.return_mismatch, 'function `main` must declare a body', id, tc.fn_header_declaration_pos(id))
 	}
 }
 
@@ -9334,12 +9201,9 @@ fn (mut tc TypeChecker) check_fn_receiver_syntax(id flat.NodeId, node flat.Node)
 		return
 	}
 	if parts[0] == 'mut' && parts[2].starts_with('&') {
-		tc.record_error_at(.call_arg_mismatch,
-			'use `(mut ${parts[1]} ${parts[2][1..]})` or `(${parts[1]} ${parts[2]})` instead of `${text}`',
-			id, pos)
+		tc.record_error_at(.call_arg_mismatch, 'use `(mut ${parts[1]} ${parts[2][1..]})` or `(${parts[1]} ${parts[2]})` instead of `${text}`', id, pos)
 	} else if parts[1] == 'mut' {
-		tc.record_warning_at(.call_arg_mismatch,
-			'use `(mut ${parts[0]} ${parts[2]})` instead of `${text}`', id, pos)
+		tc.record_warning_at(.call_arg_mismatch, 'use `(mut ${parts[0]} ${parts[2]})` instead of `${text}`', id, pos)
 	}
 }
 
@@ -9373,8 +9237,7 @@ fn (mut tc TypeChecker) check_sumtype_builtin_method_override(id flat.NodeId, no
 	receiver := node.value.all_before_last('.')
 	qualified := tc.qualify_name(receiver)
 	if receiver in tc.sum_types || qualified in tc.sum_types {
-		tc.record_error_at(.duplicate_decl, 'method overrides built-in sum type method', id,
-			tc.fn_declaration_diagnostic_pos(node))
+		tc.record_error_at(.duplicate_decl, 'method overrides built-in sum type method', id, tc.fn_declaration_diagnostic_pos(node))
 	}
 }
 
@@ -9415,9 +9278,7 @@ fn (mut tc TypeChecker) check_interface_field_method_collisions(node flat.Node) 
 		field_id := tc.a.child(&node, i)
 		field := tc.a.node(field_id)
 		if field.kind == .interface_field && field.op == .dot && field_names[field.value] {
-			tc.record_error_at(.duplicate_decl,
-				'type `${node.value}` has both field and method named `${field.value}`', field_id,
-				tc.source_line_declaration_pos(field_id))
+			tc.record_error_at(.duplicate_decl, 'type `${node.value}` has both field and method named `${field.value}`', field_id, tc.source_line_declaration_pos(field_id))
 		}
 	}
 }
@@ -9432,9 +9293,7 @@ fn (mut tc TypeChecker) check_method_field_name_collision(id flat.NodeId, node f
 	fields := tc.structs[qualified_receiver] or { tc.structs[receiver] or { return } }
 	if fields.any(it.name == method && unalias_type(it.typ) is FnType)
 		&& !tc.struct_has_invalid_reference_default(receiver) {
-		tc.record_error_at(.duplicate_decl,
-			'type `${receiver.all_after_last('.')}` has both field and method named `${method}`',
-			id, tc.fn_declaration_diagnostic_pos(node))
+		tc.record_error_at(.duplicate_decl, 'type `${receiver.all_after_last('.')}` has both field and method named `${method}`', id, tc.fn_declaration_diagnostic_pos(node))
 	}
 }
 
@@ -9447,8 +9306,7 @@ fn (tc &TypeChecker) struct_has_invalid_reference_default(receiver string) bool 
 		}
 		default_id := tc.a.child(field, 0)
 		if tc.errors.any(it.node == default_id
-			&& it.msg == 'field is not reference but default value is reference')
-		{
+			&& it.msg == 'field is not reference but default value is reference') {
 			return true
 		}
 	}
@@ -9463,8 +9321,7 @@ fn (mut tc TypeChecker) check_reserved_parameter_name(id flat.NodeId) {
 	if param.kind != .param || param.value.len == 0 || !reserved_const_type_name(param.value) {
 		return
 	}
-	tc.record_error_at(.duplicate_decl,
-		'invalid use of reserved type `${param.value}` as a parameter name', id, param.pos)
+	tc.record_error_at(.duplicate_decl, 'invalid use of reserved type `${param.value}` as a parameter name', id, param.pos)
 }
 
 fn (tc &TypeChecker) declaration_keyword_name_pos(node_id flat.NodeId, keyword string) token.Pos {
@@ -9533,16 +9390,11 @@ fn (mut tc TypeChecker) check_test_fn_signature(id flat.NodeId, node flat.Node) 
 		param_count++
 	}
 	if param_count != 0 {
-		tc.record_error_at(.call_arg_mismatch,
-			'invalid test signature: test functions should take 0 parameters', id,
-			tc.fn_declaration_diagnostic_pos(node))
+		tc.record_error_at(.call_arg_mismatch, 'invalid test signature: test functions should take 0 parameters', id, tc.fn_declaration_diagnostic_pos(node))
 	}
 	return_type := trimmed_space(node.typ)
-	if return_type.len > 0 && return_type !in ['void', '?', '!']
-		&& !return_type.starts_with('?void') && !return_type.starts_with('!void') {
-		tc.record_error_at(.return_mismatch,
-			'invalid test signature: test functions should either return nothing at all, or be marked to return `?` or `!`',
-			id, tc.fn_declaration_diagnostic_pos(node))
+	if return_type.len > 0 && return_type !in ['void', '?', '!'] && !return_type.starts_with('?void') && !return_type.starts_with('!void') {
+		tc.record_error_at(.return_mismatch, 'invalid test signature: test functions should either return nothing at all, or be marked to return `?` or `!`', id, tc.fn_declaration_diagnostic_pos(node))
 	}
 }
 
@@ -9581,8 +9433,7 @@ fn (mut tc TypeChecker) check_test_file_has_test_fn() {
 	source_file := tc.a.source_files[pos.id] or { return }
 	saved_file := tc.cur_file
 	tc.cur_file = source_file.name
-	tc.record_error_with_details_at(.unknown_fn,
-		'a _test.v file should have *at least* one `test_` function', first_source_node, pos, [
+	tc.record_error_with_details_at(.unknown_fn, 'a _test.v file should have *at least* one `test_` function', first_source_node, pos, [
 		'The name of a test function in V, should start with `test_`.',
 		'The test function should take 0 parameters, and no return type. Example:',
 		'fn test_xyz(){ assert 2 + 2 == 4 }',
@@ -9644,8 +9495,7 @@ fn (mut tc TypeChecker) check_top_level_file_statements(node flat.Node) {
 					file := tc.a.source_files[unexpected_pos.id] or { continue }
 					source := tc.source_texts_by_file[file.name] or { continue }
 					name := source[unexpected_pos.offset..unexpected_pos.end]
-					tc.record_error_at(.unknown_ident, 'unexpected name `${name}`', child_id,
-						unexpected_pos)
+					tc.record_error_at(.unknown_ident, 'unexpected name `${name}`', child_id, unexpected_pos)
 					reported_unexpected_name_lines[unexpected_pos.offset] = true
 				}
 				continue
@@ -9864,9 +9714,9 @@ fn (mut tc TypeChecker) collect_selected_file_called_fns_transitively() {
 				qname := checker_qualified_fn_name(cur_module, node.value)
 				if qname !in decls {
 					decls[qname] = SelectedFnDecl{
-						idx:  i
+						idx: i
 						file: cur_file
-						mod:  cur_module
+						mod: cur_module
 					}
 				}
 			}
@@ -9894,8 +9744,7 @@ fn (mut tc TypeChecker) collect_selected_file_top_level_called_fns(node flat.Nod
 		child_id := tc.a.child(&node, i)
 		child := tc.a.nodes[int(child_id)]
 		match child.kind {
-			.fn_decl, .struct_decl, .type_decl, .interface_decl, .enum_decl, .c_fn_decl,
-			.import_decl, .module_decl, .directive {
+			.fn_decl, .struct_decl, .type_decl, .interface_decl, .enum_decl, .c_fn_decl, .import_decl, .module_decl, .directive {
 				continue
 			}
 			else {
@@ -9983,8 +9832,7 @@ fn (mut tc TypeChecker) collect_selected_file_for_in_called_fns(node flat.Node) 
 	tc.collect_selected_file_node_called_fns(container_id)
 	has_val := int(val_id) >= 0
 	if header == 4 {
-		tc.insert_selected_file_decl_binding_type(key_id, tc.range_loop_var_type(container_id, tc.a.child(&node,
-			3)))
+		tc.insert_selected_file_decl_binding_type(key_id, tc.range_loop_var_type(container_id, tc.a.child(&node, 3)))
 		tc.collect_selected_file_node_called_fns(tc.a.child(&node, 3))
 	} else {
 		clean := tc.for_in_iterable_type(container_id)
@@ -10024,11 +9872,9 @@ fn (mut tc TypeChecker) collect_selected_file_for_in_called_fns(node flat.Node) 
 			_ = generic_name
 			if has_val {
 				tc.insert_selected_file_decl_binding_type(key_id, Type(int_))
-				tc.insert_selected_file_decl_binding_type(val_id,
-					unknown_type('unbounded iterator generic'))
+				tc.insert_selected_file_decl_binding_type(val_id, unknown_type('unbounded iterator generic'))
 			} else {
-				tc.insert_selected_file_decl_binding_type(key_id,
-					unknown_type('unbounded iterator generic'))
+				tc.insert_selected_file_decl_binding_type(key_id, unknown_type('unbounded iterator generic'))
 			}
 		} else if elem_type := tc.iterator_for_in_elem_type(clean) {
 			if has_val {
@@ -10040,8 +9886,7 @@ fn (mut tc TypeChecker) collect_selected_file_for_in_called_fns(node flat.Node) 
 		} else {
 			container := tc.a.nodes[int(container_id)]
 			if container.kind == .range {
-				tc.insert_selected_file_decl_binding_type(key_id, tc.range_loop_var_type(tc.a.child(&container,
-					0), tc.a.child(&container, 1)))
+				tc.insert_selected_file_decl_binding_type(key_id, tc.range_loop_var_type(tc.a.child(&container, 0), tc.a.child(&container, 1)))
 			}
 		}
 	}
@@ -10251,13 +10096,10 @@ fn (mut tc TypeChecker) check_export_attrs() {
 					}
 					name := if export_name.len > 0 { export_name } else { field.value }
 					if !is_valid_export_c_name(name) {
-						tc.record_error_at(.unsupported_generic,
-							'export name `${name}` should be a valid identifier', field_id,
-							tc.node_value_diagnostic_pos(field_id))
+						tc.record_error_at(.unsupported_generic, 'export name `${name}` should be a valid identifier', field_id, tc.node_value_diagnostic_pos(field_id))
 					}
 					if name in export_symbols {
-						tc.record_error_at(.unsupported_generic, 'duplicate export name `${name}`',
-							field_id, tc.node_value_diagnostic_pos(field_id))
+						tc.record_error_at(.unsupported_generic, 'duplicate export name `${name}`', field_id, tc.node_value_diagnostic_pos(field_id))
 					} else {
 						export_symbols[name] = field.value
 					}
@@ -10283,9 +10125,7 @@ fn (mut tc TypeChecker) check_export_attrs() {
 					field_id := tc.a.child(&node, field_idx)
 					field := tc.a.node(field_id)
 					if field.value in export_symbols {
-						tc.record_error_at(.unsupported_generic,
-							'duplicate export name `${field.value}`', field_id,
-							tc.node_value_diagnostic_pos(field_id))
+						tc.record_error_at(.unsupported_generic, 'duplicate export name `${field.value}`', field_id, tc.node_value_diagnostic_pos(field_id))
 					}
 				}
 			}
@@ -10307,8 +10147,7 @@ fn (mut tc TypeChecker) check_export_attrs() {
 			.fn_decl {
 				qname := export_qualified_fn_name(cur_module, node.value)
 				if pos := tc.declaration_attribute_without_value_pos(flat.NodeId(i), 'export') {
-					tc.record_error_at(.unsupported_generic,
-						'missing argument for @[export] attribute', flat.NodeId(i), pos)
+					tc.record_error_at(.unsupported_generic, 'missing argument for @[export] attribute', flat.NodeId(i), pos)
 					continue
 				}
 				export_name := tc.a.export_fn_names[qname] or {
@@ -10317,8 +10156,7 @@ fn (mut tc TypeChecker) check_export_attrs() {
 					}
 				}
 				if export_name.len == 0 {
-					tc.record_error_unfiltered(.unsupported_generic,
-						'empty export name for `${qname}`', flat.NodeId(i))
+					tc.record_error_unfiltered(.unsupported_generic, 'empty export name for `${qname}`', flat.NodeId(i))
 					continue
 				}
 				if !is_valid_export_c_name(export_name) {
@@ -10327,17 +10165,13 @@ fn (mut tc TypeChecker) check_export_attrs() {
 					} else {
 						'export name `${export_name}` should be a valid identifier'
 					}
-					tc.record_error_at(.unsupported_generic, message, flat.NodeId(i),
-						tc.fn_declaration_diagnostic_pos(node))
+					tc.record_error_at(.unsupported_generic, message, flat.NodeId(i), tc.fn_declaration_diagnostic_pos(node))
 				}
 				if synthetic_main_reserved && export_name == 'main' {
-					tc.record_error_unfiltered(.unsupported_generic,
-						'export name `main` for `${qname}` collides with synthetic entry point `main`',
-						flat.NodeId(i))
+					tc.record_error_unfiltered(.unsupported_generic, 'export name `main` for `${qname}` collides with synthetic entry point `main`', flat.NodeId(i))
 				}
 				if node.generic_params().len > 0 {
-					tc.record_error_unfiltered(.unsupported_generic,
-						'generic function `${qname}` cannot be exported', flat.NodeId(i))
+					tc.record_error_unfiltered(.unsupported_generic, 'generic function `${qname}` cannot be exported', flat.NodeId(i))
 				}
 				for pi in 0 .. node.children_count {
 					p := tc.a.child_node(&node, pi)
@@ -10348,15 +10182,12 @@ fn (mut tc TypeChecker) check_export_attrs() {
 						continue
 					}
 					if p.value.len == 0 || p.typ.len == 0 {
-						tc.record_error_unfiltered(.unsupported_generic,
-							'exported function `${qname}` must name all parameters', flat.NodeId(i))
+						tc.record_error_unfiltered(.unsupported_generic, 'exported function `${qname}` must name all parameters', flat.NodeId(i))
 					}
 				}
 				if existing := export_symbols[export_name] {
 					if existing != qname {
-						tc.record_error_at(.unsupported_generic,
-							'duplicate export name `${export_name}`', flat.NodeId(i),
-							tc.fn_declaration_diagnostic_pos(node))
+						tc.record_error_at(.unsupported_generic, 'duplicate export name `${export_name}`', flat.NodeId(i), tc.fn_declaration_diagnostic_pos(node))
 					}
 				} else {
 					export_symbols[export_name] = qname
@@ -10365,9 +10196,7 @@ fn (mut tc TypeChecker) check_export_attrs() {
 					// A main-module function can be prefixed in C when an explicit export
 					// owns its otherwise natural symbol, matching the established backend.
 					if existing != qname && natural_symbol_modules[export_name] !in ['', 'main'] {
-						tc.record_error_unfiltered(.unsupported_generic,
-							'export name `${export_name}` for `${qname}` collides with `${existing}`',
-							flat.NodeId(i))
+						tc.record_error_unfiltered(.unsupported_generic, 'export name `${export_name}` for `${qname}` collides with `${existing}`', flat.NodeId(i))
 					}
 				}
 			}
@@ -10377,12 +10206,10 @@ fn (mut tc TypeChecker) check_export_attrs() {
 	for qname, export_name in tc.a.export_fn_names {
 		if is_valid_export_c_name(export_name)
 			|| tc.errors.any(it.kind == .unsupported_generic
-			&& it.msg.contains('export name `${export_name}` should be a valid identifier')) {
+				&& it.msg.contains('export name `${export_name}` should be a valid identifier')) {
 			continue
 		}
-		tc.record_error_unfiltered(.unsupported_generic,
-			'export name `${export_name}` should be a valid identifier for `${qname}`',
-			flat.NodeId(0))
+		tc.record_error_unfiltered(.unsupported_generic, 'export name `${export_name}` should be a valid identifier for `${qname}`', flat.NodeId(0))
 	}
 }
 
@@ -10522,8 +10349,7 @@ fn (tc &TypeChecker) is_c_top_level_stmt(id flat.NodeId) bool {
 	}
 	node := tc.a.nodes[int(id)]
 	return match node.kind {
-		.expr_stmt, .assign, .decl_assign, .selector_assign, .index_assign, .for_stmt,
-		.for_in_stmt, .if_expr, .match_stmt, .assert_stmt, .defer_stmt {
+		.expr_stmt, .assign, .decl_assign, .selector_assign, .index_assign, .for_stmt, .for_in_stmt, .if_expr, .match_stmt, .assert_stmt, .defer_stmt {
 			true
 		}
 		.block, .comptime_if {
@@ -10783,9 +10609,7 @@ fn (mut tc TypeChecker) check_veb_app_method_params(fn_id flat.NodeId, node flat
 		if tc.is_veb_context_type(param_type) {
 			if !param.is_mut {
 				display_type := param.typ.trim_left('&').all_after_last('.')
-				tc.record_error_at(.call_arg_mismatch,
-					'veb app method `${method}` must declare context parameter `${param.value}` as mutable, e.g. `mut ${param.value} ${display_type}`',
-					param_id, tc.node_value_diagnostic_pos(param_id))
+				tc.record_error_at(.call_arg_mismatch, 'veb app method `${method}` must declare context parameter `${param.value}` as mutable, e.g. `mut ${param.value} ${display_type}`', param_id, tc.node_value_diagnostic_pos(param_id))
 			}
 			continue
 		}
@@ -10793,9 +10617,7 @@ fn (mut tc TypeChecker) check_veb_app_method_params(fn_id flat.NodeId, node flat
 		if clean is String || clean.is_integer() || clean.name() == 'bool' || clean is Interface {
 			continue
 		}
-		tc.record_error_at(.call_arg_mismatch,
-			'veb app method `${method}` parameter `${param.value}` has unsupported type `${param.typ}`; parameters after the context are populated from strings and must be `string`, integer, or `bool`',
-			param_id, tc.node_value_diagnostic_pos(param_id))
+		tc.record_error_at(.call_arg_mismatch, 'veb app method `${method}` parameter `${param.value}` has unsupported type `${param.typ}`; parameters after the context are populated from strings and must be `string`, integer, or `bool`', param_id, tc.node_value_diagnostic_pos(param_id))
 	}
 }
 
@@ -10868,8 +10690,7 @@ fn (mut tc TypeChecker) check_fn_body(node flat.Node) {
 		}
 	}
 	if tc.valid_node_id(unreachable_id) && tc.should_diagnose(unreachable_id) {
-		tc.record_error_at(.return_mismatch, 'unreachable code', unreachable_id,
-			tc.unreachable_statement_diagnostic_pos(unreachable_id))
+		tc.record_error_at(.return_mismatch, 'unreachable code', unreachable_id, tc.unreachable_statement_diagnostic_pos(unreachable_id))
 	}
 }
 
@@ -10920,16 +10741,13 @@ fn (mut tc TypeChecker) check_decl_type_strings(node_id flat.NodeId, node flat.N
 		if imported_name := tc.selective_imported_builtin_in_type(node.typ) {
 			base := 'unknown type `${imported_name}`'
 			message := util.new_suggestion(imported_name, tc.known_type_name_candidates()).say(base)
-			tc.record_error_at(.unknown_type, message, node_id, tc.type_diagnostic_pos(node_id,
-				node.typ.trim_space()))
+			tc.record_error_at(.unknown_type, message, node_id, tc.type_diagnostic_pos(node_id, node.typ.trim_space()))
 		}
 		alias_name := node.typ.trim_space()
 		alias_type := tc.parse_type(alias_name)
 		if alias_type is Alias && alias_type.base_type is FnType {
 			original_type := Type(alias_type.base_type).name().replace_once('fn(', 'fn (')
-			tc.record_error_at(.unknown_type,
-				'type `${alias_name}` is an alias, use the original alias type `${original_type}` instead',
-				node_id, tc.type_diagnostic_pos(node_id, alias_name))
+			tc.record_error_at(.unknown_type, 'type `${alias_name}` is an alias, use the original alias type `${original_type}` instead', node_id, tc.type_diagnostic_pos(node_id, alias_name))
 		}
 	}
 	if node.kind == .fn_decl {
@@ -10951,19 +10769,16 @@ fn (mut tc TypeChecker) check_decl_type_strings(node_id flat.NodeId, node flat.N
 			is_static = first.kind != .param || first.op != .dot
 		}
 		if is_static && !tc.type_name_known(receiver_name) {
-			tc.record_error_at(.unknown_type, 'unknown type `${receiver_name}`', node_id, tc.type_diagnostic_pos(node_id,
-				receiver_name))
+			tc.record_error_at(.unknown_type, 'unknown type `${receiver_name}`', node_id, tc.type_diagnostic_pos(node_id, receiver_name))
 		}
 	}
 	if node.kind == .type_decl && node.typ.trim_space().starts_with('!') {
-		tc.record_error_with_details_at(.unknown_type, 'cannot make an alias of Result type',
-			node_id, tc.type_diagnostic_pos(node_id, node.typ.trim_space()), [
+		tc.record_error_with_details_at(.unknown_type, 'cannot make an alias of Result type', node_id, tc.type_diagnostic_pos(node_id, node.typ.trim_space()), [
 			'Result types cannot be stored and have to be unwrapped immediately',
 		])
 	}
 	if node.kind == .type_decl && node.typ.trim_space() == 'none' {
-		tc.record_error_at(.unknown_type, 'cannot create a type alias of `none` as it is a value',
-			node_id, tc.type_diagnostic_pos(node_id, 'none'))
+		tc.record_error_at(.unknown_type, 'cannot create a type alias of `none` as it is a value', node_id, tc.type_diagnostic_pos(node_id, 'none'))
 	}
 	if node.kind == .struct_decl {
 		if comma_attr_text_has(node.typ, 'generic') && tc.reject_unsupported_generics {
@@ -10971,8 +10786,7 @@ fn (mut tc TypeChecker) check_decl_type_strings(node_id flat.NodeId, node flat.N
 		}
 	} else {
 		if node.generic_params().len > 0 && tc.reject_unsupported_generics {
-			tc.record_unsupported_generic('unsupported generic declaration `${node.value}`',
-				node_id)
+			tc.record_unsupported_generic('unsupported generic declaration `${node.value}`', node_id)
 		}
 		if !invalid_generic_struct_alias && (!decl_generic_mentions_error
 			|| tc.unmentioned_generic_names_in_type(node.typ, generic_param_map_from_names(node.generic_params())).len == 0) {
@@ -10997,17 +10811,13 @@ fn (mut tc TypeChecker) check_decl_type_strings(node_id flat.NodeId, node flat.N
 		}
 		if node.kind == .interface_decl && child.kind == .interface_field && child.op == .dot
 			&& child.generic_params().len > 0 {
-			tc.record_error_at(.unsupported_generic,
-				"no need to add generic type names in generic interface's method", child_id, tc.interface_method_generic_param_pos(child,
-				child.generic_params()[0]))
+			tc.record_error_at(.unsupported_generic, "no need to add generic type names in generic interface's method", child_id, tc.interface_method_generic_param_pos(child, child.generic_params()[0]))
 		}
 		if node.kind == .interface_decl && child.kind == .interface_field && child.op != .dot {
 			field_type := unalias_type(tc.parse_type(child.typ))
 			if field_type is Interface
 				&& tc.interface_metadata_name(field_type.name) == tc.interface_metadata_name(node.value) {
-				tc.record_error_at(.assignment_mismatch,
-					'recursive interface fields are not allowed because they cannot be initialised',
-					child_id, tc.type_diagnostic_pos(child_id, child.typ))
+				tc.record_error_at(.assignment_mismatch, 'recursive interface fields are not allowed because they cannot be initialised', child_id, tc.type_diagnostic_pos(child_id, child.typ))
 			}
 		}
 		if child.kind == .param && child.typ.trim_space().starts_with('!') {
@@ -11017,8 +10827,7 @@ fn (mut tc TypeChecker) check_decl_type_strings(node_id flat.NodeId, node flat.N
 				supported_result_callback = unalias_type(param_type.base_type) is FnType
 			}
 			if !supported_result_callback {
-				tc.record_error_at(.unknown_type, 'result type arguments are not supported',
-					child_id, tc.type_diagnostic_pos(child_id, child.typ.trim_space()))
+				tc.record_error_at(.unknown_type, 'result type arguments are not supported', child_id, tc.type_diagnostic_pos(child_id, child.typ.trim_space()))
 			}
 		}
 		if node.kind == .struct_decl {
@@ -11026,8 +10835,7 @@ fn (mut tc TypeChecker) check_decl_type_strings(node_id flat.NodeId, node flat.N
 			field_type := unalias_type(tc.parse_type(child.typ))
 			if child.kind == .field_decl && field_type is Map
 				&& unalias_type(field_type.value_type) is ResultType {
-				tc.record_error_at(.unknown_type, 'cannot use Result type as map value type',
-					child_id, tc.struct_field_type_pos(child))
+				tc.record_error_at(.unknown_type, 'cannot use Result type as map value type', child_id, tc.struct_field_type_pos(child))
 			}
 		}
 		if node.kind == .type_decl && child.value.len > 0 {
@@ -11044,8 +10852,7 @@ fn (mut tc TypeChecker) check_decl_type_strings(node_id flat.NodeId, node flat.N
 			}
 			if !decl_generic_mentions_error
 				|| tc.unmentioned_generic_names_in_type(grandchild.typ, explicit_decl_params).len == 0 {
-				tc.check_type_string_for_unsupported_generics(grandchild.typ, grandchild_id,
-					generic_params)
+				tc.check_type_string_for_unsupported_generics(grandchild.typ, grandchild_id, generic_params)
 			}
 		}
 	}
@@ -11073,9 +10880,7 @@ fn (mut tc TypeChecker) check_type_alias_generic_struct_application(node_id flat
 		return false
 	}
 	short_name := lookup.all_after_last('.')
-	tc.record_error_at(.unknown_type,
-		'${short_name} type is generic struct, must specify the generic type names, e.g. ${short_name}[int]',
-		node_id, tc.type_diagnostic_pos(node_id, clean))
+	tc.record_error_at(.unknown_type, '${short_name} type is generic struct, must specify the generic type names, e.g. ${short_name}[int]', node_id, tc.type_diagnostic_pos(node_id, clean))
 	return true
 }
 
@@ -11187,9 +10992,7 @@ fn (mut tc TypeChecker) check_struct_or_interface_decl_generic_mentions(node_id 
 		} else {
 			tc.source_line_declaration_pos(node_id)
 		}
-		tc.record_error_at(.unsupported_generic,
-			'generic ${kind} `${node.value}` declaration must specify the generic type names, e.g. ${node.value}[T]',
-			node_id, pos)
+		tc.record_error_at(.unsupported_generic, 'generic ${kind} `${node.value}` declaration must specify the generic type names, e.g. ${node.value}[T]', node_id, pos)
 		return true
 	}
 	decl_name := if node.kind == .interface_decl {
@@ -11222,9 +11025,7 @@ fn (mut tc TypeChecker) check_struct_or_interface_decl_generic_mentions(node_id 
 			} else {
 				child_type
 			}
-			tc.record_error_at(.unknown_type,
-				'generic type name `${name}` is not mentioned in ${kind} `${decl_name}`${unmentioned_generic_unknown_suffix(name)}',
-				child_id, tc.type_diagnostic_pos(child_id, pos_text))
+			tc.record_error_at(.unknown_type, 'generic type name `${name}` is not mentioned in ${kind} `${decl_name}`${unmentioned_generic_unknown_suffix(name)}', child_id, tc.type_diagnostic_pos(child_id, pos_text))
 		}
 		if node.kind != .interface_decl || child.op != .dot {
 			continue
@@ -11238,9 +11039,7 @@ fn (mut tc TypeChecker) check_struct_or_interface_decl_generic_mentions(node_id 
 					continue
 				}
 				diagnosed[key] = true
-				tc.record_error_at(.unknown_type,
-					'generic type name `${name}` is not mentioned in ${kind} `${decl_name}`${unmentioned_generic_unknown_suffix(name)}',
-					param_id, tc.type_diagnostic_pos(param_id, param.typ))
+				tc.record_error_at(.unknown_type, 'generic type name `${name}` is not mentioned in ${kind} `${decl_name}`${unmentioned_generic_unknown_suffix(name)}', param_id, tc.type_diagnostic_pos(param_id, param.typ))
 			}
 		}
 	}
@@ -11252,9 +11051,7 @@ fn (mut tc TypeChecker) check_fn_bare_generic_signature_types(node_id flat.NodeI
 		if name := tc.bare_generic_decl_type_name(node.typ) {
 			kind, params := tc.generic_decl_kind_and_params(name)
 			if kind.len > 0 {
-				tc.record_error_at(.unsupported_generic,
-					'return generic ${kind} `${name}` in fn declaration must specify the generic type names, e.g. ${name}[${params.join(', ')}]',
-					node_id, tc.fn_return_type_diagnostic_pos(node))
+				tc.record_error_at(.unsupported_generic, 'return generic ${kind} `${name}` in fn declaration must specify the generic type names, e.g. ${name}[${params.join(', ')}]', node_id, tc.fn_return_type_diagnostic_pos(node))
 			}
 		}
 	}
@@ -11271,9 +11068,7 @@ fn (mut tc TypeChecker) check_fn_bare_generic_signature_types(node_id flat.NodeI
 	if kind.len == 0 {
 		return
 	}
-	tc.record_error_at(.unsupported_generic,
-		'generic ${kind} `${name}` in fn declaration must specify the generic type names, e.g. ${name}[${params.join(', ')}]',
-		receiver_id, tc.type_diagnostic_pos(receiver_id, receiver.typ))
+	tc.record_error_at(.unsupported_generic, 'generic ${kind} `${name}` in fn declaration must specify the generic type names, e.g. ${name}[${params.join(', ')}]', receiver_id, tc.type_diagnostic_pos(receiver_id, receiver.typ))
 }
 
 fn (tc &TypeChecker) fn_decl_has_bare_generic_signature_type(node flat.Node) bool {
@@ -11387,23 +11182,17 @@ fn (mut tc TypeChecker) check_fn_decl_unmentioned_generic_types(node_id flat.Nod
 	}
 	if node.generic_params().len == 0 {
 		if node.value.contains('.') {
-			tc.record_error_with_details_at(.unsupported_generic,
-				'generic method declaration must specify generic type names', node_id,
-				tc.fn_declaration_diagnostic_pos(node), [
+			tc.record_error_with_details_at(.unsupported_generic, 'generic method declaration must specify generic type names', node_id, tc.fn_declaration_diagnostic_pos(node), [
 				'use `fn (r SomeType[T]) foo[T]() {`, not just `fn (r SomeType[T]) foo() {`',
 			])
 		} else {
-			tc.record_error_with_details_at(.unsupported_generic,
-				'generic function declaration must specify generic type names', node_id,
-				tc.fn_declaration_diagnostic_pos(node), [
+			tc.record_error_with_details_at(.unsupported_generic, 'generic function declaration must specify generic type names', node_id, tc.fn_declaration_diagnostic_pos(node), [
 				'use `fn foo[T](x T) {`, not just `fn foo(x T) {`',
 			])
 		}
 	}
 	for i, name in missing_names {
-		tc.record_error_at(.unknown_type,
-			'generic type name `${name}` is not mentioned in fn `${node.value.all_after_last('.')}[${node.generic_params().join(', ')}]`${unmentioned_generic_unknown_suffix(name)}',
-			missing_ids[i], tc.type_diagnostic_pos(missing_ids[i], missing_types[i]))
+		tc.record_error_at(.unknown_type, 'generic type name `${name}` is not mentioned in fn `${node.value.all_after_last('.')}[${node.generic_params().join(', ')}]`${unmentioned_generic_unknown_suffix(name)}', missing_ids[i], tc.type_diagnostic_pos(missing_ids[i], missing_types[i]))
 	}
 }
 
@@ -11414,9 +11203,7 @@ fn (mut tc TypeChecker) check_bare_generic_fntype_param(node_id flat.NodeId, typ
 		tc.interface_generic_params[qualified] or { []string{} }
 	}
 	if interface_params.len > 0 {
-		tc.record_error_at(.unsupported_generic,
-			'generic interface `${name}` in fn declaration must specify the generic type names, e.g. ${name}[${interface_params.join(', ')}]',
-			node_id, tc.type_diagnostic_pos(node_id, type_text))
+		tc.record_error_at(.unsupported_generic, 'generic interface `${name}` in fn declaration must specify the generic type names, e.g. ${name}[${interface_params.join(', ')}]', node_id, tc.type_diagnostic_pos(node_id, type_text))
 		return
 	}
 	params := tc.type_alias_generic_params[name] or {
@@ -11425,9 +11212,7 @@ fn (mut tc TypeChecker) check_bare_generic_fntype_param(node_id flat.NodeId, typ
 	if params.len == 0 || unalias_type(tc.parse_type(name)) !is FnType {
 		return
 	}
-	tc.record_error_at(.unsupported_generic,
-		'generic function `${name}` in fn declaration must specify the generic type names, e.g. ${name}[${params.join(', ')}]',
-		node_id, tc.type_diagnostic_pos(node_id, type_text))
+	tc.record_error_at(.unsupported_generic, 'generic function `${name}` in fn declaration must specify the generic type names, e.g. ${name}[${params.join(', ')}]', node_id, tc.type_diagnostic_pos(node_id, type_text))
 }
 
 fn (mut tc TypeChecker) check_implicit_generic_sumtype_decl(node_id flat.NodeId, node flat.Node) {
@@ -11449,9 +11234,7 @@ fn (mut tc TypeChecker) check_implicit_generic_sumtype_decl(node_id flat.NodeId,
 			}
 			for arg in args {
 				if is_bare_generic_param(arg) && arg !in decl_params {
-					tc.record_error_at(.unknown_type,
-						'generic type name `${arg}` of generic struct `${variant}` is not mentioned in sumtype `${node.value}[${decl_params.join(', ')}]`',
-						child_id, tc.type_diagnostic_pos(node_id, variant))
+					tc.record_error_at(.unknown_type, 'generic type name `${arg}` of generic struct `${variant}` is not mentioned in sumtype `${node.value}[${decl_params.join(', ')}]`', child_id, tc.type_diagnostic_pos(node_id, variant))
 				}
 			}
 		}
@@ -11498,9 +11281,7 @@ fn (mut tc TypeChecker) check_implicit_generic_sumtype_decl(node_id flat.NodeId,
 			} else {
 				'sumtype'
 			}
-			tc.record_error_at(.unknown_type,
-				'generic ${kind} `${lookup}` must specify generic type names, e.g. ${lookup}[${params.join(', ')}]',
-				child_id, tc.type_diagnostic_pos(node_id, variant))
+			tc.record_error_at(.unknown_type, 'generic ${kind} `${lookup}` must specify generic type names, e.g. ${lookup}[${params.join(', ')}]', child_id, tc.type_diagnostic_pos(node_id, variant))
 			continue
 		}
 		for arg in args {
@@ -11517,9 +11298,7 @@ fn (mut tc TypeChecker) check_implicit_generic_sumtype_decl(node_id flat.NodeId,
 		if example_params.len == 0 {
 			example_params = ['T']
 		}
-		tc.record_error_at(.unsupported_generic,
-			'generic sumtype `${node.value}` must specify generic type names, e.g. ${node.value}[${example_params.join(', ')}]',
-			node_id, tc.type_diagnostic_pos(node_id, node.value))
+		tc.record_error_at(.unsupported_generic, 'generic sumtype `${node.value}` must specify generic type names, e.g. ${node.value}[${example_params.join(', ')}]', node_id, tc.type_diagnostic_pos(node_id, node.value))
 	}
 }
 
@@ -11622,8 +11401,7 @@ fn (mut tc TypeChecker) check_struct_implements(node_id flat.NodeId, node flat.N
 		}
 		diagnostic_pos := tc.struct_implements_type_pos(node, type_name, implements_index)
 		if interface_params.len > 0 && !is_generic {
-			tc.record_error_at(.unknown_type, 'missing generic type on ${lookup}', node_id,
-				diagnostic_pos)
+			tc.record_error_at(.unknown_type, 'missing generic type on ${lookup}', node_id, diagnostic_pos)
 			continue
 		}
 		if is_generic && interface_params.len > 0 {
@@ -11636,11 +11414,8 @@ fn (mut tc TypeChecker) check_struct_implements(node_id flat.NodeId, node flat.N
 				}
 			}
 			if unknown_arg.len > 0 {
-				base_pos := token.new_span(diagnostic_pos.id, diagnostic_pos.offset, int_min(diagnostic_pos.end,
-
-					diagnostic_pos.offset + raw_lookup.len))
-				tc.record_error_at(.unknown_type, 'unknown generic type ${unknown_arg}', node_id,
-					base_pos)
+				base_pos := token.new_span(diagnostic_pos.id, diagnostic_pos.offset, int_min(diagnostic_pos.end, diagnostic_pos.offset + raw_lookup.len))
+				tc.record_error_at(.unknown_type, 'unknown generic type ${unknown_arg}', node_id, base_pos)
 				continue
 			}
 		}
@@ -11648,9 +11423,7 @@ fn (mut tc TypeChecker) check_struct_implements(node_id flat.NodeId, node flat.N
 			interface_name := if lookup in tc.interface_names { lookup } else { qualified }
 			if seen_interfaces[interface_name] {
 				if !reported_interfaces[interface_name] {
-					tc.record_error_at(.assignment_mismatch,
-						'struct type ${node.value} cannot implement interface `${interface_name} more than once`',
-						node_id, diagnostic_pos)
+					tc.record_error_at(.assignment_mismatch, 'struct type ${node.value} cannot implement interface `${interface_name} more than once`', node_id, diagnostic_pos)
 					reported_interfaces[interface_name] = true
 				}
 				continue
@@ -11663,16 +11436,14 @@ fn (mut tc TypeChecker) check_struct_implements(node_id flat.NodeId, node flat.N
 				name: interface_name
 			}
 			if !tc.type_implements_interface(actual, expected) {
-				tc.record_interface_implementation_error(.assignment_mismatch, actual, expected,
-					node_id, tc.struct_declaration_name_pos(node))
+				tc.record_interface_implementation_error(.assignment_mismatch, actual, expected, node_id, tc.struct_declaration_name_pos(node))
 			}
 			continue
 		}
 		if is_generic && (lookup in tc.interface_names || qualified in tc.interface_names) {
 			continue
 		}
-		tc.record_error_at(.assignment_mismatch, '`${type_name}` is not an interface type',
-			node_id, diagnostic_pos)
+		tc.record_error_at(.assignment_mismatch, '`${type_name}` is not an interface type', node_id, diagnostic_pos)
 	}
 }
 
@@ -11772,9 +11543,7 @@ fn (mut tc TypeChecker) check_missing_struct_field_generic_type(node_id flat.Nod
 	} else {
 		tc.type_diagnostic_pos(node_id, type_text)
 	}
-	tc.record_error_at(.unknown_type,
-		'`${name}` type is generic ${kind}, must specify the generic type names, e.g. ${name}[${context_name}], ${name}[int]',
-		node_id, pos)
+	tc.record_error_at(.unknown_type, '`${name}` type is generic ${kind}, must specify the generic type names, e.g. ${name}[${context_name}], ${name}[int]', node_id, pos)
 }
 
 fn bare_generic_type_is_inside_container(type_text string) bool {
@@ -11833,8 +11602,7 @@ fn (tc &TypeChecker) bare_generic_decl_type_name(type_text string) ?string {
 	}
 	qualified := tc.qualify_name(clean)
 	if qualified != clean && tc.type_name_known_in_current_module(clean)
-		&& qualified !in tc.struct_generic_params && qualified !in tc.sum_generic_params
-		&& qualified !in tc.type_alias_generic_params && qualified !in tc.interface_generic_params {
+		&& qualified !in tc.struct_generic_params && qualified !in tc.sum_generic_params && qualified !in tc.type_alias_generic_params && qualified !in tc.interface_generic_params {
 		return none
 	}
 	if clean in tc.struct_generic_params || qualified in tc.struct_generic_params
@@ -12216,8 +11984,7 @@ fn (mut tc TypeChecker) check_type_string_for_unsupported_generics(typ string, n
 			return
 		}
 		if node.kind == .type_decl && clean !in generic_params && !tc.type_name_known(clean) {
-			tc.record_error_at(.unknown_type, 'unknown aliased type `${clean}`', node_id, tc.type_diagnostic_pos(node_id,
-				clean))
+			tc.record_error_at(.unknown_type, 'unknown aliased type `${clean}`', node_id, tc.type_diagnostic_pos(node_id, clean))
 			return
 		}
 	}
@@ -12252,10 +12019,8 @@ fn (mut tc TypeChecker) check_type_string_for_unsupported_generics(typ string, n
 	if clean.starts_with('map[') {
 		bracket_end := find_matching_bracket(clean, 3)
 		if bracket_end < clean.len {
-			tc.check_type_string_for_unsupported_generics(clean[4..bracket_end], node_id,
-				generic_params)
-			tc.check_type_string_for_unsupported_generics(clean[bracket_end + 1..], node_id,
-				generic_params)
+			tc.check_type_string_for_unsupported_generics(clean[4..bracket_end], node_id, generic_params)
+			tc.check_type_string_for_unsupported_generics(clean[bracket_end + 1..], node_id, generic_params)
 		}
 		return
 	}
@@ -12278,8 +12043,7 @@ fn (mut tc TypeChecker) check_type_string_for_unsupported_generics(typ string, n
 	}
 	if generic_type_application(clean) {
 		if tc.reject_unsupported_generics {
-			tc.record_unsupported_generic('unsupported generic type application `${clean}`',
-				node_id)
+			tc.record_unsupported_generic('unsupported generic type application `${clean}`', node_id)
 			return
 		}
 		bracket := clean.index_u8(`[`)
@@ -12340,9 +12104,7 @@ fn (mut tc TypeChecker) check_sum_type_decl(node_id flat.NodeId, node flat.Node)
 		semantic_name := variant_type.name()
 		variant_key := if variant_type is Unknown { variant_name } else { semantic_name }
 		if seen[variant_key] {
-			tc.record_error_at(.duplicate_decl,
-				'sum type ${node.value} cannot hold the type `${semantic_name.all_after_last('.')}` more than once',
-				variant_id, tc.type_diagnostic_pos(variant_id, variant_name))
+			tc.record_error_at(.duplicate_decl, 'sum type ${node.value} cannot hold the type `${semantic_name.all_after_last('.')}` more than once', variant_id, tc.type_diagnostic_pos(variant_id, variant_name))
 			continue
 		}
 		seen[variant_key] = true
@@ -12356,37 +12118,32 @@ fn (mut tc TypeChecker) check_sum_type_decl(node_id flat.NodeId, node flat.Node)
 			} else {
 				'(', ')'
 			}
-			tc.record_error_with_details_at(.assignment_mismatch,
-				'sum type cannot hold a reference type', variant_id, tc.type_diagnostic_pos(variant_id,
-				variant_name), [
+			tc.record_error_with_details_at(.assignment_mismatch, 'sum type cannot hold a reference type', variant_id, tc.type_diagnostic_pos(variant_id, variant_name), [
 				'declare the sum type with non-reference types: `${node.value} = ${display_variant} | ...`\nand use a reference to the sum type instead: `var := &${node.value}(${display_variant}${left}val${right})`',
 			])
 			pointer_reported = true
 		}
 		if variant_type is ResultType && !result_reported {
-			tc.record_error_at(.assignment_mismatch, 'sum type cannot hold a Result type',
-				variant_id, tc.type_diagnostic_pos(variant_id, variant_name))
+			tc.record_error_at(.assignment_mismatch, 'sum type cannot hold a Result type', variant_id, tc.type_diagnostic_pos(variant_id, variant_name))
 			result_reported = true
 		}
 		sum_name := tc.sum_base_name(node.value)
 		variant_sum := tc.sum_base_name(variant_name)
 		if variant_sum == sum_name {
-			tc.record_error_at(.assignment_mismatch, 'sum type cannot hold itself', variant_id, tc.type_diagnostic_pos(variant_id,
-				variant_name))
+			tc.record_error_at(.assignment_mismatch, 'sum type cannot hold itself', variant_id, tc.type_diagnostic_pos(variant_id, variant_name))
 		} else {
 			mut seen_sums := map[string]bool{}
 			if (variant_sum in tc.sum_types
 				&& tc.sum_type_reaches_sum(variant_sum, sum_name, mut seen_sums))
 				|| ((variant_name.starts_with('fn(')
-				|| variant_name.starts_with('fn ('))
-				&& type_text_contains_symbol(variant_name, node.value)) {
+					|| variant_name.starts_with('fn ('))
+					&& type_text_contains_symbol(variant_name, node.value)) {
 				pos := if variant_name.starts_with('fn(') || variant_name.starts_with('fn (') {
 					tc.sum_type_variant_source_pos(node, variant_name)
 				} else {
 					tc.type_diagnostic_pos(variant_id, variant_name)
 				}
-				tc.record_error_at(.assignment_mismatch,
-					'sum type `${node.value}` cannot be defined recursively', variant_id, pos)
+				tc.record_error_at(.assignment_mismatch, 'sum type `${node.value}` cannot be defined recursively', variant_id, pos)
 			}
 		}
 	}
@@ -12457,14 +12214,11 @@ fn (mut tc TypeChecker) record_invalid_any_decl_type(node_id flat.NodeId) {
 		return
 	}
 	node := tc.a.nodes[int(node_id)]
-	if node.kind !in [.fn_decl, .c_fn_decl, .param, .field_decl, .interface_field, .type_decl,
-		.ident] {
+	if node.kind !in [.fn_decl, .c_fn_decl, .param, .field_decl, .interface_field, .type_decl, .ident] {
 		return
 	}
 	if node.kind == .param {
-		tc.record_notice_at(.unknown_type,
-			'the `any` type is deprecated and will be removed soon - either use an empty interface, or a sum type',
-			node_id, tc.node_value_diagnostic_pos(node_id))
+		tc.record_notice_at(.unknown_type, 'the `any` type is deprecated and will be removed soon - either use an empty interface, or a sum type', node_id, tc.node_value_diagnostic_pos(node_id))
 		return
 	}
 	msg := if node.kind == .type_decl {
@@ -12494,8 +12248,7 @@ fn (mut tc TypeChecker) record_unknown_decl_type(name string, node_id flat.NodeI
 	// selected main file declares the same type.
 	qualified := if tc.cur_module.len > 0 { '${tc.cur_module}.${name}' } else { name }
 	report_import_scope_error := !should_diagnose && !name.contains('.')
-		&& name !in ['Error', 'MessageError', 'IError'] && tc.cur_module !in ['', 'main', 'builtin']
-		&& tc.selected_main_file_declares_type(name) && !tc.qualify_candidate_type_exists(qualified)
+		&& name !in ['Error', 'MessageError', 'IError'] && tc.cur_module !in ['', 'main', 'builtin'] && tc.selected_main_file_declares_type(name) && !tc.qualify_candidate_type_exists(qualified)
 		&& !tc.source_declares_type_in_scope(name, tc.cur_file, tc.cur_module)
 	if !should_diagnose && !report_import_scope_error {
 		return
@@ -13197,13 +12950,13 @@ fn (tc &TypeChecker) resolve_known_field_type(type_name string, fallback Type) T
 	}
 	if qname in tc.type_aliases {
 		return Type(Alias{
-			name:      qname
+			name: qname
 			base_type: tc.parse_type(tc.type_aliases[qname])
 		})
 	}
 	if allow_bare_symbol && type_name in tc.type_aliases {
 		return Type(Alias{
-			name:      type_name
+			name: type_name
 			base_type: tc.parse_type(tc.type_aliases[type_name])
 		})
 	}
@@ -13279,10 +13032,8 @@ fn (mut tc TypeChecker) check_struct_field_defaults(node_id flat.NodeId, node fl
 		}
 		field_type_text := if field.typ.len > 0 { field.typ } else { field.value }
 		if bound := fixed_array_bound_text(field_type_text) {
-			if bound.starts_with('$') && !bound.starts_with('$d(') {
-				tc.record_error_at(.assignment_mismatch,
-					'only $d() is supported as fixed array size quantifier at compile time',
-					field_id, tc.fixed_array_bound_pos(*field, bound))
+			if bound.starts_with('\$') && !bound.starts_with('\$d(') {
+				tc.record_error_at(.assignment_mismatch, 'only \$d() is supported as fixed array size quantifier at compile time', field_id, tc.fixed_array_bound_pos(*field, bound))
 			}
 		}
 		field_type_raw := tc.parse_type(field_type_text)
@@ -13291,113 +13042,83 @@ fn (mut tc TypeChecker) check_struct_field_defaults(node_id flat.NodeId, node fl
 			recursive_type := unalias_type(field_type.base_type)
 			if recursive_type is Struct
 				&& tc.qualify_name(recursive_type.name) == tc.qualify_name(node.value) {
-				tc.record_error_at(.unknown_type,
-					'recursive struct is only possible with optional pointer (e.g. ?&${node.value.all_after_last('.')})',
-					field_id, field.pos)
+				tc.record_error_at(.unknown_type, 'recursive struct is only possible with optional pointer (e.g. ?&${node.value.all_after_last('.')})', field_id, field.pos)
 			}
 		}
 		is_embed := source_field_decl_is_embed(field, field_type_text)
 		if is_embed && field_type is Struct
 			&& tc.qualify_name(field_type.name) == tc.qualify_name(node.value) {
-			tc.record_error_at(.unknown_type, 'invalid recursive struct `${node.value}`', node_id,
-				tc.recursive_struct_declaration_pos(node))
+			tc.record_error_at(.unknown_type, 'invalid recursive struct `${node.value}`', node_id, tc.recursive_struct_declaration_pos(node))
 		}
 		if field_type_text == 'map' {
-			tc.record_error_at(.unknown_type,
-				'cannot use the map type without key and value definition', field_id,
-				tc.struct_field_type_pos(*field))
+			tc.record_error_at(.unknown_type, 'cannot use the map type without key and value definition', field_id, tc.struct_field_type_pos(*field))
 		}
 		if !is_embed && field.value in seen_field_names {
-			tc.record_error_at(.duplicate_decl, 'field name `${field.value}` duplicate', field_id,
-				tc.struct_field_declaration_pos(*field))
+			tc.record_error_at(.duplicate_decl, 'field name `${field.value}` duplicate', field_id, tc.struct_field_declaration_pos(*field))
 		} else if !is_embed {
 			seen_field_names[field.value] = true
 		}
 		if !is_embed && node.value != 'C.' && !node.value.starts_with('C.')
 			&& tc.should_check_source_name(field_id) && !snake_case_name_is_valid(field.value) {
-			tc.check_snake_case_name(field_id, field.value, 'field name',
-				tc.struct_field_declaration_pos(*field))
+			tc.check_snake_case_name(field_id, field.value, 'field name', tc.struct_field_declaration_pos(*field))
 		}
 		if field_type is MultiReturn {
-			tc.record_error_at(.assignment_mismatch, 'cannot use multi return as field type',
-				field_id, tc.struct_field_type_pos(*field))
+			tc.record_error_at(.assignment_mismatch, 'cannot use multi return as field type', field_id, tc.struct_field_type_pos(*field))
 		}
 		if field_type is None {
-			tc.record_error_at(.assignment_mismatch, 'cannot use `none` as field type', field_id,
-				tc.struct_field_type_pos(*field))
+			tc.record_error_at(.assignment_mismatch, 'cannot use `none` as field type', field_id, tc.struct_field_type_pos(*field))
 		}
 		embedded_alias_target := unalias_type(unwrap_all_pointers(field_type))
 		if is_embed && field_type_raw is Alias && embedded_alias_target !is Struct
 			&& embedded_alias_target !is Interface && embedded_alias_target !is FnType {
 			is_anonymous := is_anonymous_struct_name(node.value)
 			if is_anonymous {
-				tc.record_error_at(.assignment_mismatch,
-					'cannot embed non-struct `${field_type_text}`', field_id,
-					tc.anonymous_struct_type_head_pos(node))
+				tc.record_error_at(.assignment_mismatch, 'cannot embed non-struct `${field_type_text}`', field_id, tc.anonymous_struct_type_head_pos(node))
 			}
 			message := if is_anonymous {
 				'cannot embed non-struct `${field_type_text}`'
 			} else {
 				'`${field_type_text}` (alias of `${field_type.name()}`) is not a struct'
 			}
-			tc.record_error_at(.assignment_mismatch, message, field_id,
-				tc.struct_field_declaration_pos(*field))
+			tc.record_error_at(.assignment_mismatch, message, field_id, tc.struct_field_declaration_pos(*field))
 		}
 		if !is_embed && field_type_raw is Alias && field_type is Struct && field_type.name.starts_with('C.') && field_type.name in tc.c_typedef_structs && (tc.structs[field_type.name] or {
 			[]StructField{}
 		}).len == 0 {
-			tc.record_error_at(.assignment_mismatch,
-				'cannot use opaque C struct `${field_type_text}` as a non-reference struct field; use `&${field_type_text}` instead',
-				field_id, tc.struct_field_type_pos(*field))
+			tc.record_error_at(.assignment_mismatch, 'cannot use opaque C struct `${field_type_text}` as a non-reference struct field; use `&${field_type_text}` instead', field_id, tc.struct_field_type_pos(*field))
 		}
 		if field.children_count > 0
 			&& tc.struct_field_type_uses_comptime_define(field_id, field_type_text) {
 			default_id := tc.a.child(field, 0)
-			tc.record_error_at(.assignment_mismatch,
-				'cannot initialize a fixed size array field that uses `$d()` as size quantifier since the size may change via -d',
-				default_id, tc.a.node(default_id).pos)
+			tc.record_error_at(.assignment_mismatch, 'cannot initialize a fixed size array field that uses `\$d()` as size quantifier since the size may change via -d', default_id, tc.a.node(default_id).pos)
 		}
 		if field_type is ResultType {
 			type_pos := tc.struct_field_type_pos(*field)
-			tc.record_error_at(.assignment_mismatch,
-				'struct field does not support storing Result', field_id, token.new_span(type_pos.id,
-				type_pos.offset, type_pos.offset + 1))
+			tc.record_error_at(.assignment_mismatch, 'struct field does not support storing Result', field_id, token.new_span(type_pos.id, type_pos.offset, type_pos.offset + 1))
 		}
 		if field.children_count > 0 {
 			default_id := tc.a.child(field, 0)
 			default := tc.a.node(default_id)
 			if tc.type_has_declaration_attribute(field_type_raw, 'nocopy') {
-				tc.record_error_at(.assignment_mismatch,
-					'cannot copy @[nocopy] struct: use a reference instead', default_id,
-					default.pos)
+				tc.record_error_at(.assignment_mismatch, 'cannot copy @[nocopy] struct: use a reference instead', default_id, default.pos)
 			}
 			if source_field_decl_is_mut(*field) && field_type is Map && default.kind == .ident
 				&& tc.const_key_for_name(default.value) != none {
-				tc.record_error_at(.assignment_mismatch,
-					'cannot copy map: call `clone` method (or use a reference)', default_id,
-					default.pos)
+				tc.record_error_at(.assignment_mismatch, 'cannot copy map: call `clone` method (or use a reference)', default_id, default.pos)
 			}
 			if default.kind == .int_literal && default.value == '0' && field_type.is_integer() {
-				tc.record_warning_at(.assignment_mismatch,
-					'unnecessary default value of `0`: struct fields are zeroed by default',
-					default_id, default.pos)
+				tc.record_warning_at(.assignment_mismatch, 'unnecessary default value of `0`: struct fields are zeroed by default', default_id, default.pos)
 			} else if default.kind == .string_literal && default.value.len == 0
 				&& field_type is String {
-				tc.record_warning_at(.assignment_mismatch,
-					"unnecessary default value of '': struct fields are zeroed by default",
-					default_id, default.pos)
+				tc.record_warning_at(.assignment_mismatch, "unnecessary default value of '': struct fields are zeroed by default", default_id, default.pos)
 			} else if default.kind == .bool_literal && default.value == 'false'
 				&& field_type.name() == 'bool' {
-				tc.record_warning_at(.assignment_mismatch,
-					'unnecessary default value `false`: struct fields are zeroed by default',
-					default_id, default.pos)
+				tc.record_warning_at(.assignment_mismatch, 'unnecessary default value `false`: struct fields are zeroed by default', default_id, default.pos)
 			}
 		}
 		if field.children_count == 0 && field_type is FnType && !tc.translated_files[tc.cur_file]
 			&& !struct_field_has_attr(*field, 'required') {
-			tc.record_notice_at(.assignment_mismatch,
-				'uninitialized `fn` struct fields are not allowed, since they can result in segfaults; use `?fn` or `@[required]` or initialize the field with `=` (if you absolutely want to have unsafe function pointers, use `= unsafe { nil }`)',
-				field_id, tc.struct_field_declaration_pos(*field))
+			tc.record_notice_at(.assignment_mismatch, 'uninitialized `fn` struct fields are not allowed, since they can result in segfaults; use `?fn` or `@[required]` or initialize the field with `=` (if you absolutely want to have unsafe function pointers, use `= unsafe { nil }`)', field_id, tc.struct_field_declaration_pos(*field))
 		}
 	}
 	for i in 0 .. node.children_count {
@@ -13408,9 +13129,7 @@ fn (mut tc TypeChecker) check_struct_field_defaults(node_id flat.NodeId, node fl
 		}
 		default_id := tc.a.child(field, 0)
 		if tc.a.node(default_id).kind == .none_expr {
-			tc.record_warning_at(.assignment_mismatch,
-				'unnecessary default value of `none`: struct fields are zeroed by default',
-				default_id, tc.a.node(default_id).pos)
+			tc.record_warning_at(.assignment_mismatch, 'unnecessary default value of `none`: struct fields are zeroed by default', default_id, tc.a.node(default_id).pos)
 		}
 	}
 	for i in 0 .. node.children_count {
@@ -13421,8 +13140,7 @@ fn (mut tc TypeChecker) check_struct_field_defaults(node_id flat.NodeId, node fl
 		}
 		default_id := tc.a.child(field, 0)
 		if tc.a.node(default_id).kind == .nil_literal {
-			tc.record_error_at(.assignment_mismatch, '`nil` is only allowed in `unsafe` code',
-				default_id, tc.a.node(default_id).pos)
+			tc.record_error_at(.assignment_mismatch, '`nil` is only allowed in `unsafe` code', default_id, tc.a.node(default_id).pos)
 		}
 	}
 	for i in 0 .. node.children_count {
@@ -13434,13 +13152,10 @@ fn (mut tc TypeChecker) check_struct_field_defaults(node_id flat.NodeId, node fl
 		if tc.a.node(default_id).kind == .nil_literal || tc.expr_is_unsafe_nil(default_id) {
 			expected := unalias_type(tc.parse_type(field.typ))
 			if expected is OptionType && unalias_type(expected.base_type) is Pointer {
-				tc.record_error_at(.assignment_mismatch, 'cannot assign `nil` to option value',
-					default_id, tc.array_element_diagnostic_pos(default_id))
+				tc.record_error_at(.assignment_mismatch, 'cannot assign `nil` to option value', default_id, tc.array_element_diagnostic_pos(default_id))
 			} else if expected !is Pointer && expected !is FnType && !(expected is OptionType
 				&& unalias_type(expected.base_type) is FnType) {
-				tc.record_error_at(.assignment_mismatch,
-					'cannot assign `nil` to a non-pointer field', default_id,
-					tc.struct_field_type_pos(*field))
+				tc.record_error_at(.assignment_mismatch, 'cannot assign `nil` to a non-pointer field', default_id, tc.struct_field_type_pos(*field))
 			}
 		}
 	}
@@ -13464,9 +13179,7 @@ fn (mut tc TypeChecker) check_struct_field_defaults(node_id flat.NodeId, node fl
 		}
 		if clean_expected is Struct
 			&& clean_expected.name.all_after_last('.') == node.value.all_after_last('.') {
-			tc.record_error_at(.assignment_mismatch,
-				'field `${field.value}` is part of `${node.value}`, they can not both have the same type', tc.a.child(&node,
-				i), tc.struct_field_type_pos(field))
+			tc.record_error_at(.assignment_mismatch, 'field `${field.value}` is part of `${node.value}`, they can not both have the same type', tc.a.child(&node, i), tc.struct_field_type_pos(field))
 			continue
 		}
 		if clean_expected is Array {
@@ -13474,9 +13187,7 @@ fn (mut tc TypeChecker) check_struct_field_defaults(node_id flat.NodeId, node fl
 			if elem_type is Struct
 				&& elem_type.name.all_after_last('.') == node.value.all_after_last('.') {
 				type_pos := tc.struct_field_type_pos(field)
-				tc.record_error_at(.assignment_mismatch,
-					'cannot initialize array of same struct type that is being defined (recursion detected)', tc.a.child(&node,
-					i), token.new_span(field.pos.id, field.pos.offset, type_pos.end))
+				tc.record_error_at(.assignment_mismatch, 'cannot initialize array of same struct type that is being defined (recursion detected)', tc.a.child(&node, i), token.new_span(field.pos.id, field.pos.offset, type_pos.end))
 				continue
 			}
 		}
@@ -13484,9 +13195,7 @@ fn (mut tc TypeChecker) check_struct_field_defaults(node_id flat.NodeId, node fl
 		tc.check_node_with_expected_context(default_id, expected)
 		actual := tc.resolve_expr(default_id, expected)
 		if type_is_unsigned_integer(expected) && tc.expr_is_negative_integer_literal(default_id) {
-			tc.record_error_at(.assignment_mismatch,
-				'cannot assign negative value to unsigned integer type', default_id,
-				default_node.pos)
+			tc.record_error_at(.assignment_mismatch, 'cannot assign negative value to unsigned integer type', default_id, default_node.pos)
 		}
 		if clean_expected !is Pointer && unalias_type(actual) is Pointer {
 			diagnostic_pos := if default_node.kind == .call && default_node.children_count > 0 {
@@ -13499,23 +13208,19 @@ fn (mut tc TypeChecker) check_struct_field_defaults(node_id flat.NodeId, node fl
 			} else {
 				default_node.pos
 			}
-			tc.record_error_at(.assignment_mismatch,
-				'field is not reference but default value is reference', default_id, diagnostic_pos)
+			tc.record_error_at(.assignment_mismatch, 'field is not reference but default value is reference', default_id, diagnostic_pos)
 			continue
 		}
 		if expected.name() == 'voidptr' && unalias_type(actual).is_integer() {
 			if tc.should_diagnose(default_id) {
 				source_value := tc.source_text_for_node(default_id)
-				tc.record_notice_at(.assignment_mismatch,
-					'voidptr variables may only be assigned voidptr values (e.g. unsafe { voidptr(${source_value}) })',
-					default_id, default_node.pos)
+				tc.record_notice_at(.assignment_mismatch, 'voidptr variables may only be assigned voidptr values (e.g. unsafe { voidptr(${source_value}) })', default_id, default_node.pos)
 			}
 			continue
 		}
 		if clean_expected is Pointer && unalias_type(actual) !is Pointer
 			&& default_node.kind in [.ident, .selector, .struct_init] {
-			tc.record_error_at(.assignment_mismatch,
-				'reference field must be initialized with reference', default_id, default_node.pos)
+			tc.record_error_at(.assignment_mismatch, 'reference field must be initialized with reference', default_id, default_node.pos)
 			continue
 		}
 		unknown_struct_init := default_node.kind == .struct_init && default_node.value != 'struct'
@@ -13527,20 +13232,18 @@ fn (mut tc TypeChecker) check_struct_field_defaults(node_id flat.NodeId, node fl
 				continue
 			}
 			actual_name := if unknown_struct_init { 'void' } else { actual.name() }
-			tc.type_mismatch(.assignment_mismatch,
-				'cannot initialize field `${field.value}` with `${actual_name}`; expected `${field_type}`',
-				default_id)
+			tc.type_mismatch(.assignment_mismatch, 'cannot initialize field `${field.value}` with `${actual_name}`; expected `${field_type}`', default_id)
 		}
 	}
 	tc.fn_context.generic_params = saved_generic_params
 }
 
 fn (tc &TypeChecker) struct_field_type_uses_comptime_define(field_id flat.NodeId, field_type_text string) bool {
-	if field_type_text.contains('$d(') {
+	if field_type_text.contains('\$d(') {
 		return true
 	}
 	source := tc.source_text_for_node(field_id)
-	define_pos := source.index('$d(') or { return false }
+	define_pos := source.index('\$d(') or { return false }
 	assign_pos := source.index('=') or { source.len }
 	return define_pos < assign_pos
 }
@@ -13609,12 +13312,10 @@ fn (mut tc TypeChecker) check_enum_backing_type(node_id flat.NodeId, node flat.N
 		tc.check_backed_enum_field_value_ranges(node, backing, bounds)
 		return
 	}
-	tc.record_error_at(.assignment_mismatch,
-		'`${backing}` is not one of `i8`,`i16`,`i32`,`int`,`i64`,`u8`,`u16`,`u32`,`u64`', node_id, tc.enum_backing_type_diagnostic_pos(node_id,
-		backing))
+	tc.record_error_at(.assignment_mismatch, '`${backing}` is not one of `i8`,`i16`,`i32`,`int`,`i64`,`u8`,`u16`,`u32`,`u64`', node_id, tc.enum_backing_type_diagnostic_pos(node_id, backing))
 	tc.check_backed_enum_field_value_ranges(node, backing, EnumBackingValueBounds{
-		min:     0
-		max:     0
+		min: 0
+		max: 0
 		has_min: true
 		has_max: true
 	})
@@ -13666,29 +13367,29 @@ fn enum_backing_value_bounds(typ Type) ?EnumBackingValueBounds {
 			return match clean.size {
 				8 {
 					EnumBackingValueBounds{
-						min:         0
-						max:         255
-						has_min:     true
-						has_max:     true
-						bits:        bits
+						min: 0
+						max: 255
+						has_min: true
+						has_max: true
+						bits: bits
 						is_unsigned: true
 					}
 				}
 				16 {
 					EnumBackingValueBounds{
-						min:         0
-						max:         65535
-						has_min:     true
-						has_max:     true
-						bits:        bits
+						min: 0
+						max: 65535
+						has_min: true
+						has_max: true
+						bits: bits
 						is_unsigned: true
 					}
 				}
 				else {
 					EnumBackingValueBounds{
-						min:         0
-						has_min:     true
-						bits:        bits
+						min: 0
+						has_min: true
+						bits: bits
 						is_unsigned: true
 					}
 				}
@@ -13697,29 +13398,29 @@ fn enum_backing_value_bounds(typ Type) ?EnumBackingValueBounds {
 		return match clean.size {
 			8 {
 				EnumBackingValueBounds{
-					min:     -128
-					max:     127
+					min: -128
+					max: 127
 					has_min: true
 					has_max: true
-					bits:    bits
+					bits: bits
 				}
 			}
 			16 {
 				EnumBackingValueBounds{
-					min:     -32768
-					max:     32767
+					min: -32768
+					max: 32767
 					has_min: true
 					has_max: true
-					bits:    bits
+					bits: bits
 				}
 			}
 			32, 0 {
 				EnumBackingValueBounds{
-					min:     -2147483647 - 1
-					max:     2147483647
+					min: -2147483647 - 1
+					max: 2147483647
 					has_min: true
 					has_max: true
-					bits:    bits
+					bits: bits
 				}
 			}
 			else {
@@ -13731,18 +13432,18 @@ fn enum_backing_value_bounds(typ Type) ?EnumBackingValueBounds {
 	}
 	if clean is Rune {
 		return EnumBackingValueBounds{
-			min:     -2147483647 - 1
-			max:     2147483647
+			min: -2147483647 - 1
+			max: 2147483647
 			has_min: true
 			has_max: true
-			bits:    32
+			bits: 32
 		}
 	}
 	if clean is USize {
 		return EnumBackingValueBounds{
-			min:         0
-			has_min:     true
-			bits:        64
+			min: 0
+			has_min: true
+			bits: 64
 			is_unsigned: true
 		}
 	}
@@ -13778,9 +13479,7 @@ fn (mut tc TypeChecker) check_backed_enum_field_value_ranges(node flat.Node, bac
 		if !is_flag && field.children_count == 0 {
 			val := if has_previous { next_val } else { 0 }
 			if previous_is_max {
-				tc.record_error_at(.assignment_mismatch,
-					'enum value overflows type `${backing}`, which has a maximum value of ${enum_backing_max_text(bounds)}',
-					field_id, field.pos)
+				tc.record_error_at(.assignment_mismatch, 'enum value overflows type `${backing}`, which has a maximum value of ${enum_backing_max_text(bounds)}', field_id, field.pos)
 			}
 			has_previous = true
 			previous_is_max = enum_backing_int_is_max(val, bounds)
@@ -13794,24 +13493,18 @@ fn (mut tc TypeChecker) check_backed_enum_field_value_ranges(node flat.Node, bac
 				if literal := tc.integer_literal_source(expr_id) {
 					clean_literal := literal.replace('_', '')
 					if enum_backing_literal_overflows(clean_literal, bounds) {
-						tc.record_error_at(.assignment_mismatch,
-							'enum value `${clean_literal}` overflows the enum type `${backing}`, values of which have to be in [${enum_backing_min_text(bounds)}, ${enum_backing_max_text(bounds)}]',
-							expr_id, tc.a.nodes[int(expr_id)].pos)
+						tc.record_error_at(.assignment_mismatch, 'enum value `${clean_literal}` overflows the enum type `${backing}`, values of which have to be in [${enum_backing_min_text(bounds)}, ${enum_backing_max_text(bounds)}]', expr_id, tc.a.nodes[int(expr_id)].pos)
 					}
 					previous_is_max = enum_backing_literal_becomes_max(clean_literal, bounds)
 				} else {
 					expr_type := tc.resolve_type(expr_id)
 					if expr_type !is Unknown && !expr_type.is_integer() {
-						tc.record_error_at(.assignment_mismatch,
-							'enum field `${field.value}` value must be integer, not `${expr_type.name()}`',
-							expr_id, tc.a.nodes[int(expr_id)].pos)
+						tc.record_error_at(.assignment_mismatch, 'enum field `${field.value}` value must be integer, not `${expr_type.name()}`', expr_id, tc.a.nodes[int(expr_id)].pos)
 					}
 				}
 			}
 			mut resolving := map[string]bool{}
-			if resolved := tc.comptime_static_enum_field_value(expr_id, tc.cur_module, node.value, mut
-				field_values, field_exprs, mut resolving)
-			{
+			if resolved := tc.comptime_static_enum_field_value(expr_id, tc.cur_module, node.value, mut field_values, field_exprs, mut resolving) {
 				val = resolved
 			} else {
 				has_checked_value = false
@@ -13820,18 +13513,14 @@ fn (mut tc TypeChecker) check_backed_enum_field_value_ranges(node flat.Node, bac
 		field_values[field.value] = val
 		if is_flag && has_checked_value && !enum_backing_value_fits(val, bounds, true) {
 			if is_flag {
-				tc.record_error(.assignment_mismatch,
-					'enum field `${field.value}` bit ${val} does not fit backing type `${backing}`',
-					field_id)
+				tc.record_error(.assignment_mismatch, 'enum field `${field.value}` bit ${val} does not fit backing type `${backing}`', field_id)
 			}
 		}
 		if !is_flag && has_checked_value && field.children_count > 0
 			&& tc.integer_literal_source(tc.a.child(&field, 0)) == none {
 			if !enum_backing_value_fits(val, bounds, false) {
 				expr_id := tc.a.child(&field, 0)
-				tc.record_error_at(.assignment_mismatch,
-					'enum value `${val}` overflows the enum type `${backing}`, values of which have to be in [${enum_backing_min_text(bounds)}, ${enum_backing_max_text(bounds)}]',
-					expr_id, tc.a.nodes[int(expr_id)].pos)
+				tc.record_error_at(.assignment_mismatch, 'enum value `${val}` overflows the enum type `${backing}`, values of which have to be in [${enum_backing_min_text(bounds)}, ${enum_backing_max_text(bounds)}]', expr_id, tc.a.nodes[int(expr_id)].pos)
 			}
 			previous_is_max = enum_backing_int_is_max(val, bounds)
 		}
@@ -13984,18 +13673,13 @@ fn (mut tc TypeChecker) check_enum_field_values(node_id flat.NodeId, node flat.N
 		}
 	}
 	if enum_field_count == 0 {
-		tc.record_error_at(.assignment_mismatch, 'enum cannot be empty', node_id,
-			tc.enum_declaration_diagnostic_pos(node_id))
+		tc.record_error_at(.assignment_mismatch, 'enum cannot be empty', node_id, tc.enum_declaration_diagnostic_pos(node_id))
 	}
 	if node.value.len == 1 && node.value[0] >= `A` && node.value[0] <= `Z` {
-		tc.record_error_at(.duplicate_decl,
-			'single letter capital names are reserved for generic template types.', node_id,
-			tc.node_value_diagnostic_pos(node_id))
+		tc.record_error_at(.duplicate_decl, 'single letter capital names are reserved for generic template types.', node_id, tc.node_value_diagnostic_pos(node_id))
 	}
 	if tc.type_declaration_exists_before(node_id, node.value) {
-		tc.record_error_at(.duplicate_decl,
-			'cannot register enum `${node.value}`, another type with this name exists', node_id,
-			tc.enum_declaration_diagnostic_pos(node_id))
+		tc.record_error_at(.duplicate_decl, 'cannot register enum `${node.value}`, another type with this name exists', node_id, tc.enum_declaration_diagnostic_pos(node_id))
 	}
 	allow_multiple := tc.declaration_has_attribute(node_id, '_allow_multiple_values')
 		|| tc.translated_files[tc.cur_file]
@@ -14018,8 +13702,7 @@ fn (mut tc TypeChecker) check_enum_field_values(node_id flat.NodeId, node flat.N
 		}
 		if tc.should_check_source_name(field_id) && !field.value.starts_with('_')
 			&& !snake_case_name_is_valid(field.value) {
-			tc.check_snake_case_name(field_id, field.value, 'field name',
-				tc.source_line_declaration_pos(field_id))
+			tc.check_snake_case_name(field_id, field.value, 'field name', tc.source_line_declaration_pos(field_id))
 		}
 		duplicate_name := seen_names[field.value]
 		if duplicate_name {
@@ -14027,8 +13710,7 @@ fn (mut tc TypeChecker) check_enum_field_values(node_id flat.NodeId, node flat.N
 			if field.children_count > 0 {
 				duplicate_pos = token.new_span(field.pos.id, field.pos.offset, field.pos.offset + 1)
 			}
-			tc.record_error_at(.duplicate_decl, 'duplicate enum field name `${field.value}`',
-				field_id, duplicate_pos)
+			tc.record_error_at(.duplicate_decl, 'duplicate enum field name `${field.value}`', field_id, duplicate_pos)
 		}
 		seen_names[field.value] = true
 		mut value := next_value
@@ -14040,17 +13722,14 @@ fn (mut tc TypeChecker) check_enum_field_values(node_id flat.NodeId, node flat.N
 			value_pos = tc.a.node(value_id).pos
 			if referenced := tc.find_enum_value_in_node(value_id, node.value) {
 				if referenced != field.value && !seen_names[referenced] {
-					tc.record_error_at(.unknown_ident,
-						'`${node.value}.${referenced}` should be declared before using it',
-						value_id, value_pos)
+					tc.record_error_at(.unknown_ident, '`${node.value}.${referenced}` should be declared before using it', value_id, value_pos)
 					continue
 				}
 			}
 			if node.generic_params().len > 0 {
 				if bounds := enum_backing_value_bounds(tc.parse_type(node.generic_params()[0])) {
 					if literal := tc.integer_literal_source(value_id) {
-						value_overflows_backing = enum_backing_literal_overflows(literal.replace('_', ''),
-							bounds)
+						value_overflows_backing = enum_backing_literal_overflows(literal.replace('_', ''), bounds)
 					}
 				}
 			}
@@ -14062,18 +13741,14 @@ fn (mut tc TypeChecker) check_enum_field_values(node_id flat.NodeId, node flat.N
 				}
 				if value_node.value == field.value {
 					if !allow_multiple {
-						tc.record_error_with_details_at(.duplicate_decl,
-							'enum value `${field.value}` is not allowed to reference itself',
-							field_id, value_pos, [
+						tc.record_error_with_details_at(.duplicate_decl, 'enum value `${field.value}` is not allowed to reference itself', field_id, value_pos, [
 							'use `@[_allow_multiple_values]` attribute to allow multiple enum values. Use only when needed',
 						])
 					}
 					continue
 				}
 				if !seen_names[value_node.value] {
-					tc.record_error_at(.unknown_ident,
-						'`${node.value}.${value_node.value}` should be declared before using it',
-						field_id, value_pos)
+					tc.record_error_at(.unknown_ident, '`${node.value}.${value_node.value}` should be declared before using it', field_id, value_pos)
 					continue
 				}
 			}
@@ -14082,18 +13757,14 @@ fn (mut tc TypeChecker) check_enum_field_values(node_id flat.NodeId, node flat.N
 				value_known = false
 			} else if !value_type.is_integer() {
 				if node.generic_params().len == 0 {
-					tc.record_error_at(.assignment_mismatch,
-						'enum field `${field.value}` value must be integer, not `${value_type.name()}`',
-						value_id, value_pos)
+					tc.record_error_at(.assignment_mismatch, 'enum field `${field.value}` value must be integer, not `${value_type.name()}`', value_id, value_pos)
 				}
 				value_known = false
 			}
 			mut resolving := map[string]bool{}
-			value = tc.comptime_static_enum_field_value(value_id, tc.cur_module, node.value, mut
-				field_values, field_exprs, mut resolving) or {
+			value = tc.comptime_static_enum_field_value(value_id, tc.cur_module, node.value, mut field_values, field_exprs, mut resolving) or {
 				if tc.node_contains_runtime_call(value_id) {
-					tc.record_error_at(.assignment_mismatch,
-						'enum field `${field.value}` value must be integer', value_id, value_pos)
+					tc.record_error_at(.assignment_mismatch, 'enum field `${field.value}` value must be integer', value_id, value_pos)
 				}
 				value_known = false
 				value
@@ -14106,8 +13777,7 @@ fn (mut tc TypeChecker) check_enum_field_values(node_id flat.NodeId, node flat.N
 			} else {
 				'use `@[_allow_multiple_values]` attribute to allow multiple enum values. Use only when it is needed'
 			}
-			tc.record_error_with_details_at(.duplicate_decl,
-				'enum value `${value}` already exists', field_id, value_pos, [
+			tc.record_error_with_details_at(.duplicate_decl, 'enum value `${value}` already exists', field_id, value_pos, [
 				detail,
 			])
 		}
@@ -14261,9 +13931,7 @@ fn (mut tc TypeChecker) record_non_heap_pointer_param_escape(id flat.NodeId) boo
 		return false
 	}
 	struct_name := tc.non_heap_pointer_param_struct(node.value) or { return false }
-	tc.record_error_at(.assignment_mismatch,
-		'`${node.value}` cannot be assigned outside `unsafe` blocks as it might refer to an object stored on stack. Consider declaring `${struct_name}` as `@[heap]`.',
-		id, node.pos)
+	tc.record_error_at(.assignment_mismatch, '`${node.value}` cannot be assigned outside `unsafe` blocks as it might refer to an object stored on stack. Consider declaring `${struct_name}` as `@[heap]`.', id, node.pos)
 	return true
 }
 
@@ -14346,34 +14014,24 @@ fn (mut tc TypeChecker) check_const_field_values(node flat.Node) {
 		module_name := if tc.cur_module.len > 0 { tc.cur_module } else { 'main' }
 		duplicate_key := '${module_name}.${field.value}'
 		if reserved_const_type_name(field.value) {
-			tc.record_error_at(.duplicate_decl,
-				'invalid use of reserved type `${field.value}` as a const name', field_id,
-				field.pos)
+			tc.record_error_at(.duplicate_decl, 'invalid use of reserved type `${field.value}` as a const name', field_id, field.pos)
 		}
 		if tc.checked_const_names[duplicate_key] {
-			tc.record_error_at(.duplicate_decl, 'duplicate const `${field.value}`', field_id,
-				tc.node_value_diagnostic_pos(field_id))
+			tc.record_error_at(.duplicate_decl, 'duplicate const `${field.value}`', field_id, tc.node_value_diagnostic_pos(field_id))
 		} else {
 			tc.checked_const_names[duplicate_key] = true
 		}
-		if field.value == tc.cur_module && tc.cur_module !in ['', 'main']
-			&& !tc.current_file_uses_nested_vlib_module_path() {
-			tc.record_error_at(.duplicate_decl, 'duplicate of a module name `${qname}`', field_id,
-				tc.node_value_diagnostic_pos(field_id))
+		if field.value == tc.cur_module && tc.cur_module !in ['', 'main'] && !tc.current_file_uses_nested_vlib_module_path() {
+			tc.record_error_at(.duplicate_decl, 'duplicate of a module name `${qname}`', field_id, tc.node_value_diagnostic_pos(field_id))
 		}
 		if field.value == '_' {
-			tc.record_error_at(.duplicate_decl, 'cannot use `_` as a const name', field_id,
-				tc.node_value_diagnostic_pos(field_id))
+			tc.record_error_at(.duplicate_decl, 'cannot use `_` as a const name', field_id, tc.node_value_diagnostic_pos(field_id))
 		} else if tc.should_check_source_name(field_id) && !field.value.starts_with('C.')
 			&& field.value != field.value.to_lower() {
-			tc.record_error_at(.duplicate_decl,
-				'const names cannot contain uppercase letters, use snake_case instead', field_id,
-				tc.node_value_diagnostic_pos(field_id))
+			tc.record_error_at(.duplicate_decl, 'const names cannot contain uppercase letters, use snake_case instead', field_id, tc.node_value_diagnostic_pos(field_id))
 		}
 		if tc.has_active_import(field.value) {
-			tc.record_error_at(.duplicate_decl,
-				'const `${field.value}` conflicts with imported module `${field.value}`', field_id,
-				tc.node_value_diagnostic_pos(field_id))
+			tc.record_error_at(.duplicate_decl, 'const `${field.value}` conflicts with imported module `${field.value}`', field_id, tc.node_value_diagnostic_pos(field_id))
 		}
 		expr_id := tc.a.child(field, 0)
 		if cycle_id := tc.find_ident_in_node(expr_id, field.value) {
@@ -14386,15 +14044,11 @@ fn (mut tc TypeChecker) check_const_field_values(node flat.Node) {
 		}
 		tc.check_node(expr_id)
 		if tc.resolve_type(expr_id) is MultiReturn {
-			tc.record_error_at(.assignment_mismatch,
-				'const declarations do not support multiple return values yet', expr_id,
-				tc.a.nodes[int(expr_id)].pos)
+			tc.record_error_at(.assignment_mismatch, 'const declarations do not support multiple return values yet', expr_id, tc.a.nodes[int(expr_id)].pos)
 		}
 		if field.typ.len == 0 && tc.resolve_type(expr_id).name() == 'int'
 			&& tc.implicit_int_literal_overflows(expr_id) {
-			tc.record_error_at(.assignment_mismatch,
-				'overflow in implicit type `int`, use explicit type casting instead', expr_id,
-				tc.a.nodes[int(expr_id)].pos)
+			tc.record_error_at(.assignment_mismatch, 'overflow in implicit type `int`, use explicit type casting instead', expr_id, tc.a.nodes[int(expr_id)].pos)
 		}
 	}
 }
@@ -14419,8 +14073,7 @@ fn (tc &TypeChecker) const_self_reference_address_state(id flat.NodeId, name str
 	mut found := false
 	mut all_addressed := true
 	for i in 0 .. node.children_count {
-		child_found, child_ok := tc.const_self_reference_address_state(tc.a.child(node, i), name,
-			child_addressed)
+		child_found, child_ok := tc.const_self_reference_address_state(tc.a.child(node, i), name, child_addressed)
 		found = found || child_found
 		all_addressed = all_addressed && child_ok
 	}
@@ -14435,17 +14088,13 @@ fn (mut tc TypeChecker) check_const_global_initializers(node flat.Node) {
 			continue
 		}
 		if field.children_count == 0 {
-			tc.record_error_severity_at(.compile_error,
-				'const globals must have an explicit initializer', field_id,
-				tc.node_value_diagnostic_pos(field_id), 'cgen error:')
+			tc.record_error_severity_at(.compile_error, 'const globals must have an explicit initializer', field_id, tc.node_value_diagnostic_pos(field_id), 'cgen error:')
 			continue
 		}
 		expr_id := tc.a.child(field, 0)
 		tc.check_node(expr_id)
 		if !tc.global_const_expr_is_c_constant(expr_id) {
-			tc.record_error_severity_at(.compile_error,
-				'const global `${field.value}` must be initialized with a C constant expression',
-				field_id, tc.node_value_diagnostic_pos(field_id), 'cgen error:')
+			tc.record_error_severity_at(.compile_error, 'const global `${field.value}` must be initialized with a C constant expression', field_id, tc.node_value_diagnostic_pos(field_id), 'cgen error:')
 		}
 	}
 }
@@ -14585,8 +14234,7 @@ fn (mut tc TypeChecker) check_noreturn_fn_semantics(id flat.NodeId, node flat.No
 		}
 	}
 	if has_return {
-		tc.record_error_at(.return_mismatch, '[noreturn] functions cannot use return statements',
-			id, tc.fn_declaration_diagnostic_pos(node))
+		tc.record_error_at(.return_mismatch, '[noreturn] functions cannot use return statements', id, tc.fn_declaration_diagnostic_pos(node))
 	}
 	valid_tail := tc.valid_node_id(tail_id)
 		&& (tc.stmt_definitely_returns(tail_id) || tc.expr_never_returns_resolving(tail_id))
@@ -14599,8 +14247,7 @@ fn (mut tc TypeChecker) check_noreturn_fn_semantics(id flat.NodeId, node flat.No
 	} else {
 		tc.fn_declaration_diagnostic_pos(node)
 	}
-	tc.record_error_at(.return_mismatch,
-		'@[noreturn] functions should end with a call to another @[noreturn] function, or with an infinite `for {}` loop', if tc.valid_node_id(tail_id) {
+	tc.record_error_at(.return_mismatch, '@[noreturn] functions should end with a call to another @[noreturn] function, or with an infinite `for {}` loop', if tc.valid_node_id(tail_id) {
 		tail_id
 	} else {
 		id
@@ -14616,8 +14263,7 @@ fn (mut tc TypeChecker) check_unreachable_after_noreturn_call(node flat.Node) {
 			continue
 		}
 		if previous_never_returns {
-			tc.record_warning_at(.return_mismatch, 'unreachable code after a @[noreturn] call',
-				child_id, tc.noreturn_statement_diagnostic_pos(child_id))
+			tc.record_warning_at(.return_mismatch, 'unreachable code after a @[noreturn] call', child_id, tc.noreturn_statement_diagnostic_pos(child_id))
 			return
 		}
 		if tc.is_prod && child.kind == .assert_stmt {
@@ -14653,8 +14299,7 @@ fn (tc &TypeChecker) noreturn_invalid_tail_pos(id flat.NodeId) token.Pos {
 			line := source[line_pos.offset..line_pos.end]
 			brace := line.index_u8(`{`)
 			if brace >= 0 {
-				return token.new_span(line_pos.id, line_pos.offset + brace, line_pos.offset +
-					brace + 1)
+				return token.new_span(line_pos.id, line_pos.offset + brace, line_pos.offset + brace + 1)
 			}
 		}
 		return line_pos
@@ -15425,8 +15070,7 @@ fn (mut tc TypeChecker) check_comptime_for_members(_id flat.NodeId, node flat.No
 		return
 	}
 	if !tc.comptime_subtree_references_var(body_id, parts[0]) {
-		tc.record_warning_at(.unknown_ident, 'unused variable: `${parts[0]}`', _id, tc.comptime_for_variable_pos(node,
-			parts[0]))
+		tc.record_warning_at(.unknown_ident, 'unused variable: `${parts[0]}`', _id, tc.comptime_for_variable_pos(node, parts[0]))
 	}
 	if tc.check_comptime_for_source_type(_id, node) {
 		return
@@ -15439,16 +15083,12 @@ fn (mut tc TypeChecker) check_comptime_for_members(_id flat.NodeId, node flat.No
 	}
 	source_is_fn := node.typ in tc.fn_ret_types || tc.qualify_fn_name(node.typ) in tc.fn_ret_types
 	if parts[1] == 'params' && source_is_type && !source_is_fn {
-		tc.record_error_at(.unknown_type,
-			'iterating over `.params` is supported only for functions, and `${node.typ}` is not a function',
-			_id, tc.comptime_for_source_pos(node))
+		tc.record_error_at(.unknown_type, 'iterating over `.params` is supported only for functions, and `${node.typ}` is not a function', _id, tc.comptime_for_source_pos(node))
 		return
 	}
 	if !source_is_type && !source_is_value && !source_is_fn && node.typ.len > 0
 		&& node.typ[0].is_capital() {
-		tc.record_error_at(.unknown_type,
-			'$for expects a type name or variable name to be used here, but ${node.typ} is not a type or variable name',
-			_id, tc.comptime_for_source_pos(node))
+		tc.record_error_at(.unknown_type, '\$for expects a type name or variable name to be used here, but ${node.typ} is not a type or variable name', _id, tc.comptime_for_source_pos(node))
 		return
 	}
 	current_fn_id := flat.NodeId(tc.fn_context.node_id)
@@ -15469,9 +15109,7 @@ fn (mut tc TypeChecker) check_comptime_for_members(_id flat.NodeId, node flat.No
 			}
 			tc.record_warning_at(.unknown_ident, 'unused variable: `${parts[0]}`', _id, var_pos)
 			for use_id in invalid_uses {
-				tc.record_error_at(.unknown_ident,
-					'undefined ident `${parts[0]}` in the anonymous function', use_id, tc.comptime_method_anon_fn_call_pos(use_id,
-					parts[0]))
+				tc.record_error_at(.unknown_ident, 'undefined ident `${parts[0]}` in the anonymous function', use_id, tc.comptime_method_anon_fn_call_pos(use_id, parts[0]))
 			}
 		}
 	}
@@ -15508,8 +15146,7 @@ fn (mut tc TypeChecker) check_comptime_for_members(_id flat.NodeId, node flat.No
 		if deferred_cases.known && deferred_cases.cases.len == 0 {
 			return
 		}
-		tc.check_comptime_static_body(body_id, parts[0], parts[1], ComptimeStaticFieldCases{},
-			deferred_cases)
+		tc.check_comptime_static_body(body_id, parts[0], parts[1], ComptimeStaticFieldCases{}, deferred_cases)
 		return
 	}
 
@@ -15544,7 +15181,7 @@ fn (tc &TypeChecker) comptime_struct_update_id(id flat.NodeId) ?flat.NodeId {
 			is_update := node.kind == .assoc
 				|| (child.kind == .prefix && child.value == '...')
 				|| tc.node_has_ellipsis_prefix(child_id)
-			if is_update && tc.node_source_contains(child_id, '$(') {
+			if is_update && tc.node_source_contains(child_id, '\$(') {
 				return child_id
 			}
 		}
@@ -15594,8 +15231,7 @@ fn (mut tc TypeChecker) check_comptime_struct_updates_preflight() {
 		body_id := tc.a.child(&node, 0)
 		if update_id := tc.comptime_struct_update_id(body_id) {
 			if !tc.errors.any(it.node == update_id && it.msg == message) {
-				tc.record_error_at(.assignment_mismatch, message, update_id,
-					tc.ellipsis_diagnostic_pos(update_id))
+				tc.record_error_at(.assignment_mismatch, message, update_id, tc.ellipsis_diagnostic_pos(update_id))
 			}
 		}
 	}
@@ -15616,11 +15252,11 @@ fn (mut tc TypeChecker) check_comptime_struct_updates_preflight() {
 }
 
 fn comptime_struct_update_pos_in_source(file_id int, source string) ?token.Pos {
-	mut cursor := source.index('$for') or { return none }
+	mut cursor := source.index('\$for') or { return none }
 	for cursor + 3 <= source.len {
 		cursor = source.index_after('...', cursor) or { return none }
 		line_end := source.index_after('\n', cursor) or { source.len }
-		if last_index_between(source, '$(', cursor, line_end) >= 0 {
+		if last_index_between(source, '\$(', cursor, line_end) >= 0 {
 			return token.new_span(file_id, cursor, cursor + 3)
 		}
 		cursor += 3
@@ -15707,7 +15343,7 @@ fn (mut tc TypeChecker) check_comptime_selectors_outside_loop(id flat.NodeId, lo
 	if node.kind == .comptime_for && comptime_for_declares_var_in_value(node.value, var_name) {
 		return
 	}
-	if node.kind == .selector && node.value == '$' && node.children_count >= 2 {
+	if node.kind == .selector && node.value == '\$' && node.children_count >= 2 {
 		field_expr := tc.a.child_node(node, 1)
 		if field_expr.kind == .selector && field_expr.children_count > 0 {
 			base := tc.a.child_node(field_expr, 0)
@@ -15727,8 +15363,8 @@ fn (tc &TypeChecker) comptime_for_variable_pos(node flat.Node, var_name string) 
 	source := tc.source_texts_by_file[file.name] or { return node.pos }
 	start := int_max(0, int_min(node.pos.offset, source.len))
 	end := int_max(start, int_min(node.pos.end, source.len))
-	if relative := source[start..end].index('$for ${var_name}') {
-		var_start := start + relative + '$for '.len
+	if relative := source[start..end].index('\$for ${var_name}') {
+		var_start := start + relative + '\$for '.len
 		return token.new_span(node.pos.id, var_start, var_start + var_name.len)
 	}
 	return node.pos
@@ -15766,10 +15402,9 @@ fn (mut tc TypeChecker) check_comptime_reflection_condition_types(id flat.NodeId
 				type_end++
 			}
 			typ := node.value[type_start..type_end]
-			if typ.len > 0 && !typ.starts_with('$') && !typ.starts_with('${loop_var}.')
+			if typ.len > 0 && !typ.starts_with('\$') && !typ.starts_with('${loop_var}.')
 				&& !tc.comptime_reflection_condition_type_known(typ) {
-				tc.record_error_at(.unknown_type, 'unknown type `${typ}`', id, tc.comptime_condition_type_pos(*node,
-					typ))
+				tc.record_error_at(.unknown_type, 'unknown type `${typ}`', id, tc.comptime_condition_type_pos(*node, typ))
 			}
 			offset = int_max(type_end, type_start + 1)
 		}
@@ -15836,14 +15471,12 @@ fn (mut tc TypeChecker) check_comptime_attribute_members(id flat.NodeId, var_nam
 					if start < end {
 						if relative := source[start..end].index('.${member}') {
 							member_start := start + relative + 1
-							pos = token.new_span(node.pos.id, member_start, member_start +
-								member.len)
+							pos = token.new_span(node.pos.id, member_start, member_start + member.len)
 						}
 					}
 				}
 			}
-			tc.record_error_at(.unknown_field, 'unknown field `${member}` from ${var_name}', id,
-				pos)
+			tc.record_error_at(.unknown_field, 'unknown field `${member}` from ${var_name}', id, pos)
 			return
 		}
 	}
@@ -15873,7 +15506,7 @@ fn (tc &TypeChecker) collect_anon_fn_comptime_method_uses(id flat.NodeId, var_na
 	} else {
 		captured
 	}
-	if is_inside && !inside_capture && node.kind == .selector && node.value == '$'
+	if is_inside && !inside_capture && node.kind == .selector && node.value == '\$'
 		&& node.children_count > 1 {
 		method_var := tc.a.child_node(node, 1)
 		if method_var.kind == .ident && method_var.value == var_name {
@@ -15882,8 +15515,7 @@ fn (tc &TypeChecker) collect_anon_fn_comptime_method_uses(id flat.NodeId, var_na
 		}
 	}
 	for i in 0 .. node.children_count {
-		tc.collect_anon_fn_comptime_method_uses(tc.a.child(node, i), var_name, is_inside,
-			inside_capture, mut uses)
+		tc.collect_anon_fn_comptime_method_uses(tc.a.child(node, i), var_name, is_inside, inside_capture, mut uses)
 	}
 }
 
@@ -15901,7 +15533,7 @@ fn (tc &TypeChecker) comptime_method_anon_fn_call_pos(id flat.NodeId, var_name s
 	}
 	line_end := source.index_after('\n', node.pos.offset) or { source.len }
 	line := source[line_start..line_end]
-	marker := '.$${var_name}()'
+	marker := '.\$${var_name}()'
 	dot_relative := line.index(marker) or { return node.pos }
 	dot := line_start + dot_relative
 	return token.new_span(node.pos.id, dot + 1, dot + marker.len)
@@ -16002,15 +15634,14 @@ fn (tc &TypeChecker) comptime_static_method_cases(source string) ComptimeStaticV
 					'void'
 				}, generic_args, generic_params)
 				cases << ComptimeStaticValueCase{
-					name:         name
-					location:     comptime_static_source_location(file_name, candidate.pos.offset,
-						line_offsets_by_file[file_name])
-					typ:          comptime_static_method_type_text(param_types, return_type)
-					return_type:  return_type
-					is_pub:       candidate.op == .arrow
-					has_is_pub:   true
-					param_names:  param_names
-					param_types:  param_types
+					name: name
+					location: comptime_static_source_location(file_name, candidate.pos.offset, line_offsets_by_file[file_name])
+					typ: comptime_static_method_type_text(param_types, return_type)
+					return_type: return_type
+					is_pub: candidate.op == .arrow
+					has_is_pub: true
+					param_names: param_names
+					param_types: param_types
 					param_is_mut: param_is_mut
 				}
 			}
@@ -16051,7 +15682,7 @@ fn (tc &TypeChecker) comptime_static_param_cases(source string) ComptimeStaticVa
 			if param.kind == .param {
 				cases << ComptimeStaticValueCase{
 					name: param.value
-					typ:  param.typ
+					typ: param.typ
 				}
 			}
 		}
@@ -16171,11 +15802,11 @@ fn comptime_static_attribute_case(raw string, kind int) ComptimeStaticValueCase 
 		arg = comptime_static_unescape(arg[1..arg.len - 1])
 	}
 	return ComptimeStaticValueCase{
-		name:          name
-		arg:           arg
-		has_arg:       has_arg
+		name: name
+		arg: arg
+		has_arg: has_arg
 		has_attr_meta: true
-		attr_kind:     kind
+		attr_kind: kind
 	}
 }
 
@@ -16200,7 +15831,7 @@ fn (tc &TypeChecker) comptime_deferred_decl_source(source string, allow_type boo
 		}
 		return ComptimeDeferredDeclSource{
 			module_name: if tc.cur_module.len > 0 { tc.cur_module } else { 'main' }
-			decl_name:   clean
+			decl_name: clean
 		}
 	}
 	dot := clean.index_u8(`.`)
@@ -16208,25 +15839,25 @@ fn (tc &TypeChecker) comptime_deferred_decl_source(source string, allow_type boo
 	if resolved := tc.resolve_import_alias(first) {
 		return ComptimeDeferredDeclSource{
 			module_name: resolved
-			decl_name:   clean[dot + 1..]
+			decl_name: clean[dot + 1..]
 		}
 	}
 	if first == tc.cur_module {
 		return ComptimeDeferredDeclSource{
 			module_name: first
-			decl_name:   clean[dot + 1..]
+			decl_name: clean[dot + 1..]
 		}
 	}
 	return ComptimeDeferredDeclSource{
 		module_name: if tc.cur_module.len > 0 { tc.cur_module } else { 'main' }
-		decl_name:   clean
+		decl_name: clean
 	}
 }
 
 fn comptime_deferred_qualified_source(source string) ComptimeDeferredDeclSource {
 	return ComptimeDeferredDeclSource{
 		module_name: source.all_before_last('.')
-		decl_name:   source.all_after_last('.')
+		decl_name: source.all_after_last('.')
 	}
 }
 
@@ -16249,7 +15880,7 @@ fn (mut tc TypeChecker) check_comptime_members(id flat.NodeId, var_name string, 
 		base_id := tc.a.child(&node, 0)
 		if tc.valid_node_id(base_id) {
 			base := tc.a.nodes[int(base_id)]
-			if base.kind == .ident && base.value == var_name && node.value != '$'
+			if base.kind == .ident && base.value == var_name && node.value != '\$'
 				&& node.value !in members {
 				tc.record_error(.unknown_field, 'unknown ${meta_name} member `${node.value}`', id)
 			}
@@ -16331,8 +15962,7 @@ fn (mut tc TypeChecker) check_comptime_static_body(id flat.NodeId, var_name stri
 		// references the loop var) must not leak past it.
 		tc.push_scope()
 		for i in 0 .. node.children_count {
-			tc.check_comptime_static_body(tc.a.child(&node, i), var_name, loop_kind, field_cases,
-				value_cases)
+			tc.check_comptime_static_body(tc.a.child(&node, i), var_name, loop_kind, field_cases, value_cases)
 		}
 		tc.pop_scope()
 		return
@@ -16345,27 +15975,23 @@ fn (mut tc TypeChecker) check_comptime_static_body(id flat.NodeId, var_name stri
 	}
 	if node.kind == .if_expr {
 		if loop_kind == 'methods' && value_cases.known && node.children_count >= 2 {
-			tc.check_comptime_static_method_runtime_if(node, var_name, loop_kind, field_cases,
-				value_cases)
+			tc.check_comptime_static_method_runtime_if(node, var_name, loop_kind, field_cases, value_cases)
 			return
 		}
 		for i in 0 .. node.children_count {
-			tc.check_comptime_static_body(tc.a.child(&node, i), var_name, loop_kind, field_cases,
-				value_cases)
+			tc.check_comptime_static_body(tc.a.child(&node, i), var_name, loop_kind, field_cases, value_cases)
 		}
 		return
 	}
 	if node.kind in [.expr_stmt, .return_stmt] {
 		for i in 0 .. node.children_count {
-			tc.check_comptime_static_body(tc.a.child(&node, i), var_name, loop_kind, field_cases,
-				value_cases)
+			tc.check_comptime_static_body(tc.a.child(&node, i), var_name, loop_kind, field_cases, value_cases)
 		}
 		return
 	}
 	if node.kind == .comptime_if && comptime_text_references_var(node.value, var_name) {
 		if loop_kind in ['methods', 'params', 'attributes'] {
-			tc.check_comptime_static_deferred_metadata_if(node, var_name, loop_kind, field_cases,
-				value_cases)
+			tc.check_comptime_static_deferred_metadata_if(node, var_name, loop_kind, field_cases, value_cases)
 			return
 		}
 		tc.check_comptime_static_metadata_if(node, var_name, loop_kind, field_cases, value_cases)
@@ -16404,8 +16030,7 @@ fn (mut tc TypeChecker) check_comptime_static_body(id flat.NodeId, var_name stri
 				continue
 			}
 			rhs_id := tc.a.child(&node, i + 1)
-			rhs_typ := tc.comptime_static_method_call_return_type(rhs_id, var_name, loop_kind,
-				value_cases) or { tc.resolve_type(rhs_id) }
+			rhs_typ := tc.comptime_static_method_call_return_type(rhs_id, var_name, loop_kind, value_cases) or { tc.resolve_type(rhs_id) }
 			typ := if rhs_typ is Unknown {
 				tc.comptime_static_reflected_field_expr_type(rhs_id, var_name, field_cases) or {
 					Type(Unknown{})
@@ -16416,22 +16041,20 @@ fn (mut tc TypeChecker) check_comptime_static_body(id flat.NodeId, var_name stri
 				rhs_typ
 			}
 			rhs := tc.a.node(rhs_id)
-			if rhs.kind == .selector && rhs.value == '$' && unalias_type(typ) is Map {
+			if rhs.kind == .selector && rhs.value == '\$' && unalias_type(typ) is Map {
 				mut pos := rhs.pos
 				if file := tc.a.source_files[rhs.pos.id] {
 					if source := tc.source_texts_by_file[file.name] {
 						start := int_max(0, rhs.pos.offset)
 						end := int_min(source.len, rhs.pos.end)
 						if start < end {
-							if relative := source[start..end].index('.$(') {
+							if relative := source[start..end].index('.\$(') {
 								pos = token.new_span(rhs.pos.id, start + relative + 1, end)
 							}
 						}
 					}
 				}
-				tc.record_error_at(.assignment_mismatch,
-					'cannot copy map: call `move` or `clone` method (or use a reference)', rhs_id,
-					pos)
+				tc.record_error_at(.assignment_mismatch, 'cannot copy map: call `move` or `clone` method (or use a reference)', rhs_id, pos)
 			}
 			tc.cur_scope.insert(lhs.value, typ)
 		}
@@ -16443,7 +16066,7 @@ fn (mut tc TypeChecker) record_deferred_comptime_field_errors(id flat.NodeId, va
 		return false
 	}
 	node := tc.a.node(id)
-	if node.kind == .selector && node.value == '$' && node.children_count >= 2 {
+	if node.kind == .selector && node.value == '\$' && node.children_count >= 2 {
 		field_expr := tc.a.child_node(node, 1)
 		if field_expr.kind == .selector && field_expr.value == 'name'
 			&& field_expr.children_count > 0 {
@@ -16451,11 +16074,8 @@ fn (mut tc TypeChecker) record_deferred_comptime_field_errors(id flat.NodeId, va
 			loop_var := tc.a.node(loop_var_id)
 			if loop_var.kind == .ident && loop_var.value == var_name {
 				pos := tc.node_value_diagnostic_pos(loop_var_id)
-				tc.record_error_at(.unknown_field,
-					'compile time field access can only be used when iterating over `T.fields`',
-					loop_var_id, pos)
-				tc.record_error_at(.unknown_ident, 'unknown `$for` variable `${var_name}`',
-					loop_var_id, pos)
+				tc.record_error_at(.unknown_field, 'compile time field access can only be used when iterating over `T.fields`', loop_var_id, pos)
+				tc.record_error_at(.unknown_ident, 'unknown `\$for` variable `${var_name}`', loop_var_id, pos)
 				return true
 			}
 		}
@@ -16479,14 +16099,13 @@ fn (mut tc TypeChecker) record_deferred_comptime_field_errors(id flat.NodeId, va
 				start := int_max(0, condition.pos.offset)
 				end := int_min(source.len, condition.pos.end)
 				if start < end {
-					if relative := source[start..end].index('.$(') {
+					if relative := source[start..end].index('.\$(') {
 						pos = token.new_span(condition.pos.id, start + relative + 1, end)
 					}
 				}
 			}
 		}
-		tc.record_error_at(.condition_mismatch, 'non-bool type `void` used as if condition',
-			condition_id, pos)
+		tc.record_error_at(.condition_mismatch, 'non-bool type `void` used as if condition', condition_id, pos)
 	}
 	return found
 }
@@ -16497,7 +16116,7 @@ fn (mut tc TypeChecker) check_comptime_static_assignment(node flat.Node, var_nam
 	}
 	lhs_id := tc.a.child(&node, 0)
 	lhs := tc.a.node(lhs_id)
-	if lhs.kind != .selector || lhs.value != '$' || lhs.children_count < 2
+	if lhs.kind != .selector || lhs.value != '\$' || lhs.children_count < 2
 		|| !tc.comptime_subtree_references_var(tc.a.child(lhs, 1), var_name) {
 		return
 	}
@@ -16511,15 +16130,13 @@ fn (mut tc TypeChecker) check_comptime_static_assignment(node flat.Node, var_nam
 	}
 	rhs := tc.a.node(rhs_id)
 	if field_types.len > 1 && tc.comptime_initializer_is_static(rhs_id) {
-		tc.record_error_at(.assignment_mismatch,
-			'mismatched types: check field type with $if to avoid this problem', rhs_id, rhs.pos)
+		tc.record_error_at(.assignment_mismatch, 'mismatched types: check field type with \$if to avoid this problem', rhs_id, rhs.pos)
 	}
 	for field in field_cases.cases {
 		expected := tc.parse_type(field.typ)
 		if unalias_type(expected) is Enum {
 			if !actual.is_integer() {
-				tc.record_error_at(.assignment_mismatch, 'enums can only be assigned `int` values',
-					rhs_id, rhs.pos)
+				tc.record_error_at(.assignment_mismatch, 'enums can only be assigned `int` values', rhs_id, rhs.pos)
 				return
 			}
 		} else if !type_contains_unknown(actual) && !tc.type_compatible(actual, expected) {
@@ -16530,9 +16147,7 @@ fn (mut tc TypeChecker) check_comptime_static_assignment(node flat.Node, var_nam
 				rhs.pos
 			}
 			actual_name := tc.diagnostic_expr_type_name(rhs_id, actual)
-			tc.record_error_at(.assignment_mismatch,
-				'cannot assign `${actual_name}` to `${expected.name()}`; cannot assign to `${tc.source_text_for_node(lhs_id)}`: expected `${expected.name()}`, not `${actual_name}`',
-				rhs_id, diagnostic_pos)
+			tc.record_error_at(.assignment_mismatch, 'cannot assign `${actual_name}` to `${expected.name()}`; cannot assign to `${tc.source_text_for_node(lhs_id)}`: expected `${expected.name()}`, not `${actual_name}`', rhs_id, diagnostic_pos)
 			return
 		}
 	}
@@ -16543,7 +16158,7 @@ fn (mut tc TypeChecker) check_comptime_static_field_selectors(id flat.NodeId, va
 		return false
 	}
 	node := tc.a.node(id)
-	if node.kind == .selector && node.value == '$' {
+	if node.kind == .selector && node.value == '\$' {
 		return tc.check_comptime_field_selector(id, *node, var_name, field_cases)
 	}
 	mut found_error := false
@@ -16571,12 +16186,9 @@ fn (mut tc TypeChecker) check_comptime_field_selector(id flat.NodeId, node flat.
 			tc.resolve_type(field_expr_id).name()
 		}
 		if actual_name != 'string' {
-			tc.record_error_at(.unknown_field,
-				'expected `string` instead of `${actual_name}` (e.g. `field.name`)', field_expr_id,
-				field_expr.pos)
+			tc.record_error_at(.unknown_field, 'expected `string` instead of `${actual_name}` (e.g. `field.name`)', field_expr_id, field_expr.pos)
 		}
-		tc.record_error_at(.unknown_field, 'expected selector expression e.g. `$(field.name)`',
-			field_expr_id, field_expr.pos)
+		tc.record_error_at(.unknown_field, 'expected selector expression e.g. `\$(field.name)`', field_expr_id, field_expr.pos)
 		if loop_var.len == 0 {
 			tc.record_invalid_comptime_selector_source_assignment(id, node)
 		}
@@ -16595,22 +16207,16 @@ fn (mut tc TypeChecker) check_comptime_field_selector(id flat.NodeId, node flat.
 		mut field_expr_type := tc.resolve_type(field_expr_id)
 		if loop_var.len == 0 && field_var.kind == .ident
 			&& tc.cur_scope.lookup(field_var.value) == none {
-			tc.record_error_at(.unknown_field, '`${field_var.value}` does not return a value',
-				field_expr_id, tc.node_value_diagnostic_pos(field_expr_id))
+			tc.record_error_at(.unknown_field, '`${field_var.value}` does not return a value', field_expr_id, tc.node_value_diagnostic_pos(field_expr_id))
 			field_expr_type = Type(void_)
 		}
 		if field_expr_type !is String {
-			tc.record_error_at(.unknown_field,
-				'expected `string` instead of `${field_expr_type.name()}` (e.g. `field.name`)',
-				field_expr_id, tc.node_value_diagnostic_pos(field_expr_id))
+			tc.record_error_at(.unknown_field, 'expected `string` instead of `${field_expr_type.name()}` (e.g. `field.name`)', field_expr_id, tc.node_value_diagnostic_pos(field_expr_id))
 		}
 		if loop_var.len == 0 {
-			tc.record_error_at(.unknown_field,
-				'compile time field access can only be used when iterating over `T.fields`',
-				field_var_id, field_var.pos)
+			tc.record_error_at(.unknown_field, 'compile time field access can only be used when iterating over `T.fields`', field_var_id, field_var.pos)
 		}
-		tc.record_error_at(.unknown_ident, 'unknown `$for` variable `${field_var_name}`',
-			field_var_id, field_var.pos)
+		tc.record_error_at(.unknown_ident, 'unknown `\$for` variable `${field_var_name}`', field_var_id, field_var.pos)
 		tc.register_synth_type(id, Type(void_))
 		return true
 	}
@@ -16618,9 +16224,7 @@ fn (mut tc TypeChecker) check_comptime_field_selector(id flat.NodeId, node flat.
 		tc.check_node(field_expr_id)
 		actual := tc.resolve_type(field_expr_id)
 		if actual !is String {
-			tc.record_error_at(.unknown_field,
-				'expected `string` instead of `${actual.name()}` (e.g. `field.name`)',
-				field_expr_id, tc.node_value_diagnostic_pos(field_expr_id))
+			tc.record_error_at(.unknown_field, 'expected `string` instead of `${actual.name()}` (e.g. `field.name`)', field_expr_id, tc.node_value_diagnostic_pos(field_expr_id))
 			tc.register_synth_type(id, Type(void_))
 			return true
 		}
@@ -16636,9 +16240,7 @@ fn (mut tc TypeChecker) check_comptime_field_selector(id flat.NodeId, node flat.
 			has_field := receiver_type is Struct
 				&& tc.struct_field_type(receiver_type.name, field.name) != none
 			if !has_field {
-				tc.record_error_severity_at(.unknown_field,
-					'`${tc.source_text_for_node(receiver_id)}` has no field named `${field.name}`',
-					receiver_id, tc.a.node(receiver_id).pos, 'cgen error:')
+				tc.record_error_severity_at(.unknown_field, '`${tc.source_text_for_node(receiver_id)}` has no field named `${field.name}`', receiver_id, tc.a.node(receiver_id).pos, 'cgen error:')
 				tc.register_synth_type(id, unknown_type('unknown imported enum'))
 				return true
 			}
@@ -16676,9 +16278,7 @@ fn (mut tc TypeChecker) record_invalid_comptime_selector_source_assignment(id fl
 	if end < source.len && source[end] == quote {
 		end++
 	}
-	tc.record_error_at(.assignment_mismatch,
-		'cannot assign to `${tc.source_text_for_node(id)}`: expected `void`, not `string`', id, token.new_span(node.pos.id,
-		cursor, end))
+	tc.record_error_at(.assignment_mismatch, 'cannot assign to `${tc.source_text_for_node(id)}`: expected `void`, not `string`', id, token.new_span(node.pos.id, cursor, end))
 }
 
 fn (tc &TypeChecker) comptime_static_reflected_field_expr_type(id flat.NodeId, var_name string, field_cases ComptimeStaticFieldCases) ?Type {
@@ -16687,17 +16287,15 @@ fn (tc &TypeChecker) comptime_static_reflected_field_expr_type(id flat.NodeId, v
 	}
 	node := tc.a.nodes[int(id)]
 	if node.kind == .paren && node.children_count > 0 {
-		return tc.comptime_static_reflected_field_expr_type(tc.a.child(&node, 0), var_name,
-			field_cases)
+		return tc.comptime_static_reflected_field_expr_type(tc.a.child(&node, 0), var_name, field_cases)
 	}
 	if node.kind == .call && node.children_count == 1 {
 		callee := tc.a.child_node(&node, 0)
 		if callee.kind == .selector && callee.value == 'clone' && callee.children_count > 0 {
-			return tc.comptime_static_reflected_field_expr_type(tc.a.child(callee, 0), var_name,
-				field_cases)
+			return tc.comptime_static_reflected_field_expr_type(tc.a.child(callee, 0), var_name, field_cases)
 		}
 	}
-	if node.kind != .selector || node.value != '$' || node.children_count < 2
+	if node.kind != .selector || node.value != '\$' || node.children_count < 2
 		|| !tc.comptime_subtree_references_var(tc.a.child(&node, 1), var_name) {
 		return none
 	}
@@ -16870,30 +16468,22 @@ fn (tc &TypeChecker) comptime_static_method_call_return_type(id flat.NodeId, var
 }
 
 fn comptime_static_subst_deferred_cond(cond string, var_name string, loop_kind string, item ComptimeStaticValueCase) string {
-	mut result := comptime_static_replace_unquoted(cond, '${var_name}.name',
-		comptime_static_string_literal(item.name))
+	mut result := comptime_static_replace_unquoted(cond, '${var_name}.name', comptime_static_string_literal(item.name))
 	if loop_kind == 'methods' {
 		result = comptime_static_subst_method_param_cond(result, var_name, item)
-		result = comptime_static_replace_unquoted(result, '${var_name}.args.len',
-			item.param_names.len.str())
-		result = comptime_static_replace_unquoted(result, '${var_name}.params.len',
-			item.param_names.len.str())
-		result = comptime_static_replace_unquoted(result, '${var_name}.location',
-			comptime_static_string_literal(item.location))
-		result = comptime_static_replace_unquoted(result, '${var_name}.return_type',
-			comptime_static_deferred_type(item.return_type))
+		result = comptime_static_replace_unquoted(result, '${var_name}.args.len', item.param_names.len.str())
+		result = comptime_static_replace_unquoted(result, '${var_name}.params.len', item.param_names.len.str())
+		result = comptime_static_replace_unquoted(result, '${var_name}.location', comptime_static_string_literal(item.location))
+		result = comptime_static_replace_unquoted(result, '${var_name}.return_type', comptime_static_deferred_type(item.return_type))
 		result = comptime_static_replace_unquoted(result, '${var_name}.typ', item.typ)
 		if item.has_is_pub {
-			result = comptime_static_replace_unquoted(result, '${var_name}.is_pub',
-				item.is_pub.str())
+			result = comptime_static_replace_unquoted(result, '${var_name}.is_pub', item.is_pub.str())
 		}
 	} else if loop_kind == 'params' {
-		result = comptime_static_replace_unquoted(result, '${var_name}.typ',
-			comptime_static_deferred_type(item.typ))
+		result = comptime_static_replace_unquoted(result, '${var_name}.typ', comptime_static_deferred_type(item.typ))
 	} else if loop_kind == 'attributes' && item.has_attr_meta {
 		result = comptime_static_replace_unquoted(result, '${var_name}.has_arg', item.has_arg.str())
-		result = comptime_static_replace_unquoted(result, '${var_name}.arg',
-			comptime_static_string_literal(item.arg))
+		result = comptime_static_replace_unquoted(result, '${var_name}.arg', comptime_static_string_literal(item.arg))
 		kind := comptime_static_attribute_kind_value(item.attr_kind)
 		result = comptime_static_replace_unquoted(result, '${var_name}.kind ==.', '${kind} == .')
 		result = comptime_static_replace_unquoted(result, '${var_name}.kind !=.', '${kind} != .')

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -3912,11 +3912,34 @@ fn (mut tc TypeChecker) resolve_inferred_global_types(a &flat.FlatAst) {
 					}
 					qname := tc.qualify_name(f.value)
 					existing := tc.file_scope.lookup(qname) or { Type(void_) }
-					if existing !is Unknown && existing !is Void {
+					if existing !is Unknown && existing !is Void
+						&& !type_contains_unknown(existing)
+						&& !generic_semantic_type_has_placeholder(existing)
+						&& !tc.type_text_has_generic_placeholder(existing.name()) {
 						continue
 					}
-					ft := tc.resolve_type(a.child(f, 0))
-					if ft is Unknown || ft is Void {
+					initializer_id := a.child(f, 0)
+					initializer := a.node(initializer_id)
+					mut ft := tc.resolve_type(initializer_id)
+					// Function bodies are checked after globals are collected. Infer an
+					// implicit generic call here so methods used on the global receiver see
+					// its concrete type during body checking (`new_atomic(0)` is a common
+					// example).
+					if initializer.kind == .call {
+						if call_info := tc.resolve_call_info(initializer_id, initializer) {
+							specialized := tc.specialized_plain_generic_call_info(initializer, call_info)
+							if specialized.return_type !is Unknown
+								&& specialized.return_type !is Void
+								&& !generic_semantic_type_has_placeholder(specialized.return_type)
+								&& !tc.type_text_has_generic_placeholder(specialized.return_type.name()) {
+								ft = specialized.return_type
+								tc.remember_expr_type(initializer_id, ft)
+							}
+						}
+					}
+					if ft is Unknown || ft is Void || type_contains_unknown(ft)
+						|| generic_semantic_type_has_placeholder(ft)
+						|| tc.type_text_has_generic_placeholder(ft.name()) {
 						continue
 					}
 					tc.file_scope.insert(f.value, ft)
@@ -10180,6 +10203,7 @@ fn (mut tc TypeChecker) check_export_attrs() {
 		return
 	}
 	mut natural_symbols := map[string]string{}
+	mut natural_symbol_modules := map[string]string{}
 	synthetic_main_reserved := tc.has_synthetic_c_entry_main()
 	mut cur_module := ''
 	for i in tc.top_level_idx {
@@ -10197,6 +10221,7 @@ fn (mut tc TypeChecker) check_export_attrs() {
 				qname := export_qualified_fn_name(cur_module, node.value)
 				natural_symbol := export_natural_c_symbol(cur_module, node.value)
 				natural_symbols[natural_symbol] = qname
+				natural_symbol_modules[natural_symbol] = cur_module
 			}
 			else {}
 		}
@@ -10337,7 +10362,9 @@ fn (mut tc TypeChecker) check_export_attrs() {
 					export_symbols[export_name] = qname
 				}
 				if existing := natural_symbols[export_name] {
-					if existing != qname {
+					// A main-module function can be prefixed in C when an explicit export
+					// owns its otherwise natural symbol, matching the established backend.
+					if existing != qname && natural_symbol_modules[export_name] !in ['', 'main'] {
 						tc.record_error_unfiltered(.unsupported_generic,
 							'export name `${export_name}` for `${qname}` collides with `${existing}`',
 							flat.NodeId(i))

--- a/vlib/v3/types/checker_comptime.v
+++ b/vlib/v3/types/checker_comptime.v
@@ -4253,7 +4253,11 @@ fn (mut tc TypeChecker) check_cast_expr(id flat.NodeId, node flat.Node) {
 				return
 			}
 		}
-		if tc.unsafe_depth == 0 && fn_param_is_voidptr_type(actual) {
+		// Match the established checker: only raw void pointers require an unsafe cast.
+		// Pointer aliases retain their declared type, and void-pointer aliases are valid
+		// cast targets without an unsafe block.
+		if tc.unsafe_depth == 0 && actual.name() in ['voidptr', '&void']
+			&& !fn_param_is_voidptr_type(target) {
 			if unalias_type(target_base) is SumType {
 				tc.record_error_at(.assignment_mismatch,
 					'cannot cast voidptr to `${target_name}` outside `unsafe`', id, node.pos)


### PR DESCRIPTION
## What this does

Speeds up large V3 builds across scanning, parsing, checking, monomorphization, and C generation.

The main changes are:

- tune production C flags for generated units of at least 8 MiB: `-O2 -flto`, plus a lower Clang inline threshold
- compile cached native support objects without LTO so they are not re-optimized during every final link
- cap parallel monomorphization for very large ASTs to reduce memory pressure and contention
- bound generic-clone scratch capacity instead of reserving space for the whole AST
- remove redundant whole-AST canonicalization passes
- reduce allocations and repeated work in scanner, parser, checker, transformer, name mangling, string interpolation, and C header processing
- preserve large VROOT Sokol/STB implementation headers as includes
- raise the ordinary V3 build memory guard to 4032 MiB while keeping the self-host limit at 3840 MiB

## Fusecode benchmark

Equivalent cache-disabled production builds used the same flags; only `-old-compiler` changed. Runs were alternated to reduce ordering bias.

| Backend | Runs | Average |
| --- | --- | --- |
| New/default | 27.99 s, 25.31 s | 26.65 s |
| Old (`-old-compiler`) | 30.27 s, 31.11 s | 30.69 s |

The optimized V3 compiler is 4.04 seconds, or 13.2%, faster on these runs. The host was under sustained background load, so the relative comparison is more useful than the absolute times.

Fusecode produces a 9,524,350-byte C unit and selects `-O2 -flto -mllvm -inline-threshold=75` with Clang.

## Validation

- production self-host build with `-gc none -d skip_fastc`
- `vlib/v/compiler_errors_test.v`: 1696 passed, 1 skipped
- `vlib/v3/gen/c/names_test.v`
- `vlib/v3/driver/environment_test.v`
- `vlib/v3/driver/c_compiler_flags_test.v`
- focused large-AST monomorph worker-limit test
- `check-md vlib/v3/README.md`
- `git diff --check`

The full `test-all` suite was not run.