### PR TITLE
builder: restore Linux cross sysroot include path

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -2722,6 +2722,11 @@ fn linux_cross_target_for_arch(arch pref.Arch) !LinuxCrossTarget {
 	}
 }
 
+fn linux_cross_compile_include_arg(sysroot string) string {
+	sysroot_include := os.join_path(sysroot, 'include')
+	return '-I ${os.quoted_path(sysroot_include)}'
+}
+
 fn (mut b Builder) cc_linux_cross() {
 	linux_cross_target := linux_cross_target_for_arch(b.pref.arch) or {
 		verror(err.msg())
@@ -2775,7 +2780,7 @@ fn (mut b Builder) cc_linux_cross() {
 		src_args << '-fPIC'
 		src_args << '-target ${linux_cross_target.triple}'
 		src_args << defines
-		src_args << '-I ${os.quoted_path('\${sysroot}/include')}'
+		src_args << linux_cross_compile_include_arg(sysroot)
 		src_args << other_flags
 		src_args << '-o ${os.quoted_path(src_obj)}'
 		src_args << '-c ${os.quoted_path(src)}'
@@ -2796,7 +2801,7 @@ fn (mut b Builder) cc_linux_cross() {
 	cc_args << '-fPIC'
 	cc_args << '-target ${linux_cross_target.triple}'
 	cc_args << defines
-	cc_args << '-I ${os.quoted_path('\${sysroot}/include')} '
+	cc_args << linux_cross_compile_include_arg(sysroot)
 	cc_args << other_flags
 	cc_args << '-o ${os.quoted_path(obj_file)}'
 	cc_args << '-c ${os.quoted_path(b.out_name_c)}'

--- a/vlib/v/builder/cc_test.v
+++ b/vlib/v/builder/cc_test.v
@@ -321,6 +321,17 @@ fn test_linux_cross_target_for_arm64_errors() {
 	}
 }
 
+fn test_linux_cross_compile_include_arg_resolves_sysroot() {
+	sysroot := os.join_path(os.vtmp_dir(), 'cross root', 'linuxroot')
+	sysroot_include := os.join_path(sysroot, 'include')
+	include_arg := linux_cross_compile_include_arg(sysroot)
+	compile_command := 'clang ${include_arg} -c main.c'
+
+	assert include_arg == '-I ${os.quoted_path(sysroot_include)}'
+	assert compile_command.contains(os.quoted_path(sysroot_include))
+	assert !compile_command.contains('\${sysroot}')
+}
+
 fn test_git_symlink_target_path_detects_placeholder_file() {
 	test_root := os.join_path(os.vtmp_dir(), 'v_builder_git_symlink_target_${os.getpid()}')
 	os.rmdir_all(test_root) or {}


### PR DESCRIPTION
Follow-up to #28327.

Restore interpolation of the bundled Linux cross-compilation sysroot include directory. Both extra-source and generated-C compilation now use one helper that resolves `linuxroot/include` with `os.join_path` before quoting it.

Add a regression test that constructs the compiler command fragment and verifies it contains the resolved include path and no literal `${sysroot}` placeholder.

Validation (serial, `VJOBS=1`):
- rebuilt `vnew`
- `./vnew -run-only test_linux_cross_compile_include_arg_resolves_sysroot -silent vlib/v/builder/cc_test.v`
- `./vnew -silent vlib/v/builder/cc_test.v`
- `./vnew -silent vlib/v/compiler_errors_test.v` (1696 passed, 1 skipped)
- `./vnew fmt -verify vlib/v/builder/cc.v vlib/v/builder/cc_test.v`
- `git diff --check`