### PR TITLE
vself: preserve the full CLI for V3 self-builds

### DIFF
--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -8,6 +8,7 @@ import v.util.vflags
 
 const args_ = arguments()
 const is_debug = args_.contains('-debug')
+const v3_self_source = 'vlib/v3/v3.v'
 
 // support a renamed `v` executable too:
 const vexe = os.getenv_opt('VEXE') or { @VEXE }
@@ -31,8 +32,12 @@ fn main() {
 	os.unsetenv('VSELF_COMMAND_INDEX')
 	repeat_count, mut args := extract_repeat_count(args_[1..], command_index)
 	mut effective_args := effective_self_build_args(args)
+	default_fastc_build := should_use_default_fastc_build(effective_args)
+	if default_fastc_build {
+		args << ['-b', 'fastc']
+		effective_args = effective_self_build_args(args)
+	}
 	fastc_self_build := uses_fastc_backend(effective_args)
-	default_v3_fastc_build := should_use_default_v3_fastc_build(effective_args)
 	if fastc_self_build && '-prod' in effective_args {
 		eprintln('`v self -b fastc` does not support `-prod`; remove `-prod`.')
 		exit(1)
@@ -41,17 +46,7 @@ fn main() {
 		args = normalize_fastc_backend_args(args)
 		effective_args = effective_self_build_args(args)
 	}
-	if default_v3_fastc_build {
-		// Build the regular cmd/v CLI through V3's scanner-direct FastC path. The
-		// real builtin keeps the resulting executable compatible with the full CLI.
-		if '-new-compiler' !in effective_args {
-			args << '-new-compiler'
-		}
-		args << ['-b', 'fastc', '-d', 'fastc_real_builtin']
-		effective_args = effective_self_build_args(args)
-	}
-	if !fastc_self_build && !default_v3_fastc_build
-		&& !has_self_build_configuration_arg(effective_args) {
+	if !fastc_self_build && !has_self_build_configuration_arg(effective_args) {
 		// compiling by default, i.e. `v self`:
 		uos := os.user_os()
 		uname := os.uname()
@@ -91,26 +86,19 @@ fn main() {
 	if obinary == '' {
 		compile_args << ['-o', 'v2']
 	}
-	if fastc_self_build {
+	if '-selfhost' !in effective_args {
 		compile_args << '-selfhost'
 	}
 	final_binary := if obinary != '' { obinary } else { 'v2' }
 	pgo_cc_kind := if fastc_self_build { '' } else { pgo_compiler_kind(args) }
-	compilation_source := if fastc_self_build {
-		'vlib/v3/v3.v'
-	} else if default_v3_fastc_build {
-		'cmd/v/v.v'
-	} else {
-		'cmd/v'
-	}
 	for run_idx in 0 .. repeat_count {
 		run_label := if repeat_count > 1 { ' [${run_idx + 1}/${repeat_count}]' } else { '' }
 		options := if args.len > 0 { '(${compile_args.join(' ')})' } else { '' }
 		println('V self compiling${run_label} ${options}...')
-		cmd := compose_v_cmd(vexe, compile_args, compilation_source)
+		cmd := compose_v_cmd(vexe, compile_args, v3_self_source)
 		mut used_pgo := false
 		if pgo_cc_kind != '' {
-			used_pgo = compile_with_pgo(vroot, vexe, args, final_binary, pgo_cc_kind)
+			used_pgo = compile_with_pgo(vroot, vexe, compile_args, final_binary, pgo_cc_kind)
 			if !used_pgo {
 				eprintln('PGO self-build failed; falling back to a regular self-build.')
 			}
@@ -122,7 +110,7 @@ fn main() {
 			}
 		} else if !used_pgo {
 			if !try_compile(cmd) {
-				bootstrap_self_build(vroot, clone_args(args), final_binary) or {
+				bootstrap_self_build(vroot, clone_args(compile_args), final_binary) or {
 					eprintln('cannot compile to `${vroot}`: \n${err.msg()}')
 					exit(1)
 				}
@@ -188,7 +176,7 @@ fn has_backend_arg(args []string) bool {
 	return false
 }
 
-fn should_use_default_v3_fastc_build(args []string) bool {
+fn should_use_default_fastc_build(args []string) bool {
 	if os.user_os() !in ['linux', 'macos'] || '-old-compiler' in args {
 		return false
 	}
@@ -563,7 +551,7 @@ fn compile_with_pgo(vroot string, vexe string, args []string, out_binary string,
 		return false
 	}
 	pgo_binary := os.join_path(pgo_workspace, 'v_pgo_gen')
-	training_output := os.join_path(pgo_workspace, 'cmd_v_training.c')
+	training_output := os.join_path(pgo_workspace, 'v3_training.c')
 	mut use_profile_flag := '-fprofile-use=${profile_dir}'
 	mut llvm_profdata := ''
 	mut profile_data := ''
@@ -577,13 +565,13 @@ fn compile_with_pgo(vroot string, vexe string, args []string, out_binary string,
 	}
 	mut generate_args := with_output_arg(args, pgo_binary)
 	generate_args << ['-cflags', '-fprofile-generate=${profile_dir}']
-	generate_cmd := compose_v_cmd(vexe, generate_args, 'cmd/v')
+	generate_cmd := compose_v_cmd(vexe, generate_args, v3_self_source)
 	run_cmd(generate_cmd) or {
 		eprintln('PGO step failed while building the instrumented compiler.')
 		eprintln(err.msg())
 		return false
 	}
-	training_cmd := '${os.quoted_path(pgo_binary)} -o ${os.quoted_path(training_output)} ${os.quoted_path('cmd/v')}'
+	training_cmd := '${os.quoted_path(pgo_binary)} -selfhost -o ${os.quoted_path(training_output)} ${os.quoted_path(v3_self_source)}'
 	run_cmd(training_cmd) or {
 		eprintln('PGO step failed while generating the profiling data.')
 		eprintln(err.msg())
@@ -602,7 +590,7 @@ fn compile_with_pgo(vroot string, vexe string, args []string, out_binary string,
 	if cc_kind == 'gcc' {
 		final_args << ['-cflags', '-fprofile-correction']
 	}
-	final_cmd := compose_v_cmd(vexe, final_args, 'cmd/v')
+	final_cmd := compose_v_cmd(vexe, final_args, v3_self_source)
 	run_cmd(final_cmd) or {
 		eprintln('PGO step failed while building the final compiler binary.')
 		eprintln(err.msg())
@@ -638,13 +626,13 @@ fn bootstrap_self_build(vroot string, args []string, final_binary string) ! {
 	mut bootstrap_args := ['-no-parallel']
 	bootstrap_args << with_output_arg(args, bootstrap_v2)
 	bootstrap_v1_cmd := os.join_path('.', bootstrap_v1)
-	bootstrap_v2_cmd := '${os.quoted_path(bootstrap_v1_cmd)} ${bootstrap_args.join(' ')} ${os.quoted_path('cmd/v')}'
+	bootstrap_v2_cmd := '${os.quoted_path(bootstrap_v1_cmd)} ${bootstrap_args.join(' ')} ${os.quoted_path(v3_self_source)}'
 	run_cmd(bootstrap_v2_cmd) or {
 		return error('bootstrap fallback failed while building v2.\n${err.msg()}')
 	}
 	final_args := with_output_arg(args, final_binary)
 	bootstrap_v2_cmd_path := os.join_path('.', bootstrap_v2)
-	final_cmd := '${os.quoted_path(bootstrap_v2_cmd_path)} ${final_args.join(' ')} ${os.quoted_path('cmd/v')}'
+	final_cmd := '${os.quoted_path(bootstrap_v2_cmd_path)} ${final_args.join(' ')} ${os.quoted_path(v3_self_source)}'
 	run_cmd(final_cmd) or {
 		return error('bootstrap fallback failed while building the final compiler.\n${err.msg()}')
 	}

--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -32,11 +32,6 @@ fn main() {
 	os.unsetenv('VSELF_COMMAND_INDEX')
 	repeat_count, mut args := extract_repeat_count(args_[1..], command_index)
 	mut effective_args := effective_self_build_args(args)
-	default_fastc_build := should_use_default_fastc_build(effective_args)
-	if default_fastc_build {
-		args << ['-b', 'fastc']
-		effective_args = effective_self_build_args(args)
-	}
 	fastc_self_build := uses_fastc_backend(effective_args)
 	if fastc_self_build && '-prod' in effective_args {
 		eprintln('`v self -b fastc` does not support `-prod`; remove `-prod`.')
@@ -162,61 +157,6 @@ fn uses_fastc_backend(args []string) bool {
 		}
 	}
 	return backend == 'fastc'
-}
-
-fn has_backend_arg(args []string) bool {
-	for i, arg in args {
-		if arg in ['-b', '-backend'] && i + 1 < args.len {
-			return true
-		}
-		if arg.starts_with('-b=') || arg.starts_with('-backend=') {
-			return true
-		}
-	}
-	return false
-}
-
-fn should_use_default_fastc_build(args []string) bool {
-	if os.user_os() !in ['linux', 'macos'] || '-old-compiler' in args {
-		return false
-	}
-	if has_backend_arg(args) || has_self_build_configuration_arg(args) {
-		return false
-	}
-	if os.getenv('CC') != '' {
-		return false
-	}
-	mut i := 0
-	for i < args.len {
-		arg := args[i]
-		if arg in ['-o', '-output'] {
-			if i + 1 >= args.len {
-				return false
-			}
-			i += 2
-			continue
-		}
-		if arg == '-gc' {
-			if i + 1 >= args.len || args[i + 1] != 'none' {
-				return false
-			}
-			i += 2
-			continue
-		}
-		if arg.starts_with('-gc=') {
-			if arg.all_after('=') != 'none' {
-				return false
-			}
-			i++
-			continue
-		}
-		if arg !in ['-new-compiler', '-silent', '-v', '-verbose', '-keepc', '-prealloc',
-			'-no-prealloc', '-retry-compilation', '-no-retry-compilation'] {
-			return false
-		}
-		i++
-	}
-	return true
 }
 
 fn normalize_fastc_backend_args(args []string) []string {

--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -32,6 +32,7 @@ fn main() {
 	repeat_count, mut args := extract_repeat_count(args_[1..], command_index)
 	mut effective_args := effective_self_build_args(args)
 	fastc_self_build := uses_fastc_backend(effective_args)
+	default_v3_fastc_build := should_use_default_v3_fastc_build(effective_args)
 	if fastc_self_build && '-prod' in effective_args {
 		eprintln('`v self -b fastc` does not support `-prod`; remove `-prod`.')
 		exit(1)
@@ -40,7 +41,17 @@ fn main() {
 		args = normalize_fastc_backend_args(args)
 		effective_args = effective_self_build_args(args)
 	}
-	if !fastc_self_build && !has_self_build_configuration_arg(effective_args) {
+	if default_v3_fastc_build {
+		// Build the regular cmd/v CLI through V3's scanner-direct FastC path. The
+		// real builtin keeps the resulting executable compatible with the full CLI.
+		if '-new-compiler' !in effective_args {
+			args << '-new-compiler'
+		}
+		args << ['-b', 'fastc', '-d', 'fastc_real_builtin']
+		effective_args = effective_self_build_args(args)
+	}
+	if !fastc_self_build && !default_v3_fastc_build
+		&& !has_self_build_configuration_arg(effective_args) {
 		// compiling by default, i.e. `v self`:
 		uos := os.user_os()
 		uname := os.uname()
@@ -85,7 +96,13 @@ fn main() {
 	}
 	final_binary := if obinary != '' { obinary } else { 'v2' }
 	pgo_cc_kind := if fastc_self_build { '' } else { pgo_compiler_kind(args) }
-	compilation_source := if fastc_self_build { 'vlib/v3/v3.v' } else { 'cmd/v' }
+	compilation_source := if fastc_self_build {
+		'vlib/v3/v3.v'
+	} else if default_v3_fastc_build {
+		'cmd/v/v.v'
+	} else {
+		'cmd/v'
+	}
 	for run_idx in 0 .. repeat_count {
 		run_label := if repeat_count > 1 { ' [${run_idx + 1}/${repeat_count}]' } else { '' }
 		options := if args.len > 0 { '(${compile_args.join(' ')})' } else { '' }
@@ -157,6 +174,61 @@ fn uses_fastc_backend(args []string) bool {
 		}
 	}
 	return backend == 'fastc'
+}
+
+fn has_backend_arg(args []string) bool {
+	for i, arg in args {
+		if arg in ['-b', '-backend'] && i + 1 < args.len {
+			return true
+		}
+		if arg.starts_with('-b=') || arg.starts_with('-backend=') {
+			return true
+		}
+	}
+	return false
+}
+
+fn should_use_default_v3_fastc_build(args []string) bool {
+	if os.user_os() !in ['linux', 'macos'] || '-old-compiler' in args {
+		return false
+	}
+	if has_backend_arg(args) || has_self_build_configuration_arg(args) {
+		return false
+	}
+	if os.getenv('CC') != '' {
+		return false
+	}
+	mut i := 0
+	for i < args.len {
+		arg := args[i]
+		if arg in ['-o', '-output'] {
+			if i + 1 >= args.len {
+				return false
+			}
+			i += 2
+			continue
+		}
+		if arg == '-gc' {
+			if i + 1 >= args.len || args[i + 1] != 'none' {
+				return false
+			}
+			i += 2
+			continue
+		}
+		if arg.starts_with('-gc=') {
+			if arg.all_after('=') != 'none' {
+				return false
+			}
+			i++
+			continue
+		}
+		if arg !in ['-new-compiler', '-silent', '-v', '-verbose', '-keepc', '-prealloc',
+			'-no-prealloc', '-retry-compilation', '-no-retry-compilation'] {
+			return false
+		}
+		i++
+	}
+	return true
 }
 
 fn normalize_fastc_backend_args(args []string) []string {

--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -8,7 +8,8 @@ import v.util.vflags
 
 const args_ = arguments()
 const is_debug = args_.contains('-debug')
-const v3_self_source = 'vlib/v3/v3.v'
+const full_v_cli_source = 'cmd/v'
+const standalone_v3_source = 'vlib/v3/v3.v'
 
 // support a renamed `v` executable too:
 const vexe = os.getenv_opt('VEXE') or { @VEXE }
@@ -81,19 +82,22 @@ fn main() {
 	if obinary == '' {
 		compile_args << ['-o', 'v2']
 	}
-	if '-selfhost' !in effective_args {
+	if fastc_self_build {
 		compile_args << '-selfhost'
 	}
 	final_binary := if obinary != '' { obinary } else { 'v2' }
 	pgo_cc_kind := if fastc_self_build { '' } else { pgo_compiler_kind(args) }
+	// Only explicit FastC builds are standalone. Regular replacements must retain
+	// cmd/v so commands such as self, up, fmt, and version remain available.
+	compilation_source := if fastc_self_build { standalone_v3_source } else { full_v_cli_source }
 	for run_idx in 0 .. repeat_count {
 		run_label := if repeat_count > 1 { ' [${run_idx + 1}/${repeat_count}]' } else { '' }
 		options := if args.len > 0 { '(${compile_args.join(' ')})' } else { '' }
 		println('V self compiling${run_label} ${options}...')
-		cmd := compose_v_cmd(vexe, compile_args, v3_self_source)
+		cmd := compose_v_cmd(vexe, compile_args, compilation_source)
 		mut used_pgo := false
 		if pgo_cc_kind != '' {
-			used_pgo = compile_with_pgo(vroot, vexe, compile_args, final_binary, pgo_cc_kind)
+			used_pgo = compile_with_pgo(vroot, vexe, args, final_binary, pgo_cc_kind)
 			if !used_pgo {
 				eprintln('PGO self-build failed; falling back to a regular self-build.')
 			}
@@ -105,7 +109,7 @@ fn main() {
 			}
 		} else if !used_pgo {
 			if !try_compile(cmd) {
-				bootstrap_self_build(vroot, clone_args(compile_args), final_binary) or {
+				bootstrap_self_build(vroot, clone_args(args), final_binary) or {
 					eprintln('cannot compile to `${vroot}`: \n${err.msg()}')
 					exit(1)
 				}
@@ -491,7 +495,7 @@ fn compile_with_pgo(vroot string, vexe string, args []string, out_binary string,
 		return false
 	}
 	pgo_binary := os.join_path(pgo_workspace, 'v_pgo_gen')
-	training_output := os.join_path(pgo_workspace, 'v3_training.c')
+	training_output := os.join_path(pgo_workspace, 'cmd_v_training.c')
 	mut use_profile_flag := '-fprofile-use=${profile_dir}'
 	mut llvm_profdata := ''
 	mut profile_data := ''
@@ -505,13 +509,13 @@ fn compile_with_pgo(vroot string, vexe string, args []string, out_binary string,
 	}
 	mut generate_args := with_output_arg(args, pgo_binary)
 	generate_args << ['-cflags', '-fprofile-generate=${profile_dir}']
-	generate_cmd := compose_v_cmd(vexe, generate_args, v3_self_source)
+	generate_cmd := compose_v_cmd(vexe, generate_args, full_v_cli_source)
 	run_cmd(generate_cmd) or {
 		eprintln('PGO step failed while building the instrumented compiler.')
 		eprintln(err.msg())
 		return false
 	}
-	training_cmd := '${os.quoted_path(pgo_binary)} -selfhost -o ${os.quoted_path(training_output)} ${os.quoted_path(v3_self_source)}'
+	training_cmd := '${os.quoted_path(pgo_binary)} -o ${os.quoted_path(training_output)} ${os.quoted_path(full_v_cli_source)}'
 	run_cmd(training_cmd) or {
 		eprintln('PGO step failed while generating the profiling data.')
 		eprintln(err.msg())
@@ -530,7 +534,7 @@ fn compile_with_pgo(vroot string, vexe string, args []string, out_binary string,
 	if cc_kind == 'gcc' {
 		final_args << ['-cflags', '-fprofile-correction']
 	}
-	final_cmd := compose_v_cmd(vexe, final_args, v3_self_source)
+	final_cmd := compose_v_cmd(vexe, final_args, full_v_cli_source)
 	run_cmd(final_cmd) or {
 		eprintln('PGO step failed while building the final compiler binary.')
 		eprintln(err.msg())
@@ -566,13 +570,13 @@ fn bootstrap_self_build(vroot string, args []string, final_binary string) ! {
 	mut bootstrap_args := ['-no-parallel']
 	bootstrap_args << with_output_arg(args, bootstrap_v2)
 	bootstrap_v1_cmd := os.join_path('.', bootstrap_v1)
-	bootstrap_v2_cmd := '${os.quoted_path(bootstrap_v1_cmd)} ${bootstrap_args.join(' ')} ${os.quoted_path(v3_self_source)}'
+	bootstrap_v2_cmd := '${os.quoted_path(bootstrap_v1_cmd)} ${bootstrap_args.join(' ')} ${os.quoted_path(full_v_cli_source)}'
 	run_cmd(bootstrap_v2_cmd) or {
 		return error('bootstrap fallback failed while building v2.\n${err.msg()}')
 	}
 	final_args := with_output_arg(args, final_binary)
 	bootstrap_v2_cmd_path := os.join_path('.', bootstrap_v2)
-	final_cmd := '${os.quoted_path(bootstrap_v2_cmd_path)} ${final_args.join(' ')} ${os.quoted_path(v3_self_source)}'
+	final_cmd := '${os.quoted_path(bootstrap_v2_cmd_path)} ${final_args.join(' ')} ${os.quoted_path(full_v_cli_source)}'
 	run_cmd(final_cmd) or {
 		return error('bootstrap fallback failed while building the final compiler.\n${err.msg()}')
 	}

--- a/cmd/tools/vself_test.v
+++ b/cmd/tools/vself_test.v
@@ -61,23 +61,22 @@ fn test_linux_tinyc_self_build_does_not_enable_prealloc() {
 	assert_vself_builds_v3(old_result.output)
 }
 
-fn test_linux_default_self_build_uses_v3_fastc() {
+fn test_linux_default_self_build_uses_v3_c_backend() {
 	$if !linux {
 		return
 	}
 	noop := os.find_abs_path_of_executable('echo') or { return }
-	tool := os.join_path(os.vtmp_dir(), 'vself_v3_fastc_test')
+	tool := os.join_path(os.vtmp_dir(), 'vself_v3_c_backend_test')
 	defer {
 		os.rm(tool) or {}
 	}
 	build := os.execute('${os.quoted_path(vexe)} -o ${os.quoted_path(tool)} ${os.quoted_path(os.join_path(vroot, 'cmd', 'tools', 'vself.v'))}')
 	assert build.exit_code == 0, build.output
 	result :=
-		os.execute('env -u CC VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -o /tmp/vself_v3_fastc_test')
+		os.execute('env -u CC VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -o /tmp/vself_v3_c_backend_test')
 	assert result.exit_code == 0, result.output
-	assert result.output.contains('-b fastc'), result.output
-	assert !result.output.contains('fastc_real_builtin'), result.output
-	assert !result.output.contains('-cc'), result.output
+	assert !result.output.contains('-b fastc'), result.output
+	assert result.output.contains('-prealloc'), result.output
 	assert_vself_builds_v3(result.output)
 }
 
@@ -95,9 +94,10 @@ fn test_macos_default_self_build_compiler_selection() {
 	default_result :=
 		os.execute('env -u CC VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -o /tmp/vself_macos_prealloc_test')
 	assert default_result.exit_code == 0, default_result.output
-	assert default_result.output.contains('-b fastc'), default_result.output
-	assert !default_result.output.contains('fastc_real_builtin'), default_result.output
-	assert !default_result.output.contains('-cc'), default_result.output
+	default_cc := if os.uname().machine in ['arm64', 'aarch64'] { 'tcc' } else { 'cc' }
+	assert !default_result.output.contains('-b fastc'), default_result.output
+	assert default_result.output.contains('-cc ${default_cc}'), default_result.output
+	assert default_result.output.contains('-prealloc'), default_result.output
 	assert_vself_builds_v3(default_result.output)
 	override_result :=
 		os.execute('CC=cc VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -o /tmp/vself_macos_prealloc_test')

--- a/cmd/tools/vself_test.v
+++ b/cmd/tools/vself_test.v
@@ -3,11 +3,17 @@ import os
 const vexe = @VEXE
 const vroot = os.dir(vexe)
 
+fn assert_vself_builds_v3(output string) {
+	assert output.contains('-selfhost'), output
+	assert output.contains('vlib/v3/v3.v'), output
+	assert !output.contains('cmd/v/v.v'), output
+}
+
 fn test_linux_tinyc_self_build_does_not_enable_prealloc() {
 	$if !linux {
 		return
 	}
-	noop := os.find_abs_path_of_executable('true') or { return }
+	noop := os.find_abs_path_of_executable('echo') or { return }
 	tool := os.join_path(os.vtmp_dir(), 'vself_prealloc_test')
 	defer {
 		os.rm(tool) or {}
@@ -21,6 +27,7 @@ fn test_linux_tinyc_self_build_does_not_enable_prealloc() {
 		assert !result.output.contains('-new-compiler'), result.output
 		assert !result.output.contains('-b fastc'), result.output
 		assert !result.output.contains('-prealloc'), result.output
+		assert_vself_builds_v3(result.output)
 	}
 	for compiler in ['tcc', 'tinyc'] {
 		result :=
@@ -30,6 +37,7 @@ fn test_linux_tinyc_self_build_does_not_enable_prealloc() {
 		assert !result.output.contains('-b fastc'), result.output
 		assert !result.output.contains('-prealloc'), result.output
 		assert !result.output.contains('-cc'), result.output
+		assert_vself_builds_v3(result.output)
 	}
 	clang_result :=
 		os.execute('VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -cc clang -o /tmp/vself_clang_test')
@@ -37,24 +45,27 @@ fn test_linux_tinyc_self_build_does_not_enable_prealloc() {
 	assert !clang_result.output.contains('-new-compiler'), clang_result.output
 	assert !clang_result.output.contains('-b fastc'), clang_result.output
 	assert clang_result.output.contains('-prealloc'), clang_result.output
+	assert_vself_builds_v3(clang_result.output)
 	clang_override_result :=
 		os.execute('VEXE=${os.quoted_path(noop)} VFLAGS="-cc tcc" ${os.quoted_path(tool)} self -cc clang -o /tmp/vself_vflags_clang_test')
 	assert clang_override_result.exit_code == 0, clang_override_result.output
 	assert !clang_override_result.output.contains('-new-compiler'), clang_override_result.output
 	assert !clang_override_result.output.contains('-b fastc'), clang_override_result.output
 	assert clang_override_result.output.contains('-prealloc'), clang_override_result.output
+	assert_vself_builds_v3(clang_override_result.output)
 	old_result :=
 		os.execute('VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -old-compiler -o /tmp/vself_old_test')
 	assert old_result.exit_code == 0, old_result.output
 	assert !old_result.output.contains('-new-compiler'), old_result.output
 	assert !old_result.output.contains('-b fastc'), old_result.output
+	assert_vself_builds_v3(old_result.output)
 }
 
 fn test_linux_default_self_build_uses_v3_fastc() {
 	$if !linux {
 		return
 	}
-	noop := os.find_abs_path_of_executable('true') or { return }
+	noop := os.find_abs_path_of_executable('echo') or { return }
 	tool := os.join_path(os.vtmp_dir(), 'vself_v3_fastc_test')
 	defer {
 		os.rm(tool) or {}
@@ -64,18 +75,17 @@ fn test_linux_default_self_build_uses_v3_fastc() {
 	result :=
 		os.execute('env -u CC VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -o /tmp/vself_v3_fastc_test')
 	assert result.exit_code == 0, result.output
-	assert result.output.contains('-new-compiler'), result.output
 	assert result.output.contains('-b fastc'), result.output
-	assert result.output.contains('-d fastc_real_builtin'), result.output
+	assert !result.output.contains('fastc_real_builtin'), result.output
 	assert !result.output.contains('-cc'), result.output
-	assert result.output.contains('-prealloc'), result.output
+	assert_vself_builds_v3(result.output)
 }
 
 fn test_macos_default_self_build_compiler_selection() {
 	$if !macos {
 		return
 	}
-	noop := os.find_abs_path_of_executable('true') or { return }
+	noop := os.find_abs_path_of_executable('echo') or { return }
 	tool := os.join_path(os.vtmp_dir(), 'vself_macos_prealloc_test')
 	defer {
 		os.rm(tool) or {}
@@ -85,11 +95,10 @@ fn test_macos_default_self_build_compiler_selection() {
 	default_result :=
 		os.execute('env -u CC VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -o /tmp/vself_macos_prealloc_test')
 	assert default_result.exit_code == 0, default_result.output
-	assert default_result.output.contains('-new-compiler'), default_result.output
 	assert default_result.output.contains('-b fastc'), default_result.output
-	assert default_result.output.contains('-d fastc_real_builtin'), default_result.output
+	assert !default_result.output.contains('fastc_real_builtin'), default_result.output
 	assert !default_result.output.contains('-cc'), default_result.output
-	assert default_result.output.contains('-prealloc'), default_result.output
+	assert_vself_builds_v3(default_result.output)
 	override_result :=
 		os.execute('CC=cc VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -o /tmp/vself_macos_prealloc_test')
 	assert override_result.exit_code == 0, override_result.output
@@ -97,9 +106,11 @@ fn test_macos_default_self_build_compiler_selection() {
 	assert !override_result.output.contains('-b fastc'), override_result.output
 	assert override_result.output.contains('-cc cc'), override_result.output
 	assert override_result.output.contains('-prealloc'), override_result.output
+	assert_vself_builds_v3(override_result.output)
 	old_result :=
 		os.execute('CC=cc VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -old-compiler -o /tmp/vself_macos_old_test')
 	assert old_result.exit_code == 0, old_result.output
 	assert !old_result.output.contains('-new-compiler'), old_result.output
 	assert !old_result.output.contains('-b fastc'), old_result.output
+	assert_vself_builds_v3(old_result.output)
 }

--- a/cmd/tools/vself_test.v
+++ b/cmd/tools/vself_test.v
@@ -18,23 +18,57 @@ fn test_linux_tinyc_self_build_does_not_enable_prealloc() {
 		result :=
 			os.execute('VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -cc ${compiler} -o /tmp/vself_${compiler}_test')
 		assert result.exit_code == 0, result.output
+		assert !result.output.contains('-new-compiler'), result.output
+		assert !result.output.contains('-b fastc'), result.output
 		assert !result.output.contains('-prealloc'), result.output
 	}
 	for compiler in ['tcc', 'tinyc'] {
 		result :=
 			os.execute('VEXE=${os.quoted_path(noop)} VFLAGS="-cc ${compiler} -no-retry-compilation" ${os.quoted_path(tool)} self -o /tmp/vself_vflags_${compiler}_test')
 		assert result.exit_code == 0, result.output
+		assert !result.output.contains('-new-compiler'), result.output
+		assert !result.output.contains('-b fastc'), result.output
 		assert !result.output.contains('-prealloc'), result.output
 		assert !result.output.contains('-cc'), result.output
 	}
 	clang_result :=
 		os.execute('VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -cc clang -o /tmp/vself_clang_test')
 	assert clang_result.exit_code == 0, clang_result.output
+	assert !clang_result.output.contains('-new-compiler'), clang_result.output
+	assert !clang_result.output.contains('-b fastc'), clang_result.output
 	assert clang_result.output.contains('-prealloc'), clang_result.output
 	clang_override_result :=
 		os.execute('VEXE=${os.quoted_path(noop)} VFLAGS="-cc tcc" ${os.quoted_path(tool)} self -cc clang -o /tmp/vself_vflags_clang_test')
 	assert clang_override_result.exit_code == 0, clang_override_result.output
+	assert !clang_override_result.output.contains('-new-compiler'), clang_override_result.output
+	assert !clang_override_result.output.contains('-b fastc'), clang_override_result.output
 	assert clang_override_result.output.contains('-prealloc'), clang_override_result.output
+	old_result :=
+		os.execute('VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -old-compiler -o /tmp/vself_old_test')
+	assert old_result.exit_code == 0, old_result.output
+	assert !old_result.output.contains('-new-compiler'), old_result.output
+	assert !old_result.output.contains('-b fastc'), old_result.output
+}
+
+fn test_linux_default_self_build_uses_v3_fastc() {
+	$if !linux {
+		return
+	}
+	noop := os.find_abs_path_of_executable('true') or { return }
+	tool := os.join_path(os.vtmp_dir(), 'vself_v3_fastc_test')
+	defer {
+		os.rm(tool) or {}
+	}
+	build := os.execute('${os.quoted_path(vexe)} -o ${os.quoted_path(tool)} ${os.quoted_path(os.join_path(vroot, 'cmd', 'tools', 'vself.v'))}')
+	assert build.exit_code == 0, build.output
+	result :=
+		os.execute('env -u CC VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -o /tmp/vself_v3_fastc_test')
+	assert result.exit_code == 0, result.output
+	assert result.output.contains('-new-compiler'), result.output
+	assert result.output.contains('-b fastc'), result.output
+	assert result.output.contains('-d fastc_real_builtin'), result.output
+	assert !result.output.contains('-cc'), result.output
+	assert result.output.contains('-prealloc'), result.output
 }
 
 fn test_macos_default_self_build_compiler_selection() {
@@ -51,12 +85,21 @@ fn test_macos_default_self_build_compiler_selection() {
 	default_result :=
 		os.execute('env -u CC VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -o /tmp/vself_macos_prealloc_test')
 	assert default_result.exit_code == 0, default_result.output
-	default_cc := if os.uname().machine in ['arm64', 'aarch64'] { 'tcc' } else { 'cc' }
-	assert default_result.output.contains('-cc ${default_cc}'), default_result.output
+	assert default_result.output.contains('-new-compiler'), default_result.output
+	assert default_result.output.contains('-b fastc'), default_result.output
+	assert default_result.output.contains('-d fastc_real_builtin'), default_result.output
+	assert !default_result.output.contains('-cc'), default_result.output
 	assert default_result.output.contains('-prealloc'), default_result.output
 	override_result :=
 		os.execute('CC=cc VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -o /tmp/vself_macos_prealloc_test')
 	assert override_result.exit_code == 0, override_result.output
+	assert !override_result.output.contains('-new-compiler'), override_result.output
+	assert !override_result.output.contains('-b fastc'), override_result.output
 	assert override_result.output.contains('-cc cc'), override_result.output
 	assert override_result.output.contains('-prealloc'), override_result.output
+	old_result :=
+		os.execute('CC=cc VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -old-compiler -o /tmp/vself_macos_old_test')
+	assert old_result.exit_code == 0, old_result.output
+	assert !old_result.output.contains('-new-compiler'), old_result.output
+	assert !old_result.output.contains('-b fastc'), old_result.output
 }

--- a/cmd/tools/vself_test.v
+++ b/cmd/tools/vself_test.v
@@ -3,10 +3,10 @@ import os
 const vexe = @VEXE
 const vroot = os.dir(vexe)
 
-fn assert_vself_builds_v3(output string) {
-	assert output.contains('-selfhost'), output
-	assert output.contains('vlib/v3/v3.v'), output
-	assert !output.contains('cmd/v/v.v'), output
+fn assert_vself_preserves_full_cli(output string) {
+	assert !output.contains('-selfhost'), output
+	assert !output.contains('vlib/v3/v3.v'), output
+	assert output.contains('cmd/v'), output
 }
 
 fn test_linux_tinyc_self_build_does_not_enable_prealloc() {
@@ -27,7 +27,7 @@ fn test_linux_tinyc_self_build_does_not_enable_prealloc() {
 		assert !result.output.contains('-new-compiler'), result.output
 		assert !result.output.contains('-b fastc'), result.output
 		assert !result.output.contains('-prealloc'), result.output
-		assert_vself_builds_v3(result.output)
+		assert_vself_preserves_full_cli(result.output)
 	}
 	for compiler in ['tcc', 'tinyc'] {
 		result :=
@@ -37,7 +37,7 @@ fn test_linux_tinyc_self_build_does_not_enable_prealloc() {
 		assert !result.output.contains('-b fastc'), result.output
 		assert !result.output.contains('-prealloc'), result.output
 		assert !result.output.contains('-cc'), result.output
-		assert_vself_builds_v3(result.output)
+		assert_vself_preserves_full_cli(result.output)
 	}
 	clang_result :=
 		os.execute('VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -cc clang -o /tmp/vself_clang_test')
@@ -45,23 +45,23 @@ fn test_linux_tinyc_self_build_does_not_enable_prealloc() {
 	assert !clang_result.output.contains('-new-compiler'), clang_result.output
 	assert !clang_result.output.contains('-b fastc'), clang_result.output
 	assert clang_result.output.contains('-prealloc'), clang_result.output
-	assert_vself_builds_v3(clang_result.output)
+	assert_vself_preserves_full_cli(clang_result.output)
 	clang_override_result :=
 		os.execute('VEXE=${os.quoted_path(noop)} VFLAGS="-cc tcc" ${os.quoted_path(tool)} self -cc clang -o /tmp/vself_vflags_clang_test')
 	assert clang_override_result.exit_code == 0, clang_override_result.output
 	assert !clang_override_result.output.contains('-new-compiler'), clang_override_result.output
 	assert !clang_override_result.output.contains('-b fastc'), clang_override_result.output
 	assert clang_override_result.output.contains('-prealloc'), clang_override_result.output
-	assert_vself_builds_v3(clang_override_result.output)
+	assert_vself_preserves_full_cli(clang_override_result.output)
 	old_result :=
 		os.execute('VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -old-compiler -o /tmp/vself_old_test')
 	assert old_result.exit_code == 0, old_result.output
 	assert !old_result.output.contains('-new-compiler'), old_result.output
 	assert !old_result.output.contains('-b fastc'), old_result.output
-	assert_vself_builds_v3(old_result.output)
+	assert_vself_preserves_full_cli(old_result.output)
 }
 
-fn test_linux_default_self_build_uses_v3_c_backend() {
+fn test_linux_default_self_build_preserves_full_cli() {
 	$if !linux {
 		return
 	}
@@ -77,7 +77,7 @@ fn test_linux_default_self_build_uses_v3_c_backend() {
 	assert result.exit_code == 0, result.output
 	assert !result.output.contains('-b fastc'), result.output
 	assert result.output.contains('-prealloc'), result.output
-	assert_vself_builds_v3(result.output)
+	assert_vself_preserves_full_cli(result.output)
 }
 
 fn test_macos_default_self_build_compiler_selection() {
@@ -98,7 +98,7 @@ fn test_macos_default_self_build_compiler_selection() {
 	assert !default_result.output.contains('-b fastc'), default_result.output
 	assert default_result.output.contains('-cc ${default_cc}'), default_result.output
 	assert default_result.output.contains('-prealloc'), default_result.output
-	assert_vself_builds_v3(default_result.output)
+	assert_vself_preserves_full_cli(default_result.output)
 	override_result :=
 		os.execute('CC=cc VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -o /tmp/vself_macos_prealloc_test')
 	assert override_result.exit_code == 0, override_result.output
@@ -106,11 +106,85 @@ fn test_macos_default_self_build_compiler_selection() {
 	assert !override_result.output.contains('-b fastc'), override_result.output
 	assert override_result.output.contains('-cc cc'), override_result.output
 	assert override_result.output.contains('-prealloc'), override_result.output
-	assert_vself_builds_v3(override_result.output)
+	assert_vself_preserves_full_cli(override_result.output)
 	old_result :=
 		os.execute('CC=cc VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -old-compiler -o /tmp/vself_macos_old_test')
 	assert old_result.exit_code == 0, old_result.output
 	assert !old_result.output.contains('-new-compiler'), old_result.output
 	assert !old_result.output.contains('-b fastc'), old_result.output
-	assert_vself_builds_v3(old_result.output)
+	assert_vself_preserves_full_cli(old_result.output)
+}
+
+fn test_plain_self_replacement_preserves_cli_and_embedded_v3() {
+	$if !macos && !linux {
+		return
+	}
+	root := os.join_path(os.vtmp_dir(), 'vself_full_cli_replacement_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	for directory in ['vlib', 'thirdparty'] {
+		os.symlink(os.join_path(vroot, directory), os.join_path(root, directory)) or { panic(err) }
+	}
+
+	// The stub keeps this test fast, but only emits a replacement when vself asks
+	// for cmd/v. Targeting standalone v3.v makes the replacement fail.
+	mock_source := os.join_path(root, 'mock_compiler.v')
+	os.write_file(mock_source, "module main
+
+import os
+
+fn main() {
+	if os.args.last() != 'cmd/v' {
+		eprintln('expected cmd/v, got ' + os.args.last())
+		exit(1)
+	}
+	mut output := ''
+	for i, arg in os.args {
+		if arg == '-o' && i + 1 < os.args.len {
+			output = os.args[i + 1]
+		}
+	}
+	if output == '' {
+		eprintln('missing -o')
+		exit(1)
+	}
+	os.cp(os.getenv('VSELF_TEST_FULL_CLI'), output) or {
+		eprintln(err)
+		exit(1)
+	}
+	println(os.args.last())
+}
+") or { panic(err) }
+	isolated_vexe := os.join_path(root, 'v')
+	mock_build := os.execute('${os.quoted_path(vexe)} -old-compiler -o ${os.quoted_path(isolated_vexe)} ${os.quoted_path(mock_source)}')
+	assert mock_build.exit_code == 0, mock_build.output
+	vself_tool := os.join_path(root, 'vself')
+	vself_build := os.execute('${os.quoted_path(vexe)} -old-compiler -o ${os.quoted_path(vself_tool)} ${os.quoted_path(os.join_path(vroot, 'cmd', 'tools', 'vself.v'))}')
+	assert vself_build.exit_code == 0, vself_build.output
+
+	self_result := os.execute('env -u CC VFLAGS="" VOSARGS="" VSELF_TEST_FULL_CLI=${os.quoted_path(vexe)} VEXE=${os.quoted_path(isolated_vexe)} ${os.quoted_path(vself_tool)} self -silent')
+	assert self_result.exit_code == 0, self_result.output
+	assert self_result.output.contains('cmd/v'), self_result.output
+	assert !self_result.output.contains('vlib/v3/v3.v'), self_result.output
+	assert os.is_executable(isolated_vexe)
+	assert os.is_executable(os.join_path(root, 'v_old'))
+
+	version_result := os.execute('VFLAGS="" VOSARGS="" VEXE=${os.quoted_path(isolated_vexe)} ${os.quoted_path(isolated_vexe)} version')
+	assert version_result.exit_code == 0, version_result.output
+	assert version_result.output.starts_with('V '), version_result.output
+	help_result := os.execute('VFLAGS="" VOSARGS="" VEXE=${os.quoted_path(isolated_vexe)} ${os.quoted_path(isolated_vexe)} help self')
+	assert help_result.exit_code == 0, help_result.output
+	assert help_result.output.contains('Rebuild V with the passed options.'), help_result.output
+
+	program_source := os.join_path(root, 'main.v')
+	os.write_file(program_source, 'fn main() { println(42) }\n') or { panic(err) }
+	program := os.join_path(root, 'program')
+	v3_build := os.execute('VFLAGS="" VOSARGS="" VEXE=${os.quoted_path(isolated_vexe)} ${os.quoted_path(isolated_vexe)} -new-compiler -gc none -silent -o ${os.quoted_path(program)} ${os.quoted_path(program_source)}')
+	assert v3_build.exit_code == 0, v3_build.output
+	program_result := os.execute(os.quoted_path(program))
+	assert program_result.exit_code == 0, program_result.output
+	assert program_result.output.trim_space() == '42', program_result.output
 }

--- a/vlib/v/help/installation/self.txt
+++ b/vlib/v/help/installation/self.txt
@@ -7,6 +7,7 @@ Usage:
 
 Options:
   All other options are passed to the build command. (e.g. -prod)
+  All self-builds compile the V3 entry point at `vlib/v3/v3.v`.
   On macOS and Linux, plain self-builds use V3 FastC and bundled TCC by default.
   Set `CC`, pass `-cc`/`-prod`/another backend, or use `-old-compiler` for a conventional build.
   With -prod and clang/gcc, `v self` may use PGO automatically when tools are available.

--- a/vlib/v/help/installation/self.txt
+++ b/vlib/v/help/installation/self.txt
@@ -7,8 +7,9 @@ Usage:
 
 Options:
   All other options are passed to the build command. (e.g. -prod)
+  On macOS and Linux, plain self-builds use V3 FastC and bundled TCC by default.
+  Set `CC`, pass `-cc`/`-prod`/another backend, or use `-old-compiler` for a conventional build.
   With -prod and clang/gcc, `v self` may use PGO automatically when tools are available.
-  On Apple Silicon, regular self-builds use bundled TCC by default; `CC` or `-cc` overrides it.
   On macOS and Linux, `-b fastc` builds the standalone experimental V3 FastC compiler.
   `-prod` cannot be combined with `-b fastc`.
   FastC replacement builds (`xN` without `-o`) reject options that the standalone compiler

--- a/vlib/v/help/installation/self.txt
+++ b/vlib/v/help/installation/self.txt
@@ -7,8 +7,7 @@ Usage:
 
 Options:
   All other options are passed to the build command. (e.g. -prod)
-  All self-builds compile the V3 entry point at `vlib/v3/v3.v`.
-  Plain self-builds use V3's regular C backend.
+  Plain self-builds compile the full `cmd/v` CLI, which embeds and defaults to V3 on macOS/Linux.
   On Apple Silicon, regular self-builds use bundled TCC by default; `CC` or `-cc` overrides it.
   With -prod and clang/gcc, `v self` may use PGO automatically when tools are available.
   On macOS and Linux, `-b fastc` builds the standalone experimental V3 FastC compiler.

--- a/vlib/v/help/installation/self.txt
+++ b/vlib/v/help/installation/self.txt
@@ -8,8 +8,8 @@ Usage:
 Options:
   All other options are passed to the build command. (e.g. -prod)
   All self-builds compile the V3 entry point at `vlib/v3/v3.v`.
-  On macOS and Linux, plain self-builds use V3 FastC and bundled TCC by default.
-  Set `CC`, pass `-cc`/`-prod`/another backend, or use `-old-compiler` for a conventional build.
+  Plain self-builds use V3's regular C backend.
+  On Apple Silicon, regular self-builds use bundled TCC by default; `CC` or `-cc` overrides it.
   With -prod and clang/gcc, `v self` may use PGO automatically when tools are available.
   On macOS and Linux, `-b fastc` builds the standalone experimental V3 FastC compiler.
   `-prod` cannot be combined with `-b fastc`.


### PR DESCRIPTION
## Summary

- keep regular self-builds targeting the full `cmd/v` CLI, including PGO and bootstrap-fallback generations
- retain the embedded V3 driver as the default compiler for user builds on macOS and Linux
- target standalone `vlib/v3/v3.v` only for explicit `-b fastc` self-builds
- keep bundled TCC as the default C compiler on Apple Silicon
- document the full-CLI/V3 relationship and test replacement behavior

## Testing

- `./vnew cmd/tools/vself_test.v`
  - performs an isolated plain `self` replacement without `-o`
  - verifies the replacement supports `version` and `help self`
  - verifies the replacement embedded V3 driver compiles and runs a program
- `VTEST_ONLY_FN=test_v_self_accepts_fastc_backend ./vnew -silent vlib/v3/tests/fastc_backend_test.v`
- `./vnew check-md vlib/v/help/installation/self.txt`
- manual isolated plain `v self` replacement using the real compiler; verified `version`, `help self`, and V3 Hello World compilation