### PR TITLE
v3: make FastC slice clones explicit

### DIFF
--- a/vlib/v3/gen/fastc/array.v
+++ b/vlib/v3/gen/fastc/array.v
@@ -43,18 +43,19 @@ fn (g &Parser) render_higher_order_method_expression(tokens []FastcExpressionTok
 		return none
 	}
 	element_type := g.array_element_type(receiver_type) or { return none }
-	mut closure_tokens := tokens[open + 1..tokens.len - 1]
+	mut closure_tokens := tokens[open + 1..tokens.len - 1].clone()
 	if closure_tokens.len == 0 {
 		return none
 	}
 	mut it_name := 'it'
 	if closure_tokens[0].tok == .pipe {
 		// Explicit closure header `|param|` names the element instead of implicit `it`.
-		if closure_tokens.len < 4 || closure_tokens[1].tok != .name || closure_tokens[2].tok != .pipe {
+		if closure_tokens.len < 4 || closure_tokens[1].tok != .name
+			|| closure_tokens[2].tok != .pipe {
 			return none
 		}
 		it_name = closure_tokens[1].lit
-		closure_tokens = closure_tokens[3..]
+		closure_tokens = closure_tokens[3..].clone()
 		if closure_tokens.len == 0 {
 			return none
 		}

--- a/vlib/v3/gen/fastc/render.v
+++ b/vlib/v3/gen/fastc/render.v
@@ -2290,7 +2290,7 @@ fn (g &Parser) rewrite_embedded_as_casts(tokens []FastcExpressionToken) ?[]Fastc
 				i++
 				continue
 			}
-			inner := result[i + 1..close]
+			inner := result[i + 1..close].clone()
 			if fastc_bare_as_cast_index(inner, 0, inner.len) == none {
 				i++
 				continue


### PR DESCRIPTION
## Summary

- make the three implicit FastC slice copies explicit with `.clone()`
- silence V3 ownership notices during Linux self-host builds
- preserve the existing copy and ownership behavior

## Testing

- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -g -keepc -o /tmp/v-fastc-implicit-slices-pr-selfhost cmd/v`
- `./vnew -no-memory-limit -silent test -run-only test_real_builtin_path_map_and_filter_lower_to_array_loops,test_higher_order_lowering_handles_pointer_receivers_callbacks_and_keyword_parameters vlib/v3/gen/fastc/fastc_test.v`
- `./vnew fmt -w vlib/v3/gen/fastc/array.v vlib/v3/gen/fastc/render.v`
- `git diff --check`