### PR TITLE
v3: avoid rescanning FastC function bodies

### DIFF
--- a/vlib/v3/gen/fastc/comptime.v
+++ b/vlib/v3/gen/fastc/comptime.v
@@ -801,6 +801,21 @@ fn (mut g Parser) parse_comptime_unary() !bool {
 		g.next()
 		return false
 	}
+	if g.tok == .string {
+		actual := g.lit.trim('\'"')
+		g.next()
+		operator := g.tok
+		if operator !in [.eq, .ne] {
+			return g.unsupported('compile-time string comparison operator `${g.token_source()}`')
+		}
+		g.next()
+		if g.tok != .string {
+			return g.unsupported('compile-time string comparison value `${g.token_source()}`')
+		}
+		expected := g.lit.trim('\'"')
+		g.next()
+		return if operator == .eq { actual == expected } else { actual != expected }
+	}
 	if g.tok == .dollar {
 		// `$pkgconfig('lib')`: true when pkg-config reports the library present.
 		g.next()

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -1998,13 +1998,12 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	timer.mark('wait_interface_dispatches')
 	// Fixed arrays that occur only in declarations or signatures are not seen by
 	// the expression renderer, so register their raw markers before emitting typedefs.
+	// Function signatures are present in the prototypes; fixed arrays reached while
+	// rendering function bodies are registered directly on the per-file parser.
 	fastc_collect_referenced_fixed_array_types(type_output.declarations_head, mut fixed_array_types)
 	fastc_collect_referenced_fixed_array_types(type_declarations, mut fixed_array_types)
 	for prototype_piece in prototype_pieces {
 		fastc_collect_referenced_fixed_array_types(prototype_piece, mut fixed_array_types)
-	}
-	for body_piece in body_pieces {
-		fastc_collect_referenced_fixed_array_types(body_piece, mut fixed_array_types)
 	}
 	fixed_array_declarations := fastc_generate_fixed_array_declarations(fixed_array_types)
 	preamble := if header_free {

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -6560,6 +6560,27 @@ fn main() {}
 	assert !c_source.contains('return 2;'), c_source
 }
 
+fn test_selfhost_comptime_literal_string_condition() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate("module main
+
+fn selected_branch() int {
+	\$if 'c' == 'arm64' {
+		return 1
+	} \$else {
+		return 2
+	}
+}
+
+fn main() {
+	println(selected_branch())
+}
+", 'comptime_literal_string_condition.v', prefs) or { panic(err) }
+	assert c_source.contains('i64 selected_branch(void) {\n\treturn 2;\n}'), c_source
+	assert !c_source.contains('i64 selected_branch(void) {\n\treturn 1;'), c_source
+}
+
 fn test_selfhost_typeof_name_interpolation_uses_the_inferred_type() {
 	mut prefs := pref.new_preferences()
 	prefs.building_v = true


### PR DESCRIPTION
## Summary

- avoid rescanning every generated function body for fixed-array markers during FastC stitching
- retain scans for declarations and prototypes while using the per-file registration collected during rendering
- accept literal string equality/inequality in compile-time conditions so current `cmd/v` remains self-host compilable
- add regression coverage for the compile-time string condition

## Performance

Measured compiling current V1 `cmd/v` (545,628 LOC) with a `-prod` compiler, using the median of 15 warmed runs:

- FastC generation: 286.319 ms -> 220.897 ms
- generation throughput: 1.91 MLOC/s -> 2.47 MLOC/s (+29.6%)
- stitch phase fixed-array work: approximately 71 ms -> 3 ms
- TinyCC compilation/link: 245.563 ms after the change
- FastC generation + TinyCC: 466.460 ms (1.17 MLOC/s)

## Validation

- rebuilt `./vnew` with `./v -g -keepc -o ./vnew cmd/v`
- targeted compile-time string comparison regression passed
- FastC-built `cmd/v` compiled, linked, ran, and reported `V 0.5.2 8c24784`
- `./vnew -silent vlib/v/compiler_errors_test.v`: 1696 passed, 1 skipped
- `git diff --check`

The complete FastC directory suite currently has pre-existing stale C-output expectations and an existing multi-return interface test panic. A broader `vlib/v` run was stopped after unrelated V3 type-checker crashes; neither failure class was introduced by this patch.
