### PR TITLE
v3: speed up large generic builds

### DIFF
--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -427,6 +427,8 @@ mut:
 	preinclude_header_owned        []CHeaderOwnershipDirective
 	header_owned_pragma_once_seen  map[string]bool
 	header_owned_macro_context     CHeaderOwnedMacroContext
+	header_owned_initial_macro_key string
+	header_owned_initial_macros    CHeaderMacroState
 	preinclude_directives          []string
 	postinclude_directives         []string
 	early_c_source_directives      map[string]bool
@@ -2970,6 +2972,8 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.preinclude_header_owned = []CHeaderOwnershipDirective{}
 	g.header_owned_pragma_once_seen.clear()
 	g.header_owned_macro_context = CHeaderOwnedMacroContext{}
+	g.header_owned_initial_macro_key = ''
+	g.header_owned_initial_macros = CHeaderMacroState{}
 	g.preinclude_directives = []string{}
 	g.postinclude_directives = []string{}
 	g.early_c_source_directives.clear()
@@ -5155,8 +5159,12 @@ fn (mut g FlatGen) ensure_header_owned_macro_context() {
 	}
 }
 
-fn (g &FlatGen) header_owned_initial_macro_state() CHeaderMacroState {
+fn (mut g FlatGen) header_owned_initial_macro_state() CHeaderMacroState {
 	effective_flags := g.header_owned_effective_c_flags()
+	cache_key := '${g.ccompiler}\x00${g.c99_mode}\x00${g.target.os}\x00${g.target.arch}\x00${g.target.abi}\x00${effective_flags.join('\x00')}'
+	if cache_key == g.header_owned_initial_macro_key {
+		return c_header_macro_state_clone(g.header_owned_initial_macros)
+	}
 	mut state := c_header_macro_state_for_flags(effective_flags)
 	compiler_values := c_header_compiler_predefined_macro_values(g.ccompiler, effective_flags, g.c99_mode, g.target)
 	for name, value in compiler_values {
@@ -5187,6 +5195,8 @@ fn (g &FlatGen) header_owned_initial_macro_state() CHeaderMacroState {
 		state.uncertain.delete(name)
 		state.defined[name] = true
 	}
+	g.header_owned_initial_macro_key = cache_key
+	g.header_owned_initial_macros = c_header_macro_state_clone(state)
 	return state
 }
 

--- a/vlib/v3/gen/c/names_test.v
+++ b/vlib/v3/gen/c/names_test.v
@@ -708,6 +708,12 @@ fn test_header_owned_compiler_state_includes_clang_guards() {
 	state := g.header_owned_initial_macro_state()
 	assert state.defined['__clang__']
 	assert state.defined['__GNUC__']
+	assert g.header_owned_initial_macro_key.len > 0
+	g.header_owned_initial_macros.defined['__v3_cached_macro_probe__'] = true
+	mut cached := g.header_owned_initial_macro_state()
+	assert cached.defined['__v3_cached_macro_probe__']
+	cached.defined.delete('__v3_cached_macro_probe__')
+	assert g.header_owned_initial_macros.defined['__v3_cached_macro_probe__']
 }
 
 fn test_header_owned_compiler_macro_probe_uses_effective_compile_context() {

--- a/vlib/v3/transform/local_decl_index_test.v
+++ b/vlib/v3/transform/local_decl_index_test.v
@@ -1,0 +1,74 @@
+module transform
+
+import v3.flat
+import v3.token
+import v3.types
+
+fn test_local_decl_type_before_pos_uses_indexed_same_file_function() {
+	mut a := flat.FlatAst.new()
+	first_lhs := a.add_node(flat.Node{
+		kind: .ident
+		value: 'value'
+		typ: 'int'
+	})
+	first_rhs := a.add_node(flat.Node{
+		kind: .int_literal
+		value: '1'
+		typ: 'int'
+	})
+	first_children := a.children.len
+	a.children << first_lhs
+	a.children << first_rhs
+	a.add_node(flat.Node{
+		kind: .decl_assign
+		typ: 'int'
+		pos: token.new_pos(1, 20)
+		children_start: first_children
+		children_count: 2
+	})
+	a.add_node(flat.Node{
+		kind: .fn_decl
+		value: 'first'
+		pos: token.new_pos(1, 10)
+	})
+	other_lhs := a.add_node(flat.Node{
+		kind: .ident
+		value: 'value'
+		typ: 'string'
+	})
+	other_rhs := a.add_node(flat.Node{
+		kind: .string_literal
+		value: 'other'
+		typ: 'string'
+	})
+	other_children := a.children.len
+	a.children << other_lhs
+	a.children << other_rhs
+	a.add_node(flat.Node{
+		kind: .decl_assign
+		typ: 'string'
+		pos: token.new_pos(2, 80)
+		children_start: other_children
+		children_count: 2
+	})
+	a.add_node(flat.Node{
+		kind: .fn_decl
+		value: 'other'
+		pos: token.new_pos(2, 10)
+	})
+	mut tc := types.TypeChecker.new(&a)
+	mut t := new_transformer(mut a, &tc, map[string]bool{})
+	t.build_source_parent_index()
+
+	assert t.fn_decl_offsets_by_file[1] == [10]
+	assert t.fn_decl_offsets_by_file[2] == [10]
+	assert t.local_decl_type_before_pos('value', flat.Node{
+		pos: token.new_pos(1, 90)
+	})? == 'int'
+}
+
+fn test_monomorph_job_limit_keeps_four_workers_for_large_programs() {
+	$if !v3_no_parallel ? {
+		assert monomorph_job_limit(12, 500_000, 0) == 4
+	}
+}

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -4787,13 +4787,18 @@ fn (mut t Transformer) concrete_fn_alias_call_return_type(id int, node flat.Node
 		return none
 	}
 	callee := t.a.child_node(&node, 0)
-	if callee.kind != .ident || callee.value.len == 0 || t.var_type(callee.value).len > 0 {
+	if callee.kind != .ident || callee.value.len == 0 {
 		return none
 	}
 	ret := t.tc.fn_ret_types[callee.value] or { return none }
 	ret_name := ret.name()
 	base, _, is_generic_alias := generic_app_parts(ret_name)
 	if !is_generic_alias {
+		return none
+	}
+	// Most call identifiers are ordinary functions. Avoid the contextual scope
+	// lookup until the return type proves this can be a generic function alias.
+	if t.var_type(callee.value).len > 0 {
 		return none
 	}
 	module_name := t.node_module_or(id, t.cur_module)
@@ -9107,17 +9112,34 @@ fn (t &Transformer) local_decl_type_before_pos(name string, before flat.Node) ?s
 		return none
 	}
 	mut fn_start := 0
-	for node in t.a.nodes {
-		if node.kind == .fn_decl && node.pos.offset > fn_start
-			&& node.pos.offset < before.pos.offset {
-			fn_start = node.pos.offset
+	if offsets := t.fn_decl_offsets_by_file[before.pos.id] {
+		mut low := 0
+		mut high := offsets.len
+		for low < high {
+			mid := (low + high) / 2
+			if offsets[mid] < before.pos.offset {
+				low = mid + 1
+			} else {
+				high = mid
+			}
+		}
+		if low > 0 {
+			fn_start = offsets[low - 1]
+		}
+	} else {
+		for node in t.a.nodes {
+			if node.kind == .fn_decl && node.pos.id == before.pos.id
+				&& node.pos.offset > fn_start && node.pos.offset < before.pos.offset {
+				fn_start = node.pos.offset
+			}
 		}
 	}
 	mut best := ''
 	mut best_offset := -1
 	for idx in t.local_decl_nodes_by_name[name] {
 		node := t.a.nodes[idx]
-		if node.pos.offset <= fn_start || node.pos.offset >= before.pos.offset
+		if node.pos.id != before.pos.id || node.pos.offset <= fn_start
+			|| node.pos.offset >= before.pos.offset
 			|| node.pos.offset <= best_offset {
 			continue
 		}

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -242,6 +242,7 @@ mut:
 	generic_alias_names           map[string]bool
 	type_alias_suffixes           map[string]string
 	local_decl_nodes_by_name      map[string][]int
+	fn_decl_offsets_by_file       map[int][]int
 	struct_field_decl_metas_cache map[string]map[string]FieldDeclMeta
 	comptime_field_metas_cache    map[string][]FieldMeta
 	comptime_reflected_for_roles  map[string]u8
@@ -3421,30 +3422,34 @@ fn (mut t Transformer) transform_serial_then_collect_pure(literal_decls []int) [
 				t.item_range_lo = old_range_lo
 				t.item_range_hi = old_range_hi
 			} else {
-				// Some lowering expands far beyond the parsed subtree cost. Aggregate
-				// interpolation emits inline autostr trees, while a const map reference
-				// can point outside this function's range at a map with thousands of
-				// entries. Fold bounded expansion into the worker cost, but defer an
-				// unbounded item to the growable master arena: the shared workers use
-				// fixed .nogrow regions, and even the complete reserved pool can be
-				// smaller than one expanded constant map.
+				// Clone-free workers need conservative expansion estimates because they
+				// append into fixed .nogrow regions. Generic transform workers have
+				// private growable ASTs, so avoid rescanning every function solely to
+				// estimate capacity they do not use.
 				if sc_profile {
 					scsw.restart()
 				}
 				mut str_est := 0
 				mut str_needs_deferred_lowering := false
-				if t.building_v && t.parallel_enabled {
-					// The compiler's interpolated types are all bounded primitives and
-					// metadata names; none can trigger aggregate auto-str expansion.
-					str_est = 0
-				} else {
-					str_est, str_needs_deferred_lowering = t.fn_span_interp_estimate(range_lo, i)
+				if t.skip_generics {
+					if t.building_v && t.parallel_enabled {
+						// The compiler's interpolated types are all bounded primitives and
+						// metadata names; none can trigger aggregate auto-str expansion.
+						str_est = 0
+					} else {
+						str_est, str_needs_deferred_lowering = t.fn_span_interp_estimate(range_lo, i)
+					}
 				}
-				map_est := t.fn_span_map_expansion_estimate(range_lo, i)
+				map_est := if t.skip_generics {
+					t.fn_span_map_expansion_estimate(range_lo, i)
+				} else {
+					0
+				}
 				if sc_profile {
 					est_ms += f64(scsw.elapsed().microseconds()) / 1000.0
 				}
-				if str_needs_deferred_lowering || map_est > deferred_map_expansion_threshold {
+				if t.skip_generics
+					&& (str_needs_deferred_lowering || map_est > deferred_map_expansion_threshold) {
 					t.deferred_expansion_items << FnWorkItem{
 						fn_idx:             i
 						range_lo:           range_lo
@@ -3919,6 +3924,7 @@ fn (t &Transformer) fork_program_view(ast &flat.FlatAst, wtc &types.TypeChecker,
 		generic_alias_names:             t.generic_alias_names
 		type_alias_suffixes:             t.type_alias_suffixes
 		local_decl_nodes_by_name:        t.local_decl_nodes_by_name
+		fn_decl_offsets_by_file:         t.fn_decl_offsets_by_file
 		struct_field_decl_metas_cache:   t.struct_field_decl_metas_cache
 		comptime_field_metas_cache:      map[string][]FieldMeta{}
 		comptime_reflected_for_roles:    t.comptime_reflected_for_roles
@@ -15849,6 +15855,7 @@ fn (t &Transformer) local_binding_before(name string, before flat.NodeId) ?bool 
 fn (mut t Transformer) build_source_parent_index() {
 	t.source_parent_ids = []int{len: t.a.nodes.len, init: -1}
 	mut decls := map[string][]int{}
+	mut fn_offsets := map[int][]int{}
 	mut shared_names := map[string]bool{}
 	for parent_id, node in t.a.nodes {
 		for i in 0 .. node.children_count {
@@ -15856,6 +15863,9 @@ fn (mut t Transformer) build_source_parent_index() {
 			if child_id >= 0 && child_id < t.source_parent_ids.len && child_id != parent_id {
 				t.source_parent_ids[child_id] = parent_id
 			}
+		}
+		if node.kind == .fn_decl && node.pos.is_valid() {
+			fn_offsets[node.pos.id] << node.pos.offset
 		}
 		if node.kind != .decl_assign || node.children_count < 2 {
 			continue
@@ -15872,7 +15882,13 @@ fn (mut t Transformer) build_source_parent_index() {
 			}
 		}
 	}
+	for file_id, offsets in fn_offsets {
+		mut sorted := offsets.clone()
+		sorted.sort()
+		fn_offsets[file_id] = sorted
+	}
 	t.local_decl_nodes_by_name = decls.move()
+	t.fn_decl_offsets_by_file = fn_offsets.move()
 	t.shared_local_decl_names = shared_names.move()
 }
 

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -101,7 +101,11 @@ $if !windows {
 		a := unsafe { &TransformChunkArgs(arg) }
 		mut w := unsafe { &Transformer(a.worker) }
 		items := unsafe { &[]FnWorkItem(a.items_ptr) }
-		w.transform_pure_items_serial(*items)
+		if w.scope_parallel_workers && w.retain_worker_results {
+			w.transform_scoped_helper_batches(*items, 1)
+		} else {
+			w.transform_pure_items_serial(*items)
+		}
 		return unsafe { nil }
 	}
 
@@ -1100,12 +1104,8 @@ fn (mut t Transformer) run_parallel_monomorphize_specs(specs []PendingGenericFnS
 			view.specialized_fn_modules = map[int]string{}
 			view.specialized_fn_files = map[int]string{}
 			mut wtc := t.tc.fork_for_parallel_transform(view)
-			wtc.ensure_private_transform_signatures()
 			mut w := t.fork_worker(view, wtc)
 			w.global_temp_counter = node_starts[ci]
-			w.fn_ret_types = t.fn_ret_types.clone()
-			w.receiver_method_suffix_index = t.receiver_method_suffix_index.clone()
-			w.signature_maps_shared = false
 			w.generic_fn_decls_cache = decls.clone()
 			w.generic_fn_decls_ready = true
 			w.generic_receiver_methods_by_name = t.generic_receiver_methods_by_name.clone()
@@ -1462,17 +1462,16 @@ fn monomorph_job_count(n_runtime_jobs int, n_specs int) int {
 	return n
 }
 
-fn monomorph_job_limit(available_jobs int, node_count int, configured_jobs int) int {
+fn monomorph_job_limit(available_jobs int, _node_count int, configured_jobs int) int {
 	if available_jobs <= 1 {
 		return 1
 	}
 	if configured_jobs > 0 {
 		return int_min(available_jobs, configured_jobs)
 	}
-	// Each helper retains a forked checker and its disposable specialization arena
-	// until the final publication barrier. Three workers keep large applications well
-	// below the normal memory limit; smaller programs retain the lower-latency four-way path.
-	return int_min(available_jobs, if node_count >= 500_000 { 3 } else { 4 })
+	// Scoped generic-transform batches keep enough memory available for the
+	// lower-latency four-way specialization path on large applications too.
+	return int_min(available_jobs, 4)
 }
 
 // monomorph_regions_can_merge_in_place reports whether sequential leftward

--- a/vlib/v3/transform/transform_parallel_test.v
+++ b/vlib/v3/transform/transform_parallel_test.v
@@ -15,7 +15,7 @@ fn test_monomorph_job_count_does_not_start_empty_workers() {
 fn test_monomorph_job_limit_caps_large_programs() {
 	$if !v3_no_parallel ? {
 		assert monomorph_job_limit(12, 499_999, 0) == 4
-		assert monomorph_job_limit(12, 500_000, 0) == 3
+		assert monomorph_job_limit(12, 500_000, 0) == 4
 		assert monomorph_job_limit(1, 500_000, 0) == 1
 		assert monomorph_job_limit(12, 500_000, 6) == 6
 		assert monomorph_job_limit(4, 500_000, 8) == 4


### PR DESCRIPTION
## Summary

- avoid interpolation and map expansion estimation scans for generic transform workers backed by private growable ASTs
- release scoped transform scratch before monomorphization, retain four specialization workers for large inputs, and clone signature maps only when mutated
- index function offsets by source file so local declaration type lookup uses a binary search instead of rescanning the full AST
- cache the compiler predefined macro probe used by header-owned C source processing

## Fusecode benchmark

Equivalent cache-disabled production builds emit C and therefore stop before the native C compiler:

```sh
V_MACOS_V3_NO_FALLBACK=1 ./vnew -nocache -cc clang -enable-globals -prod -gc none -cflags -DLARGE_CONFIG /Users/alex/code/fusecode-v3-perf.hLRRAl -o /tmp/fusecode-v3-stage-bench.c
```

| Measurement | Result |
| --- | ---: |
| Internal non-CC stage total | 1.686 s |
| Wall runs | 1.68, 1.68, 1.68, 1.69 s |
| Wall average | 1.683 s |

A full production native Fusecode link also completed successfully.

## Validation

- `./v -prod -gc none -o ./vnew cmd/v`
- `./vnew -silent vlib/v3/transform/local_decl_index_test.v`
- `./vnew -silent vlib/v3/transform/monomorphize_test.v`
- `./vnew -silent vlib/v3/gen/c/names_test.v`
- vfmt verification for the clean touched files; the two large pre-existing legacy transform files remain globally unformatted
- broad suites were intentionally skipped at request