### PR TITLE
v3: speed up FastC self-host compilation

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -7407,6 +7407,10 @@ $if !skip_fastc ? {
 			final_args << '-lpthread'
 		}
 		final_args << '-lm'
+		atomic_arg := tcc_atomic_arg(prefs, tcc_path, tcc_resources.include_arg)
+		if atomic_arg.len > 0 {
+			final_args << atomic_arg
+		}
 		final_args << environment_ld_flags
 		mut shim_dir := fastc.FastcCodesignShim{}
 		defer {

--- a/vlib/v3/gen/fastc/c_abi.v
+++ b/vlib/v3/gen/fastc/c_abi.v
@@ -110,6 +110,7 @@ fn fastc_c_abi_functions(target_os string, target_arch string) []FastcCAbiFuncti
 		fastc_c_abi_fn('fprintf', 'int @(FILE *, const char *, ...);', ''),
 		fastc_c_abi_fn('printf', 'int @(const char *, ...);', ''),
 		fastc_c_abi_fn('snprintf', 'int @(char *, size_t, const char *, ...);', ''),
+		fastc_c_abi_fn('sscanf', 'int @(const char *, const char *, ...);', ''),
 		fastc_c_abi_fn('setvbuf', 'int @(FILE *, char *, int, size_t);', ''),
 		fastc_c_abi_fn('getline', 'ssize_t @(char **, size_t *, FILE *);', ''),
 		fastc_c_abi_fn('popen', 'FILE *@(const char *, const char *);', ''),
@@ -121,7 +122,9 @@ fn fastc_c_abi_functions(target_os string, target_arch string) []FastcCAbiFuncti
 		fastc_c_abi_fn('lseek', 'off_t @(int, off_t, int);', ''),
 		fastc_c_abi_fn('ftruncate', 'int @(int, off_t);', ''),
 		fastc_c_abi_fn('symlink', 'int @(const char *, const char *);', ''),
+		fastc_c_abi_fn('link', 'int @(const char *, const char *);', ''),
 		fastc_c_abi_fn('fcntl', 'int @(int, int, ...);', ''),
+		fastc_c_abi_fn('flock', 'int @(int, int);', ''),
 		fastc_c_abi_fn('ioctl', 'int @(int, unsigned long, ...);', ''),
 		fastc_c_abi_fn('isatty', 'int @(int);', ''),
 		fastc_c_abi_fn('dup2', 'int @(int, int);', ''),
@@ -130,11 +133,14 @@ fn fastc_c_abi_functions(target_os string, target_arch string) []FastcCAbiFuncti
 		fastc_c_abi_fn('chdir', 'int @(const char *);', ''),
 		fastc_c_abi_fn('getcwd', 'char *@(char *, size_t);', ''),
 		fastc_c_abi_fn('mkdir', 'int @(const char *, mode_t);', ''),
+		fastc_c_abi_fn('mkstemp', 'int @(char *);', ''),
 		fastc_c_abi_fn('rmdir', 'int @(const char *);', ''),
 		fastc_c_abi_fn('unlink', 'int @(const char *);', ''),
 		fastc_c_abi_fn('remove', 'int @(const char *);', ''),
 		fastc_c_abi_fn('rename', 'int @(const char *, const char *);', ''),
 		fastc_c_abi_fn('chmod', 'int @(const char *, mode_t);', ''),
+		fastc_c_abi_fn('utime', 'int @(const char *, const struct utimbuf *);', ''),
+		fastc_c_abi_fn('uname', 'int @(struct utsname *);', ''),
 		fastc_c_abi_fn('readlink', 'ssize_t @(const char *, char *, size_t);', ''),
 		fastc_c_abi_fn('realpath', 'char *@(const char *, char *);', realpath_label),
 		fastc_c_abi_fn('stat', 'int @(const char *, struct stat *);', stat_label),
@@ -147,17 +153,23 @@ fn fastc_c_abi_functions(target_os string, target_arch string) []FastcCAbiFuncti
 		fastc_c_abi_fn('setenv', 'int @(const char *, const char *, int);', ''),
 		fastc_c_abi_fn('unsetenv', 'int @(const char *);', ''),
 		fastc_c_abi_fn('exit', 'void @(int);', ''),
+		fastc_c_abi_fn('atexit', 'int @(void (*)(void));', ''),
 		fastc_c_abi_fn('abort', 'void @(void);', ''),
+		fastc_c_abi_fn('system', 'int @(const char *);', ''),
+		fastc_c_abi_fn('signal', 'void (*@(int, void (*)(int)))(int);', ''),
 		fastc_c_abi_fn('getpid', 'pid_t @(void);', ''),
 		fastc_c_abi_fn('getuid', 'uid_t @(void);', ''),
+		fastc_c_abi_fn('geteuid', 'uid_t @(void);', ''),
 		fastc_c_abi_fn('fork', 'pid_t @(void);', ''),
 		fastc_c_abi_fn('execve', 'int @(const char *, char *const *, char *const *);', ''),
+		fastc_c_abi_fn('execvp', 'int @(const char *, char *const *);', ''),
 		fastc_c_abi_fn('wait', 'pid_t @(int *);', ''),
 		fastc_c_abi_fn('waitpid', 'pid_t @(pid_t, int *, int);', ''),
 		fastc_c_abi_fn('setpgid', 'int @(pid_t, pid_t);', ''),
 		fastc_c_abi_fn('sysconf', 'long @(int);', ''),
 		fastc_c_abi_fn('pthread_create', 'int @(pthread_t *, const pthread_attr_t *, void *(*)(void *), void *);', ''),
 		fastc_c_abi_fn('pthread_join', 'int @(pthread_t, void **);', ''),
+		fastc_c_abi_fn('pthread_detach', 'int @(pthread_t);', ''),
 		fastc_c_abi_fn('pthread_self', 'pthread_t @(void);', ''),
 		fastc_c_abi_fn('pthread_attr_init', 'int @(pthread_attr_t *);', ''),
 		fastc_c_abi_fn('pthread_attr_destroy', 'int @(pthread_attr_t *);', ''),
@@ -169,17 +181,41 @@ fn fastc_c_abi_functions(target_os string, target_arch string) []FastcCAbiFuncti
 		fastc_c_abi_fn('pthread_once', 'int @(pthread_once_t *, void (*)(void));', ''),
 		fastc_c_abi_fn('pthread_mutex_init', 'int @(pthread_mutex_t *, const pthread_mutexattr_t *);', ''),
 		fastc_c_abi_fn('pthread_mutex_lock', 'int @(pthread_mutex_t *);', ''),
+		fastc_c_abi_fn('pthread_mutex_trylock', 'int @(pthread_mutex_t *);', ''),
 		fastc_c_abi_fn('pthread_mutex_unlock', 'int @(pthread_mutex_t *);', ''),
 		fastc_c_abi_fn('pthread_mutex_destroy', 'int @(pthread_mutex_t *);', ''),
 		fastc_c_abi_fn('clock_gettime', 'int @(clockid_t, struct timespec *);', ''),
+		fastc_c_abi_fn('gettimeofday', 'int @(struct timeval *, void *);', ''),
 		fastc_c_abi_fn('nanosleep', 'int @(const struct timespec *, struct timespec *);', ''),
 		fastc_c_abi_fn('localtime_r', 'struct tm *@(const time_t *, struct tm *);', ''),
+		fastc_c_abi_fn('gmtime_r', 'struct tm *@(const time_t *, struct tm *);', ''),
 		fastc_c_abi_fn('time', 'time_t @(time_t *);', ''),
+		fastc_c_abi_fn('strftime', 'size_t @(char *, size_t, const char *, const struct tm *);', ''),
 		fastc_c_abi_fn('mmap', 'void *@(void *, size_t, int, int, int, off_t);', ''),
 		fastc_c_abi_fn('munmap', 'int @(void *, size_t);', ''),
 		fastc_c_abi_fn('select', 'int @(int, fd_set *, fd_set *, fd_set *, struct timeval *);', ''),
+		fastc_c_abi_fn('pow', 'double @(double, double);', ''),
 	]
 	if macos {
+		fns << fastc_c_abi_fn('getrusage', 'int @(int, struct rusage *);', '')
+		fns << fastc_c_abi_fn('task_info', 'int @(uint32_t, uint32_t, int *, uint32_t *);', '')
+		fns << fastc_c_abi_fn('pthread_condattr_init', 'int @(pthread_condattr_t *);', '')
+		fns << fastc_c_abi_fn('pthread_attr_set_qos_class_np', 'int @(pthread_attr_t *, uint32_t, int);', '')
+		fns << fastc_c_abi_fn('pthread_condattr_setpshared', 'int @(pthread_condattr_t *, int);', '')
+		fns << fastc_c_abi_fn('pthread_condattr_destroy', 'int @(pthread_condattr_t *);', '')
+		fns << fastc_c_abi_fn('pthread_cond_init', 'int @(pthread_cond_t *, const pthread_condattr_t *);', '')
+		fns << fastc_c_abi_fn('pthread_cond_signal', 'int @(pthread_cond_t *);', '')
+		fns << fastc_c_abi_fn('pthread_cond_wait', 'int @(pthread_cond_t *, pthread_mutex_t *);', '')
+		fns << fastc_c_abi_fn('pthread_cond_timedwait', 'int @(pthread_cond_t *, pthread_mutex_t *, const struct timespec *);', '')
+		fns << fastc_c_abi_fn('pthread_cond_destroy', 'int @(pthread_cond_t *);', '')
+		fns << fastc_c_abi_fn('pthread_rwlockattr_init', 'int @(pthread_rwlockattr_t *);', '')
+		fns << fastc_c_abi_fn('pthread_rwlock_init', 'int @(pthread_rwlock_t *, const pthread_rwlockattr_t *);', '')
+		fns << fastc_c_abi_fn('pthread_rwlock_rdlock', 'int @(pthread_rwlock_t *);', '')
+		fns << fastc_c_abi_fn('pthread_rwlock_tryrdlock', 'int @(pthread_rwlock_t *);', '')
+		fns << fastc_c_abi_fn('pthread_rwlock_wrlock', 'int @(pthread_rwlock_t *);', '')
+		fns << fastc_c_abi_fn('pthread_rwlock_trywrlock', 'int @(pthread_rwlock_t *);', '')
+		fns << fastc_c_abi_fn('pthread_rwlock_unlock', 'int @(pthread_rwlock_t *);', '')
+		fns << fastc_c_abi_fn('pthread_rwlock_destroy', 'int @(pthread_rwlock_t *);', '')
 		fns << fastc_c_abi_fn('__error', 'int *@(void);', '')
 		fns << fastc_c_abi_fn('CC_SHA256', 'unsigned char *@(const void *, unsigned int, unsigned char *);', '')
 		fns << fastc_c_abi_fn('mach_absolute_time', 'uint64_t @(void);', '')
@@ -219,6 +255,11 @@ fn fastc_c_abi_prelude(target_os string, target_arch string, p string) string {
 		b.writeln('typedef struct ${p}v_dir ${p}DIR;')
 		b.writeln('struct ${p}timespec { long tv_sec; long tv_nsec; };')
 		b.writeln('struct ${p}timeval { long tv_sec; ${p}suseconds_t tv_usec; };')
+		b.writeln('struct ${p}utimbuf { ${p}time_t actime; ${p}time_t modtime; };')
+		b.writeln('struct ${p}utsname { char sysname[256]; char nodename[256]; char release[256]; char version[256]; char machine[256]; };')
+		b.writeln('struct ${p}rusage { struct ${p}timeval ru_utime; struct ${p}timeval ru_stime; long ru_maxrss; long ru_ixrss; long ru_idrss; long ru_isrss; long ru_minflt; long ru_majflt; long ru_nswap; long ru_inblock; long ru_oublock; long ru_msgsnd; long ru_msgrcv; long ru_nsignals; long ru_nvcsw; long ru_nivcsw; };')
+		b.writeln('struct __attribute__((packed, aligned(4))) ${p}task_basic_info { int suspend_count; ${p}uint64_t virtual_size; ${p}uint64_t resident_size; struct { int seconds; int microseconds; } user_time; struct { int seconds; int microseconds; } system_time; int policy; };')
+		b.writeln('struct ${p}flock { ${p}off_t l_start; ${p}off_t l_len; ${p}pid_t l_pid; short l_type; short l_whence; };')
 		b.writeln('struct ${p}stat { ${p}dev_t st_dev; ${p}mode_t st_mode; ${p}nlink_t st_nlink; ${p}ino_t st_ino; ${p}uid_t st_uid; ${p}gid_t st_gid; ${p}dev_t st_rdev; struct ${p}timespec st_atimespec; struct ${p}timespec st_mtimespec; struct ${p}timespec st_ctimespec; struct ${p}timespec st_birthtimespec; ${p}off_t st_size; long long st_blocks; int st_blksize; unsigned int st_flags; unsigned int st_gen; int st_lspare; long long st_qspare[2]; };')
 		b.writeln('#define ${p}st_atime st_atimespec.tv_sec')
 		b.writeln('#define ${p}st_mtime st_mtimespec.tv_sec')
@@ -229,11 +270,16 @@ fn fastc_c_abi_prelude(target_os string, target_arch string, p string) string {
 		b.writeln('typedef struct { long __sig; char __opaque[56]; } ${p}pthread_mutex_t;')
 		b.writeln('typedef struct { long __sig; char __opaque[8]; } ${p}pthread_mutexattr_t;')
 		b.writeln('typedef struct { long __sig; char __opaque[8]; } ${p}pthread_once_t;')
+		b.writeln('typedef struct { long __sig; char __opaque[40]; } ${p}pthread_cond_t;')
+		b.writeln('typedef struct { long __sig; char __opaque[8]; } ${p}pthread_condattr_t;')
+		b.writeln('typedef struct { long __sig; char __opaque[192]; } ${p}pthread_rwlock_t;')
+		b.writeln('typedef struct { long __sig; char __opaque[16]; } ${p}pthread_rwlockattr_t;')
 		b.writeln('#define ${p}PTHREAD_ONCE_INIT {0x30B1BCBA, {0}}')
 		b.writeln('typedef unsigned long ${p}pthread_key_t;')
 		b.writeln('typedef struct { ${p}uint32_t numer; ${p}uint32_t denom; } ${p}mach_timebase_info_data_t;')
 		b.writeln('struct mach_header;')
 		b.writeln('#define ${p}PTHREAD_CREATE_DETACHED 2')
+		b.writeln('#define ${p}PTHREAD_PROCESS_PRIVATE 2')
 		b.writeln('typedef struct { ${p}int32_t fds_bits[32]; } ${p}fd_set;')
 		b.writeln('#define ${p}FD_SETSIZE 1024')
 		b.writeln('#define ${p}FD_ZERO(set) ${p}memset((set), 0, sizeof(*(set)))')
@@ -255,9 +301,40 @@ fn fastc_c_abi_prelude(target_os string, target_arch string, p string) string {
 		b.writeln('#define ${p}O_SYNC 0x80')
 		b.writeln('#define ${p}O_NONBLOCK 0x4')
 		b.writeln('#define ${p}O_NOCTTY 0x20000')
+		b.writeln('#define ${p}F_SETLK 8')
+		b.writeln('#define ${p}F_SETLKW 9')
+		b.writeln('#define ${p}F_RDLCK 1')
+		b.writeln('#define ${p}F_UNLCK 2')
+		b.writeln('#define ${p}F_WRLCK 3')
+		b.writeln('#define ${p}LOCK_SH 0x01')
+		b.writeln('#define ${p}LOCK_EX 0x02')
+		b.writeln('#define ${p}LOCK_NB 0x04')
+		b.writeln('#define ${p}LOCK_UN 0x08')
 		b.writeln('#define ${p}EAGAIN 35')
+		b.writeln('#define ${p}EINVAL 22')
+		b.writeln('#define ${p}ETIMEDOUT 60')
+		b.writeln('#define ${p}SIGHUP 1')
+		b.writeln('#define ${p}SIGINT 2')
+		b.writeln('#define ${p}SIGQUIT 3')
+		b.writeln('#define ${p}SIGILL 4')
+		b.writeln('#define ${p}SIGABRT 6')
+		b.writeln('#define ${p}SIGFPE 8')
+		b.writeln('#define ${p}SIGKILL 9')
+		b.writeln('#define ${p}SIGSEGV 11')
+		b.writeln('#define ${p}SIGPIPE 13')
+		b.writeln('#define ${p}SIGALRM 14')
+		b.writeln('#define ${p}SIGTERM 15')
+		b.writeln('#define ${p}SIG_DFL ((void (*)(int))0)')
+		b.writeln('#define ${p}SIG_IGN ((void (*)(int))1)')
+		b.writeln('#define ${p}SIG_ERR ((void (*)(int))-1)')
+		b.writeln('#define ${p}MACH_TASK_BASIC_INFO_COUNT 12')
+		b.writeln('#define ${p}TASK_BASIC_INFO ${if arm { 18 } else { 5 }}')
+		b.writeln('#define ${p}KERN_SUCCESS 0')
+		b.writeln('#define ${p}QOS_CLASS_USER_INITIATED 0x19')
+		b.writeln('#define ${p}RUSAGE_SELF 0')
 		b.writeln('#define ${p}BUFSIZ 1024')
 		b.writeln('#define ${p}MAP_ANONYMOUS 0x1000')
+		b.writeln('#define ${p}MAP_ANON ${p}MAP_ANONYMOUS')
 		b.writeln('#define ${p}CLOCK_MONOTONIC 6')
 		b.writeln('#define ${p}_SC_NPROCESSORS_ONLN 58')
 		b.writeln('#define ${p}FIONREAD 0x4004667fUL')
@@ -328,8 +405,16 @@ fn fastc_c_abi_prelude(target_os string, target_arch string, p string) string {
 	b.writeln('struct ${p}tm { int tm_sec; int tm_min; int tm_hour; int tm_mday; int tm_mon; int tm_year; int tm_wday; int tm_yday; int tm_isdst; long tm_gmtoff; char *tm_zone; };')
 	if p == '' {
 		b.writeln('extern char **environ;')
+		if macos {
+			b.writeln('extern ${p}uint32_t mach_task_self_;')
+			b.writeln('#define mach_task_self() mach_task_self_')
+		}
 	} else {
 		b.writeln('extern char **${p}environ __asm__("${symbol_prefix}environ");')
+		if macos {
+			b.writeln('extern ${p}uint32_t ${p}mach_task_self_ __asm__("${symbol_prefix}mach_task_self_");')
+			b.writeln('#define ${p}mach_task_self() ${p}mach_task_self_')
+		}
 	}
 	b.writeln('#define ${p}S_IRUSR 0400')
 	b.writeln('#define ${p}S_IWUSR 0200')
@@ -364,6 +449,7 @@ fn fastc_c_abi_prelude(target_os string, target_arch string, p string) string {
 	b.writeln('#define ${p}PROT_READ 1')
 	b.writeln('#define ${p}PROT_WRITE 2')
 	b.writeln('#define ${p}MAP_PRIVATE 2')
+	b.writeln('#define ${p}MAP_SHARED 1')
 	b.writeln('#define ${p}MAP_FAILED ((void *)-1)')
 	b.writeln('#define ${p}CLOCK_REALTIME 0')
 	b.writeln('#define ${p}WNOHANG 1')

--- a/vlib/v3/gen/fastc/c_abi_test.v
+++ b/vlib/v3/gen/fastc/c_abi_test.v
@@ -80,6 +80,7 @@ fn fastc_c_abi_check_source(host_os string, prelude string) string {
 	out << '#include <sys/mman.h>'
 	out << '#include <sys/wait.h>'
 	out << '#include <errno.h>'
+	out << '#include <signal.h>'
 	out << '#include <dirent.h>'
 	if macos {
 		out << '#include <CommonCrypto/CommonDigest.h>'
@@ -87,7 +88,12 @@ fn fastc_c_abi_check_source(host_os string, prelude string) string {
 	out << '#include <unistd.h>'
 	out << '#include <fcntl.h>'
 	out << '#include <time.h>'
+	out << '#include <math.h>'
 	if macos {
+		out << '#include <utime.h>'
+		out << '#include <sys/resource.h>'
+		out << '#include <sys/utsname.h>'
+		out << '#include <mach/mach.h>'
 		out << '#include <mach/mach_time.h>'
 		out << '#include <mach-o/dyld.h>'
 	}
@@ -111,9 +117,17 @@ fn fastc_c_abi_check_source(host_os string, prelude string) string {
 		'S_IWOTH', 'S_IXOTH', 'S_IFMT', 'S_IFDIR', 'S_IFREG', 'S_IFLNK', 'S_IFSOCK', 'S_IFIFO',
 		'S_IFCHR', 'S_IFBLK', 'F_GETFD', 'F_SETFD', 'FD_CLOEXEC', 'EINTR', 'EAGAIN', 'ENOENT',
 		'EEXIST', 'SEEK_SET', 'SEEK_CUR', 'SEEK_END', 'EOF', '_IOFBF', '_IOLBF', '_IONBF', 'BUFSIZ',
-		'PROT_READ', 'PROT_WRITE', 'MAP_PRIVATE', 'MAP_ANONYMOUS', 'CLOCK_REALTIME', 'CLOCK_MONOTONIC',
-		'WNOHANG', '_SC_NPROCESSORS_ONLN', 'STDIN_FILENO', 'STDOUT_FILENO', 'STDERR_FILENO',
-		'FIONREAD', 'FD_SETSIZE', 'PTHREAD_CREATE_DETACHED']
+		'PROT_READ', 'PROT_WRITE', 'MAP_PRIVATE', 'MAP_SHARED', 'MAP_ANONYMOUS', 'CLOCK_REALTIME',
+		'CLOCK_MONOTONIC', 'WNOHANG', '_SC_NPROCESSORS_ONLN', 'STDIN_FILENO', 'STDOUT_FILENO',
+		'STDERR_FILENO', 'FIONREAD', 'FD_SETSIZE', 'PTHREAD_CREATE_DETACHED',
+		'PTHREAD_PROCESS_PRIVATE']
+	if macos {
+		macros << ['MAP_ANON', 'F_SETLK', 'F_SETLKW', 'F_RDLCK', 'F_UNLCK', 'F_WRLCK', 'LOCK_SH',
+			'LOCK_EX', 'LOCK_NB', 'LOCK_UN', 'EINVAL', 'ETIMEDOUT', 'SIGHUP', 'SIGINT', 'SIGQUIT',
+			'SIGILL', 'SIGABRT', 'SIGFPE', 'SIGKILL', 'SIGSEGV', 'SIGPIPE', 'SIGALRM', 'SIGTERM',
+			'MACH_TASK_BASIC_INFO_COUNT', 'TASK_BASIC_INFO', 'KERN_SUCCESS',
+			'QOS_CLASS_USER_INITIATED', 'RUSAGE_SELF']
+	}
 	for name in macros {
 		out << 'CHECK_EQ(v_abi_${name}, ${name});'
 	}
@@ -126,6 +140,15 @@ fn fastc_c_abi_check_source(host_os string, prelude string) string {
 		out << 'CHECK_SIZE(${name});'
 	}
 	if macos {
+		out << 'CHECK_SIZE(pthread_cond_t);'
+		out << 'CHECK_SIZE(pthread_condattr_t);'
+		out << 'CHECK_SIZE(pthread_rwlock_t);'
+		out << 'CHECK_SIZE(pthread_rwlockattr_t);'
+		out << 'CHECK_STRUCT_SIZE(flock);'
+		out << 'CHECK_STRUCT_SIZE(utimbuf);'
+		out << 'CHECK_STRUCT_SIZE(utsname);'
+		out << 'CHECK_STRUCT_SIZE(rusage);'
+		out << 'CHECK_STRUCT_SIZE(task_basic_info);'
 		out << 'CHECK_SIZE(mach_timebase_info_data_t);'
 		out << 'CHECK_EQ(offsetof(v_abi_mach_timebase_info_data_t, denom), offsetof(mach_timebase_info_data_t, denom));'
 	}

--- a/vlib/v3/gen/fastc/decl.v
+++ b/vlib/v3/gen/fastc/decl.v
@@ -2702,7 +2702,7 @@ fn fastc_render_enum_symbol(tokens []FastcExpressionToken, start int, source_fil
 }
 
 fn fastc_emit_enum_print_function(c_name string, name string, fields []string, is_flag bool, mut out strings.Builder) {
-	out.writeln('static void v_fastc_print_enum_${c_name}(${c_name} value, bool newline) {')
+	out.writeln('void v_fastc_print_enum_${c_name}(${c_name} value, bool newline) {')
 	if is_flag {
 		out.writeln('\tfputs("${name}{", stdout);')
 		out.writeln('\tbool written = false;')
@@ -2736,7 +2736,7 @@ fn fastc_generate_enum_string_helpers(infos []FastcEnumInfo) ([]string, []string
 	mut texts := []string{cap: infos.len * 2}
 	for info in infos {
 		mut out := strings.new_builder(256)
-		out.writeln('static string v_fastc_enum_str_${info.c_name}(${info.c_name} value) {')
+		out.writeln('string v_fastc_enum_str_${info.c_name}(${info.c_name} value) {')
 		if info.is_flag {
 			out.writeln('\tstring parts[${info.fields.len * 2 + 2}] = {0};')
 			out.writeln('\tint part_count = 0;')
@@ -2769,7 +2769,7 @@ fn fastc_generate_enum_string_helpers(infos []FastcEnumInfo) ([]string, []string
 		mut from_out := strings.new_builder(256)
 		// `Enum.from_string(s)` maps a field-name string back to its value, returning
 		// `?Enum` (none when no field name matches).
-		from_out.writeln('static Option ${info.c_name}__from_string(string __v_fastc_from) {')
+		from_out.writeln('Option ${info.c_name}__from_string(string __v_fastc_from) {')
 		for field in info.fields {
 			from_out.writeln('\tif (builtin__string_eq(__v_fastc_from, _S("${field}"))) { ${info.c_name} __v_fastc_value = ${info.c_name}__${field}; return (Option){.data=v_fastc_interface_box(&__v_fastc_value, sizeof(${info.c_name})), .state=0}; }')
 		}

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -500,6 +500,20 @@ const c_selfhost_preamble_includes = r'#include <stdint.h>
 const c_selfhost_post_directives = r'#ifndef PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP
 #define pthread_rwlockattr_setkind_np(a, b) (0)
 #endif
+#ifndef memory_order_relaxed
+#define memory_order_relaxed 0
+#define memory_order_acquire 2
+#define memory_order_release 3
+#define memory_order_acq_rel 4
+#define memory_order_seq_cst 5
+#endif
+#if defined(__TINYC__) && defined(__aarch64__)
+#undef atomic_thread_fence
+#undef __atomic_thread_fence
+extern void _V_atomic_thread_fence(int order);
+#define atomic_thread_fence(order) _V_atomic_thread_fence(order)
+#define __atomic_thread_fence(order) _V_atomic_thread_fence(order)
+#endif
 
 '
 
@@ -966,11 +980,18 @@ pub:
 // (the globals), with extern_texts holding those declarations.
 pub struct FastcUnitLayout {
 pub mut:
-	head_end       int
-	solo_end       int
-	unit_starts    []int
-	extern_indexes []int
-	extern_texts   []string
+	head_end           int
+	solo_end           int
+	unit_starts        []int
+	extern_indexes     []int
+	extern_texts       []string
+	prototype_start    int
+	prototype_end      int
+	prototype_texts    []string
+	unit_ref_starts    []int
+	unit_ref_ids       []int
+	solo_prototype_ids []int
+	tail_prototype_ids []int
 	// define_texts are the same pieces with `static` dropped, for the first
 	// unit: a static definition would not satisfy the other units' externs.
 	define_texts []string
@@ -1799,9 +1820,12 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	for name, _ in constant_output.composite_types {
 		composite_types[name] = true
 	}
-	// The fixed ABI prelude covers the bootstrap compiler. The real-builtin
-	// path reaches the wider C API used by cmd/v and must retain its headers.
-	header_free := prefs.building_v && 'fastc_real_builtin' !in prefs.user_defines && fastc_c_abi_supported(prefs.target.os, prefs.target.arch, fastc_host_uses_glibc())
+	// The wider real-builtin ABI is covered on macOS. Linux keeps its headers
+	// until the matching pthread, signal, file-lock and Mach-independent types
+	// have been added to the glibc table too.
+	header_free := prefs.building_v
+		&& ('fastc_real_builtin' !in prefs.user_defines || prefs.target.os == 'macos')
+		&& fastc_c_abi_supported(prefs.target.os, prefs.target.arch, fastc_host_uses_glibc())
 	global_output := fastc_generate_global_declarations(ordered_sources, global_sources, prefs, header_free, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info, functions, constants, constant_output.compile_time_values, public_constants, constant_types, globals, public_globals, mut global_types)!
 	timer.mark('global_declarations')
 	for name, _ in global_output.composite_types {
@@ -2018,6 +2042,7 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	mut kept_body_ranges := hoisted_body.body_ranges.clone()
 	mut kept_conditional_ranges := hoisted_body.conditional_ranges.clone()
 	mut kept_proto_ranges := [0, proto_len]
+	mut solo_prototype_ids := []int{}
 	mut enum_helpers_len := 0
 	for helper_text in type_output.enum_helper_texts {
 		enum_helpers_len += helper_text.len
@@ -2059,6 +2084,7 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 		if id := function_ids['main'] {
 			root_ids << id
 		}
+		solo_prototype_ids = root_ids.clone()
 		// The enum helpers join the walk as one more output placed after the
 		// bodies, so their unreachable pieces are dropped the same way.
 		mut helper_output := FastcFileGenOutput{}
@@ -2098,6 +2124,47 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 		kept_proto_ranges = fastc_subtract_ranges(kept_proto_ranges, dead_proto_ranges)
 		kept_helper_ranges = fastc_subtract_ranges(kept_helper_ranges, dead_helper_ranges)
 		timer.mark('prune')
+	}
+	mut prototype_texts := []string{}
+	mut unit_ref_starts := []int{}
+	mut unit_ref_ids := []int{}
+	mut tail_prototype_ids := []int{}
+	mut unindexed_prototypes := strings.new_builder(256)
+	if prune_unreachable {
+		prototype_texts = []string{len: function_ids.len}
+		unit_ref_starts = []int{cap: outputs.len + 1}
+		for oi, output in outputs {
+			unit_ref_starts << unit_ref_ids.len
+			unit_ref_ids << output.refs
+			tail_prototype_ids << output.root_refs
+			mut proto_cursor := 0
+			for fi, id in output.function_ids {
+				proto_start := output.proto_spans[2 * fi]
+				proto_end := output.proto_spans[2 * fi + 1]
+				if proto_cursor < proto_start {
+					// On-demand monomorphizations append declarations outside the
+					// ordinary function spans, so they remain shared by every unit.
+					unindexed_prototypes.write_string(output.prototypes[proto_cursor..proto_start])
+				}
+				if proto_end > proto_cursor {
+					proto_cursor = proto_end
+				}
+				if proto_start >= proto_end
+					|| !fastc_range_is_kept(kept_proto_ranges, output_proto_offsets[oi] + proto_start, output_proto_offsets[oi] + proto_end) {
+					continue
+				}
+				prototype := output.prototypes[proto_start..proto_end]
+				if id >= 0 {
+					prototype_texts[id] = prototype
+				} else {
+					unindexed_prototypes.write_string(prototype)
+				}
+			}
+			if proto_cursor < output.prototypes.len {
+				unindexed_prototypes.write_string(output.prototypes[proto_cursor..])
+			}
+		}
+		unit_ref_starts << unit_ref_ids.len
 	}
 	mut pieces := []string{cap: 64 + body_pieces.len * 3}
 	pieces << fastc_piece(preamble)
@@ -2150,6 +2217,17 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	extern_texts << fastc_extern_declarations(global_output.declarations, true)
 	define_texts << fastc_extern_declarations(global_output.declarations, false)
 	pieces << fastc_piece(global_output.declarations)
+	// Helper implementations are emitted once in the first translation unit.
+	// Keep only their declarations in the shared head parsed by every TinyCC job.
+	runtime_definitions := if prefs.building_v {
+		c_selfhost_runtime.replace('static ', '')
+	} else {
+		''
+	}
+	pieces << fastc_definition_prototypes(runtime_definitions)
+	for helper_text in type_output.enum_helper_texts {
+		pieces << fastc_definition_prototypes(helper_text)
+	}
 	// Generated formatting helpers can be registered while parsing a function
 	// that reachability later removes, even though another live helper calls
 	// them. Keep their declarations outside the per-function prototype ranges.
@@ -2157,10 +2235,15 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	spawn_helper_names.sort()
 	mut spawn_helper_prototypes := strings.new_builder(256)
 	for spawn_helper_name in spawn_helper_names {
-		spawn_helper_prototypes.write_string(fastc_definition_prototypes(spawn_helpers[spawn_helper_name]))
+		helper_definitions := spawn_helpers[spawn_helper_name].replace('static ', '')
+		spawn_helpers[spawn_helper_name] = helper_definitions
+		spawn_helper_prototypes.write_string(fastc_definition_prototypes(helper_definitions))
 	}
 	pieces << fastc_take_string(mut spawn_helper_prototypes)
+	pieces << fastc_take_string(mut unindexed_prototypes)
+	prototype_start := pieces.len
 	fastc_collect_c_piece_ranges(mut pieces, prototype_pieces, kept_proto_ranges)
+	prototype_end := pieces.len
 	if startup_initializers.len > 0 {
 		pieces << 'static void v_fastc_init_globals(void);'
 		pieces << '\n'
@@ -2170,9 +2253,11 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 		pieces << '\n'
 	}
 	pieces << '\n'
-	if prefs.building_v {
-		pieces << fastc_piece(c_selfhost_runtime)
-	}
+	// The interface dispatch functions are definitions, so they belong to
+	// one unit; every unit sees their prototypes.
+	pieces << fastc_definition_prototypes(interface_dispatches)
+	head_end := pieces.len
+	pieces << fastc_piece(runtime_definitions)
 	fastc_collect_c_piece_ranges(mut pieces, type_output.enum_helper_texts, kept_helper_ranges)
 	if spawn_helpers.len > 0 {
 		for spawn_helper_name in spawn_helper_names {
@@ -2181,10 +2266,6 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 			pieces << '\n'
 		}
 	}
-	// The interface dispatch functions are definitions, so they belong to
-	// one unit; every unit sees their prototypes.
-	pieces << fastc_definition_prototypes(interface_dispatches)
-	head_end := pieces.len
 	pieces << fastc_piece(interface_dispatches)
 	if startup_initializers.len > 0 {
 		pieces << 'static void v_fastc_init_globals(void) {'
@@ -2241,6 +2322,15 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	units.extern_indexes = extern_indexes
 	units.extern_texts = extern_texts
 	units.define_texts = define_texts
+	if prune_unreachable {
+		units.prototype_start = prototype_start
+		units.prototype_end = prototype_end
+		units.prototype_texts = prototype_texts
+		units.unit_ref_starts = unit_ref_starts
+		units.unit_ref_ids = unit_ref_ids
+		units.solo_prototype_ids = solo_prototype_ids
+		units.tail_prototype_ids = tail_prototype_ids
+	}
 	timer.mark('assemble')
 	if header_free {
 		// A C function without a prototype in the ABI table must fail the
@@ -2251,16 +2341,18 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 }
 
 // fastc_definition_prototypes returns a prototype for every function
-// definition of `text` (a definition starts a line and ends it with `) {`).
+// definition of `text` (a definition starts a line and contains `) {`).
 fn fastc_definition_prototypes(text string) string {
 	if text.len == 0 {
 		return ''
 	}
 	mut out := strings.new_builder(text.len / 8 + 64)
 	for line in text.split_into_lines() {
-		if line.len > 4 && !line[0].is_space() && line.ends_with(') {') && !line.starts_with('static ')
+		if line.len > 4 && !line[0].is_space() && !line.starts_with('static ')
 			&& !line.starts_with('#') {
-			out.writeln(line[..line.len - 2] + ';')
+			if body_start := line.index(') {') {
+				out.writeln(line[..body_start + 1] + ';')
+			}
 		}
 	}
 	return out.str()
@@ -2314,6 +2406,18 @@ fn fastc_window_ranges(ranges []int, window_start int, window_end int) []int {
 	return out
 }
 
+fn fastc_range_is_kept(ranges []int, start int, end int) bool {
+	for i := 0; i + 1 < ranges.len; i += 2 {
+		if ranges[i] <= start && end <= ranges[i + 1] {
+			return true
+		}
+		if ranges[i] > start {
+			break
+		}
+	}
+	return false
+}
+
 // fastc_extern_declarations rewrites the `static` variable definitions of a
 // declaration block for a split build: as `extern` declarations (`as_extern`)
 // for the units that share the globals, or as external definitions (without
@@ -2364,8 +2468,8 @@ fn fastc_parallel_worker_limit(prefs &pref.Preferences) int {
 // program's translation units with.
 pub fn fastc_tcc_job_count(prefs &pref.Preferences) int {
 	mut jobs := fastc_parallel_worker_limit(prefs)
-	if jobs > 8 {
-		jobs = 8
+	if jobs > 18 {
+		jobs = 18
 	}
 	if jobs < 1 {
 		jobs = 1
@@ -2414,7 +2518,11 @@ pub fn fastc_write_c_units(prefix string, pieces []string, units FastcUnitLayout
 				break
 			}
 			if size > 0 && remaining_groups > 0 && size + unit_sizes[u] > target {
-				break
+				under_target := target - size
+				over_target := size + unit_sizes[u] - target
+				if under_target <= over_target {
+					break
+				}
 			}
 			size += unit_sizes[u]
 			remaining -= unit_sizes[u]
@@ -2451,6 +2559,10 @@ fn fastc_write_c_unit(path string, pieces []string, units &FastcUnitLayout, g in
 	// One buffered write per unit: piecewise writes cost several times more.
 	mut out := strings.new_builder(1024 * 1024)
 	for k in 0 .. units.head_end {
+		if units.prototype_start < units.prototype_end && k >= units.prototype_start
+			&& k < units.prototype_end {
+			continue
+		}
 		mut text := pieces[k]
 		for e, index in units.extern_indexes {
 			if index == k {
@@ -2458,6 +2570,30 @@ fn fastc_write_c_unit(path string, pieces []string, units &FastcUnitLayout, g in
 			}
 		}
 		out.write_string(text)
+	}
+	if units.prototype_start < units.prototype_end && units.prototype_texts.len > 0
+		&& units.unit_ref_starts.len == units.unit_starts.len {
+		mut needed := []bool{len: units.prototype_texts.len}
+		if g == 0 {
+			for id in units.solo_prototype_ids {
+				needed[id] = true
+			}
+		}
+		for u in first_unit .. end_unit {
+			for r in units.unit_ref_starts[u] .. units.unit_ref_starts[u + 1] {
+				needed[units.unit_ref_ids[r]] = true
+			}
+		}
+		if end_unit == units.unit_starts.len - 1 {
+			for id in units.tail_prototype_ids {
+				needed[id] = true
+			}
+		}
+		for id, include_prototype in needed {
+			if include_prototype {
+				out.write_string(units.prototype_texts[id])
+			}
+		}
 	}
 	if g == 0 {
 		for k in units.head_end .. units.solo_end {
@@ -2834,6 +2970,7 @@ fn fastc_partition_c_directive_ranges(total_len int, lines []FastcCDirectiveLine
 // it cannot be read (so the C compiler reports the problem).
 fn fastc_inlined_c_header(path string) string {
 	content := os.read_file(path) or { return '#include "${path}"\n' }
+	is_tcc_atomic := path.ends_with('/thirdparty/stdatomic/nix/atomic.h')
 	// The helper headers' own includes (Windows and MSVC branches, or the
 	// system headers the prelude replaces) are left out: the build has none.
 	mut out := strings.new_builder(content.len + 64)
@@ -2843,7 +2980,14 @@ fn fastc_inlined_c_header(path string) string {
 			out.writeln('')
 			continue
 		}
-		out.writeln(line)
+		// TinyCC's ARM atomic fallbacks are external inline definitions. A
+		// header-free parallel build emits this header in every translation unit,
+		// so keep those fallback definitions local to their unit.
+		out.writeln(if is_tcc_atomic {
+			line.replace('extern inline ', 'static inline ')
+		} else {
+			line
+		})
 	}
 	return out.str()
 }

--- a/vlib/v3/gen/fastc/fn.v
+++ b/vlib/v3/gen/fastc/fn.v
@@ -955,11 +955,13 @@ fn (mut g Parser) parse_function(enabled bool) ! {
 	if is_main {
 		g.write_line('return 0;')
 	}
-	function_body := g.out.cut_to(function_body_start)
-	for declaration in g.function_defer_declarations {
-		g.write_line(declaration)
+	if g.function_defer_declarations.len > 0 {
+		function_body := g.out.cut_to(function_body_start)
+		for declaration in g.function_defer_declarations {
+			g.write_line(declaration)
+		}
+		g.out.write_string(function_body)
 	}
-	g.out.write_string(function_body)
 	g.in_main = previous_in_main
 	g.return_type = previous_return_type
 	g.return_types = previous_return_types.clone()

--- a/vlib/v3/gen/fastc/types.v
+++ b/vlib/v3/gen/fastc/types.v
@@ -10,6 +10,16 @@ fn fastc_matching_rpar(tokens []FastcExpressionToken, open int) ?int {
 // when the tokens are a bare `X as T` cast (no surrounding binary operator, so
 // `a == b as T` — a comparison — is excluded). Returns none otherwise.
 fn fastc_bare_as_cast_index(tokens []FastcExpressionToken, start int, end int) ?int {
+	mut contains_as := false
+	for i := start; i < end; i++ {
+		if tokens[i].tok == .key_as {
+			contains_as = true
+			break
+		}
+	}
+	if !contains_as {
+		return none
+	}
 	mut depth := 0
 	mut as_index := -1
 	for i := start; i < end; i++ {
@@ -439,14 +449,6 @@ fn (g &Parser) infer_expression_type_range_impl(tokens []FastcExpressionToken, e
 	if start >= end {
 		return ''
 	}
-	// `X as T` yields the target type `T` (so `(x as T).field` resolves).
-	if as_index := fastc_bare_as_cast_index(tokens, start, end) {
-		if as_index + 1 < end {
-			if target := g.type_from_expression_tokens(tokens[as_index + 1..end]) {
-				return fastc_normalize_inferred_type(target)
-			}
-		}
-	}
 	if end - start == 1 {
 		item := tokens[start]
 		if item.typ != '' {
@@ -487,6 +489,14 @@ fn (g &Parser) infer_expression_type_range_impl(tokens []FastcExpressionToken, e
 			}
 			else {
 				''
+			}
+		}
+	}
+	// `X as T` yields the target type `T` (so `(x as T).field` resolves).
+	if as_index := fastc_bare_as_cast_index(tokens, start, end) {
+		if as_index + 1 < end {
+			if target := g.type_from_expression_tokens(tokens[as_index + 1..end]) {
+				return fastc_normalize_inferred_type(target)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- extend the macOS header-free C ABI so the real-builtin cmd/v build does not parse system headers in every TinyCC unit
- emit FastC runtime, enum, and generated helper bodies once, and select only the function prototypes referenced by each translation unit
- link the cached atomic support object and keep TinyCC ARM atomic fallbacks local to each unit
- use up to 18 TinyCC units, balance unit packing around the closest target size, and avoid unnecessary function-body and as-cast scans

## Performance

Measured with an optimized compiler while compiling the 545,628-LOC cmd/v source graph with FastC + TinyCC on macOS arm64. Clean final-code samples:

- 219.7 ms FastC + 151.5 ms C = 371.2 ms, 1.470 M LOC/s
- 214.0 ms FastC + 148.3 ms C = 362.2 ms, 1.506 M LOC/s
- 216.2 ms FastC + 146.8 ms C = 363.0 ms, 1.503 M LOC/s

The host also had intermittent unrelated compiler and QEMU work, so consecutive saturated bursts are slower. The prior merged baseline was about 466 ms combined, or 1.17 M LOC/s.

## Validation

- ./vnew vlib/v3/gen/fastc/c_abi_test.v
- ./vnew vlib/v3/gen/fastc/macho_sign_test.v
- ./vnew -silent vlib/v/compiler_errors_test.v (1696 passed, 1 skipped)
- debug and optimized FastC cmd/v builds; produced binaries report V 0.5.2
- FastC-built compiler compiled cmd/v again with -no-memory-limit; gen-2 binary reports V 0.5.2

The broad fastc_test.v run reaches its existing self-host multi-return-interface panic. The full vlib/v run was stopped after the V3 compiler twice segfaulted in its unrelated parallel TypeChecker_local_fn_decl_exists map lookup.