### PR TITLE
v3: test shared field fallback disambiguation

### DIFF
--- a/vlib/v3/tests/lock_codegen_test.v
+++ b/vlib/v3/tests/lock_codegen_test.v
@@ -480,3 +480,37 @@ pub mut:
 	})
 	assert c_code.contains('.values->val, 1, 1, 0)'), c_code
 }
+
+fn test_shared_field_fallback_disambiguates_plain_homonym() {
+	c_code := lock_codegen_gen_c_sources('shared_field_plain_homonym', {
+		'main.v':          'module main
+
+import guarded
+import plain
+
+fn main() {
+	guarded_record := guarded.Record{}
+	plain_record := plain.Record{}
+	println(guarded_record)
+	println(plain_record)
+}
+'
+		'guarded/types.v': 'module guarded
+
+pub struct Record {
+pub mut:
+	values shared map[string]string
+}
+'
+		'plain/types.v':   'module plain
+
+pub struct Record {
+pub:
+	values map[string]string
+}
+'
+	})
+	assert c_code.contains('v3_map_str(guarded_record.values->val, 1, 1, 0)'), c_code
+	assert c_code.contains('v3_map_str(plain_record.values, 1, 1, 0)'), c_code
+	assert !c_code.contains('v3_map_str(plain_record.values->val,'), c_code
+}


### PR DESCRIPTION
Follow-up to the post-merge review of #28340.

Adds a focused two-module regression where guarded.Record.values is shared and plain.Record.values is not. The generated C assertions require the guarded selector to read through ->val and require the plain selector to remain direct, including an explicit negative assertion against a false shared-field match.

Validation (VJOBS=1):

- ./vnew fmt -verify vlib/v3/tests/lock_codegen_test.v
- ./vnew -old-compiler test -run-only test_shared_map_field_stringification_reads_payload,test_shared_field_fallback_disambiguates_plain_homonym vlib/v3/tests/lock_codegen_test.v