### PR TITLE
cgen: resolve Windows FLS APIs for TinyCC

### DIFF
--- a/vlib/v/gen/c/autostr_tls_test.v
+++ b/vlib/v/gen/c/autostr_tls_test.v
@@ -1,0 +1,26 @@
+module c
+
+import strings
+import v.pref
+
+fn test_tinyc_windows_autostr_tls_resolves_fls_at_runtime() {
+	preferences := pref.Preferences{}
+	mut reflection_strings := map[string]int{}
+	mut g := Gen{
+		pref: &preferences
+		anon_fn: unsafe { nil }
+		reflection_strings: &reflection_strings
+	}
+	mut builder := strings.new_builder(1024)
+	g.write_autostr_tls_global(mut builder, '', 'AutostrState', 'g_autostr_addr_state')
+	windows_code := builder.str().all_before('#elif defined(__TINYC__)')
+	assert windows_code.contains('GetProcAddress(kernel32, "FlsAlloc")')
+	assert windows_code.contains('GetProcAddress(kernel32, "FlsGetValue")')
+	assert windows_code.contains('GetProcAddress(kernel32, "FlsSetValue")')
+	assert windows_code.contains('fls_alloc(g_autostr_addr_state_tls_free)')
+	assert windows_code.contains('g_autostr_addr_state_fls_get(g_autostr_addr_state_tls_key)')
+	assert windows_code.contains('g_autostr_addr_state_fls_set(g_autostr_addr_state_tls_key, p)')
+	assert !windows_code.contains('FlsAlloc(g_autostr_addr_state_tls_free)')
+	assert !windows_code.contains('FlsGetValue(g_autostr_addr_state_tls_key)')
+	assert !windows_code.contains('FlsSetValue(g_autostr_addr_state_tls_key, p)')
+}

--- a/vlib/v/gen/c/consts_and_globals.v
+++ b/vlib/v/gen/c/consts_and_globals.v
@@ -748,11 +748,24 @@ fn (mut g Gen) write_autostr_tls_global(mut def_builder strings.Builder, linkage
 	slot_fn := 'v_${cname}_tls_slot'
 	slot_linkage := if g.pref.parallel_cc { '' } else { 'static ' }
 	def_builder.writeln('#if defined(__TINYC__) && defined(_WIN32)')
+	// TinyCC's bundled import library does not expose the Fls* symbols. Resolve
+	// them at runtime so Windows can still release each slot at thread exit.
+	def_builder.writeln('typedef DWORD (WINAPI *${cname}_fls_alloc_fn)(void (WINAPI *)(void*));')
+	def_builder.writeln('typedef void* (WINAPI *${cname}_fls_get_fn)(DWORD);')
+	def_builder.writeln('typedef BOOL (WINAPI *${cname}_fls_set_fn)(DWORD, void*);')
 	def_builder.writeln('static DWORD ${cname}_tls_key = 0xFFFFFFFF;')
+	def_builder.writeln('static ${cname}_fls_get_fn ${cname}_fls_get;')
+	def_builder.writeln('static ${cname}_fls_set_fn ${cname}_fls_set;')
 	def_builder.writeln('static void WINAPI ${cname}_tls_free(void* p) { free(p); }')
 	def_builder.writeln('static void ${cname}_tls_init(void) __attribute__((constructor));')
-	def_builder.writeln('static void ${cname}_tls_init(void) { ${cname}_tls_key = FlsAlloc(${cname}_tls_free); }')
-	def_builder.writeln('${slot_linkage}${styp}* ${slot_fn}(void) { void* p = FlsGetValue(${cname}_tls_key); if (!p) { p = calloc(1, sizeof(${styp})); FlsSetValue(${cname}_tls_key, p); } return (${styp}*)p; }')
+	def_builder.writeln('static void ${cname}_tls_init(void) {')
+	def_builder.writeln('\tvoid* kernel32 = GetModuleHandleA("kernel32.dll");')
+	def_builder.writeln('\t${cname}_fls_alloc_fn fls_alloc = (${cname}_fls_alloc_fn)GetProcAddress(kernel32, "FlsAlloc");')
+	def_builder.writeln('\t${cname}_fls_get = (${cname}_fls_get_fn)GetProcAddress(kernel32, "FlsGetValue");')
+	def_builder.writeln('\t${cname}_fls_set = (${cname}_fls_set_fn)GetProcAddress(kernel32, "FlsSetValue");')
+	def_builder.writeln('\t${cname}_tls_key = fls_alloc && ${cname}_fls_get && ${cname}_fls_set ? fls_alloc(${cname}_tls_free) : TlsAlloc();')
+	def_builder.writeln('}')
+	def_builder.writeln('${slot_linkage}${styp}* ${slot_fn}(void) { void* p = ${cname}_fls_get ? ${cname}_fls_get(${cname}_tls_key) : TlsGetValue(${cname}_tls_key); if (!p) { p = calloc(1, sizeof(${styp})); if (${cname}_fls_set) ${cname}_fls_set(${cname}_tls_key, p); else TlsSetValue(${cname}_tls_key, p); } return (${styp}*)p; }')
 	def_builder.writeln('#define ${cname} (*${slot_fn}())')
 	def_builder.writeln('#elif defined(__TINYC__)')
 	def_builder.writeln('#include <pthread.h>')

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -21296,9 +21296,8 @@ fn (mut g FlatGen) headerless_libc_preamble() {
 	g.writeln('DWORD WINAPI TlsAlloc(void);')
 	g.writeln('void* WINAPI TlsGetValue(DWORD index);')
 	g.writeln('BOOL WINAPI TlsSetValue(DWORD index, void* value);')
-	g.writeln('DWORD WINAPI FlsAlloc(void (WINAPI *callback)(void*));')
-	g.writeln('void* WINAPI FlsGetValue(DWORD index);')
-	g.writeln('BOOL WINAPI FlsSetValue(DWORD index, void* value);')
+	g.writeln('void* WINAPI GetModuleHandleA(const char* module_name);')
+	g.writeln('void* WINAPI GetProcAddress(void* module, const char* proc_name);')
 	g.writeln('typedef struct { HANDLE handle; void* context; } __v_thread;')
 	g.writeln('static bool __v_thread_equal(__v_thread a, __v_thread b) { return a.handle == b.handle; }')
 	g.writeln('typedef void* (*__v_thread_start_fn)(void*);')
@@ -24282,14 +24281,27 @@ fn (g &FlatGen) is_builtin_autostr_addr_state(name string) bool {
 
 fn (mut g FlatGen) emit_tinyc_windows_thread_local_slot(cname string, ct string, dims string) {
 	g.writeln('#if defined(__TINYC__) && defined(_WIN32)')
+	// TinyCC's bundled import library does not expose the Fls* symbols. Resolve
+	// them at runtime so Windows can still release each slot at thread exit.
+	g.writeln('typedef DWORD (WINAPI *${cname}_fls_alloc_fn)(void (WINAPI *)(void*));')
+	g.writeln('typedef void* (WINAPI *${cname}_fls_get_fn)(DWORD);')
+	g.writeln('typedef BOOL (WINAPI *${cname}_fls_set_fn)(DWORD, void*);')
 	g.writeln('static DWORD ${cname}_key = 0xFFFFFFFF;')
+	g.writeln('static ${cname}_fls_get_fn ${cname}_fls_get;')
+	g.writeln('static ${cname}_fls_set_fn ${cname}_fls_set;')
 	g.writeln('static void WINAPI ${cname}_slot_free(void* p) { free(p); }')
 	g.writeln('static void ${cname}_key_init(void) __attribute__((constructor));')
-	g.writeln('static void ${cname}_key_init(void) { ${cname}_key = FlsAlloc(${cname}_slot_free); }')
+	g.writeln('static void ${cname}_key_init(void) {')
+	g.writeln('\tvoid* kernel32 = GetModuleHandleA("kernel32.dll");')
+	g.writeln('\t${cname}_fls_alloc_fn fls_alloc = (${cname}_fls_alloc_fn)GetProcAddress(kernel32, "FlsAlloc");')
+	g.writeln('\t${cname}_fls_get = (${cname}_fls_get_fn)GetProcAddress(kernel32, "FlsGetValue");')
+	g.writeln('\t${cname}_fls_set = (${cname}_fls_set_fn)GetProcAddress(kernel32, "FlsSetValue");')
+	g.writeln('\t${cname}_key = fls_alloc && ${cname}_fls_get && ${cname}_fls_set ? fls_alloc(${cname}_slot_free) : TlsAlloc();')
+	g.writeln('}')
 	if dims.len > 0 {
-		g.writeln('static ${ct} (*${cname}_slot(void))${dims} { void* p = FlsGetValue(${cname}_key); if (!p) { p = calloc(1, sizeof(*${cname}_slot())); FlsSetValue(${cname}_key, p); } return p; }')
+		g.writeln('static ${ct} (*${cname}_slot(void))${dims} { void* p = ${cname}_fls_get ? ${cname}_fls_get(${cname}_key) : TlsGetValue(${cname}_key); if (!p) { p = calloc(1, sizeof(*${cname}_slot())); if (${cname}_fls_set) ${cname}_fls_set(${cname}_key, p); else TlsSetValue(${cname}_key, p); } return p; }')
 	} else {
-		g.writeln('static ${ct}* ${cname}_slot(void) { void* p = FlsGetValue(${cname}_key); if (!p) { p = calloc(1, sizeof(${ct})); FlsSetValue(${cname}_key, p); } return (${ct}*)p; }')
+		g.writeln('static ${ct}* ${cname}_slot(void) { void* p = ${cname}_fls_get ? ${cname}_fls_get(${cname}_key) : TlsGetValue(${cname}_key); if (!p) { p = calloc(1, sizeof(${ct})); if (${cname}_fls_set) ${cname}_fls_set(${cname}_key, p); else TlsSetValue(${cname}_key, p); } return (${ct}*)p; }')
 	}
 	g.writeln('#define ${cname} (*${cname}_slot())')
 	g.writeln('#elif defined(__TINYC__)')

--- a/vlib/v3/gen/c/preamble_test.v
+++ b/vlib/v3/gen/c/preamble_test.v
@@ -15,9 +15,15 @@ fn test_tinyc_windows_thread_local_slot_uses_win32_tls() {
 	c_code := g.sb.str()
 	windows_code := c_code.all_before('#elif defined(__TINYC__)')
 	assert windows_code.contains('#if defined(__TINYC__) && defined(_WIN32)')
-	assert windows_code.contains('state_key = FlsAlloc(state_slot_free);')
-	assert windows_code.contains('FlsGetValue(state_key)')
-	assert windows_code.contains('FlsSetValue(state_key, p)')
+	assert windows_code.contains('GetProcAddress(kernel32, "FlsAlloc")')
+	assert windows_code.contains('GetProcAddress(kernel32, "FlsGetValue")')
+	assert windows_code.contains('GetProcAddress(kernel32, "FlsSetValue")')
+	assert windows_code.contains('fls_alloc(state_slot_free)')
+	assert windows_code.contains('state_fls_get(state_key)')
+	assert windows_code.contains('state_fls_set(state_key, p)')
+	assert !windows_code.contains('FlsAlloc(state_slot_free)')
+	assert !windows_code.contains('FlsGetValue(state_key)')
+	assert !windows_code.contains('FlsSetValue(state_key, p)')
 	assert windows_code.contains('state_slot_free(void* p) { free(p); }')
 	assert !windows_code.contains('pthread_')
 }
@@ -83,9 +89,11 @@ fn test_headerless_libc_preamble_declares_printf_for_cached_test_harnesses() {
 	assert c_code.contains('DWORD WINAPI TlsAlloc(void);'), c_code
 	assert c_code.contains('void* WINAPI TlsGetValue(DWORD index);'), c_code
 	assert c_code.contains('BOOL WINAPI TlsSetValue(DWORD index, void* value);'), c_code
-	assert c_code.contains('DWORD WINAPI FlsAlloc(void (WINAPI *callback)(void*));'), c_code
-	assert c_code.contains('void* WINAPI FlsGetValue(DWORD index);'), c_code
-	assert c_code.contains('BOOL WINAPI FlsSetValue(DWORD index, void* value);'), c_code
+	assert c_code.contains('void* WINAPI GetModuleHandleA(const char* module_name);'), c_code
+	assert c_code.contains('void* WINAPI GetProcAddress(void* module, const char* proc_name);'), c_code
+	assert !c_code.contains('DWORD WINAPI FlsAlloc('), c_code
+	assert !c_code.contains('void* WINAPI FlsGetValue('), c_code
+	assert !c_code.contains('BOOL WINAPI FlsSetValue('), c_code
 }
 
 fn test_headerless_libc_preamble_declares_qsort_for_generated_sort_helpers() {


### PR DESCRIPTION
## What changed

- resolve the Windows FLS APIs through GetProcAddress for TinyCC-generated programs
- retain FLS thread-exit cleanup when available, with the existing TLS API as a compatibility fallback
- remove direct FLS declarations/imports from the V3 headerless preamble
- cover both V1 autostr TLS and V3 thread-local slot generation

## Why

The bundled Windows TinyCC import library exports GetModuleHandleA, GetProcAddress, and the TLS APIs, but not FlsAlloc, FlsGetValue, or FlsSetValue. Direct FLS calls therefore broke vc bootstrap and nested compiler builds across all completed Windows master jobs.

## Validation

All commands used VJOBS=1.

- rebuilt vnew from cmd/v
- V1 autostr TLS regression
- V3 preamble regression
- V C-output suite: 231 applicable fixtures passed
- compiler error suite: 1696 passed, 1 skipped
- generated Windows compiler C with both backends; verified no direct FLS calls remain

FastC failures are intentionally out of scope.
