### PR TITLE
ci: fix remaining master failures

### DIFF
--- a/.github/workflows/sdl_ci.yml
+++ b/.github/workflows/sdl_ci.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     env:
-      VFLAGS: -cc tcc
+      VFLAGS: -cc tcc -old-compiler
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/cache-apt-packages-action

--- a/vlib/json/tests/json_decode_test.v
+++ b/vlib/json/tests/json_decode_test.v
@@ -15,7 +15,7 @@ mut:
 fn test_json_decode_fails_to_decode_unrecognised_array_of_dicts() {
 	data := '[{"twins":[{"id":123,"seed":"abcde","pubkey":"xyzasd"},{"id":456,"seed":"dfgdfgdfgd","pubkey":"skjldskljh45sdf"}]}]'
 	json.decode(TestTwins, data) or {
-		assert err.msg() == "expected field 'twins' is missing"
+		assert err.msg().starts_with('Json element is not an object:')
 		return
 	}
 	assert false

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -1317,6 +1317,12 @@ fn (mut v Builder) setup_ccompiler_options(ccompiler string) {
 				}
 			}
 		}
+		if ccoptions.cc == .clang && ccoptions.source_args.contains('-x none') {
+			// Clang 21 warns that this language reset is unused when no source follows it.
+			// Keep the reset for cached/object inputs, but do not let -cstrict promote that
+			// command-line warning to an error.
+			ccoptions.wargs << '-Wno-unused-command-line-argument'
+		}
 	}
 	if !v.pref.no_std {
 		ccoptions.source_args << ['-std=${c_std}', '-D_DEFAULT_SOURCE']

--- a/vlib/v/builder/cc_test.v
+++ b/vlib/v/builder/cc_test.v
@@ -118,6 +118,20 @@ fn test_macos_compile_args_append_macosx_version_min_after_cflags() {
 	]
 }
 
+fn test_macos_clang_cstrict_ignores_trailing_language_reset_warning() {
+	compile_args := macos_compile_args([
+		'-os',
+		'macos',
+		'-cc',
+		'clang',
+		'-cstrict',
+		'-usecache',
+		hello_world_example(),
+	])
+	assert compile_args.contains('-x none')
+	assert compile_args.contains('-Wno-unused-command-line-argument')
+}
+
 fn test_cc_from_string_detects_cl_as_msvc() {
 	assert pref.cc_from_string('cl') == .msvc
 	assert pref.cc_from_string('C:/Program Files/Microsoft Visual Studio/cl.exe') == .msvc

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -1238,15 +1238,11 @@ fn (mut g Gen) gen_str_for_struct(typ ast.Type, info ast.Struct, lang ast.Langua
 		if i in field_skips {
 			continue
 		}
-		ftyp_noshared := if field.typ.has_flag(.shared_f) {
-			field.typ.deref().clear_flag(.shared_f)
-		} else {
-			field.typ
-		}
+		ftyp_noshared := auto_str_shared_payload_type(field.typ)
 		mut ptr_amp := if ftyp_noshared.is_ptr() { '&' } else { '' }
 		mut base_typ := g.unwrap_generic(field.typ)
 		if base_typ.has_flag(.shared_f) {
-			base_typ = base_typ.clear_flag(.shared_f).deref()
+			base_typ = auto_str_shared_payload_type(base_typ)
 		}
 		base_fmt := g.type_to_fmt(base_typ)
 		is_opt_field := field.typ.has_flag(.option)
@@ -1371,8 +1367,8 @@ fn (mut g Gen) gen_str_for_struct(typ ast.Type, info ast.Struct, lang ast.Langua
 			if field.typ in ast.charptr_types {
 				fn_body.write_string('builtin__tos4((byteptr)${func})')
 			} else {
-				is_ptr_field := field.typ.is_ptr() && sym.kind in [.struct, .interface]
-				is_opt_ptr_field := field.typ.has_flag(.option) && field.typ.is_ptr()
+				is_ptr_field := ftyp_noshared.is_ptr() && sym.kind in [.struct, .interface]
+				is_opt_ptr_field := ftyp_noshared.has_flag(.option) && ftyp_noshared.is_ptr()
 					&& sym.kind in [.struct, .interface]
 				if is_ptr_field && !field.typ.has_flag(.option) {
 					// Use address-based circular reference detection for pointer fields.
@@ -1458,8 +1454,9 @@ fn struct_auto_str_func(sym &ast.TypeSymbol, lang ast.Language, _field_type ast.
 	$if trace_autostr ? {
 		eprintln('> struct_auto_str_func: ${sym.name} | field_type.debug() | ${fn_name} | ${field_name} | ${has_custom_str} | ${expects_ptr}')
 	}
-	field_type := if _field_type.has_flag(.shared_f) { _field_type.deref() } else { _field_type }
-	sufix := if field_type.has_flag(.shared_f) { '->val' } else { '' }
+	is_shared_field := _field_type.has_flag(.shared_f)
+	field_type := auto_str_shared_payload_type(_field_type)
+	sufix := if is_shared_field { '->val' } else { '' }
 	deref, _ := deref_kind(expects_ptr, field_type.is_ptr(), field_type)
 	final_field_name := if lang == .c { field_name } else { c_name(field_name) }
 	op := if lang == .c { '->' } else { '.' }
@@ -1535,6 +1532,14 @@ fn struct_auto_str_func(sym &ast.TypeSymbol, lang ast.Language, _field_type ast.
 		}
 		return method_str, false
 	}
+}
+
+fn auto_str_shared_payload_type(typ ast.Type) ast.Type {
+	if !typ.has_flag(.shared_f) {
+		return typ
+	}
+	payload_typ := typ.clear_flag(.shared_f)
+	return if payload_typ.is_ptr() { payload_typ.deref() } else { payload_typ }
 }
 
 fn data_str(x StrIntpType) string {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -13627,7 +13627,12 @@ fn (mut g Gen) type_default_impl(typ_ ast.Type, decode_sumtype bool) string {
 			if sym.is_empty_struct_array() {
 				return '{E_STRUCT}'
 			}
-			return '{0}'
+			info := sym.info as ast.ArrayFixed
+			elem_default := g.type_default(info.elem_type)
+			if elem_default in ['0', '{0}'] || g.inside_global_decl || g.inside_const {
+				return '{0}'
+			}
+			return '{${[]string{len: info.size, init: elem_default}.join(', ')}}'
 		}
 		.sum_type {
 			return if decode_sumtype { g.type_default_sumtype(typ, sym) } else { '{0}' }

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -3050,6 +3050,10 @@ fn (mut g Gen) gen_to_str_method_call(node ast.CallExpr, unwrapped_rec_type ast.
 			return true
 		}
 	}
+	if node.from_embed_types.len > 0 {
+		g.gen_expr_to_string(left_node, rec_type)
+		return true
+	}
 	rec_sym := g.table.sym(rec_type)
 	if g.alias_uses_parent_str(rec_sym) {
 		rec_type = (rec_sym.info as ast.Alias).parent_type

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -103,7 +103,7 @@ fn (mut g Gen) gen_jsons() {
 				init_styp += init_generated
 			} else if utyp.is_ptr() {
 				ptr_styp := g.styp(utyp.set_nr_muls(utyp.nr_muls() - 1))
-				init_styp += ' = HEAP(${ptr_styp}, {0})'
+				init_styp += ' = cJSON_IsNull(root) ? 0 : HEAP(${ptr_styp}, {0})'
 			}
 		}
 
@@ -182,6 +182,14 @@ ${enc_fn_dec} {
 		}
 		if is_js_prim(sym.name) && utyp.is_ptr() {
 			g.gen_prim_enc_dec(utyp, mut enc, mut dec)
+		} else if sym.name == 'time.Time' && !utyp.has_flag(.option) && !utyp.is_ptr() {
+			tmp_time_res := g.new_tmp_var()
+			dec.writeln('\t${result_name}_time__Time ${tmp_time_res} = json__decode_time(root);')
+			dec.writeln('\tif (${tmp_time_res}.is_error) {')
+			dec.writeln('\t\treturn ${tmp_time_res};')
+			dec.writeln('\t}')
+			dec.writeln('\tres = *(time__Time*)${tmp_time_res}.data;')
+			enc.writeln('\to = ${js_enc_name('i64')}(time__Time_unix(val));')
 		} else if sym.kind in [.array, .array_fixed] {
 			array_size := if sym.kind == .array_fixed {
 				(sym.info as ast.ArrayFixed).size
@@ -215,7 +223,7 @@ ${enc_fn_dec} {
 				}
 			} else if psym.info is ast.Struct {
 				enc.writeln('\to = cJSON_CreateObject();')
-				gen_struct_root_validation(ret_styp, mut dec)
+				gen_struct_root_validation(utyp, ret_styp, mut dec)
 				g.gen_struct_enc_dec(utyp, psym.info, ret_styp, mut enc, mut dec, '')
 			} else if psym.kind == .enum {
 				g.gen_enum_enc_dec(utyp, psym, mut enc, mut dec)
@@ -227,6 +235,16 @@ ${enc_fn_dec} {
 				g.gen_json_for_type(m.value_type)
 				dec.writeln(g.decode_map(utyp, m.key_type, m.value_type, ret_styp))
 				enc.writeln(g.encode_map(utyp, m.key_type, m.value_type))
+			} else if psym.kind in [.array, .array_fixed] {
+				array_size := if psym.kind == .array_fixed {
+					(psym.info as ast.ArrayFixed).size
+				} else {
+					-1
+				}
+				value_type := g.table.value_type(parent_typ)
+				g.gen_json_for_type(value_type)
+				dec.writeln(g.decode_array(utyp, value_type, array_size, ret_styp))
+				enc.writeln(g.encode_array(utyp, value_type, array_size))
 			} else if utyp.has_flag(.option) {
 				g.gen_option_enc_dec(utyp, mut enc, mut dec)
 			} else {
@@ -250,7 +268,7 @@ ${enc_fn_dec} {
 			if sym.info !is ast.Struct {
 				g.json_error(utyp, 'json: ${sym.name} is not struct')
 			}
-			gen_struct_root_validation(ret_styp, mut dec)
+			gen_struct_root_validation(utyp, ret_styp, mut dec)
 			g.gen_struct_enc_dec(utyp, sym.info, ret_styp, mut enc, mut dec, '')
 		}
 		// cJSON_delete
@@ -388,8 +406,15 @@ fn (mut g Gen) gen_prim_enc_dec(typ ast.Type, mut enc strings.Builder, mut dec s
 	}
 }
 
-fn gen_struct_root_validation(ret_styp string, mut dec strings.Builder) {
-	dec.writeln('\tif (!cJSON_IsObject(root) && !cJSON_IsNull(root) && !cJSON_IsArray(root)) {')
+fn gen_struct_root_validation(utyp ast.Type, ret_styp string, mut dec strings.Builder) {
+	if utyp.is_ptr() && !utyp.has_flag(.option) {
+		dec.writeln('\tif (cJSON_IsNull(root)) {')
+		dec.writeln('\t\t${result_name}_${ret_styp} ret;')
+		dec.writeln('\t\tbuiltin___result_ok(&res, (${result_name}*)&ret, sizeof(res));')
+		dec.writeln('\t\treturn ret;')
+		dec.writeln('\t}')
+	}
+	dec.writeln('\tif (!cJSON_IsObject(root)) {')
 	dec.writeln('\t\treturn (${result_name}_${ret_styp}){ .is_error = true, .err = builtin___v_error(builtin__string__plus(_S("Json element is not an object: "), json__json_print(root))), .data = {0} };')
 	dec.writeln('\t}')
 }

--- a/vlib/v/tests/usecache_interface_index_symbol_test.v
+++ b/vlib/v/tests/usecache_interface_index_symbol_test.v
@@ -56,7 +56,10 @@ fn test_usecache_builtin_autostr_globals_are_extern_only() {
 		os.execute('${os.quoted_path(vexe)} -old-compiler -usecache -o - ${os.quoted_path(source_path)}')
 	assert res.exit_code == 0, res.output
 	assert res.output.contains('extern Array_fixed_int_64 g_autostr_type_stack;'), res.output
-	assert res.output.contains('extern AutostrAddrStackState g_autostr_addr_state;'), res.output
+	assert res.output.contains('#define g_autostr_addr_state (*v_g_autostr_addr_state_tls_slot())'), res.output
+	assert res.output.contains('extern __declspec(thread) AutostrAddrStackState g_autostr_addr_state;'), res.output
+	assert res.output.contains('extern thread_local AutostrAddrStackState g_autostr_addr_state;'), res.output
+	assert res.output.contains('extern _Thread_local AutostrAddrStackState g_autostr_addr_state;'), res.output
 	assert !res.output.contains('extern Array_fixed_int_64 g_autostr_type_stack = {0};'), res.output
 	assert !res.output.contains('extern AutostrAddrStackState g_autostr_addr_state ='), res.output
 	assert !res.output.contains('g_autostr_type_stack = {0}; // global 3'), res.output

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -4231,19 +4231,24 @@ fn shared_storage_from_payload_value_expr(expr string) ?string {
 	return storage
 }
 
-fn (mut g FlatGen) gen_shared_array_push_arg(marker string, arg_id flat.NodeId) bool {
-	if !marker.starts_with('shared_array_push:') {
-		return false
-	}
+fn (mut g FlatGen) gen_shared_array_push_arg(marker string, target_id flat.NodeId, arg_id flat.NodeId) bool {
 	if int(arg_id) < 0 || int(arg_id) >= g.a.nodes.len {
 		return false
 	}
-	inner := marker['shared_array_push:'.len..].trim_space()
-	if inner.len == 0 {
-		return false
+	mut qualified := ''
+	mut wrapper := ''
+	if marker.starts_with('shared_array_push:') {
+		inner := marker['shared_array_push:'.len..].trim_space()
+		if inner.len == 0 {
+			return false
+		}
+		qualified = g.shared_qualify_type_text(inner, g.tc.cur_module)
+		wrapper = g.shared_wrapper_c_name(qualified)
+	} else {
+		info := g.shared_array_info_for_expr(target_id) or { return false }
+		qualified = info.inner
+		wrapper = info.wrapper
 	}
-	qualified := g.shared_qualify_type_text(inner, g.tc.cur_module)
-	wrapper := g.shared_wrapper_c_name(qualified)
 	mut value_id := arg_id
 	arg := g.a.nodes[int(arg_id)]
 	if arg.kind == .prefix && arg.op == .amp && arg.children_count > 0 {
@@ -7533,7 +7538,7 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 					}
 				}
 				if arg_idx == 1 && emitted_callee_name in ['array_push', 'array__push']
-					&& g.gen_shared_array_push_arg(node.value, arg_id) {
+					&& g.gen_shared_array_push_arg(node.value, g.a.child(&node, arg_start), arg_id) {
 					continue
 				}
 				if !is_c_call && arg_idx < typed_param_count
@@ -15381,7 +15386,7 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 			}
 		}
 		if arg_idx == 1 && fn_name in ['array_push', 'array__push']
-			&& g.gen_shared_array_push_arg(node.value, arg_id) {
+			&& g.gen_shared_array_push_arg(node.value, g.a.child(&node, start), arg_id) {
 			continue
 		}
 		if arg_idx == 0 && call_name_is_isnil(fn_name, callee_name)

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -2925,8 +2925,11 @@ fn (mut g FlatGen) shared_array_info_for_expr(id flat.NodeId) ?SharedArrayInfo {
 	if node.kind == .paren && node.children_count > 0 {
 		return g.shared_array_info_for_expr(g.a.child(&node, 0))
 	}
-	if node.kind == .prefix && node.op == .mul && node.children_count > 0 {
+	if node.kind == .prefix && node.op in [.amp, .mul] && node.children_count > 0 {
 		info := g.shared_array_info_for_expr(g.a.child(&node, 0))?
+		if node.op == .amp {
+			return info
+		}
 		return SharedArrayInfo{
 			inner: info.inner
 			wrapper: info.wrapper

--- a/vlib/v3/tests/lock_codegen_test.v
+++ b/vlib/v3/tests/lock_codegen_test.v
@@ -514,3 +514,21 @@ pub:
 	assert c_code.contains('v3_map_str(plain_record.values, 1, 1, 0)'), c_code
 	assert !c_code.contains('v3_map_str(plain_record.values->val,'), c_code
 }
+
+fn test_array_of_shared_append_boxes_payload() {
+	c_code := lock_codegen_gen_c('array_of_shared_append', 'struct Item {
+	value int
+}
+
+fn main() {
+	mut items := []shared Item{}
+	item := Item{
+		value: 7
+	}
+	items << item
+}
+')
+	assert c_code.contains('array_push(&items, &(__shared__main__main__Item*[]){'), c_code
+	assert c_code.contains('__dup__shared__main__main__Item'), c_code
+	assert !c_code.contains('main__Item __arr_val_0 = item;\n\tarray_push(&items, &__arr_val_0);'), c_code
+}


### PR DESCRIPTION
Fixes the remaining non-FastC failures from the latest completed master workflows.

- handle the Clang trailing language-reset warning in strict macOS usecache builds
- repair legacy Cgen JSON aliases, root validation, time decoding, and recursive fixed-array defaults
- avoid shared-field auto-string dereference panics and preserve outer embedded struct formatting
- box V3 array-of-shared append values even when the transform marker is unavailable
- update the auto-string cache assertion after the Windows TLS/FLS fix
- keep the SDL non-V3 workflow on the old compiler to avoid V3 memory-limit failures

Validation used VJOBS=1 throughout:
- 1696 compiler-error fixtures passed (1 skipped)
- full C-output suite passed (98 output fixtures + 133 pattern fixtures; platform skips excluded)
- all 50 vlib/json/tests cases passed
- exact Docker, s390, shared, usecache, and builder failures passed
- strict macOS Clang usecache build passed

FastC failures are intentionally excluded.