### PR TITLE
v3: speed up large application builds

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -10194,9 +10194,9 @@ pub fn run(args []string) {
 			monomorph_errors = clone_string_list(monomorph_errors)
 			generated_monomorph_specs = clone_monomorph_cache_specs(generated_monomorph_specs)
 			// Scoped specialization can leave parse-cache key text in a disposable
-			// worker arena. Cgen must reparse from the promoted AST instead of reading
-			// those keys after the monomorph scope is released.
-			pre_tc.set_fresh_type_cache(false)
+			// worker arena. Discard those entries, but keep parsing memoized for cgen:
+			// its keys come from the promoted AST and are safe after this scope ends.
+			pre_tc.set_fresh_type_cache(true)
 			prealloc_scope_free_for_v3(monomorph_scope)
 		} else {
 			monomorph_used_fns, monomorph_errors, generated_monomorph_specs = transform.monomorphize_with_used_checked_config_scoped_cached(mut a, &pre_tc, monomorph_input_used, !current_no_parallel

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -504,6 +504,8 @@ mut:
 	decl_attrs                    map[int][]string
 	decl_attrs_by_source_position map[u64][]string
 	c_decl_abi_names              map[string]string
+	export_c_abi_decls            map[string]flat.NodeId
+	main_export_owners            map[string][]string
 	c_extern_global_names         map[string]string
 	shared_type_names             map[string]SharedTypeInfo // __shared__ wrapper name -> wrapped type metadata
 	shared_alias_pointer_shorts   map[string]string // alias short name -> shared inner type; '' means ambiguous
@@ -1222,6 +1224,8 @@ pub fn FlatGen.new() FlatGen {
 		decl_attrs: map[int][]string{}
 		decl_attrs_by_source_position: map[u64][]string{}
 		c_decl_abi_names: map[string]string{}
+		export_c_abi_decls: map[string]flat.NodeId{}
+		main_export_owners: map[string][]string{}
 		c_extern_global_names: map[string]string{}
 		shared_type_names: map[string]SharedTypeInfo{}
 		shared_alias_pointer_shorts: map[string]string{}
@@ -3032,6 +3036,8 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.decl_attrs.clear()
 	g.decl_attrs_by_source_position.clear()
 	g.c_decl_abi_names.clear()
+	g.export_c_abi_decls.clear()
+	g.main_export_owners.clear()
 	g.c_extern_global_names.clear()
 	g.shared_type_names.clear()
 	g.shared_alias_pointer_shorts.clear()
@@ -4064,6 +4070,7 @@ fn (mut g FlatGen) collect_gen_info(no_parallel bool) {
 	mut presw := time.new_stopwatch()
 	g.unused_param_seen = &UnusedParamSeen{}
 	g.reserve_collect_gen_info_maps(no_parallel)
+	g.precompute_export_lookups()
 	if profile {
 		g.timing_profile('  [ttime]   ci reserve maps  ${f64(presw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		presw.restart()
@@ -10919,11 +10926,12 @@ fn c_strip_comments(text string) string {
 }
 
 fn (mut g FlatGen) collect_inlined_c_declared_fns(text string) {
-	g.collect_inlined_c_declarations(text)
+	without_comments := c_strip_comments(text)
+	g.collect_inlined_c_declarations_without_comments(without_comments)
 	// Inlined source text has not gone through the active-branch scanner. Keep
 	// every visible definition conservative, as before; only preserved headers
 	// can use their final preprocessor state to prove that a later #undef wins.
-	for line in c_strip_comments(text).split_into_lines() {
+	for line in without_comments.split_into_lines() {
 		clean := line.trim_space()
 		if clean.len == 0 || clean[0] != `#` || c_directive_name(clean) != 'define' {
 			continue
@@ -10940,11 +10948,15 @@ fn (mut g FlatGen) collect_inlined_c_declared_fns(text string) {
 }
 
 fn (mut g FlatGen) collect_inlined_c_declarations(text string) {
+	g.collect_inlined_c_declarations_without_comments(c_strip_comments(text))
+}
+
+fn (mut g FlatGen) collect_inlined_c_declarations_without_comments(text string) {
 	// Header declarations often span several lines (one parameter per line);
 	// accumulate a pending declaration until its terminating `;` so those are
 	// collected too, not just single-line prototypes.
 	mut pending := ''
-	for line in c_strip_comments(text).split_into_lines() {
+	for line in text.split_into_lines() {
 		clean := line.trim_space()
 		for name in c_macro_declared_fn_names(clean) {
 			g.inlined_c_declared_fns[name] = true

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -1071,8 +1071,24 @@ fn (g &FlatGen) export_fn_c_abi_key(module_name string, name string) ?string {
 	return none
 }
 
-fn (g &FlatGen) export_fn_c_abi_decl(module_name string, name string) ?flat.Node {
-	export_name := g.export_fn_name_in_module(module_name, name) or { return none }
+fn export_lookup_module(module_name string) string {
+	return if module_name in ['', 'main'] { 'main' } else { module_name }
+}
+
+fn export_c_abi_lookup_key(module_name string, export_name string) string {
+	return '${export_lookup_module(module_name)}\x01${export_name}'
+}
+
+fn (mut g FlatGen) precompute_export_lookups() {
+	g.export_c_abi_decls.clear()
+	g.main_export_owners.clear()
+	for qname, export_name in g.a.export_fn_names {
+		mut owners := g.main_export_owners[export_name] or { []string{} }
+		if qname !in owners {
+			owners << qname
+			g.main_export_owners[export_name] = owners
+		}
+	}
 	mut cur_module := ''
 	for idx in g.top_level_nodes() {
 		node := g.a.nodes[idx]
@@ -1084,13 +1100,21 @@ fn (g &FlatGen) export_fn_c_abi_decl(module_name string, name string) ?flat.Node
 			cur_module = node.value
 			continue
 		}
-		if node.kind != .c_fn_decl || node.value.trim_string_left('C.') != export_name {
+		if node.kind != .c_fn_decl {
 			continue
 		}
-		if cur_module == module_name
-			|| (cur_module in ['', 'main'] && module_name in ['', 'main']) {
-			return node
+		key := export_c_abi_lookup_key(cur_module, node.value.trim_string_left('C.'))
+		if key !in g.export_c_abi_decls {
+			g.export_c_abi_decls[key] = flat.NodeId(idx)
 		}
+	}
+}
+
+fn (g &FlatGen) export_fn_c_abi_decl(module_name string, name string) ?flat.Node {
+	export_name := g.export_fn_name_in_module(module_name, name) or { return none }
+	key := export_c_abi_lookup_key(module_name, export_name)
+	if idx := g.export_c_abi_decls[key] {
+		return g.a.nodes[int(idx)]
 	}
 	return none
 }
@@ -1236,8 +1260,8 @@ fn (g &FlatGen) main_export_name_owned_by_other_fn(module_name string, name stri
 		return false
 	}
 	natural_name := g.cname(name.trim_string_left('main.'))
-	for qname, export_name in g.a.export_fn_names {
-		if export_name == natural_name && qname != name && qname != 'main.${name}' {
+	for qname in g.main_export_owners[natural_name] {
+		if qname != name && qname != 'main.${name}' {
 			return true
 		}
 	}

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -2411,6 +2411,8 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		global_inits: g.global_inits
 		global_init_order: g.global_init_order
 		c_decl_abi_names: g.c_decl_abi_names
+		export_c_abi_decls: g.export_c_abi_decls
+		main_export_owners: g.main_export_owners
 		c_extern_global_names: g.c_extern_global_names
 		enum_backing_infos: g.enum_backing_infos
 		iface_impls: g.iface_impls

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -6842,11 +6842,24 @@ fn (t &Transformer) decode_single_generic_specialized_type_args(name string) ?[]
 	if isnil(t.tc) {
 		return none
 	}
+	if !isnil(t.generic_spec_decode_cache) {
+		mut cache := t.generic_spec_decode_cache
+		if decoded := cache.entries[name] {
+			return [decoded]
+		}
+		if name in cache.misses {
+			return none
+		}
+	}
 	for base, params in t.tc.struct_generic_params {
 		if params.len != 1 {
 			continue
 		}
-		if args := decode_single_generic_specialized_type_args_for_base(name, base) {
+		if args := t.decode_single_generic_specialized_type_args_for_base(name, base) {
+			if !isnil(t.generic_spec_decode_cache) {
+				mut cache := t.generic_spec_decode_cache
+				cache.entries[name] = args[0]
+			}
 			return args
 		}
 	}
@@ -6854,25 +6867,56 @@ fn (t &Transformer) decode_single_generic_specialized_type_args(name string) ?[]
 		if params.len != 1 {
 			continue
 		}
-		if args := decode_single_generic_specialized_type_args_for_base(name, base) {
+		if args := t.decode_single_generic_specialized_type_args_for_base(name, base) {
+			if !isnil(t.generic_spec_decode_cache) {
+				mut cache := t.generic_spec_decode_cache
+				cache.entries[name] = args[0]
+			}
 			return args
+		}
+	}
+	if !isnil(t.generic_spec_decode_cache) {
+		mut cache := t.generic_spec_decode_cache
+		cache.misses[name] = true
+	}
+	return none
+}
+
+fn (t &Transformer) decode_single_generic_specialized_type_args_for_base(name string, base string) ?[]string {
+	short_base := base.all_after_last('.')
+	if decoded := decode_single_generic_specialized_type_arg_with_prefix(name, base, base) {
+		return [decoded]
+	}
+	base_cname := t.tc.cached_c_name(base)
+	if base_cname != base {
+		if decoded := decode_single_generic_specialized_type_arg_with_prefix(name, base_cname, base) {
+			return [decoded]
+		}
+	}
+	if short_base != base {
+		if decoded := decode_single_generic_specialized_type_arg_with_prefix(name, short_base, base) {
+			return [decoded]
+		}
+	}
+	short_cname := t.tc.cached_c_name(short_base)
+	if short_cname != base && short_cname != base_cname && short_cname != short_base {
+		if decoded := decode_single_generic_specialized_type_arg_with_prefix(name, short_cname, base) {
+			return [decoded]
 		}
 	}
 	return none
 }
 
-fn decode_single_generic_specialized_type_args_for_base(name string, base string) ?[]string {
-	short_base := base.all_after_last('.')
-	for prefix in [base, c_name(base), short_base, c_name(short_base)] {
-		if !name.starts_with('${prefix}_') {
-			continue
-		}
-		decoded := generic_type_arg_from_suffix_with_containers(name[prefix.len + 1..])
-		if decoded.len > 0 && generic_specialized_type_matches_flat_name(name, base, [
-			decoded,
-		]) {
-			return [decoded]
-		}
+fn decode_single_generic_specialized_type_arg_with_prefix(name string, prefix string, base string) ?string {
+	if prefix.len == 0 || name.len <= prefix.len || name[prefix.len] != `_`
+		|| !name.starts_with(prefix) {
+		return none
+	}
+	decoded := generic_type_arg_from_suffix_with_containers(name[prefix.len + 1..])
+	if decoded.len > 0 && generic_specialized_type_matches_flat_name(name, base, [
+		decoded,
+	]) {
+		return decoded
 	}
 	return none
 }

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -4438,7 +4438,7 @@ fn (mut t Transformer) specialized_signature_type_text(decl GenericFnDecl, typ s
 }
 
 fn (t &Transformer) specialized_direct_generic_type_text(typ string, args []string, params []string) ?string {
-	clean := typ.trim_space()
+	clean := trimmed_transform_text(typ)
 	for i, param in params {
 		if clean == param && i < args.len {
 			return args[i]
@@ -11368,7 +11368,7 @@ fn generic_app_parts(typ string) (string, []string, bool) {
 	if bracket_end <= bracket || bracket_end >= typ.len {
 		return '', []string{}, false
 	}
-	inner := typ[bracket + 1..bracket_end].trim_space()
+	inner := trimmed_transform_text(typ[bracket + 1..bracket_end])
 	if typeof_display_is_fixed_array_len_text(inner) && !inner.starts_with('C.')
 		&& !inner.starts_with('JS.') {
 		return '', []string{}, false
@@ -11412,14 +11412,14 @@ fn split_generic_args(s string) []string {
 			}
 			`,` {
 				if bracket_depth == 0 && paren_depth == 0 {
-					parts << s[start..i].trim_space()
+					parts << trimmed_transform_text(s[start..i])
 					start = i + 1
 				}
 			}
 			else {}
 		}
 	}
-	parts << s[start..].trim_space()
+	parts << trimmed_transform_text(s[start..])
 	return parts
 }
 
@@ -11432,7 +11432,7 @@ fn normalize_generic_args(args []string, module_name string) []string {
 }
 
 fn normalize_generic_arg(arg string, module_name string) string {
-	clean := arg.trim_space()
+	clean := trimmed_transform_text(arg)
 	if clean.len == 0 {
 		return clean
 	}
@@ -11652,7 +11652,7 @@ fn substitute_generic_type_text(typ string, args []string) string {
 
 @[direct_array_access]
 fn substitute_generic_type_text_with_params(typ string, args []string, params []string) string {
-	clean := typ.trim_space()
+	clean := trimmed_transform_text(typ)
 	if clean.len == 0 || args.len == 0 {
 		return typ
 	}
@@ -13359,7 +13359,8 @@ fn (t &Transformer) canonical_short_fixed_array_arg(arg string) ?string {
 }
 
 fn (t &Transformer) recorded_generic_specialization_args(typ string) ?[]string {
-	clean := typ.trim_space().trim_left('&')
+	trimmed := trimmed_transform_text(typ)
+	clean := if trimmed.starts_with('&') { trimmed.trim_left('&') } else { trimmed }
 	if clean.len == 0 {
 		return none
 	}

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -225,6 +225,7 @@ mut:
 	module_type_cache             &AliasCache = unsafe { nil }
 	struct_guess_cache            &AliasCache = unsafe { nil }
 	generic_unresolved_cache      &GenericUnresolvedCache = unsafe { nil }
+	generic_spec_decode_cache     &LookupCache = unsafe { nil }
 	struct_field_type_cache       &LookupCache = unsafe { nil }
 	variant_short_name_cache      &AliasCache = unsafe { nil }
 	selector_type_cache           &SelectorTypeCache = unsafe { nil }
@@ -1708,6 +1709,10 @@ fn (mut t Transformer) prepare() {
 	t.struct_guess_cache = &AliasCache{}
 	t.var_type_cache = &VarTypeIndexCache{}
 	t.generic_unresolved_cache = &GenericUnresolvedCache{}
+	t.generic_spec_decode_cache = &LookupCache{
+		entries: map[string]string{}
+		misses: map[string]bool{}
+	}
 	t.receiver_method_cache = &ReceiverMethodCache{}
 	t.promote_text_cache = &PromoteTextCache{}
 	t.struct_field_type_cache = &LookupCache{
@@ -3657,6 +3662,10 @@ fn (t &Transformer) fork_worker_config(ast &flat.FlatAst, wtc &types.TypeChecker
 	w.struct_guess_cache = &AliasCache{}
 	w.var_type_cache = &VarTypeIndexCache{}
 	w.generic_unresolved_cache = &GenericUnresolvedCache{}
+	w.generic_spec_decode_cache = &LookupCache{
+		entries: map[string]string{}
+		misses: map[string]bool{}
+	}
 	w.receiver_method_cache = &ReceiverMethodCache{}
 	w.promote_text_cache = &PromoteTextCache{}
 	w.struct_field_type_cache = &LookupCache{
@@ -3788,6 +3797,10 @@ fn (t &Transformer) fork_scan_worker(wtc &types.TypeChecker) &Transformer {
 	w.struct_guess_cache = &AliasCache{}
 	w.var_type_cache = &VarTypeIndexCache{}
 	w.generic_unresolved_cache = &GenericUnresolvedCache{}
+	w.generic_spec_decode_cache = &LookupCache{
+		entries: map[string]string{}
+		misses: map[string]bool{}
+	}
 	w.receiver_method_cache = &ReceiverMethodCache{}
 	w.promote_text_cache = &PromoteTextCache{}
 	w.struct_field_type_cache = &LookupCache{
@@ -4249,6 +4262,9 @@ fn (mut t Transformer) clone_scoped_worker_node(idx int, scope voidptr) {
 	if node.typ.len > 0 && transform_scope_owns(scope, node.typ.str) {
 		_, typ := t.a.intern_text(node.typ)
 		node.typ = typ
+	}
+	if isnil(node.payload) {
+		return
 	}
 	old_params := node.generic_params()
 	if old_params.len > 0 {

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -1693,6 +1693,9 @@ fn (mut t Transformer) promote_scoped_node_to_current(idx int, scope voidptr) {
 	if node.typ.len > 0 && transform_scope_owns(scope, node.typ.str) {
 		node.typ = t.promote_scoped_result_text(node.typ)
 	}
+	if isnil(node.payload) {
+		return
+	}
 	old_params := node.generic_params()
 	if old_params.len == 0 {
 		return

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -424,6 +424,8 @@ mut:
 	struct_field_last_state     i8
 	struct_field_fn_diagnostics map[string]string
 	sum_variant_pattern_entries map[string]string
+	recv_pattern_entries        map[string]GenericReceiverMethodPatternMatch
+	recv_pattern_misses         map[string]bool
 	lexical_smartcast_entries   map[int]Type
 	lexical_smartcast_misses    map[int]bool
 	ierror_compat_entries       map[string]int
@@ -1560,6 +1562,8 @@ pub fn (mut tc TypeChecker) set_fresh_type_cache(parse_enabled bool) {
 		cache.clear_c_type_entries()
 		cache.struct_field_entries.clear()
 		cache.struct_field_misses.clear()
+		cache.recv_pattern_entries.clear()
+		cache.recv_pattern_misses.clear()
 		cache.ierror_compat_entries.clear()
 		cache.interface_impl_entries.clear()
 		cache.source_error_embed_entries.clear()
@@ -1659,6 +1663,8 @@ pub fn (mut tc TypeChecker) free_parallel_transform_caches() {
 			tc.type_cache.c_entries.free()
 			tc.type_cache.struct_field_entries.free()
 			tc.type_cache.struct_field_misses.free()
+			tc.type_cache.recv_pattern_entries.free()
+			tc.type_cache.recv_pattern_misses.free()
 			tc.type_cache.ierror_compat_entries.free()
 			tc.type_cache.interface_impl_entries.free()
 			tc.type_cache.source_error_embed_entries.free()
@@ -6263,6 +6269,7 @@ pub fn (mut tc TypeChecker) register_generated_fn_param_types(name string, param
 pub fn (mut tc TypeChecker) rebuild_fn_param_suffix_index() {
 	// Allocate a new map so callers rebuilding after a disposable prealloc
 	// scope do not retain its keys, values, or backing storage.
+	tc.clear_generic_receiver_pattern_cache()
 	tc.receiver_method_suffix_index = map[string]string{}
 	tc.generic_receiver_method_index = map[string][]string{}
 	tc.receiver_method_suffix_index.reserve(u32(tc.fn_param_types.len * 3))
@@ -6299,6 +6306,7 @@ fn (mut tc TypeChecker) add_receiver_method_suffix_index(name string) {
 		if name !in indexed {
 			indexed << name
 			tc.generic_receiver_method_index[method] = indexed
+			tc.clear_generic_receiver_pattern_cache()
 		}
 	}
 	tc.set_receiver_method_suffix_index(name, name)
@@ -6313,6 +6321,15 @@ fn (mut tc TypeChecker) add_receiver_method_suffix_index(name string) {
 			tc.set_receiver_method_suffix_index(name[i + 1..], name)
 		}
 	}
+}
+
+fn (tc &TypeChecker) clear_generic_receiver_pattern_cache() {
+	if isnil(tc.type_cache) {
+		return
+	}
+	mut cache := tc.type_cache
+	cache.recv_pattern_entries.clear()
+	cache.recv_pattern_misses.clear()
 }
 
 fn (mut tc TypeChecker) set_receiver_method_suffix_index(key string, name string) {

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -17068,6 +17068,16 @@ fn (tc &TypeChecker) generic_struct_method_alias_target(type_name string) string
 }
 
 fn (tc &TypeChecker) generic_receiver_method_pattern_match(base string, actual_args []string, method string) ?GenericReceiverMethodPatternMatch {
+	cache_key := '${tc.cur_file}\x00${tc.cur_module}\x00${tc.fn_context.generic_params.join(',')}\x00${base}\x00${actual_args.join(',')}\x00${method}'
+	if !isnil(tc.type_cache) {
+		cache := tc.type_cache
+		if matched := cache.recv_pattern_entries[cache_key] {
+			return matched
+		}
+		if cache.recv_pattern_misses[cache_key] {
+			return none
+		}
+	}
 	mut best := GenericReceiverMethodPatternMatch{}
 	mut found := false
 	for method_spelling in [method, '@${method}'] {
@@ -17117,7 +17127,15 @@ fn (tc &TypeChecker) generic_receiver_method_pattern_match(base string, actual_a
 		}
 	}
 	if !found {
+		if !isnil(tc.type_cache) {
+			mut cache := tc.type_cache
+			cache.recv_pattern_misses[cache_key] = true
+		}
 		return none
+	}
+	if !isnil(tc.type_cache) {
+		mut cache := tc.type_cache
+		cache.recv_pattern_entries[cache_key] = best
 	}
 	return best
 }


### PR DESCRIPTION
## Summary

- keep the fresh V3 type parse cache enabled for C generation after scoped monomorphization
- memoize repeated generic receiver and specialized type decoding queries
- precompute exported C ABI lookups and share them with Cgen workers
- avoid duplicate inline-C comment stripping and unnecessary AST payload/type-text allocations

## Fusecode benchmark

Cache-disabled production builds used Clang, `-gc none`, `-enable-globals`, and `-cflags -DLARGE_CONFIG` with `VJOBS=10`.

| Compiler | Runs | Average |
| --- | --- | ---: |
| optimized V3 | 20.65s, 20.53s | 20.59s |
| V 0.5.2 | 25.27s, 25.35s | 25.31s |

Optimized V3 is 4.72s (18.6%) faster end to end. A post-rebase confirmation measured 21.96s for V3 versus 26.24s for 0.5.2 (16.3% faster).

The frontend-only path improved from roughly 1.9s on the starting V3 revision to about 1.49s. V 0.5.2 remains around 0.89s frontend-only, while V3 emits about 9.53 MB of C versus 11.66 MB from 0.5.2, recovering the gap during Clang/LTO.

## Validation

- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew fmt -verify` for all changed V files
- `./vnew -old-compiler -check cmd/v`
- `./vnew -old-compiler vlib/v3/transform/monomorphize_test.v`
- `./vnew -old-compiler vlib/v3/transform/fn_test.v`
- `./vnew -old-compiler vlib/v3/types/checker_parallel_test.v`
- `./vnew -old-compiler vlib/v3/gen/c/inlined_c_header_scan_test.v`
- two full Fusecode builds with each compiler, plus one post-rebase confirmation pair
