### PR TITLE
v3: stop repeated lvalue stabilization

### DIFF
--- a/vlib/v3/tests/lvalue_receiver_stabilization_codegen_test.v
+++ b/vlib/v3/tests/lvalue_receiver_stabilization_codegen_test.v
@@ -1,0 +1,76 @@
+import os
+
+const lvalue_stabilization_vexe = @VEXE
+const lvalue_stabilization_tests_dir = os.dir(@FILE)
+const lvalue_stabilization_v3_dir = os.dir(lvalue_stabilization_tests_dir)
+const lvalue_stabilization_vlib_dir = os.dir(lvalue_stabilization_v3_dir)
+const lvalue_stabilization_v3_src = os.join_path(lvalue_stabilization_v3_dir, 'v3.v')
+
+fn test_lvalue_receiver_stabilization_finishes_after_one_redispatch() {
+	pid := os.getpid()
+	v3_bin := os.join_path(os.temp_dir(), 'v3_lvalue_stabilization_test_${pid}')
+	os.rm(v3_bin) or {}
+	build := os.execute('${os.quoted_path(lvalue_stabilization_vexe)} -old-compiler -gc none -no-parallel -path "${lvalue_stabilization_vlib_dir}|@vlib|@vmodules" -o ${os.quoted_path(v3_bin)} ${os.quoted_path(lvalue_stabilization_v3_src)}')
+	assert build.exit_code == 0, build.output
+
+	src := os.join_path(os.temp_dir(), 'v3_lvalue_stabilization_${pid}.v')
+	os.write_file(src, 'module main
+
+struct First {}
+
+struct Second {}
+
+type Node = First | Second
+
+struct Item {
+mut:
+	value int
+}
+
+fn (mut item Item) add(value int) {
+	item.value += value
+}
+
+struct Holder {
+mut:
+	item Item
+}
+
+fn update(node Node) int {
+	mut holder := Holder{
+		item: Item{
+			value: 40
+		}
+	}
+	holder.item.add(10 + (match node {
+		First { 5 }
+		Second { 6 }
+	}))
+	return holder.item.value
+}
+
+fn update_index(node Node) int {
+	mut items := [Item{
+		value: 40
+	}]
+	index := 0
+	items[index].add(10 + (match node {
+		First { 5 }
+		Second { 6 }
+	}))
+	return items[0].value
+}
+
+fn main() {
+	println(update(First{}))
+	println(update_index(First{}))
+}
+') or { panic(err) }
+	bin := os.join_path(os.temp_dir(), 'v3_lvalue_stabilization_${pid}')
+	compile := os.execute('${os.quoted_path(v3_bin)} -no-parallel ${os.quoted_path(src)} -b c -o ${os.quoted_path(bin)}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+	run := os.execute(os.quoted_path(bin))
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '55\n55', run.output
+}

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -11679,7 +11679,11 @@ fn (mut t Transformer) stabilize_original_lvalue_receiver(id flat.NodeId) ?flat.
 			if node.children_count == 0 {
 				return none
 			}
-			inner := t.stabilize_original_lvalue_receiver(t.a.child(&node, 0))?
+			child := t.a.child(&node, 0)
+			inner := t.stabilize_original_lvalue_receiver(child)?
+			if inner == child {
+				return id
+			}
 			return t.rebuild_transformed_lvalue(node, [inner])
 		}
 		.prefix {
@@ -11692,13 +11696,20 @@ fn (mut t Transformer) stabilize_original_lvalue_receiver(id flat.NodeId) ?flat.
 			} else {
 				t.spill_original_lvalue_component(child_id, 'recv_deref')
 			}
+			if new_child == child_id {
+				return id
+			}
 			return t.rebuild_transformed_lvalue(node, [new_child])
 		}
 		.selector {
 			if node.children_count == 0 {
 				return none
 			}
-			base := t.stabilize_original_lvalue_receiver(t.a.child(&node, 0))?
+			base_child := t.a.child(&node, 0)
+			base := t.stabilize_original_lvalue_receiver(base_child)?
+			if base == base_child {
+				return id
+			}
 			mut children := [base]
 			for i in 1 .. node.children_count {
 				children << t.a.child(&node, i)
@@ -11722,6 +11733,7 @@ fn (mut t Transformer) stabilize_original_lvalue_receiver(id flat.NodeId) ?flat.
 			} else {
 				t.stabilize_original_lvalue_receiver(base_child)?
 			}
+			mut changed := base != base_child
 			mut children := [base]
 			for i in 1 .. node.children_count {
 				comp_id := t.a.child(&node, i)
@@ -11729,11 +11741,18 @@ fn (mut t Transformer) stabilize_original_lvalue_receiver(id flat.NodeId) ?flat.
 				// prelude could mutate) into a temp while keeping the surrounding lvalue shape,
 				// so `items[idx].update(match ... { change(mut idx)! } ...)` mutates the element
 				// at the source-order index. A pure constant index needs no snapshot.
-				children << if t.is_pure_constant_expr(comp_id) {
+				component := if t.is_pure_constant_expr(comp_id) {
 					comp_id
 				} else {
 					t.spill_original_lvalue_component(comp_id, 'recv_index')
 				}
+				if component != comp_id {
+					changed = true
+				}
+				children << component
+			}
+			if !changed {
+				return id
 			}
 			return t.rebuild_transformed_lvalue(node, children)
 		}
@@ -11744,7 +11763,13 @@ fn (mut t Transformer) stabilize_original_lvalue_receiver(id flat.NodeId) ?flat.
 }
 
 fn (mut t Transformer) spill_original_lvalue_component(id flat.NodeId, prefix string) flat.NodeId {
+	if t.is_ordering_snapshot_temp(id) {
+		return id
+	}
 	transformed := t.transform_expr(id)
+	if t.is_ordering_snapshot_temp(transformed) {
+		return transformed
+	}
 	tmp_name := t.new_temp(prefix)
 	mut typ := t.node_type(transformed)
 	if typ.len == 0 {
@@ -11755,6 +11780,7 @@ fn (mut t Transformer) spill_original_lvalue_component(id flat.NodeId, prefix st
 	} else {
 		t.pending_stmts << t.make_decl_assign(tmp_name, transformed)
 	}
+	t.ordering_snapshot_names[tmp_name] = true
 	return t.make_ident(tmp_name)
 }
 


### PR DESCRIPTION
Fix a V3 transformer stack overflow in mutable method calls whose stable selector or indexed receiver precedes an argument containing a nested value match.

The ordering pass re-dispatched the rebuilt call but always rebuilt the same already-stable lvalue receiver, so the call recursively re-entered transform_call_expr until signal 139. Preserve an unchanged lvalue node and mark spilled dynamic receiver components as ordering snapshots so stabilization becomes idempotent.

This restores compilation of vlang/ui examples/rectangles.v, the non-FastC failure from the last completed V Apps and Modules master run.

Validation, all with VJOBS=1 and no parallel compiler work:
- focused lvalue stabilization codegen regression
- vlib/v3/transform/ordering_guard_test.v
- vlib/v/compiler_errors_test.v: 1696 passed, 1 skipped
- current vlang/ui examples/rectangles.v compiles successfully

The standalone regression exits 139 on pristine master and passes with this patch. The broad vlib/v suite was not run because previous broad sessions exhausted 100 GB; targeted serial coverage was used instead.