### PR TITLE
fmt: fix ECDSA and QUIC files

### DIFF
--- a/vlib/crypto/ecdsa/ecdsa_notd_use_openssl.c.v
+++ b/vlib/crypto/ecdsa/ecdsa_notd_use_openssl.c.v
@@ -356,7 +356,7 @@ fn C.mbedtls_ecdsa_init(ctx &C.mbedtls_ecdsa_context)
 
 fn C.mbedtls_ecdsa_free(ctx &C.mbedtls_ecdsa_context)
 
-fn C.mbedtls_ecdsa_genkey(ctx &C.mbedtls_ecdsa_context, gid int, f_rng fn(voidptr, &u8, usize) int, p_rng voidptr) int
+fn C.mbedtls_ecdsa_genkey(ctx &C.mbedtls_ecdsa_context, gid int, f_rng fn (voidptr, &u8, usize) int, p_rng voidptr) int
 
 // mbedtls_ecdsa_write_signature/read_signature operate on a whole context
 // (not bare grp/d/Q like the lower-level mbedtls_ecdsa_sign/verify) and
@@ -373,7 +373,7 @@ fn C.mbedtls_ecdsa_genkey(ctx &C.mbedtls_ecdsa_context, gid int, f_rng fn(voidpt
 // fails -- which it always does for MBEDTLS_MD_NONE (0), since md.c's own
 // switch has no case for it. PrivateKey.sign() (ecdsa_notd_use_openssl.v)
 // relies on this: it never calls write_signature with md_alg 0.
-fn C.mbedtls_ecdsa_write_signature(ctx &C.mbedtls_ecdsa_context, md_alg int, hash &u8, hlen usize, sig &u8, sig_size usize, slen &usize, f_rng fn(voidptr, &u8, usize) int, p_rng voidptr) int
+fn C.mbedtls_ecdsa_write_signature(ctx &C.mbedtls_ecdsa_context, md_alg int, hash &u8, hlen usize, sig &u8, sig_size usize, slen &usize, f_rng fn (voidptr, &u8, usize) int, p_rng voidptr) int
 
 fn C.mbedtls_ecdsa_read_signature(ctx &C.mbedtls_ecdsa_context, hash &u8, hlen usize, sig &u8, slen usize) int
 
@@ -421,13 +421,13 @@ fn C.mbedtls_mpi_cmp_mpi(x &C.mbedtls_mpi, y &C.mbedtls_mpi) int
 // directly from bare grp/d/Q -- the lower-level API, not the stateful
 // mbedtls_ecdh_context one, since this module never needs to hold ECDH
 // state across calls the way a TLS handshake would.
-fn C.mbedtls_ecdh_compute_shared(grp &C.mbedtls_ecp_group, z &C.mbedtls_mpi, q &C.mbedtls_ecp_point, d &C.mbedtls_mpi, f_rng fn(voidptr, &u8, usize) int, p_rng voidptr) int
+fn C.mbedtls_ecdh_compute_shared(grp &C.mbedtls_ecp_group, z &C.mbedtls_mpi, q &C.mbedtls_ecp_point, d &C.mbedtls_mpi, f_rng fn (voidptr, &u8, usize) int, p_rng voidptr) int
 
 fn C.mbedtls_ctr_drbg_init(ctx &C.mbedtls_ctr_drbg_context)
 
 fn C.mbedtls_ctr_drbg_free(ctx &C.mbedtls_ctr_drbg_context)
 
-fn C.mbedtls_ctr_drbg_seed(ctx &C.mbedtls_ctr_drbg_context, f_entropy fn(voidptr, &u8, usize), p_entropy voidptr, custom &u8, len usize) int
+fn C.mbedtls_ctr_drbg_seed(ctx &C.mbedtls_ctr_drbg_context, f_entropy fn (voidptr, &u8, usize), p_entropy voidptr, custom &u8, len usize) int
 
 fn C.mbedtls_ctr_drbg_random(p_rng voidptr, output &u8, output_len usize) int
 

--- a/vlib/crypto/ecdsa/ecdsa_notd_use_openssl_test.v
+++ b/vlib/crypto/ecdsa/ecdsa_notd_use_openssl_test.v
@@ -16,7 +16,7 @@ import crypto.sha512
 // crypto.ecdsa directory is run with -d use_openssl explicitly (this file
 // carries no vtest vflags of its own to force the flag either way).
 fn test_sign_with_custom_hash_is_not_implemented() ! {
-	$if use_openssl? {
+	$if use_openssl ? {
 		eprintln('skipping: .with_custom_hash signing IS implemented under -d use_openssl')
 		return
 	}

--- a/vlib/crypto/ecdsa/util_notd_use_openssl_test.v
+++ b/vlib/crypto/ecdsa/util_notd_use_openssl_test.v
@@ -13,7 +13,7 @@ module ecdsa
 // own to force the flag either way).
 
 fn test_pubkey_from_bytes_stub_error() {
-	$if use_openssl? {
+	$if use_openssl ? {
 		eprintln('skipping: pubkey_from_bytes IS implemented under -d use_openssl')
 		return
 	}
@@ -25,7 +25,7 @@ fn test_pubkey_from_bytes_stub_error() {
 }
 
 fn test_pubkey_from_string_stub_error() {
-	$if use_openssl? {
+	$if use_openssl ? {
 		eprintln('skipping: pubkey_from_string IS implemented under -d use_openssl')
 		return
 	}
@@ -37,7 +37,7 @@ fn test_pubkey_from_string_stub_error() {
 }
 
 fn test_privkey_from_string_stub_error() {
-	$if use_openssl? {
+	$if use_openssl ? {
 		eprintln('skipping: privkey_from_string IS implemented under -d use_openssl')
 		return
 	}

--- a/vlib/net/quic/coalesce_test.v
+++ b/vlib/net/quic/coalesce_test.v
@@ -303,7 +303,6 @@ fn test_split_coalesced_datagram_ignores_packet_with_mismatched_dcid() {
 
 	packets := split_coalesced_datagram(buf)!
 	assert packets.len == 2 // the mismatched middle packet is excluded
-	
 
 	h_first, _ := parse_long_header(packets[0].bytes)!
 	h_last, _ := parse_long_header(packets[1].bytes)!

--- a/vlib/net/quic/congestion_control_test.v
+++ b/vlib/net/quic/congestion_control_test.v
@@ -78,7 +78,6 @@ fn test_slow_start_resumes_after_persistent_congestion_drops_below_ssthresh() {
 	]
 	c.on_packets_acked(acked)
 	assert c.congestion_window == 2400 + 1200 // full slow-start growth
-	
 }
 
 fn test_on_packets_acked_does_not_grow_window_during_recovery() {
@@ -131,7 +130,6 @@ fn test_on_packets_lost_ordinary_loss_halves_window_via_ssthresh() {
 
 	assert c.bytes_in_flight == 0
 	assert c.ssthresh or { 0 } == 6000 // initial_window(12000) * 0.5
-	
 
 	assert c.congestion_window == 6000
 	assert c.congestion_recovery_start_time or { 0 } == 5000
@@ -180,7 +178,6 @@ fn test_single_reaction_per_recovery_episode() {
 	]
 	c.on_packets_lost(first_loss, false, 5000)
 	assert c.congestion_window == 6000 // 12000 * 0.5
-	
 
 	assert c.congestion_recovery_start_time or { 0 } == 5000
 
@@ -197,10 +194,8 @@ fn test_single_reaction_per_recovery_episode() {
 	]
 	c.on_packets_lost(second_loss, false, 6000)
 	assert c.congestion_window == 6000 // unchanged: still one reaction
-	
 
 	assert c.congestion_recovery_start_time or { 0 } == 5000 // unchanged
-	
 
 	// Sent at time 7000, AFTER the recovery episode started (5000) -- a
 	// genuinely new loss episode, must react again.
@@ -215,7 +210,6 @@ fn test_single_reaction_per_recovery_episode() {
 	]
 	c.on_packets_lost(third_loss, false, 8000)
 	assert c.congestion_window == 3000 // 6000 * 0.5
-	
 
 	assert c.congestion_recovery_start_time or { 0 } == 8000
 }

--- a/vlib/net/quic/conn_test.v
+++ b/vlib/net/quic/conn_test.v
@@ -490,7 +490,6 @@ fn test_stream_write_read_round_trip_over_fake_transport() {
 
 	stream_id := c.open_stream(true)!
 	assert stream_id == 0 // first client-initiated bidi stream id, RFC 9000 §2.1
-	
 
 	c.write_stream(stream_id, 'hello from client'.bytes(), true)!
 	result := c.poll(none, now)!
@@ -581,7 +580,6 @@ fn test_close_sends_connection_close_and_transitions_to_closing() {
 
 	c.close(42, 'bye')
 	assert c.state() == .established // deferred -- nothing happens synchronously
-	
 
 	result := c.poll(none, now)!
 	assert c.state() == .closing
@@ -659,7 +657,6 @@ fn test_close_before_one_rtt_keys_downgrades_to_transport_connection_close() {
 	assert result2.events.len == 0
 	assert c.handshake.state() == .wait_certificate
 	assert c.app_write_keys == none // still pre-1-RTT -- the window this bug lives in
-	
 
 	now += 10
 
@@ -1466,7 +1463,6 @@ fn test_stream_recv_status_reports_all_three_terminal_states() {
 		c.handshake.free()
 	}
 	assert c.stream_recv_status(1) == none // never seen at all
-	
 
 	read_keys := c.app_read_keys or { panic('unreachable: established asserts this') }
 	server_app_keys := read_keys.current_keys

--- a/vlib/net/quic/crypto_stream_test.v
+++ b/vlib/net/quic/crypto_stream_test.v
@@ -82,10 +82,8 @@ fn test_crypto_stream_reassembler_merges_partially_overlapping_pending_fragments
 		r.add(u64(100 + i), []u8{len: 100, init: 0x41})!
 	}
 	assert r.pending.len == 1 // all merged into one entry, never hit the cap
-	
 
 	assert r.consumed_len() == 0 // gap before offset 100 still open
-	
 
 	r.add(0, []u8{len: 100})! // close the gap
 	// merged pending range is [100, 200+count-1) -- union of every
@@ -157,7 +155,6 @@ fn test_crypto_stream_reassembler_deduplicates_retransmitted_pending_fragment() 
 		r.add(100, 'retransmitted'.bytes())!
 	}
 	assert r.consumed_len() == 0 // gap before offset 100 still open
-	
 
 	r.add(0, []u8{len: 100})! // close the gap
 	assert r.data()[100..].bytestr() == 'retransmitted'
@@ -168,7 +165,6 @@ fn test_crypto_stream_reassembler_three_way_out_of_order() {
 	r.add(7, 'World!'.bytes())! // 'Hello'(5) + ', '(2) = offset 7
 	r.add(5, ', '.bytes())!
 	assert r.consumed_len() == 0 // still a gap before offset 5
-	
 
 	r.add(0, 'Hello'.bytes())!
 	assert r.data().bytestr() == 'Hello, World!'

--- a/vlib/net/quic/flow_control_test.v
+++ b/vlib/net/quic/flow_control_test.v
@@ -52,11 +52,9 @@ fn test_receive_window_auto_growth_heuristic() {
 	assert w.should_advertise_more() == false
 	w.note_read(40)
 	assert w.should_advertise_more() == false // less than half
-	
 
 	w.note_read(50)
 	assert w.should_advertise_more() == true // >= half (50/100)
-	
 
 	next := w.next_advertised_limit()
 	assert next == 200
@@ -76,7 +74,6 @@ fn test_receive_window_note_read_is_capped_to_received() {
 	w.note_received(30)!
 	w.note_read(80) // must never be trusted beyond what has actually arrived
 	assert w.should_advertise_more() == false // true only if the uncapped 80 were trusted (80 >= 50)
-	
 }
 
 fn test_receive_window_mark_advertised_never_regresses() {
@@ -122,24 +119,18 @@ fn test_initial_stream_limits_hand_derived_client_perspective() {
 	// SEND limits (how much the CLIENT may send), governed by the SERVER's
 	// (peer's) parameters:
 	assert initial_send_limit_for_stream(client_bidi, .client, peer_params) == 2000 // peer's _bidi_remote
-	
 
 	assert initial_send_limit_for_stream(server_bidi, .client, peer_params) == 1000 // peer's _bidi_local
-	
 
 	assert initial_send_limit_for_stream(client_uni, .client, peer_params) == 3000 // peer's _uni
-	
 
 	// RECEIVE limits (how much the CLIENT has told the server it may
 	// send), governed by the CLIENT's OWN parameters:
 	assert initial_receive_limit_for_stream(client_bidi, .client, own_params) == 4000 // own _bidi_local
-	
 
 	assert initial_receive_limit_for_stream(server_bidi, .client, own_params) == 5000 // own _bidi_remote
-	
 
 	assert initial_receive_limit_for_stream(server_uni, .client, own_params) == 6000 // own _uni
-	
 }
 
 fn test_initial_stream_limits_default_to_zero_when_absent() {
@@ -169,7 +160,6 @@ fn test_connection_vs_stream_window_interplay() {
 	conn_window.consume(100)!
 	assert conn_window.available() == 0
 	assert stream_window.available() == 900 // stream itself still has room
-	
 
 	// A further send that the STREAM window alone would happily allow
 	// must still be rejected because the CONNECTION window is exhausted --

--- a/vlib/net/quic/frame_test.v
+++ b/vlib/net/quic/frame_test.v
@@ -165,7 +165,6 @@ fn test_ack_frame_with_ecn_counts_round_trip() {
 	}
 	encoded := encode_ack_frame(ranges, 0, ecn)!
 	assert encoded[0] == 0x03 // ACK-with-ECN frame type
-	
 
 	frame, _ := parse_frame(encoded)!
 	match frame {
@@ -236,7 +235,6 @@ fn test_encode_ack_frame_rejects_range_with_largest_less_than_smallest() {
 
 fn test_scaled_ack_delay_micros_normal_value() {
 	assert scaled_ack_delay_micros(100, 3) == 800 // 100 << 3
-	
 }
 
 fn test_scaled_ack_delay_micros_saturates_instead_of_wrapping() {

--- a/vlib/net/quic/h3_frame_test.v
+++ b/vlib/net/quic/h3_frame_test.v
@@ -13,7 +13,6 @@ fn test_data_frame_roundtrip() {
 	}
 	assert encoded[0] == u8(h3_frame_data)
 	assert encoded[1] == u8(5) // length, 1-byte varint
-	
 }
 
 fn test_headers_frame_roundtrip() {

--- a/vlib/net/quic/h3_reserved_test.v
+++ b/vlib/net/quic/h3_reserved_test.v
@@ -25,31 +25,22 @@ fn test_is_h3_reserved_codepoint_rejects_defined_values() {
 	// None of the values this phase actually assigns meaning to may ever
 	// collide with the grease sequence -- spot-check the ones in scope.
 	assert !is_h3_reserved_codepoint(0x00) // DATA / control stream type
-	
 
 	assert !is_h3_reserved_codepoint(0x01) // HEADERS / push stream type
-	
 
 	assert !is_h3_reserved_codepoint(0x03) // CANCEL_PUSH
-	
 
 	assert !is_h3_reserved_codepoint(0x04) // SETTINGS
-	
 
 	assert !is_h3_reserved_codepoint(0x06) // MAX_FIELD_SECTION_SIZE setting
-	
 
 	assert !is_h3_reserved_codepoint(0x07) // GOAWAY
-	
 
 	assert !is_h3_reserved_codepoint(0x0d) // MAX_PUSH_ID
-	
 
 	assert !is_h3_reserved_codepoint(0x0100) // H3_NO_ERROR
-	
 
 	assert !is_h3_reserved_codepoint(0x0110) // H3_VERSION_FALLBACK
-	
 }
 
 fn test_is_h3_reserved_codepoint_rejects_values_below_first_grease_term() {

--- a/vlib/net/quic/handshake_confirm_test.v
+++ b/vlib/net/quic/handshake_confirm_test.v
@@ -24,12 +24,10 @@ fn test_handshake_completion_requires_both_finished_events() {
 	mut s := new_handshake_completion_state()
 	s.mark_own_finished_sent()
 	assert s.is_complete() == false // only one of the two conditions met
-	
 
 	mut s2 := new_handshake_completion_state()
 	s2.mark_peer_finished_verified()
 	assert s2.is_complete() == false // only the other condition met
-	
 
 	mut s3 := new_handshake_completion_state()
 	s3.mark_own_finished_sent()
@@ -58,7 +56,6 @@ fn test_handshake_completion_confirmed_after_normal_ordering() {
 	s.mark_own_finished_sent()
 	s.mark_peer_finished_verified()
 	assert s.is_confirmed() == false // complete, but HANDSHAKE_DONE not yet seen
-	
 
 	s.mark_handshake_done_received()
 	assert s.is_confirmed() == true

--- a/vlib/net/quic/header_test.v
+++ b/vlib/net/quic/header_test.v
@@ -286,16 +286,12 @@ fn test_encode_short_header_round_trips_through_parse() {
 	// function assumes header protection has already been removed and would
 	// reject these reserved bits as nonzero.
 	assert encoded[0] & 0x40 != 0 // Fixed Bit always set
-	
 
 	assert encoded[0] & 0x20 != 0 // spin_bit
-	
 
 	assert encoded[0] & 0x04 != 0 // key_phase
-	
 
 	assert encoded[0] & 0x03 == 0x3 // pn_length_bits
-	
 
 	assert encoded[1..] == dcid
 

--- a/vlib/net/quic/idle_timeout_test.v
+++ b/vlib/net/quic/idle_timeout_test.v
@@ -66,14 +66,12 @@ fn test_idle_timeout_state_reset_asymmetry() {
 	// very next sentence).
 	s.note_packet_received(ms1400)
 	assert !s.is_idle(timeout, ms1500, 0) // now measured from ms1400
-	
 
 	assert s.is_idle(timeout, ms2500, 0)
 
 	// ANY send restarts the timer, ack-eliciting or not.
 	s.note_packet_sent(ms2400)
 	assert !s.is_idle(timeout, ms2500, 0) // now measured from ms2400
-	
 
 	assert s.is_idle(timeout, ms3500, 0)
 }

--- a/vlib/net/quic/key_update_test.v
+++ b/vlib/net/quic/key_update_test.v
@@ -97,7 +97,6 @@ fn test_key_update_state_tolerates_resolving_before_committing() {
 	resolution_b := s.resolve_read_keys(true, 105)!
 	assert resolution_a.is_new_update == true
 	assert resolution_b.is_new_update == true // stale-but-expected: nothing committed yet
-	
 
 	s.note_successful_decrypt(resolution_a, 100)!
 	assert s.current_phase_bit() == true
@@ -170,7 +169,6 @@ fn test_key_update_state_second_update_does_not_corrupt_bookkeeping_via_stale_re
 	// Commit the genuine second update first.
 	s.note_successful_decrypt(new_resolution, 200)!
 	assert s.current_phase_bit() == false // back to phase 0, by parity -- generation 2
-	
 
 	// Commit the OLD, generation-0 resolution. Its phase bit (false) now
 	// coincidentally matches s.current_phase (also false, but for

--- a/vlib/net/quic/qpack_appendix_b_test.v
+++ b/vlib/net/quic/qpack_appendix_b_test.v
@@ -48,7 +48,6 @@ fn test_appendix_b2_dynamic_table() {
 
 	assert dec.dynamic_table.insert_count() == 2
 	assert dec.dynamic_table.size() == 106 // RFC's own shown running total
-	
 
 	field_section := [u8(0x03), 0x81, 0x10, 0x11]
 	result := dec.decode_field_section(4, field_section) or { panic('${err}') }

--- a/vlib/net/quic/qpack_dynamic_table_test.v
+++ b/vlib/net/quic/qpack_dynamic_table_test.v
@@ -186,10 +186,8 @@ fn test_dynamic_table_can_set_capacity_forbids_evicting_unacknowledged_entry() {
 	// here makes it doubly so. Shrinking to 10 can't fit the 34-byte entry.
 	assert !t.can_set_capacity(10, 0)
 	assert t.can_set_capacity(100, 0) // no shrink needed -- always safe
-	
 
 	assert t.can_set_capacity(1000, 0) // growth -- always safe
-	
 }
 
 fn test_dynamic_table_can_set_capacity_allows_evicting_acknowledged_unreferenced_entry() {

--- a/vlib/net/quic/qpack_encoder_test.v
+++ b/vlib/net/quic/qpack_encoder_test.v
@@ -138,7 +138,6 @@ fn test_encoder_full_round_trip_through_decoder_with_insertion() {
 	]
 	result := e.encode_field_section(5, lines) or { panic('${err}') }
 	assert result.encoder_instructions.len > 0 // new name+value -> should insert
-	
 
 	applied := dec.apply_encoder_instruction(result.encoder_instructions) or { panic('${err}') }
 	assert applied.applied
@@ -222,7 +221,6 @@ fn test_phase_r_dynamic_name_reference_without_insertion_tracks_required_insert_
 		},
 	]) or { panic('${err}') }
 	assert first.encoder_instructions.len > 0 // confirms it actually got inserted
-	
 
 	e.note_section_acknowledged(1) or { panic('${err}') }
 
@@ -278,5 +276,4 @@ fn test_phase_r_set_capacity_rejects_reducing_below_a_referenced_entry() {
 	assert got.name == 'x'
 	assert got.value == '1'
 	assert e.dynamic_table.capacity() == 100 // the resize itself must not have taken effect
-	
 }

--- a/vlib/net/quic/qpack_primitives_test.v
+++ b/vlib/net/quic/qpack_primitives_test.v
@@ -88,7 +88,6 @@ fn test_decode_prefixed_string_huffman_flag_set_correctly() {
 	_, huffman, _ := decode_prefixed_string(out, 7) or { panic('${err}') }
 	assert huffman
 	assert out.len < 11 // shorter than the 1 (length byte) + 10 (raw) it would take unencoded
-	
 }
 
 fn test_decode_prefixed_string_rejects_oversized_declared_length() {

--- a/vlib/net/quic/rtt_test.v
+++ b/vlib/net/quic/rtt_test.v
@@ -42,13 +42,10 @@ fn test_rtt_estimator_subsequent_sample_uses_ewma() {
 	r.update(.application_data, 140 * time.millisecond, 10 * time.millisecond, 25 * time.millisecond, false)
 
 	assert r.min_rtt == 100 * time.millisecond // unchanged: 140ms is not a new minimum
-	
 
 	assert r.rttvar == 45 * time.millisecond // (50*3 + |100-130|) / 4 = 180/4
-	
 
 	assert r.smoothed_rtt == 103_750_000 * time.nanosecond // (100*7 + 130) / 8 = 830/8
-	
 
 	assert r.latest_rtt == 140 * time.millisecond
 }
@@ -69,10 +66,8 @@ fn test_rtt_estimator_ack_delay_never_pushes_below_min_rtt() {
 
 	assert r.min_rtt == 50 * time.millisecond
 	assert r.rttvar == 112_500_000 * time.nanosecond // (100*3 + |200-50|) / 4 = 450/4
-	
 
 	assert r.smoothed_rtt == 181_250_000 * time.nanosecond // (200*7 + 50) / 8 = 1450/8
-	
 }
 
 // test_rtt_estimator_ack_delay_ignored_for_initial_and_handshake confirms
@@ -107,20 +102,16 @@ fn test_rtt_estimator_max_ack_delay_clamp_only_after_confirmation() {
 	unconfirmed.update(.application_data, 150 * time.millisecond, 40 * time.millisecond, 10 * time.millisecond, false)
 	// unclamped: adjusted_rtt = 150 - 40 = 110ms
 	assert unconfirmed.rttvar == 40 * time.millisecond // (50*3 + |100-110|)/4 = 160/4
-	
 
 	assert unconfirmed.smoothed_rtt == 101_250_000 * time.nanosecond // (100*7+110)/8 = 810/8
-	
 
 	mut confirmed := new_rtt_estimator()
 	confirmed.update(.application_data, 100 * time.millisecond, 0, 0, false)
 	confirmed.update(.application_data, 150 * time.millisecond, 40 * time.millisecond, 10 * time.millisecond, true)
 	// clamped to max_ack_delay: adjusted_rtt = 150 - 10 = 140ms
 	assert confirmed.rttvar == 47_500_000 * time.nanosecond // (50*3 + |100-140|)/4 = 190/4
-	
 
 	assert confirmed.smoothed_rtt == 105 * time.millisecond // (100*7+140)/8 = 840/8
-	
 }
 
 fn test_rtt_estimator_pto_period_uses_kinitialrtt_before_any_sample() {

--- a/vlib/net/quic/stream_layer_test.v
+++ b/vlib/net/quic/stream_layer_test.v
@@ -71,7 +71,6 @@ fn test_multi_stream_interleaved_reassembly_and_flow_control() {
 	assert s3.recv.reassembler.data().bytestr() == 'FooBar'
 	assert s3.recv.state == .data_recvd
 	assert !s3.has_send() // confirmed recv-only, as a peer-initiated uni stream must be
-	
 
 	assert s4.recv.reassembler.data().bytestr() == 'X'
 	assert s4.recv.state == .data_recvd

--- a/vlib/net/quic/stream_reassembly_test.v
+++ b/vlib/net/quic/stream_reassembly_test.v
@@ -52,7 +52,6 @@ fn test_stream_reassembler_discard_frees_held_window_and_preserves_consumed_len(
 	r.discard(5)!
 	assert r.data().bytestr() == 'world'
 	assert r.consumed_len() == 10 // unchanged -- discard doesn't un-receive data
-	
 }
 
 fn test_stream_reassembler_discard_is_idempotent_for_a_stale_base() {

--- a/vlib/net/quic/stream_test.v
+++ b/vlib/net/quic/stream_test.v
@@ -200,11 +200,9 @@ fn test_recv_half_state_transitions_data_then_fin() {
 	assert h.state == .recv
 	h.note_data(0, [u8(1), 2, 3])!
 	assert h.state == .recv // final size still unknown
-	
 
 	h.note_size_known(3)!
 	assert h.state == .data_recvd // all 3 bytes already present
-	
 }
 
 fn test_recv_half_state_transitions_fin_before_all_data() {
@@ -213,7 +211,6 @@ fn test_recv_half_state_transitions_fin_before_all_data() {
 	}
 	h.note_size_known(5)!
 	assert h.state == .size_known // final size known, but no data yet
-	
 
 	h.note_data(0, [u8(1), 2, 3, 4, 5])!
 	assert h.state == .data_recvd
@@ -240,7 +237,6 @@ fn test_send_half_reset_sent_does_not_regress_from_reset_recvd() {
 	h.mark_reset_sent(9)
 	assert h.state == .reset_recvd
 	assert h.error_code or { 0 } == 7 // unchanged from the original reset
-	
 }
 
 fn test_recv_half_reset_recvd() {

--- a/vlib/net/quic/tls13_client_hello_test.v
+++ b/vlib/net/quic/tls13_client_hello_test.v
@@ -331,7 +331,6 @@ fn test_build_client_hello_structure() {
 	body := msg.body
 	mut cursor := 0
 	assert body[cursor] == 0x03 && body[cursor + 1] == 0x03 // legacy_version
-	
 
 	cursor += 2
 	assert body[cursor..cursor + 32] == random
@@ -343,7 +342,6 @@ fn test_build_client_hello_structure() {
 	assert cipher_suites_len == 2
 	cursor += 2
 	assert body[cursor] == 0x13 && body[cursor + 1] == 0x01 // TLS_AES_128_GCM_SHA256
-	
 
 	cursor += cipher_suites_len
 	compression_len := int(body[cursor])
@@ -386,7 +384,6 @@ fn test_build_client_hello_structure() {
 	list_len := (u32(alpn_data[0]) << 8) | u32(alpn_data[1])
 	assert list_len == 3
 	assert alpn_data[2] == 2 // protocol name length
-	
 
 	assert alpn_data[3..5].bytestr() == 'h3'
 }

--- a/vlib/net/quic/tls13_server_hello_test.v
+++ b/vlib/net/quic/tls13_server_hello_test.v
@@ -23,7 +23,6 @@ fn test_parse_server_hello_matches_rfc8448_vector() {
 			assert result.cipher_suite == cipher_suite_tls_aes_128_gcm_sha256
 			assert result.selected_version == tls_version_1_3
 			assert result.key_share_group == 0x001d // x25519, per RFC 8448's own trace
-			
 
 			assert result.key_share_key_exchange == hex.decode(rfc8448_server_hello_x25519_key_exchange)!
 			assert result.extensions.len == 2
@@ -369,7 +368,6 @@ fn test_parse_encrypted_extensions_rejects_key_share() {
 	body << ext
 	parse_encrypted_extensions(body) or {
 		assert err.msg().contains('0x0033') // ext_key_share == 0x33
-		
 
 		assert err.code() == int(tls_alert_to_quic_error(.unsupported_extension))
 		return
@@ -471,7 +469,6 @@ fn test_parse_server_hello_rejects_unsolicited_alpn() {
 	body := build_test_server_hello([]u8{len: 32}, ks_ext, alpn_ext)
 	parse_server_hello(body) or {
 		assert err.msg().contains('0x0010') // ext_alpn == 0x10
-		
 
 		assert err.code() == int(tls_alert_to_quic_error(.unsupported_extension))
 		return


### PR DESCRIPTION
Fix the 25 vfmt failures introduced by the ECDSA mbedTLS and QUIC merge now on master.

This is formatting-only: normalize function-type spacing in the mbedTLS declarations, custom-define spacing in ECDSA tests, and redundant blank lines in QUIC tests.

Validation, all with VJOBS=1:
- v fmt -inprocess -verify on all 25 affected files
- vlib/crypto/ecdsa: 8 passed
- vlib/net/quic: 54 passed
- git diff --check

The failure was taken directly from the completed tcc-linux check on PR #28303, whose merge commit is now on master.