### PR TITLE
v3: reduce monomorph metadata rescans

### DIFF
--- a/vlib/v3/transform/comptime.v
+++ b/vlib/v3/transform/comptime.v
@@ -2411,7 +2411,8 @@ fn (t &Transformer) comptime_option_unwrapped_local_type(name string, call flat.
 	for _ in 0 .. 4 {
 		mut found_offset := -1
 		mut next_name := ''
-		for candidate in t.a.nodes {
+		for candidate_id in t.local_decl_nodes_by_name[source_name] {
+			candidate := t.a.nodes[candidate_id]
 			if candidate.kind != .decl_assign || candidate.children_count < 2
 				|| !candidate.pos.is_valid() || candidate.pos.id != call.pos.id
 				|| candidate.pos.offset >= call.pos.offset || candidate.pos.offset <= found_offset {
@@ -2429,27 +2430,41 @@ fn (t &Transformer) comptime_option_unwrapped_local_type(name string, call flat.
 		}
 		source_name = next_name
 	}
-	for candidate in t.a.nodes {
-		if candidate.kind != .if_expr || candidate.children_count < 2 {
-			continue
+	if t.source_parent_ids.len > 0 {
+		for candidate_id in t.if_expr_nodes_by_file[call.pos.id] {
+			if t.comptime_option_guard_unwraps(t.a.nodes[candidate_id], source_name, call) {
+				return fm.comptime_typ[1..].trim_space()
+			}
 		}
-		body := t.a.child_node(&candidate, 1)
-		if !body.pos.is_valid() || body.pos.id != call.pos.id || call.pos.offset < body.pos.offset
-			|| call.pos.offset > body.pos.end {
-			continue
-		}
-		condition := t.a.child_node(&candidate, 0)
-		if condition.kind != .infix || condition.op != .ne || condition.children_count < 2 {
-			continue
-		}
-		left := t.a.child_node(condition, 0)
-		right := t.a.child_node(condition, 1)
-		if (left.kind == .ident && left.value == source_name && right.kind == .none_expr)
-			|| (right.kind == .ident && right.value == source_name && left.kind == .none_expr) {
-			return fm.comptime_typ[1..].trim_space()
+	} else {
+		// Hand-built transform tests may invoke this helper without prepare(), so
+		// retain the complete scan when the immutable source indexes are unavailable.
+		for candidate in t.a.nodes {
+			if t.comptime_option_guard_unwraps(candidate, source_name, call) {
+				return fm.comptime_typ[1..].trim_space()
+			}
 		}
 	}
 	return none
+}
+
+fn (t &Transformer) comptime_option_guard_unwraps(candidate flat.Node, source_name string, call flat.Node) bool {
+	if candidate.kind != .if_expr || candidate.children_count < 2 {
+		return false
+	}
+	body := t.a.child_node(&candidate, 1)
+	if !body.pos.is_valid() || body.pos.id != call.pos.id || call.pos.offset < body.pos.offset
+		|| call.pos.offset > body.pos.end {
+		return false
+	}
+	condition := t.a.child_node(&candidate, 0)
+	if condition.kind != .infix || condition.op != .ne || condition.children_count < 2 {
+		return false
+	}
+	left := t.a.child_node(condition, 0)
+	right := t.a.child_node(condition, 1)
+	return (left.kind == .ident && left.value == source_name && right.kind == .none_expr)
+		|| (right.kind == .ident && right.value == source_name && left.kind == .none_expr)
 }
 
 fn (mut t Transformer) comptime_reflected_for_in_local_type(name string, fm FieldMeta) ?string {

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -625,43 +625,23 @@ fn (mut t Transformer) seed_cached_monomorph_specs(specs []MonomorphCacheSpec) {
 	}
 }
 
-fn (mut t Transformer) materialize_monomorph_signature_types(specs []MonomorphCacheSpec) {
-	if isnil(t.tc) || specs.len == 0 {
+fn (mut t Transformer) materialize_monomorph_signature_types() {
+	if isnil(t.tc) || t.monomorph_signature_types.len == 0 {
 		return
 	}
-	fn_decls := t.cached_generic_fn_decls()
 	struct_decls := t.collect_generic_struct_decls()
 	sum_decls := t.collect_generic_sum_decls()
 	if struct_decls.len == 0 && sum_decls.len == 0 {
+		t.monomorph_signature_types.clear()
 		return
 	}
 	mut struct_specs := map[string]string{}
 	mut sum_specs := map[string]GenericSpecContext{}
-	for spec in specs {
-		decl := fn_decls[spec.decl_key] or { continue }
-		args := t.canonical_generic_specialization_args(spec.args)
-		if args.len == 0 || t.generic_args_have_placeholders(args) {
-			continue
-		}
-		generic_params := t.generic_fn_param_names(decl.node, decl.module)
-		mut signature_types := [
-			t.specialized_signature_type_text(decl, t.generic_fn_return_type_text(decl), args, generic_params),
-		]
-		for i in 0 .. decl.node.children_count {
-			param := t.a.child_node(&decl.node, i)
-			if param.kind != .param {
-				if t.prefix_param_scan {
-					break
-				}
-				continue
-			}
-			signature_types << t.specialized_signature_type_text(decl, param.typ, args, generic_params)
-		}
-		for typ in signature_types {
-			t.collect_generic_struct_spec_from_type(typ, decl.module, decl.file, struct_decls, mut struct_specs)
-			t.collect_generic_sum_spec_from_type(typ, decl.module, decl.file, sum_decls, mut sum_specs)
-		}
+	for signature in t.monomorph_signature_types {
+		t.collect_generic_struct_spec_from_type(signature.typ, signature.module, signature.file, struct_decls, mut struct_specs)
+		t.collect_generic_sum_spec_from_type(signature.typ, signature.module, signature.file, sum_decls, mut sum_specs)
 	}
+	t.monomorph_signature_types.clear()
 	t.expand_generic_materialization_specs(struct_decls, sum_decls, mut struct_specs, mut sum_specs)
 	for spec, context in sum_specs {
 		decl := sum_decls[context.base] or { continue }
@@ -4306,6 +4286,11 @@ fn (mut t Transformer) register_specialized_fn_signature_value(decl GenericFnDec
 	}
 	generic_params := t.generic_fn_param_names(decl.node, decl.module)
 	ret_name := t.specialized_signature_type_text(decl, t.generic_fn_return_type_text(decl), concrete_args, generic_params)
+	t.monomorph_signature_types << MonomorphSignatureType{
+		typ: ret_name
+		module: decl.module
+		file: decl.file
+	}
 	ret := if !isnil(t.tc) {
 		t.tc.parse_resolution_type(ret_name)
 	} else {
@@ -4322,6 +4307,11 @@ fn (mut t Transformer) register_specialized_fn_signature_value(decl GenericFnDec
 			continue
 		}
 		param_type := explicit_mut_pointer_param_type_text(child, t.specialized_signature_type_text(decl, child.typ, concrete_args, generic_params))
+		t.monomorph_signature_types << MonomorphSignatureType{
+			typ: param_type
+			module: decl.module
+			file: decl.file
+		}
 		if param_type.starts_with('...') {
 			variadic = true
 		}
@@ -12984,7 +12974,7 @@ fn (mut t Transformer) record_generic_specialization_args_in_module(base string,
 	}
 	for key in keys {
 		if key.len > 0 && !t.has_recorded_generic_specialization_args(key) {
-			t.generic_specialization_args[key] = recorded_args.clone()
+			t.generic_specialization_args[key] = recorded_args
 			t.generic_specialization_args_log << key
 		}
 	}
@@ -13001,7 +12991,7 @@ fn (mut t Transformer) record_generic_specialization_args_for_names(names []stri
 	recorded_args := args.clone()
 	for name in names {
 		if name.len > 0 && !t.has_recorded_generic_specialization_args(name) {
-			t.generic_specialization_args[name] = recorded_args.clone()
+			t.generic_specialization_args[name] = recorded_args
 			t.generic_specialization_args_log << name
 		}
 	}

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -95,6 +95,12 @@ pub:
 	args     []string
 }
 
+struct MonomorphSignatureType {
+	typ    string
+	module string
+	file   string
+}
+
 // SmartcastContext stores smartcast context state used by transform.
 pub struct SmartcastContext {
 pub:
@@ -247,6 +253,7 @@ mut:
 	type_alias_suffixes           map[string]string
 	local_decl_nodes_by_name      map[string][]int
 	fn_decl_offsets_by_file       map[int][]int
+	if_expr_nodes_by_file         map[int][]int
 	struct_field_decl_metas_cache map[string]map[string]FieldDeclMeta
 	comptime_field_metas_cache    map[string][]FieldMeta
 	comptime_reflected_for_roles  map[string]u8
@@ -368,6 +375,7 @@ mut:
 	generic_fn_specs_in_progress       map[string]bool
 	generic_fn_spec_nodes              map[string]flat.NodeId
 	monomorph_cache_specs              map[string]MonomorphCacheSpec
+	monomorph_signature_types          []MonomorphSignatureType
 	generic_clone_children             []flat.NodeId
 	node_context_stack                 []flat.NodeId
 	specialization_decl_nodes_by_name  map[string][]int
@@ -1452,7 +1460,7 @@ pub fn monomorphize_with_used_checked_config_scoped_cached(mut a flat.FlatAst, t
 	// intact and alternate both passes until late reachability stops growing.
 	for {
 		generated_names := t.monomorphize_pass()
-		t.materialize_monomorph_signature_types(t.sorted_monomorph_cache_specs())
+		t.materialize_monomorph_signature_types()
 		t.monomorph_profile('mono wrapper pass: ${time.ticks() - debug_started} ms')
 		for name in generated_names {
 			t.mark_used_fn_key(name)
@@ -1535,7 +1543,7 @@ pub fn register_cached_monomorph_signatures(a &flat.FlatAst, tc &types.TypeCheck
 	mut t := new_transformer_view(a, tc, used_fns)
 	t.prepare()
 	t.seed_cached_monomorph_specs(cached_specs)
-	t.materialize_monomorph_signature_types(cached_specs)
+	t.materialize_monomorph_signature_types()
 }
 
 fn new_transformer(mut a flat.FlatAst, tc &types.TypeChecker, used_fns map[string]bool) Transformer {
@@ -3921,6 +3929,7 @@ fn (t &Transformer) fork_program_view(ast &flat.FlatAst, wtc &types.TypeChecker,
 		type_alias_suffixes: t.type_alias_suffixes
 		local_decl_nodes_by_name: t.local_decl_nodes_by_name
 		fn_decl_offsets_by_file: t.fn_decl_offsets_by_file
+		if_expr_nodes_by_file: t.if_expr_nodes_by_file
 		struct_field_decl_metas_cache: t.struct_field_decl_metas_cache
 		comptime_field_metas_cache: map[string][]FieldMeta{}
 		comptime_reflected_for_roles: t.comptime_reflected_for_roles
@@ -15715,6 +15724,7 @@ fn (mut t Transformer) build_source_parent_index() {
 	t.source_parent_ids = []int{len: t.a.nodes.len, init: -1}
 	mut decls := map[string][]int{}
 	mut fn_offsets := map[int][]int{}
+	mut if_exprs := map[int][]int{}
 	mut shared_names := map[string]bool{}
 	for parent_id, node in t.a.nodes {
 		for i in 0 .. node.children_count {
@@ -15725,6 +15735,9 @@ fn (mut t Transformer) build_source_parent_index() {
 		}
 		if node.kind == .fn_decl && node.pos.is_valid() {
 			fn_offsets[node.pos.id] << node.pos.offset
+		}
+		if node.kind == .if_expr && node.pos.is_valid() {
+			if_exprs[node.pos.id] << parent_id
 		}
 		if node.kind != .decl_assign || node.children_count < 2 {
 			continue
@@ -15748,6 +15761,7 @@ fn (mut t Transformer) build_source_parent_index() {
 	}
 	t.local_decl_nodes_by_name = decls.move()
 	t.fn_decl_offsets_by_file = fn_offsets.move()
+	t.if_expr_nodes_by_file = if_exprs.move()
 	t.shared_local_decl_names = shared_names.move()
 }
 

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -1235,6 +1235,7 @@ fn (mut t Transformer) run_parallel_monomorphize_specs(specs []PendingGenericFnS
 						t.generic_specialization_args[name.clone()] = spec_args.clone()
 					}
 				}
+				t.monomorph_signature_types << w.monomorph_signature_types
 			}
 			for idx in args[ci].scan_nodes {
 				t.parallel_monomorph_scan_nodes << idx + node_shift


### PR DESCRIPTION
## Summary

- record concrete monomorph signature type spellings as signatures are registered, then materialize generic signature types from that compact log instead of rebuilding every cached specialization signature
- index option-unwrapping declaration aliases by local name and guard expressions by source file, avoiding repeated full-AST scans during reflected generic specialization
- share immutable generic-specialization argument slices across alias keys instead of cloning the same slice for every spelling

## Performance

Cache-disabled Fusecode-to-C builds with `VJOBS=10`, `-new-compiler -nocache -cc clang -enable-globals -prod -gc none -cflags -DLARGE_CONFIG`:

- merged #28348 tree: median 1.56 s over 7 alternating runs
- this PR: median 1.50 s over 7 alternating runs
- V 0.5.2 on the current identical Fusecode tree: clean median 3.56 s (one contention outlier excluded)

The historical 0.94 s V 0.5.2 result used an older Fusecode tree. The current tree has grown from 487 files / 145,936 lines to 584 files / 167,540 lines.

## Validation

- `./vnew fmt -verify vlib/v3/transform/comptime.v vlib/v3/transform/monomorphize.v vlib/v3/transform/transform.v vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v`
- `./vnew -old-compiler vlib/v3/transform/local_decl_index_test.v`
- `./vnew -old-compiler vlib/v3/transform/fn_test.v`
- `./vnew -old-compiler vlib/v3/transform/monomorphize_test.v`
- full cache-disabled Fusecode-to-C generation (10,483,710-byte output)

Broad suites were skipped as requested.