### PR TITLE
v3: preserve raw C header semantics

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -2564,7 +2564,7 @@ fn prepare_v3_cache_external_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 		cache_input_modules[module_name] = true
 	}
 	cache_input_modules['main'] = true
-	native_inputs_language := cgen.cache_native_inputs_language(a, prefs.vroot, user_c_flags, prefs.c99, prefs.target)
+	native_inputs_language := cgen.cache_native_inputs_language(a, prefs.vroot, user_c_flags, prefs.c99, prefs.ccompiler, prefs.target)
 	compiler_macros, compiler_macro_environment_complete := cache_c_compiler_predefined_macros(user_c_flags, prefs.ccompiler, prefs.target, native_inputs_language)
 	mut external_inputs, mut native_source_roots, mut native_root_contexts, unscoped_inputs, static_storage_inputs, resolution_dirs, missing_resolution_paths, mut external_input_digests, has_untracked_c_include := cgen.cache_external_input_snapshot_with_resolved_flags(a, prefs.vroot, cache_input_modules, user_c_flags, prefs.target, module_cache_source_path_set(user_files), compiler_macros, compiler_macro_environment_complete)
 	state.module_external_inputs = external_inputs.move()
@@ -2642,7 +2642,7 @@ fn prepare_v3_checker_native_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 		cache_input_modules[module_name] = true
 	}
 	cache_input_modules['main'] = true
-	native_inputs_language := cgen.cache_native_inputs_language(a, prefs.vroot, user_c_flags, prefs.c99, prefs.target)
+	native_inputs_language := cgen.cache_native_inputs_language(a, prefs.vroot, user_c_flags, prefs.c99, prefs.ccompiler, prefs.target)
 	compiler_macros, compiler_macro_environment_complete := cache_c_compiler_predefined_macros(user_c_flags, prefs.ccompiler, prefs.target, native_inputs_language)
 	mut external_inputs, mut native_source_roots, mut native_root_contexts, _, _, resolution_dirs, missing_resolution_paths, mut external_input_digests, has_untracked_c_include := cgen.cache_external_input_snapshot_with_resolved_flags(a, prefs.vroot, cache_input_modules, user_c_flags, prefs.target, module_cache_source_path_set(user_files), compiler_macros, compiler_macro_environment_complete)
 	state.module_external_inputs = external_inputs.move()
@@ -10575,6 +10575,7 @@ pub fn run(args []string) {
 		mut all_compile_c_flags := environment_c_flags.clone()
 		all_compile_c_flags << generated_c_flags
 		needs_objective_c := c_flags_need_objective_c(all_compile_c_flags)
+			|| cgen.cache_native_inputs_need_objective_c(a, prefs.vroot, user_c_flags, prefs.c99, prefs.ccompiler, prefs.target)
 		large_prod_c_unit := os.is_file(published_c_source)
 			&& v3_is_large_prod_c_unit(os.file_size(published_c_source))
 		limit_large_unit_inlining := large_prod_c_unit && effective_c_compiler == 'clang'

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -9343,10 +9343,18 @@ fn dedupe_top_level_c_includes(directives []string) []string {
 		}
 		result << directive
 		name := c_directive_name(clean)
+		if depth == 0 && name in ['define', 'undef'] {
+			// A repeated unguarded include can intentionally observe a different macro
+			// state. Only deduplicate within one unchanged top-level macro epoch.
+			seen_includes.clear()
+		}
 		if name in ['if', 'ifdef', 'ifndef'] {
 			depth++
 		} else if name == 'endif' && depth > 0 {
 			depth--
+			if depth == 0 {
+				seen_includes.clear()
+			}
 		}
 	}
 	return result

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -1764,34 +1764,14 @@ fn c_add_cache_native_source_root(mut native_source_roots map[string][]string, m
 	return true
 }
 
-// cache_native_inputs_need_objective_c reports whether cgen will implicitly
-// compile the generated translation unit as Objective-C because of a source
-// directive rather than an explicit compiler flag.
-pub fn cache_native_inputs_need_objective_c(a &flat.FlatAst, vroot string, c_flags []string, c99_mode bool, target pref.Target) bool {
-	include_dirs := c_flag_include_dirs(c_flags)
-	mut cur_file := ''
-	for node in a.nodes {
-		if node.kind == .file {
-			cur_file = node.value
-			continue
-		}
-		if node.kind != .directive || node.value !in ['include', 'insert'] || node.typ.len == 0 {
-			continue
-		}
-		include_arg := c_include_arg_for_target(node.typ, vroot, cur_file, target)
-		if include_arg.len == 0 || c_include_arg_is_builtin_abi_helper(include_arg, vroot) {
-			continue
-		}
-		if c_include_arg_is_source_file(include_arg) {
-			for path in c_include_file_paths(include_arg, vroot, cur_file, include_dirs) {
-				if cache_native_input_path_needs_objective_c(path, c_flags, c99_mode, target) {
-					return true
-				}
-			}
-			continue
-		}
-	}
-	return false
+// cache_native_inputs_need_objective_c reports whether cgen must implicitly
+// compile the generated translation unit as Objective-C because of a native
+// input rather than an explicit compiler flag.
+pub fn cache_native_inputs_need_objective_c(a &flat.FlatAst, vroot string, c_flags []string, c99_mode bool, ccompiler string, target pref.Target) bool {
+	return cache_native_inputs_language(a, vroot, c_flags, c99_mode, ccompiler, target) in [
+		'objective-c',
+		'objective-c++',
+	]
 }
 
 // cache_native_input_path_needs_objective_c reports whether a native input
@@ -1833,7 +1813,7 @@ pub fn cache_native_input_language(path string, c_flags []string, c99_mode bool,
 // native input requires. The shared compiler-macro probe uses it so it never omits
 // a language macro (`__OBJC__`, `__cplusplus`) that an input's active branches
 // depend on.
-pub fn cache_native_inputs_language(a &flat.FlatAst, vroot string, c_flags []string, c99_mode bool, target pref.Target) string {
+pub fn cache_native_inputs_language(a &flat.FlatAst, vroot string, c_flags []string, c99_mode bool, ccompiler string, target pref.Target) string {
 	include_dirs := c_flag_include_dirs(c_flags)
 	mut need_objc := false
 	mut need_cpp := false
@@ -1843,7 +1823,8 @@ pub fn cache_native_inputs_language(a &flat.FlatAst, vroot string, c_flags []str
 			cur_file = node.value
 			continue
 		}
-		if node.kind != .directive || node.value !in ['include', 'insert'] || node.typ.len == 0 {
+		if node.kind != .directive
+			|| node.value !in ['include', 'insert', 'preinclude', 'postinclude'] || node.typ.len == 0 {
 			continue
 		}
 		include_arg := c_include_arg_for_target(node.typ, vroot, cur_file, target)
@@ -1866,6 +1847,11 @@ pub fn cache_native_inputs_language(a &flat.FlatAst, vroot string, c_flags []str
 					else {}
 				}
 			}
+		} else if target.os in ['macos', 'ios'] && ccompiler !in ['tcc', 'tinyc'] {
+			// Match V1's conservative Darwin behavior without opening the header.
+			// Apple headers can expose Objective-C declarations based on __OBJC__, so
+			// the cache probe and generated translation unit must both define it.
+			need_objc = true
 		}
 	}
 	return c_native_language_from_features(need_objc, need_cpp)

--- a/vlib/v3/gen/c/source_directive_test.v
+++ b/vlib/v3/gen/c/source_directive_test.v
@@ -380,6 +380,17 @@ fn test_cache_split_uses_system_sigaction_declaration() {
 }
 
 fn test_c_struct_declared_in_platform_binding_stays_header_owned() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_c_struct_source_owner_${os.getpid()}')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	defer {
+		os.rmdir_all(dir) or {}
+	}
+	header_backed_file := os.join_path(dir, 'header_backed.v')
+	headerless_file := os.join_path(dir, 'headerless.v')
+	os.write_file(header_backed_file, 'module main\n#include "types.h"\n')!
+	os.write_file(headerless_file, 'module main\n')!
+
 	mut ast := &flat.FlatAst{}
 	mut tc := types.TypeChecker.new(ast)
 	mut g := FlatGen.new()
@@ -388,8 +399,26 @@ fn test_c_struct_declared_in_platform_binding_stays_header_owned() {
 	g.register_struct_decl_info('C.NSFont', 'C.NSFont', 'uiold', 'ui_darwin.c.v', flat.Node{})
 	assert g.skip_builtin_struct('C.NSFont')
 
-	g.register_struct_decl_info('C.Local', 'C.Local', 'main', 'main.v', flat.Node{})
+	g.register_struct_decl_info('C.HeaderOwned', 'C.HeaderOwned', 'main', header_backed_file, flat.Node{})
+	assert g.skip_builtin_struct('C.HeaderOwned')
+
+	g.register_struct_decl_info('C.Local', 'C.Local', 'main', headerless_file, flat.Node{})
 	assert !g.skip_builtin_struct('C.Local')
+
+	g.register_struct_decl_info('C.Alias', 'C.Alias', 'main', headerless_file, flat.Node{})
+	tc.c_typedef_structs['C.Alias'] = true
+	assert g.skip_builtin_struct('C.Alias')
+}
+
+fn test_top_level_include_deduplication_resets_after_preprocessor_state_changes() {
+	macro_directives := dedupe_top_level_c_includes(['#include <types.h>', '#include <types.h>',
+		'#define FEATURE 1', '#include <types.h>'])
+	assert macro_directives == ['#include <types.h>', '#define FEATURE 1', '#include <types.h>']
+
+	conditional_directives := dedupe_top_level_c_includes(['#include <types.h>', '#if FEATURE',
+		'#include <types.h>', '#endif', '#include <types.h>'])
+	assert conditional_directives == ['#include <types.h>', '#if FEATURE', '#include <types.h>',
+		'#endif', '#include <types.h>']
 }
 
 fn test_headerless_preamble_keeps_explicit_puts_declaration() {

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -1,5 +1,6 @@
 module c
 
+import os
 import v3.flat
 import v3.gen.c.naming
 import v3.types
@@ -5054,6 +5055,11 @@ fn (g &FlatGen) skip_builtin_struct(name string) bool {
 		return true
 	}
 	if name.starts_with('C.') {
+		// Match V1: `@[typedef]` C structs name types supplied by native code and
+		// must never get a synthesized V-owned declaration or body.
+		if name in g.tc.c_typedef_structs {
+			return true
+		}
 		if g.cache_native_c_symbols[name[2..]] {
 			return true
 		}
@@ -5061,10 +5067,10 @@ fn (g &FlatGen) skip_builtin_struct(name string) bool {
 			return true
 		}
 		if info := g.struct_decl_infos[name] {
-			// Platform binding files describe types supplied by their C/Objective-C
-			// headers. Emitting a fallback body can redefine Objective-C classes such
-			// as NSFont, while V1 deliberately leaves these declarations header-owned.
-			if info.file.ends_with('.c.v') {
+			// Platform binding files and plain V files with a header directive describe
+			// types supplied by native code. Keep the cheap V1 source-file heuristic;
+			// inspecting the included header itself is unnecessary.
+			if info.file.ends_with('.c.v') || c_source_looks_header_backed(info.file) {
 				return true
 			}
 		}
@@ -5202,6 +5208,28 @@ fn (g &FlatGen) cached_support_has_c_type(c_name string) bool {
 	for prefix in ['struct ', 'union '] {
 		if c_name.starts_with(prefix) {
 			return g.cached_support_identifiers[c_name[prefix.len..]]
+		}
+	}
+	return false
+}
+
+fn c_source_looks_header_backed(path string) bool {
+	source := os.read_file(path) or { return false }
+	for line in source.split_into_lines() {
+		trimmed := line.trim_space()
+		if trimmed.len == 0 || trimmed.starts_with('//') {
+			continue
+		}
+		if trimmed.starts_with('#include') {
+			return true
+		}
+		if trimmed.starts_with('#insert') {
+			lower_trimmed := trimmed.to_lower()
+			if lower_trimmed.contains('.h"') || lower_trimmed.contains(".h'")
+				|| lower_trimmed.contains('.h ') || lower_trimmed.contains('.hpp')
+				|| lower_trimmed.ends_with('.h') {
+				return true
+			}
 		}
 	}
 	return false

--- a/vlib/v3/gen/c/target_test.v
+++ b/vlib/v3/gen/c/target_test.v
@@ -1010,7 +1010,8 @@ fn test_cache_native_input_language_detects_implicit_objective_c_sources() {
 	os.write_file(objective_c_header, '@interface V3CacheImplementation\n@end\n')!
 	os.write_file(plain_header, 'int plain_declaration(void);\n')!
 	mut prefs := pref.new_preferences()
-	prefs.target = pref.host_target()
+	prefs.target = pref.target_from('macos', 'arm64') or { panic(err) }
+	linux := pref.target_from('linux', 'amd64') or { panic(err) }
 	assert cache_native_input_path_needs_objective_c(objective_c_source, []string{}, false,
 		prefs.target)
 	assert cache_native_input_path_needs_objective_c(objective_c_header, []string{}, false,
@@ -1018,14 +1019,16 @@ fn test_cache_native_input_language_detects_implicit_objective_c_sources() {
 	assert !cache_native_input_path_needs_objective_c(plain_header, []string{}, false, prefs.target)
 	for include, expected in {
 		'"implementation.m"': true
-		'"implementation.h"': false
-		'"plain.h"':          false
+		'"implementation.h"': true
+		'"plain.h"':          true
 	} {
 		source := os.join_path(dir, 'sample_${expected}_${include.len}.v')
 		os.write_file(source, 'module sample\n#include ${include}\n')!
 		mut p := parser.Parser.new(prefs)
 		a := p.parse_file(source)
-		assert cache_native_inputs_need_objective_c(a, '', []string{}, false, prefs.target) == expected
+		assert cache_native_inputs_need_objective_c(a, '', []string{}, false, 'clang', prefs.target) == expected
+		linux_expected := include == '"implementation.m"'
+		assert cache_native_inputs_need_objective_c(a, '', []string{}, false, 'clang', linux) == linux_expected
 	}
 }
 
@@ -1059,44 +1062,54 @@ fn test_cache_native_input_language_reports_source_language() {
 	os.write_file(mm_program, 'module sample\n#include "impl.mm"\n')!
 	mut p := parser.Parser.new(prefs)
 	a := p.parse_file(mm_program)
-	assert cache_native_inputs_language(a, '', []string{}, false, prefs.target) == 'objective-c++'
+	assert cache_native_inputs_language(a, '', []string{}, false, 'clang', prefs.target) == 'objective-c++'
 }
 
-// Header directives are left to the real preprocessor and do not select the
-// generated translation unit's language. Only included native source files do.
-fn test_cache_native_inputs_language_ignores_headers() {
+// Darwin header directives select Objective-C without opening the headers, while
+// other targets keep using C. This keeps the cache probe and final compile aligned.
+fn test_cache_native_inputs_language_uses_objective_c_for_darwin_headers() {
 	dir := os.join_path(os.vtmp_dir(), 'v3_native_language_header_${os.getpid()}')
 	os.rmdir_all(dir) or {}
 	os.mkdir_all(dir) or { panic(err) }
 	defer {
 		os.rmdir_all(dir) or {}
 	}
-	mut prefs := pref.new_preferences()
-	prefs.target = pref.host_target()
+	mut macos_prefs := pref.new_preferences()
+	macos_prefs.target = pref.target_from('macos', 'arm64') or { panic(err) }
+	ios := pref.target_from('ios', 'arm64') or { panic(err) }
+	linux := pref.target_from('linux', 'amd64') or { panic(err) }
 
 	objc_dir := os.join_path(dir, 'objc_mod')
 	os.mkdir_all(objc_dir) or { panic(err) }
 	os.write_file(os.join_path(objc_dir, 'shared.h'), '@interface V3HeaderBranch\n@end\n')!
 	objc_program := os.join_path(objc_dir, 'prog.v')
 	os.write_file(objc_program, 'module objc_mod\n#include "shared.h"\n')!
-	mut p1 := parser.Parser.new(prefs)
+	mut p1 := parser.Parser.new(macos_prefs)
 	a1 := p1.parse_file(objc_program)
-	assert cache_native_inputs_language(a1, '', []string{}, false, prefs.target) == 'c'
+	assert cache_native_inputs_language(a1, '', []string{}, false, 'clang', macos_prefs.target) == 'objective-c'
+	assert cache_native_inputs_language(a1, '', []string{}, false, 'clang', ios) == 'objective-c'
+	assert cache_native_inputs_language(a1, '', []string{}, false, 'tinyc', macos_prefs.target) == 'c'
+	assert cache_native_inputs_language(a1, '', []string{}, false, 'clang', linux) == 'c'
 
-	// A plain header in the same shape stays c.
+	// The choice is based only on the directive and target, not header contents.
 	plain_dir := os.join_path(dir, 'plain_mod')
 	os.mkdir_all(plain_dir) or { panic(err) }
 	os.write_file(os.join_path(plain_dir, 'shared.h'), 'int plain_decl(void);\n')!
 	plain_program := os.join_path(plain_dir, 'prog.v')
 	os.write_file(plain_program, 'module plain_mod\n#include "shared.h"\n')!
-	mut p2 := parser.Parser.new(prefs)
+	mut p2 := parser.Parser.new(macos_prefs)
 	a2 := p2.parse_file(plain_program)
-	assert cache_native_inputs_language(a2, '', []string{}, false, prefs.target) == 'c'
+	assert cache_native_inputs_language(a2, '', []string{}, false, 'clang', macos_prefs.target) == 'objective-c'
+	assert cache_native_inputs_language(a2, '', []string{}, false, 'clang', linux) == 'c'
 
-	// Multiple same-named headers remain ignored regardless of their contents.
-	mut p3 := parser.Parser.new(prefs)
-	a3 := p3.parse_files([plain_program, objc_program])
-	assert cache_native_inputs_language(a3, '', []string{}, false, prefs.target) == 'c'
+	// Missing pre/postinclude headers prove the language choice does not read them.
+	placed_program := os.join_path(dir, 'placed.v')
+	os.write_file(placed_program,
+		'module placed\n#preinclude "missing_early.h"\n#postinclude <missing_late.h>\n')!
+	mut p3 := parser.Parser.new(macos_prefs)
+	a3 := p3.parse_file(placed_program)
+	assert cache_native_inputs_language(a3, '', []string{}, false, 'clang', macos_prefs.target) == 'objective-c'
+	assert cache_native_inputs_language(a3, '', []string{}, false, 'clang', linux) == 'c'
 }
 
 fn test_cache_input_scan_rejects_ambiguous_include_macro_literal() {

--- a/vlib/v3/gen/c/target_test.v
+++ b/vlib/v3/gen/c/target_test.v
@@ -996,7 +996,7 @@ fn test_cache_input_scan_rejects_repeated_native_root_with_different_context() {
 	]
 }
 
-fn test_cache_native_input_language_detects_implicit_objective_c() {
+fn test_cache_native_input_language_detects_implicit_objective_c_sources() {
 	dir := os.join_path(os.vtmp_dir(), 'v3_native_objective_c_${os.getpid()}')
 	os.rmdir_all(dir) or {}
 	os.mkdir_all(dir) or { panic(err) }
@@ -1018,7 +1018,7 @@ fn test_cache_native_input_language_detects_implicit_objective_c() {
 	assert !cache_native_input_path_needs_objective_c(plain_header, []string{}, false, prefs.target)
 	for include, expected in {
 		'"implementation.m"': true
-		'"implementation.h"': true
+		'"implementation.h"': false
 		'"plain.h"':          false
 	} {
 		source := os.join_path(dir, 'sample_${expected}_${include.len}.v')
@@ -1062,16 +1062,9 @@ fn test_cache_native_input_language_reports_source_language() {
 	assert cache_native_inputs_language(a, '', []string{}, false, prefs.target) == 'objective-c++'
 }
 
-// cache_native_inputs_language memoizes each header include's Objective-C
-// classification, keyed on the include argument alone for `<...>` (which
-// resolves independently of the including file) and on including-file + argument
-// for a quoted include (which resolves relative to that file). This exercises
-// the header-include branch directly -- the only other test that reaches
-// cache_native_inputs_language passes an `.mm` SOURCE file, which takes the
-// unrelated source-file branch -- and pins the quoted-include key: two
-// same-named headers in different module directories with different
-// Objective-C-ness must not share a cache entry.
-fn test_cache_native_inputs_language_header_branch_and_memo_key() {
+// Header directives are left to the real preprocessor and do not select the
+// generated translation unit's language. Only included native source files do.
+fn test_cache_native_inputs_language_ignores_headers() {
 	dir := os.join_path(os.vtmp_dir(), 'v3_native_language_header_${os.getpid()}')
 	os.rmdir_all(dir) or {}
 	os.mkdir_all(dir) or { panic(err) }
@@ -1081,9 +1074,6 @@ fn test_cache_native_inputs_language_header_branch_and_memo_key() {
 	mut prefs := pref.new_preferences()
 	prefs.target = pref.host_target()
 
-	// A quoted `.h` header carrying `@interface` reaches the header-include
-	// branch (a `.h` is not a native source file) and must classify as
-	// objective-c.
 	objc_dir := os.join_path(dir, 'objc_mod')
 	os.mkdir_all(objc_dir) or { panic(err) }
 	os.write_file(os.join_path(objc_dir, 'shared.h'), '@interface V3HeaderBranch\n@end\n')!
@@ -1091,7 +1081,7 @@ fn test_cache_native_inputs_language_header_branch_and_memo_key() {
 	os.write_file(objc_program, 'module objc_mod\n#include "shared.h"\n')!
 	mut p1 := parser.Parser.new(prefs)
 	a1 := p1.parse_file(objc_program)
-	assert cache_native_inputs_language(a1, '', []string{}, false, prefs.target) == 'objective-c'
+	assert cache_native_inputs_language(a1, '', []string{}, false, prefs.target) == 'c'
 
 	// A plain header in the same shape stays c.
 	plain_dir := os.join_path(dir, 'plain_mod')
@@ -1103,15 +1093,10 @@ fn test_cache_native_inputs_language_header_branch_and_memo_key() {
 	a2 := p2.parse_file(plain_program)
 	assert cache_native_inputs_language(a2, '', []string{}, false, prefs.target) == 'c'
 
-	// Both modules in one AST, the plain one walked first, each including its
-	// own directory-local `"shared.h"`. If the quoted-include memo key dropped
-	// the including-file component, the plain module's entry (`shared.h` ->
-	// clean) would shadow the objc module's header, and the whole probe would
-	// be misclassified as c -- silently dropping __OBJC__ from the shared
-	// compiler-macro probe. Correct keying keeps them distinct.
+	// Multiple same-named headers remain ignored regardless of their contents.
 	mut p3 := parser.Parser.new(prefs)
 	a3 := p3.parse_files([plain_program, objc_program])
-	assert cache_native_inputs_language(a3, '', []string{}, false, prefs.target) == 'objective-c'
+	assert cache_native_inputs_language(a3, '', []string{}, false, prefs.target) == 'c'
 }
 
 fn test_cache_input_scan_rejects_ambiguous_include_macro_literal() {

--- a/vlib/v3/tests/header_owned_c_struct_codegen_test.v
+++ b/vlib/v3/tests/header_owned_c_struct_codegen_test.v
@@ -131,3 +131,36 @@ fn main() {
 	assert define > first_include, generated
 	assert generated[define..].contains('#include "library.h"'), generated
 }
+
+fn test_macos_header_only_objective_c_uses_objective_c_translation_unit() {
+	$if macos {
+		root := os.join_path(os.vtmp_dir(), 'v3_header_only_objective_c_${os.getpid()}')
+		os.rmdir_all(root) or {}
+		os.mkdir_all(root) or { panic(err) }
+		defer {
+			os.rmdir_all(root) or {}
+		}
+		os.write_file(os.join_path(root, 'objective_c_api.h'), '#ifndef __OBJC__
+#error this header requires an Objective-C translation unit
+#endif
+@interface V3HeaderOnlyObject
+@end
+')!
+		os.write_file(os.join_path(root, 'main.v'), 'module main
+
+#flag -I @DIR
+#include "objective_c_api.h"
+
+fn main() {
+	println(42)
+}
+')!
+		v3_bin := header_owned_build_v3()
+		out := os.join_path(root, 'out')
+		compile := os.execute('${os.quoted_path(v3_bin)} -new-compiler -nocache --no-parallel -cc clang ${os.quoted_path(os.join_path(root, 'main.v'))} -b c -o ${os.quoted_path(out)}')
+		assert compile.exit_code == 0, compile.output
+		run := os.execute(os.quoted_path(out))
+		assert run.exit_code == 0, run.output
+		assert run.output.trim_space() == '42', run.output
+	}
+}

--- a/vlib/v3/tests/header_owned_c_struct_codegen_test.v
+++ b/vlib/v3/tests/header_owned_c_struct_codegen_test.v
@@ -1,0 +1,133 @@
+import os
+
+const header_owned_vexe = @VEXE
+const header_owned_tests_dir = os.dir(@FILE)
+const header_owned_v3_dir = os.dir(header_owned_tests_dir)
+const header_owned_vlib_dir = os.dir(header_owned_v3_dir)
+const header_owned_v3_src = os.join_path(header_owned_v3_dir, 'v3.v')
+
+fn header_owned_v3_bin_path() string {
+	return os.join_path(os.vtmp_dir(), 'v3_header_owned_test_${os.getpid()}')
+}
+
+fn header_owned_build_v3() string {
+	v3_bin := header_owned_v3_bin_path()
+	if os.is_executable(v3_bin) {
+		return v3_bin
+	}
+	build := os.execute('${os.quoted_path(header_owned_vexe)} -gc none -path "${header_owned_vlib_dir}|@vlib|@vmodules" -o ${os.quoted_path(v3_bin)} ${os.quoted_path(header_owned_v3_src)}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn testsuite_begin() {
+	os.rm(header_owned_v3_bin_path()) or {}
+	_ = header_owned_build_v3()
+}
+
+fn testsuite_end() {
+	os.rm(header_owned_v3_bin_path()) or {}
+}
+
+fn test_plain_v_header_owned_c_structs_are_not_redeclared() {
+	root := os.join_path(os.vtmp_dir(), 'v3_header_owned_struct_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	v3_bin := header_owned_build_v3()
+
+	os.write_file(os.join_path(root, 'types.h'), '#ifndef V3_HEADER_OWNED_TYPES_H
+#define V3_HEADER_OWNED_TYPES_H
+typedef struct V3HeaderOwnedImpl_ {
+	long long value;
+} V3HeaderOwnedAlias;
+typedef struct V3HeaderOwnedTag {
+	long long value;
+} V3HeaderOwnedTag;
+#endif
+')!
+	os.write_file(os.join_path(root, 'wrapper.h'), '#include "types.h"\n')!
+	os.write_file(os.join_path(root, 'main.v'), 'module main
+
+#flag -I @DIR
+#include "wrapper.h"
+
+@[typedef]
+struct C.V3HeaderOwnedAlias {
+	value int
+}
+
+struct C.V3HeaderOwnedTag {
+	value int
+}
+
+fn main() {
+	alias := C.V3HeaderOwnedAlias{
+		value: 40
+	}
+	tag := C.V3HeaderOwnedTag{
+		value: 2
+	}
+	println(alias.value + tag.value)
+}
+')!
+	out := os.join_path(root, 'out')
+	compile := os.execute('${os.quoted_path(v3_bin)} --no-parallel ${os.quoted_path(os.join_path(root, 'main.v'))} -b c -o ${os.quoted_path(out)}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(os.quoted_path(out))
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '42', run.output
+	generated := os.read_file(out + '.c')!
+	assert !generated.contains('typedef struct V3HeaderOwnedAlias V3HeaderOwnedAlias;'), generated
+	assert !generated.contains('struct V3HeaderOwnedAlias {'), generated
+	assert !generated.contains('struct V3HeaderOwnedTag {'), generated
+}
+
+fn test_repeated_header_after_define_preserves_preprocessor_semantics() {
+	root := os.join_path(os.vtmp_dir(), 'v3_repeated_header_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	os.write_file(os.join_path(root, 'library.h'), '#ifndef V3_SINGLE_HEADER_DECLARATION
+#define V3_SINGLE_HEADER_DECLARATION
+int v3_single_header_value(void);
+#endif
+
+#ifdef V3_SINGLE_HEADER_IMPLEMENTATION
+int v3_single_header_value(void) {
+	return 42;
+}
+#endif
+')!
+	os.write_file(os.join_path(root, 'main.v'), 'module main
+
+#flag -I @DIR
+#include "library.h"
+#define V3_SINGLE_HEADER_IMPLEMENTATION
+#include "library.h"
+
+fn C.v3_single_header_value() int
+
+fn main() {
+	println(C.v3_single_header_value())
+}
+')!
+	v3_bin := header_owned_build_v3()
+	out := os.join_path(root, 'out')
+	compile := os.execute('${os.quoted_path(v3_bin)} --no-parallel ${os.quoted_path(os.join_path(root, 'main.v'))} -b c -o ${os.quoted_path(out)}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(os.quoted_path(out))
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '42', run.output
+	generated := os.read_file(out + '.c')!
+	assert generated.count('#include "library.h"') == 2, generated
+	first_include := generated.index('#include "library.h"') or { -1 }
+	define := generated.index('#define V3_SINGLE_HEADER_IMPLEMENTATION') or { -1 }
+	assert first_include >= 0, generated
+	assert define > first_include, generated
+	assert generated[define..].contains('#include "library.h"'), generated
+}


### PR DESCRIPTION
Follow-up to #28348.

## Summary

- keep `@[typedef] C.*` declarations and C structs from header-backed plain `.v` files owned by native headers, using the V1 source-file heuristic without scanning headers
- reset top-level include deduplication after macro changes and conditional boundaries so repeated single-header implementation includes are preserved
- select Objective-C for raw include, insert, preinclude, and postinclude headers on macOS/iOS without opening them, while preserving the V1 TinyCC exemption
- use the same implicit native-input language for module-cache macro probes and the final generated translation unit
- restore focused compile/run regressions for header-owned structs, repeated includes across macro changes, and header-only Objective-C under direct `-new-compiler`

## Tests

- `./vnew -silent vlib/v3/gen/c/target_test.v`
- `./vnew -silent vlib/v3/tests/header_owned_c_struct_codegen_test.v`
- `./vnew -silent test vlib/v3/gen/c/` (18 passed)
- `./vnew -silent test vlib/v3/driver/` (6 passed)
- `./vnew -silent vlib/v3/driver/cache_prune_test.v`
- `./vnew -silent vlib/v/compiler_errors_test.v` (1696 passed, 1 skipped)

## Existing test issues

- `./vnew -silent vlib/v3/tests/c_directive_order_codegen_test.v` still fails on the merged #28348 base because that suite expects local `#insert` headers to be recursively inlined and removed from generated C.
- `./vnew -silent vlib/v/gen/c/coutput_test.v` reaches one stale V3 assertion in `test_c_fallback_decl_uses_c_helper_submodule_includes`, which still expects a declaration recovered by the header scanner removed in #28348.

This follow-up leaves both unrelated stale assertions unchanged.