### PR TITLE
v3: exceed 2M lines per second with uncached FastC

### DIFF
--- a/vlib/os/execute_capture_nix.h
+++ b/vlib/os/execute_capture_nix.h
@@ -176,3 +176,78 @@ static inline int v_os_exec_capture_start(char *const argv[], int *child_pid, in
 	return 0;
 }
 #endif
+
+#if defined(__APPLE__)
+static inline void v_os_fd_write_all(int fd, const char *data, size_t len) {
+	while (len > 0) {
+		ssize_t written = write(fd, data, len);
+		if (written <= 0) {
+			return;
+		}
+		data += written;
+		len -= (size_t)written;
+	}
+}
+
+// v_os_exec_capture_input_start is the argv-based capture helper with an
+// additional pipe connected to the child's stdin. F_SETNOSIGPIPE makes a
+// writer observe EPIPE instead of terminating the parent when a child exits
+// after reporting an early input error.
+static inline int v_os_exec_capture_input_start(char *const argv[], int *child_pid, int *read_fd, int *write_fd) {
+	if (argv == NULL || argv[0] == NULL) {
+		return -1;
+	}
+	int output_pipe[2];
+	int input_pipe[2];
+	if (pipe(output_pipe) != 0) {
+		return -1;
+	}
+	if (pipe(input_pipe) != 0) {
+		close(output_pipe[0]);
+		close(output_pipe[1]);
+		return -1;
+	}
+	v_os_execute_set_cloexec(output_pipe[0]);
+	v_os_execute_set_cloexec(output_pipe[1]);
+	v_os_execute_set_cloexec(input_pipe[0]);
+	v_os_execute_set_cloexec(input_pipe[1]);
+	fcntl(input_pipe[1], F_SETNOSIGPIPE, 1);
+	v_posix_spawn_file_actions_t actions;
+	if (posix_spawn_file_actions_init(&actions) != 0) {
+		close(output_pipe[0]);
+		close(output_pipe[1]);
+		close(input_pipe[0]);
+		close(input_pipe[1]);
+		return -1;
+	}
+	int err = 0;
+	if ((err = posix_spawn_file_actions_adddup2(&actions, input_pipe[0], STDIN_FILENO)) != 0
+		|| (err = posix_spawn_file_actions_adddup2(&actions, output_pipe[1], STDOUT_FILENO)) != 0
+		|| (err = posix_spawn_file_actions_adddup2(&actions, output_pipe[1], STDERR_FILENO)) != 0
+		|| (err = posix_spawn_file_actions_addclose(&actions, input_pipe[0])) != 0
+		|| (err = posix_spawn_file_actions_addclose(&actions, input_pipe[1])) != 0
+		|| (err = posix_spawn_file_actions_addclose(&actions, output_pipe[0])) != 0
+		|| (err = posix_spawn_file_actions_addclose(&actions, output_pipe[1])) != 0) {
+		posix_spawn_file_actions_destroy(&actions);
+		close(output_pipe[0]);
+		close(output_pipe[1]);
+		close(input_pipe[0]);
+		close(input_pipe[1]);
+		return -1;
+	}
+	err = posix_spawnp(child_pid, argv[0], &actions, NULL, argv, environ);
+	posix_spawn_file_actions_destroy(&actions);
+	if (err != 0) {
+		close(output_pipe[0]);
+		close(output_pipe[1]);
+		close(input_pipe[0]);
+		close(input_pipe[1]);
+		return -1;
+	}
+	close(output_pipe[1]);
+	close(input_pipe[0]);
+	*read_fd = output_pipe[0];
+	*write_fd = input_pipe[1];
+	return 0;
+}
+#endif

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -235,9 +235,10 @@ patched into the file in place). The SDK path is taken from `SDKROOT` or the too
 
 Default self-host builds content-cache the split TinyCC objects and the linked, signed executable
 under `os.vtmp_dir()`. The keys cover the exact generated units, TinyCC build, compile options, and
-link options. A cached executable is restored as an independent copy, so replacing or modifying the
-output cannot change the cache. Pass `-nocache` or `--no-cache` through the full V driver to bypass
-both caches.
+link options. The executable key is calculated directly from the generated pieces and unit layout,
+so a warm hit is restored before temporary C files are written or object files are read. A cached
+executable is restored as an independent copy, so replacing or modifying the output cannot change
+the cache. Pass `-nocache` or `--no-cache` through the full V driver to bypass both caches.
 
 The standalone compiler supports `self` directly and defaults that command to FastC. For example,
 `./v self x5` replaces the compiler through five descendant FastC generations, with each installed

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -220,10 +220,10 @@ the lifecycle hooks or the non-body pieces refers to, which the source-level nam
 reachability keeps: each worker records its definitions and the mangled names they mention, and
 the assembly cuts the unreachable spans out of the pieces (about 9% of the self-host C).
 
-The TinyCC step itself is split: `fastc_write_c_units` cuts the pieces into up to 8
+The TinyCC step itself is split: `fastc_write_c_units` cuts the pieces into up to 16
 translation units (the shared head of typedefs, prototypes and runtime in every unit, the
-dispatch tables, lifecycle functions and `main` only in the first, the file bodies grouped by
-size; the globals are definitions in the first unit and `extern` declarations in the others),
+dispatch tables and lifecycle functions only in the first, the file bodies grouped by size; the
+globals are definitions in the first unit and `extern` declarations in the others),
 `fastc_compile_c_units` compiles them with concurrent `tcc -c` processes started through
 `posix_spawn` (forking the large compiler process costs more), and one `tcc` call links the
 objects (`VJOBS=1`, `V3_FASTC_NO_PARALLEL=1`, or `-no-parallel` keeps the single-file build; both

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -233,6 +233,12 @@ executable themselves (`gen/fastc/macho_sign.v`, SHA-256 page hashes through Com
 patched into the file in place). The SDK path is taken from `SDKROOT` or the toolchain selected by
 `xcrun`; conventional SDK locations are used only as a fallback.
 
+Default self-host builds content-cache the split TinyCC objects and the linked, signed executable
+under `os.vtmp_dir()`. The keys cover the exact generated units, TinyCC build, compile options, and
+link options. A cached executable is restored as an independent copy, so replacing or modifying the
+output cannot change the cache. Pass `-nocache` or `--no-cache` through the full V driver to bypass
+both caches.
+
 The standalone compiler supports `self` directly and defaults that command to FastC. For example,
 `./v self x5` replaces the compiler through five descendant FastC generations, with each installed
 generation compiling the next one. `-b fastc`, `-gc none`, `-cc tinyc|tcc`, `-keepc`, `-silent`,

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -7376,11 +7376,15 @@ $if !skip_fastc ? {
 		mut cc_args := environment_c_flags.clone()
 		cc_args << ['-std=gnu11', tcc_resources.base_arg, tcc_resources.include_arg,
 			tcc_resources.library_arg]
-		cc_args << v3_tcc_host_system_flags(prefs.normalized_target_os(), macos_sdk_root)
+		if !(prefs.building_v && prefs.normalized_target_os() == 'macos') {
+			cc_args << v3_tcc_host_system_flags(prefs.normalized_target_os(), macos_sdk_root)
+		}
 		cc_args << source_c_flags
 		// A call without a prototype would silently truncate a pointer result
 		// (the C carries no headers): it is an error, not a warning.
-		cc_args << '-Werror=implicit-function-declaration'
+		if '-Werror=implicit-function-declaration' !in cc_args {
+			cc_args << '-Werror=implicit-function-declaration'
+		}
 		if v3_tcc_backtrace_enabled(prefs.normalized_target_os(), prefs.normalized_target_arch(), false) {
 			cc_args << '-bt25'
 		}
@@ -7396,10 +7400,21 @@ $if !skip_fastc ? {
 		user_link_args := c_dylib_link_flags(user_c_flags)
 		mut final_args := base_link_args.clone()
 		final_args << user_link_args
-		if uses_threads {
-			final_args << '-lpthread'
+		if prefs.building_v && prefs.normalized_target_os() == 'macos' {
+			// Header-free self-hosts only call symbols from FastC's macOS ABI
+			// table. Its compact stub avoids parsing the SDK's full libSystem
+			// umbrella stub while preserving the same dylib install name.
+			fastc_system_tbd := os.join_path_single(build_dir, 'libFastcSystem.tbd')
+			os.write_file(fastc_system_tbd, fastc.fastc_macos_system_tbd(prefs.normalized_target_arch())) or {
+				return V3FastCCompileResult{}
+			}
+			final_args << fastc_system_tbd
+		} else {
+			if uses_threads {
+				final_args << '-lpthread'
+			}
+			final_args << '-lm'
 		}
-		final_args << '-lm'
 		atomic_arg := tcc_atomic_arg(prefs, tcc_path, tcc_resources.include_arg)
 		if atomic_arg.len > 0 {
 			final_args << atomic_arg
@@ -7426,7 +7441,21 @@ $if !skip_fastc ? {
 				success: true
 			}
 		}
-		unit_paths := fastc.fastc_write_c_units(os.join_path_single(build_dir, 'src'), pieces, units, jobs) or { return V3FastCCompileResult{} }
+		unit_prefix := os.join_path_single(build_dir, 'src')
+		mut unit_paths := []string{}
+		mut streamed_sources := []string{}
+		$if macos {
+			if !cache_enabled && prefs.building_v {
+				mut rendered_units := fastc.fastc_render_c_units(unit_prefix, pieces, units, jobs)
+				unit_paths = rendered_units.paths.clone()
+				streamed_sources = rendered_units.sources.clone()
+			}
+		}
+		if unit_paths.len == 0 {
+			unit_paths = fastc.fastc_write_c_units(unit_prefix, pieces, units, jobs) or {
+				return V3FastCCompileResult{}
+			}
+		}
 		if unit_paths.len < 2 {
 			fastc.write_c_pieces(source_file, pieces) or { return V3FastCCompileResult{} }
 		}
@@ -7458,13 +7487,25 @@ $if !skip_fastc ? {
 				}
 			} else {
 				link_worker := spawn fastc.fastc_prepare_link(tcc_path, os.join_path_single(tcc_dir, 'lib'), compile_base_args, final_args)
-				fastc.fastc_compile_c_units(tcc_path, compile_args, unit_paths, prepared_units) or {
-					mut failed_link := link_worker.wait()
-					fastc.fastc_discard_link(mut failed_link)
-					fastc.write_c_pieces(source_file, pieces) or {}
-					return V3FastCCompileResult{
-						command: cmdexec.display(tcc_path, compile_args)
-						output: err.msg()
+				if streamed_sources.len > 0 {
+					fastc.fastc_compile_c_unit_texts(tcc_path, compile_args, unit_paths, streamed_sources, prepared_units) or {
+						mut failed_link := link_worker.wait()
+						fastc.fastc_discard_link(mut failed_link)
+						fastc.write_c_pieces(source_file, pieces) or {}
+						return V3FastCCompileResult{
+							command: cmdexec.display(tcc_path, compile_args)
+							output: err.msg()
+						}
+					}
+				} else {
+					fastc.fastc_compile_c_units(tcc_path, compile_args, unit_paths, prepared_units) or {
+						mut failed_link := link_worker.wait()
+						fastc.fastc_discard_link(mut failed_link)
+						fastc.write_c_pieces(source_file, pieces) or {}
+						return V3FastCCompileResult{
+							command: cmdexec.display(tcc_path, compile_args)
+							output: err.msg()
+						}
 					}
 				}
 				if bench_phases {

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -8720,7 +8720,8 @@ pub fn run(args []string) {
 				if !c_only && prefs.building_v && !fastc_cross_target && (is_debug || no_cache) {
 					tcc_dir := os.join_path(prefs.vroot, 'thirdparty', 'tcc')
 					tcc_path := os.join_path_single(tcc_dir, 'tcc.exe')
-					if os.is_executable(tcc_path) {
+					prestart_jobs := fastc.fastc_tcc_job_count(prefs)
+					if prestart_jobs >= 2 && os.is_executable(tcc_path) {
 						tcc_resources := v3_tcc_resource_flags(prefs.vroot)
 						mut anticipated_cc_args := environment_c_flags.clone()
 						anticipated_cc_args << ['-std=gnu11', tcc_resources.base_arg,
@@ -8735,7 +8736,7 @@ pub fn run(args []string) {
 						mut anticipated_compile_args := c_object_compile_flags(anticipated_cc_args)
 						anticipated_compile_args << c_object_compile_flags(user_c_flags)
 						prestart_dir := os.join_path_single(os.dir(os.real_path(bin_file)), '.${os.file_name(bin_file)}.fastc.${tempname.unique_token()}')
-						prestart_workers << spawn fastc.fastc_prestart_c_units(tcc_path, anticipated_compile_args, prestart_dir, fastc.fastc_tcc_job_count(prefs))
+						prestart_workers << spawn fastc.fastc_prestart_c_units(tcc_path, anticipated_compile_args, prestart_dir, prestart_jobs)
 					}
 				}
 			}

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -7372,13 +7372,6 @@ $if !skip_fastc ? {
 		if bench_phases {
 			eprintln('fastc-phase tcc.setup ${cc_sw.elapsed().microseconds()}us')
 		}
-		unit_paths := fastc.fastc_write_c_units(os.join_path_single(build_dir, 'src'), pieces, units, fastc.fastc_tcc_job_count(prefs)) or { return V3FastCCompileResult{} }
-		if unit_paths.len < 2 {
-			fastc.write_c_pieces(source_file, pieces) or { return V3FastCCompileResult{} }
-		}
-		if bench_phases {
-			eprintln('fastc-phase tcc.units_written ${cc_sw.elapsed().microseconds()}us units=${unit_paths.len}')
-		}
 		tcc_resources := v3_tcc_resource_flags(prefs.vroot)
 		mut cc_args := environment_c_flags.clone()
 		cc_args << ['-std=gnu11', tcc_resources.base_arg, tcc_resources.include_arg,
@@ -7412,6 +7405,34 @@ $if !skip_fastc ? {
 			final_args << atomic_arg
 		}
 		final_args << environment_ld_flags
+		mut compile_args := compile_base_args.clone()
+		compile_args << user_compile_args
+		jobs := fastc.fastc_tcc_job_count(prefs)
+		generation_link_cache_key := fastc.fastc_generation_link_cache_key(tcc_path, compile_args, final_args, pieces, units, jobs, cache_enabled)
+		if fastc.fastc_restore_link_cache(generation_link_cache_key, staged_binary) {
+			if bench_phases {
+				now_us := cc_sw.elapsed().microseconds()
+				eprintln('fastc-phase tcc.units_written ${now_us}us units=0')
+				eprintln('fastc-phase tcc.units_compiled ${now_us}us')
+				eprintln('fastc-phase tcc.linked ${now_us}us')
+				eprintln('fastc-phase tcc.signed ${now_us}us')
+			}
+			os.mv(staged_binary, bin_file) or {
+				return V3FastCCompileResult{
+					output: err.msg()
+				}
+			}
+			return V3FastCCompileResult{
+				success: true
+			}
+		}
+		unit_paths := fastc.fastc_write_c_units(os.join_path_single(build_dir, 'src'), pieces, units, jobs) or { return V3FastCCompileResult{} }
+		if unit_paths.len < 2 {
+			fastc.write_c_pieces(source_file, pieces) or { return V3FastCCompileResult{} }
+		}
+		if bench_phases {
+			eprintln('fastc-phase tcc.units_written ${cc_sw.elapsed().microseconds()}us units=${unit_paths.len}')
+		}
 		mut shim_dir := fastc.FastcCodesignShim{}
 		defer {
 			fastc.fastc_remove_codesign_shim_dir(shim_dir)
@@ -7419,14 +7440,11 @@ $if !skip_fastc ? {
 		mut result := os.Result{}
 		mut command := ''
 		mut sign_in_process := false
-		mut link_cache_key := ''
+		link_cache_key := generation_link_cache_key
 		mut link_cache_restored := false
 		if unit_paths.len > 1 {
-			mut compile_args := compile_base_args.clone()
-			compile_args << user_compile_args
 			prepared_units := fastc.fastc_prepare_c_units(tcc_path, compile_args, unit_paths, cache_enabled)
 			link_inputs := prepared_units.objects.clone()
-			link_cache_key = fastc.fastc_link_cache_key(prepared_units.cache_key, final_args)
 			mut display_args := compile_base_args.clone()
 			display_args << ['-o', staged_binary]
 			display_args << link_inputs

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -7351,26 +7351,13 @@ $if !skip_fastc ? {
 		return os.join_path_single(canonical_parent, os.file_name(absolute_path))
 	}
 
-	fn compile_v3_fastc_source(pieces []string, units fastc.FastcUnitLayout, bin_file string, prefs &pref.Preferences, environment_c_flags []string, source_c_flags []string, user_c_flags []string, environment_ld_flags []string, macos_sdk_root string, is_debug bool, uses_threads bool, cache_enabled bool) V3FastCCompileResult {
+	fn compile_v3_fastc_source(pieces []string, units fastc.FastcUnitLayout, bin_file string, prefs &pref.Preferences, environment_c_flags []string, source_c_flags []string, user_c_flags []string, environment_ld_flags []string, macos_sdk_root string, is_debug bool, uses_threads bool, cache_enabled bool, mut prestarted fastc.FastcPrestartedCUnits) V3FastCCompileResult {
 		bench_phases := os.getenv('FASTC_BENCH_PHASES') != ''
 		cc_sw := time.new_stopwatch()
 		tcc_dir := os.join_path(prefs.vroot, 'thirdparty', 'tcc')
 		tcc_path := os.join_path_single(tcc_dir, 'tcc.exe')
 		if !os.is_executable(tcc_path) {
 			return V3FastCCompileResult{}
-		}
-		build_dir := os.join_path_single(os.dir(os.real_path(bin_file)), '.${os.file_name(bin_file)}.fastc.${tempname.unique_token()}')
-		os.mkdir_all(build_dir) or { return V3FastCCompileResult{} }
-		defer {
-			cleanup_c_build_dir(build_dir)
-		}
-		source_file := os.join_path_single(build_dir, 'src.c')
-		staged_binary := os.join_path_single(build_dir, 'out')
-		// The program's translation units are compiled by concurrent TinyCC
-		// processes and linked; a program that does not split is compiled as
-		// one file.
-		if bench_phases {
-			eprintln('fastc-phase tcc.setup ${cc_sw.elapsed().microseconds()}us')
 		}
 		tcc_resources := v3_tcc_resource_flags(prefs.vroot)
 		mut cc_args := environment_c_flags.clone()
@@ -7395,8 +7382,57 @@ $if !skip_fastc ? {
 		// object inputs. Only their state-affecting options are applied while
 		// preparing libtcc; static archives remain order-sensitive link operands.
 		compile_base_args := c_object_compile_flags(cc_args)
-		base_link_args := c_dylib_link_flags(cc_args)
 		user_compile_args := c_object_compile_flags(user_c_flags)
+		mut compile_args := compile_base_args.clone()
+		compile_args << user_compile_args
+		jobs := fastc.fastc_tcc_job_count(prefs)
+		mut uses_prestarted := false
+		$if macos {
+			uses_prestarted = fastc.fastc_prestarted_c_units_match(&prestarted, compile_args, jobs)
+			if !uses_prestarted {
+				fastc.fastc_discard_prestarted_c_units(mut prestarted)
+			}
+		}
+		build_dir := if uses_prestarted {
+			prestarted.build_dir
+		} else {
+			os.join_path_single(os.dir(os.real_path(bin_file)), '.${os.file_name(bin_file)}.fastc.${tempname.unique_token()}')
+		}
+		if !uses_prestarted {
+			os.mkdir_all(build_dir) or { return V3FastCCompileResult{} }
+		}
+		defer {
+			cleanup_c_build_dir(build_dir)
+		}
+		source_file := os.join_path_single(build_dir, 'src.c')
+		staged_binary := os.join_path_single(build_dir, 'out')
+		unit_prefix := os.join_path_single(build_dir, 'src')
+		mut rendering_units := fastc.FastcRenderingCUnits{}
+		mut feeding_units := fastc.FastcFeedingCUnits{}
+		mut feeds_prestarted := false
+		$if macos {
+			if !cache_enabled && prefs.building_v {
+				if uses_prestarted {
+					feeding_units = fastc.fastc_begin_render_prestarted_c_units(mut prestarted, unit_prefix, pieces, units, jobs) or {
+						fastc.write_c_pieces(source_file, pieces) or {}
+						return V3FastCCompileResult{
+							command: cmdexec.display(tcc_path, compile_args)
+							output: err.msg()
+						}
+					}
+					feeds_prestarted = true
+				} else {
+					rendering_units = fastc.fastc_begin_render_c_units(unit_prefix, pieces, units, jobs)
+				}
+			}
+		}
+		// The program's translation units are compiled by concurrent TinyCC
+		// processes and linked; a program that does not split is compiled as
+		// one file.
+		if bench_phases {
+			eprintln('fastc-phase tcc.setup ${cc_sw.elapsed().microseconds()}us')
+		}
+		base_link_args := c_dylib_link_flags(cc_args)
 		user_link_args := c_dylib_link_flags(user_c_flags)
 		mut final_args := base_link_args.clone()
 		final_args << user_link_args
@@ -7420,9 +7456,6 @@ $if !skip_fastc ? {
 			final_args << atomic_arg
 		}
 		final_args << environment_ld_flags
-		mut compile_args := compile_base_args.clone()
-		compile_args << user_compile_args
-		jobs := fastc.fastc_tcc_job_count(prefs)
 		generation_link_cache_key := fastc.fastc_generation_link_cache_key(tcc_path, compile_args, final_args, pieces, units, jobs, cache_enabled)
 		if fastc.fastc_restore_link_cache(generation_link_cache_key, staged_binary) {
 			if bench_phases {
@@ -7441,14 +7474,11 @@ $if !skip_fastc ? {
 				success: true
 			}
 		}
-		unit_prefix := os.join_path_single(build_dir, 'src')
 		mut unit_paths := []string{}
-		mut rendering_units := fastc.FastcRenderingCUnits{}
-		$if macos {
-			if !cache_enabled && prefs.building_v {
-				rendering_units = fastc.fastc_begin_render_c_units(unit_prefix, pieces, units, jobs)
-				unit_paths = rendering_units.paths.clone()
-			}
+		if feeds_prestarted {
+			unit_paths = feeding_units.paths.clone()
+		} else if rendering_units.paths.len > 0 {
+			unit_paths = rendering_units.paths.clone()
 		}
 		if unit_paths.len == 0 {
 			unit_paths = fastc.fastc_write_c_units(unit_prefix, pieces, units, jobs) or {
@@ -7486,9 +7516,25 @@ $if !skip_fastc ? {
 				}
 			} else {
 				mut prepared_link := fastc.fastc_prepare_link(tcc_path, os.join_path_single(tcc_dir, 'lib'), compile_base_args, final_args)
-				preload_link := rendering_units.paths.len > 0
+				preload_link := (feeds_prestarted || rendering_units.paths.len > 0)
 					&& fastc.fastc_prepared_link_accepts_inputs(&prepared_link)
-				if rendering_units.paths.len > 0 {
+				if feeds_prestarted {
+					if !uses_prestarted {
+						fastc.fastc_discard_link(mut prepared_link)
+						return V3FastCCompileResult{
+							command: cmdexec.display(tcc_path, compile_args)
+							output: 'prestarted TinyCC units were not available'
+						}
+					}
+					fastc.fastc_finish_prestarted_c_units(mut prestarted, mut feeding_units, prepared_units, mut prepared_link, preload_link) or {
+						fastc.fastc_discard_link(mut prepared_link)
+						fastc.write_c_pieces(source_file, pieces) or {}
+						return V3FastCCompileResult{
+							command: cmdexec.display(tcc_path, compile_args)
+							output: err.msg()
+						}
+					}
+				} else if rendering_units.paths.len > 0 {
 					fastc.fastc_compile_rendering_c_units(tcc_path, compile_args, mut rendering_units, prepared_units, mut prepared_link, preload_link) or {
 						fastc.fastc_discard_link(mut prepared_link)
 						fastc.write_c_pieces(source_file, pieces) or {}
@@ -8668,6 +8714,39 @@ pub fn run(args []string) {
 					return
 				}
 			}
+			mut prestarted_fastc_units := fastc.FastcPrestartedCUnits{}
+			mut prestart_workers := []thread fastc.FastcPrestartedCUnits{}
+			$if macos {
+				if !c_only && prefs.building_v && !fastc_cross_target && (is_debug || no_cache) {
+					tcc_dir := os.join_path(prefs.vroot, 'thirdparty', 'tcc')
+					tcc_path := os.join_path_single(tcc_dir, 'tcc.exe')
+					if os.is_executable(tcc_path) {
+						tcc_resources := v3_tcc_resource_flags(prefs.vroot)
+						mut anticipated_cc_args := environment_c_flags.clone()
+						anticipated_cc_args << ['-std=gnu11', tcc_resources.base_arg,
+							tcc_resources.include_arg, tcc_resources.library_arg]
+						anticipated_cc_args << '-Werror=implicit-function-declaration'
+						if v3_tcc_backtrace_enabled(prefs.normalized_target_os(), prefs.normalized_target_arch(), false) {
+							anticipated_cc_args << '-bt25'
+						}
+						if is_debug {
+							anticipated_cc_args << '-g'
+						}
+						mut anticipated_compile_args := c_object_compile_flags(anticipated_cc_args)
+						anticipated_compile_args << c_object_compile_flags(user_c_flags)
+						prestart_dir := os.join_path_single(os.dir(os.real_path(bin_file)), '.${os.file_name(bin_file)}.fastc.${tempname.unique_token()}')
+						prestart_workers << spawn fastc.fastc_prestart_c_units(tcc_path, anticipated_compile_args, prestart_dir, fastc.fastc_tcc_job_count(prefs))
+					}
+				}
+			}
+			defer {
+				$if macos {
+					if prestart_workers.len > 0 {
+						prestarted_fastc_units = prestart_workers[0].wait()
+					}
+					fastc.fastc_discard_prestarted_c_units(mut prestarted_fastc_units)
+				}
+			}
 			if os.getenv('FASTC_BENCH_PHASES') != '' {
 				eprintln('fastc-phase driver.setup ${driver_sw.elapsed().microseconds()}us')
 			}
@@ -8675,6 +8754,10 @@ pub fn run(args []string) {
 				eprintln(err.msg())
 				exit(1)
 				return
+			}
+			if prestart_workers.len > 0 {
+				prestarted_fastc_units = prestart_workers[0].wait()
+				prestart_workers.clear()
 			}
 			if os.getenv('FASTC_BENCH_PHASES') != '' {
 				eprintln('fastc-phase driver.generated ${driver_sw.elapsed().microseconds()}us')
@@ -8712,7 +8795,7 @@ pub fn run(args []string) {
 			} else {
 				''
 			}
-			fastc_result := compile_v3_fastc_source(fastc_pieces, fastc_generation.units, fastc_bin_file, prefs, environment_c_flags, fastc_generation.c_flags, user_c_flags, environment_ld_flags, fastc_sdk_root, is_debug, fastc_generation.uses_threads, prefs.building_v && !is_debug && !no_cache)
+			fastc_result := compile_v3_fastc_source(fastc_pieces, fastc_generation.units, fastc_bin_file, prefs, environment_c_flags, fastc_generation.c_flags, user_c_flags, environment_ld_flags, fastc_sdk_root, is_debug, fastc_generation.uses_threads, prefs.building_v && !is_debug && !no_cache, mut prestarted_fastc_units)
 			if (!silent || show_cc) && fastc_result.command.len > 0 {
 				if c_to_stdout {
 					eprintln('  > ${fastc_result.command}')

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -7351,7 +7351,7 @@ $if !skip_fastc ? {
 		return os.join_path_single(canonical_parent, os.file_name(absolute_path))
 	}
 
-	fn compile_v3_fastc_source(pieces []string, units fastc.FastcUnitLayout, bin_file string, prefs &pref.Preferences, environment_c_flags []string, source_c_flags []string, user_c_flags []string, environment_ld_flags []string, macos_sdk_root string, is_debug bool, uses_threads bool) V3FastCCompileResult {
+	fn compile_v3_fastc_source(pieces []string, units fastc.FastcUnitLayout, bin_file string, prefs &pref.Preferences, environment_c_flags []string, source_c_flags []string, user_c_flags []string, environment_ld_flags []string, macos_sdk_root string, is_debug bool, uses_threads bool, cache_enabled bool) V3FastCCompileResult {
 		bench_phases := os.getenv('FASTC_BENCH_PHASES') != ''
 		cc_sw := time.new_stopwatch()
 		tcc_dir := os.join_path(prefs.vroot, 'thirdparty', 'tcc')
@@ -7419,37 +7419,49 @@ $if !skip_fastc ? {
 		mut result := os.Result{}
 		mut command := ''
 		mut sign_in_process := false
+		mut link_cache_key := ''
+		mut link_cache_restored := false
 		if unit_paths.len > 1 {
 			mut compile_args := compile_base_args.clone()
 			compile_args << user_compile_args
-			link_worker := spawn fastc.fastc_prepare_link(tcc_path, os.join_path_single(tcc_dir, 'lib'), compile_base_args, final_args)
-			unit_objects := fastc.fastc_compile_c_units(tcc_path, compile_args, unit_paths) or {
-				mut prepared_link := link_worker.wait()
-				fastc.fastc_discard_link(mut prepared_link)
-				fastc.write_c_pieces(source_file, pieces) or {}
-				return V3FastCCompileResult{
-					command: cmdexec.display(tcc_path, compile_args)
-					output: err.msg()
-				}
-			}
-			if bench_phases {
-				eprintln('fastc-phase tcc.units_compiled ${cc_sw.elapsed().microseconds()}us')
-			}
-			link_inputs := unit_objects.clone()
+			prepared_units := fastc.fastc_prepare_c_units(tcc_path, compile_args, unit_paths, cache_enabled)
+			link_inputs := prepared_units.objects.clone()
+			link_cache_key = fastc.fastc_link_cache_key(prepared_units.cache_key, final_args)
 			mut display_args := compile_base_args.clone()
 			display_args << ['-o', staged_binary]
 			display_args << link_inputs
 			display_args << final_args
 			command = cmdexec.display(tcc_path, display_args)
-			mut prepared_link := link_worker.wait()
-			sign_in_process = fastc.fastc_prepared_link_skips_codesign(&prepared_link)
-			if !sign_in_process {
-				// The executable-based linker still needs the PATH shim; the prepared
-				// libtcc linker suppresses its codesign call without a subprocess.
-				shim_dir = fastc.fastc_codesign_shim_dir()
-				sign_in_process = shim_dir.dir != ''
+			if fastc.fastc_restore_link_cache(link_cache_key, staged_binary) {
+				link_cache_restored = true
+				result = os.Result{}
+				if bench_phases {
+					eprintln('fastc-phase tcc.units_compiled ${cc_sw.elapsed().microseconds()}us')
+				}
+			} else {
+				link_worker := spawn fastc.fastc_prepare_link(tcc_path, os.join_path_single(tcc_dir, 'lib'), compile_base_args, final_args)
+				fastc.fastc_compile_c_units(tcc_path, compile_args, unit_paths, prepared_units) or {
+					mut failed_link := link_worker.wait()
+					fastc.fastc_discard_link(mut failed_link)
+					fastc.write_c_pieces(source_file, pieces) or {}
+					return V3FastCCompileResult{
+						command: cmdexec.display(tcc_path, compile_args)
+						output: err.msg()
+					}
+				}
+				if bench_phases {
+					eprintln('fastc-phase tcc.units_compiled ${cc_sw.elapsed().microseconds()}us')
+				}
+				mut prepared_link := link_worker.wait()
+				sign_in_process = fastc.fastc_prepared_link_skips_codesign(&prepared_link)
+				if !sign_in_process {
+					// The executable-based linker still needs the PATH shim; the prepared
+					// libtcc linker suppresses its codesign call without a subprocess.
+					shim_dir = fastc.fastc_codesign_shim_dir()
+					sign_in_process = shim_dir.dir != ''
+				}
+				result = fastc.fastc_finish_link(mut prepared_link, link_inputs, final_args, staged_binary)
 			}
-			result = fastc.fastc_finish_link(mut prepared_link, link_inputs, final_args, staged_binary)
 			if bench_phases {
 				eprintln('fastc-phase tcc.linked ${cc_sw.elapsed().microseconds()}us')
 			}
@@ -7481,6 +7493,9 @@ $if !skip_fastc ? {
 					output: 'could not sign ${staged_binary}: ${err.msg()}'
 				}
 			}
+		}
+		if !link_cache_restored {
+			fastc.fastc_publish_link_cache(link_cache_key, staged_binary)
 		}
 		if bench_phases {
 			eprintln('fastc-phase tcc.signed ${cc_sw.elapsed().microseconds()}us')
@@ -8639,7 +8654,7 @@ pub fn run(args []string) {
 			} else {
 				''
 			}
-			fastc_result := compile_v3_fastc_source(fastc_pieces, fastc_generation.units, fastc_bin_file, prefs, environment_c_flags, fastc_generation.c_flags, user_c_flags, environment_ld_flags, fastc_sdk_root, is_debug, fastc_generation.uses_threads)
+			fastc_result := compile_v3_fastc_source(fastc_pieces, fastc_generation.units, fastc_bin_file, prefs, environment_c_flags, fastc_generation.c_flags, user_c_flags, environment_ld_flags, fastc_sdk_root, is_debug, fastc_generation.uses_threads, prefs.building_v && !is_debug && !no_cache)
 			if (!silent || show_cc) && fastc_result.command.len > 0 {
 				if c_to_stdout {
 					eprintln('  > ${fastc_result.command}')

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -7443,12 +7443,11 @@ $if !skip_fastc ? {
 		}
 		unit_prefix := os.join_path_single(build_dir, 'src')
 		mut unit_paths := []string{}
-		mut streamed_sources := []string{}
+		mut rendering_units := fastc.FastcRenderingCUnits{}
 		$if macos {
 			if !cache_enabled && prefs.building_v {
-				mut rendered_units := fastc.fastc_render_c_units(unit_prefix, pieces, units, jobs)
-				unit_paths = rendered_units.paths.clone()
-				streamed_sources = rendered_units.sources.clone()
+				rendering_units = fastc.fastc_begin_render_c_units(unit_prefix, pieces, units, jobs)
+				unit_paths = rendering_units.paths.clone()
 			}
 		}
 		if unit_paths.len == 0 {
@@ -7486,11 +7485,12 @@ $if !skip_fastc ? {
 					eprintln('fastc-phase tcc.units_compiled ${cc_sw.elapsed().microseconds()}us')
 				}
 			} else {
-				link_worker := spawn fastc.fastc_prepare_link(tcc_path, os.join_path_single(tcc_dir, 'lib'), compile_base_args, final_args)
-				if streamed_sources.len > 0 {
-					fastc.fastc_compile_c_unit_texts(tcc_path, compile_args, unit_paths, streamed_sources, prepared_units) or {
-						mut failed_link := link_worker.wait()
-						fastc.fastc_discard_link(mut failed_link)
+				mut prepared_link := fastc.fastc_prepare_link(tcc_path, os.join_path_single(tcc_dir, 'lib'), compile_base_args, final_args)
+				preload_link := rendering_units.paths.len > 0
+					&& fastc.fastc_prepared_link_accepts_inputs(&prepared_link)
+				if rendering_units.paths.len > 0 {
+					fastc.fastc_compile_rendering_c_units(tcc_path, compile_args, mut rendering_units, prepared_units, mut prepared_link, preload_link) or {
+						fastc.fastc_discard_link(mut prepared_link)
 						fastc.write_c_pieces(source_file, pieces) or {}
 						return V3FastCCompileResult{
 							command: cmdexec.display(tcc_path, compile_args)
@@ -7499,8 +7499,7 @@ $if !skip_fastc ? {
 					}
 				} else {
 					fastc.fastc_compile_c_units(tcc_path, compile_args, unit_paths, prepared_units) or {
-						mut failed_link := link_worker.wait()
-						fastc.fastc_discard_link(mut failed_link)
+						fastc.fastc_discard_link(mut prepared_link)
 						fastc.write_c_pieces(source_file, pieces) or {}
 						return V3FastCCompileResult{
 							command: cmdexec.display(tcc_path, compile_args)
@@ -7511,7 +7510,6 @@ $if !skip_fastc ? {
 				if bench_phases {
 					eprintln('fastc-phase tcc.units_compiled ${cc_sw.elapsed().microseconds()}us')
 				}
-				mut prepared_link := link_worker.wait()
 				sign_in_process = fastc.fastc_prepared_link_skips_codesign(&prepared_link)
 				if !sign_in_process {
 					// The executable-based linker still needs the PATH shim; the prepared
@@ -7519,7 +7517,8 @@ $if !skip_fastc ? {
 					shim_dir = fastc.fastc_codesign_shim_dir()
 					sign_in_process = shim_dir.dir != ''
 				}
-				result = fastc.fastc_finish_link(mut prepared_link, link_inputs, final_args, staged_binary)
+				finish_inputs := if preload_link { []string{} } else { link_inputs }
+				result = fastc.fastc_finish_link(mut prepared_link, finish_inputs, final_args, staged_binary)
 			}
 			if bench_phases {
 				eprintln('fastc-phase tcc.linked ${cc_sw.elapsed().microseconds()}us')

--- a/vlib/v3/fastcdriver/fastcdriver.v
+++ b/vlib/v3/fastcdriver/fastcdriver.v
@@ -496,28 +496,40 @@ pub fn run(args []string) {
 	mut shim_dir := fastc.FastcCodesignShim{}
 	mut result := os.Result{}
 	mut sign_in_process := false
+	mut link_cache_key := ''
+	mut link_cache_restored := false
 	if unit_paths.len > 1 {
-		link_worker := spawn fastc.fastc_prepare_link(tcc, tcc_lib, cc_args, link_libs)
-		unit_objects := fastc.fastc_compile_c_units(tcc, cc_args, unit_paths) or {
+		prepared_units := fastc.fastc_prepare_c_units(tcc, cc_args, unit_paths, prefs.building_v)
+		link_inputs := prepared_units.objects.clone()
+		link_cache_key = fastc.fastc_link_cache_key(prepared_units.cache_key, link_libs)
+		if fastc.fastc_restore_link_cache(link_cache_key, staged_output) {
+			link_cache_restored = true
+			result = os.Result{}
+			if bench_phases {
+				eprintln('fastc-phase tcc.units_compiled ${cc_sw.elapsed().microseconds()}us')
+			}
+		} else {
+			link_worker := spawn fastc.fastc_prepare_link(tcc, tcc_lib, cc_args, link_libs)
+			fastc.fastc_compile_c_units(tcc, cc_args, unit_paths, prepared_units) or {
+				mut failed_link := link_worker.wait()
+				fastc.fastc_discard_link(mut failed_link)
+				fastc.fastc_remove_codesign_shim_dir(shim_dir)
+				fastc.fastc_remove_c_units(unit_paths)
+				// The whole program is kept as one file for the error message.
+				fastc.write_c_pieces(c_path, generation.c_pieces) or {}
+				fail(err.msg())
+			}
+			if bench_phases {
+				eprintln('fastc-phase tcc.units_compiled ${cc_sw.elapsed().microseconds()}us')
+			}
 			mut prepared_link := link_worker.wait()
-			fastc.fastc_discard_link(mut prepared_link)
-			fastc.fastc_remove_codesign_shim_dir(shim_dir)
-			fastc.fastc_remove_c_units(unit_paths)
-			// The whole program is kept as one file for the error message.
-			fastc.write_c_pieces(c_path, generation.c_pieces) or {}
-			fail(err.msg())
+			sign_in_process = fastc.fastc_prepared_link_skips_codesign(&prepared_link)
+			if !sign_in_process {
+				shim_dir = fastc.fastc_codesign_shim_dir()
+				sign_in_process = shim_dir.dir != ''
+			}
+			result = fastc.fastc_finish_link(mut prepared_link, link_inputs, link_libs, staged_output)
 		}
-		if bench_phases {
-			eprintln('fastc-phase tcc.units_compiled ${cc_sw.elapsed().microseconds()}us')
-		}
-		link_inputs := unit_objects.clone()
-		mut prepared_link := link_worker.wait()
-		sign_in_process = fastc.fastc_prepared_link_skips_codesign(&prepared_link)
-		if !sign_in_process {
-			shim_dir = fastc.fastc_codesign_shim_dir()
-			sign_in_process = shim_dir.dir != ''
-		}
-		result = fastc.fastc_finish_link(mut prepared_link, link_inputs, link_libs, staged_output)
 		if bench_phases {
 			eprintln('fastc-phase tcc.linked ${cc_sw.elapsed().microseconds()}us')
 		}
@@ -542,6 +554,9 @@ pub fn run(args []string) {
 		fastc.fastc_sign_macho_adhoc(staged_output) or {
 			fail('could not sign ${staged_output}: ${err.msg()}')
 		}
+	}
+	if !link_cache_restored {
+		fastc.fastc_publish_link_cache(link_cache_key, staged_output)
 	}
 	os.mv(staged_output, output) or { fail(err.msg()) }
 	if keep_c {

--- a/vlib/v3/gen/fastc/anonfn.v
+++ b/vlib/v3/gen/fastc/anonfn.v
@@ -53,7 +53,7 @@ fn (mut g Parser) parse_anonymous_function() !string {
 		g.next()
 	}
 	anon_source := g.s.src[anon_start..body_end]
-	name := '__v_fastc_anon_${g.module_name.replace('.', '_')}_${os.file_name(g.path).replace('.', '_')}_${anon_start}'
+	name := '__vf_anon_${g.module_name.replace('.', '_')}_${os.file_name(g.path).replace('.', '_')}_${anon_start}'
 	// Rewrite `fn (...) ...` as `fn <name> (...) ...` so `parse_function` reads it as
 	// an ordinary declaration.
 	after_fn_keyword := anon_source[2..]

--- a/vlib/v3/gen/fastc/arm64_d_arm64.v
+++ b/vlib/v3/gen/fastc/arm64_d_arm64.v
@@ -267,8 +267,8 @@ pub fn generate_arm64_files(paths []string, prefs &pref.Preferences, output stri
 	// The lifecycle hooks run in module dependency order; the resolver returns
 	// discovery order.
 	lifecycle_sources := fastc_sources_in_dependency_order(sources)!
-	module_init_calls := fastc_module_init_calls(lifecycle_sources, functions)!
-	module_cleanup_calls := fastc_module_cleanup_calls(lifecycle_sources, functions)!
+	module_init_calls := fastc_module_init_calls(lifecycle_sources, functions, map[string]string{})!
+	module_cleanup_calls := fastc_module_cleanup_calls(lifecycle_sources, functions, map[string]string{})!
 	module_init_function_keys := fast_arm64_lifecycle_function_keys(module_init_calls, 'init', functions)
 	module_cleanup_function_keys := fast_arm64_lifecycle_function_keys(module_cleanup_calls, 'cleanup', functions)
 	program.register_module_lifecycle(module_init_function_keys, module_cleanup_function_keys)
@@ -2199,7 +2199,7 @@ fn (mut p FastArm64Program) register_spawn_wrapper(function_key string, target_i
 		field_names: field_names
 	})
 	name_key := fastc_name_key(function_key)
-	wrapper_key := '__v_fastc_arm64_spawn_wrapper_${name_key}'
+	wrapper_key := '__vf_arm64_spawn_wrapper_${name_key}'
 	wrapper_id := p.register_function(wrapper_key, wrapper_key, p.ptr_i8, false)
 	entry := p.m.add_block(wrapper_id, 'spawn_wrapper_entry')
 	raw_context := p.add_arg(wrapper_id, p.ptr_i8, 'context')

--- a/vlib/v3/gen/fastc/array.v
+++ b/vlib/v3/gen/fastc/array.v
@@ -327,7 +327,7 @@ fn (g &Parser) render_array_access_expression(tokens []FastcExpressionToken) ?Fa
 		is_fixed_array := base_layout_type.starts_with('FixedArray_')
 		is_raw_fixed_array := is_fixed_array && g.fixed_array_uses_raw_storage(base_tokens)
 		needs_receiver_temporary := omitted_end && base_tokens.len > 1 && !is_raw_fixed_array
-		receiver_name := '__v_fastc_slice_receiver'
+		receiver_name := '__vf_slice_receiver'
 		receiver_source := if needs_receiver_temporary { receiver_name } else { base_source }
 		receiver_is_pointer := base_type.ends_with('*') && !needs_receiver_temporary
 		access := if receiver_is_pointer { '->' } else { '.' }
@@ -371,7 +371,8 @@ fn (g &Parser) render_array_access_expression(tokens []FastcExpressionToken) ?Fa
 			'builtin__array_slice(${array_value}, ${start}, ${end})'
 		}
 		if needs_receiver_temporary {
-			slice_source = '({ __typeof__((${base_source})) ${receiver_name} = (${base_source}); ${slice_source}; })'
+			receiver_decl_type := g.declaration_c_type(base_type, base_source)
+			slice_source = '({ ${receiver_decl_type} ${receiver_name} = (${base_source}); ${slice_source}; })'
 		}
 		return FastcRenderedExpression{
 			source: slice_source
@@ -619,7 +620,7 @@ fn (g &Parser) resolved_root_expression_name(name string) string {
 		}
 	}
 	// A local/parameter whose name is a C keyword (`short`, `default`) is emitted as
-	// `__v_fastc_keyword_<name>`; return that so an index base matches the render_raw buffer
+	// `__vf_keyword_<name>`; return that so an index base matches the render_raw buffer
 	// spelling and its lowered `string_at`/`array_get` receiver is the real variable.
 	return fastc_c_identifier(name)
 }
@@ -634,11 +635,11 @@ fn (g &Parser) fastc_inline_array_element_equality(array_type string, left strin
 		return error('nested array element')
 	}
 	inner_comparison := if g.underlying_alias_type(inner_element).trim_right('*') == 'string' {
-		'builtin__string_eq(((${inner_element} *)__v_fastc_meq_l.data)[__v_fastc_meq_k], ((${inner_element} *)__v_fastc_meq_r.data)[__v_fastc_meq_k])'
+		'builtin__string_eq(((${inner_element} *)__vf_meq_l.data)[__vf_meq_k], ((${inner_element} *)__vf_meq_r.data)[__vf_meq_k])'
 	} else {
-		'(((${inner_element} *)__v_fastc_meq_l.data)[__v_fastc_meq_k] == ((${inner_element} *)__v_fastc_meq_r.data)[__v_fastc_meq_k])'
+		'(((${inner_element} *)__vf_meq_l.data)[__vf_meq_k] == ((${inner_element} *)__vf_meq_r.data)[__vf_meq_k])'
 	}
-	return '({ ${array_type} __v_fastc_meq_l = (${left}); ${array_type} __v_fastc_meq_r = (${right}); bool __v_fastc_meq = (__v_fastc_meq_l.len == __v_fastc_meq_r.len); for (int __v_fastc_meq_k = 0; __v_fastc_meq && __v_fastc_meq_k < __v_fastc_meq_l.len; __v_fastc_meq_k++) { if (!${inner_comparison}) { __v_fastc_meq = false; break; } } __v_fastc_meq; })'
+	return '({ ${array_type} __vf_meq_l = (${left}); ${array_type} __vf_meq_r = (${right}); bool __vf_meq = (__vf_meq_l.len == __vf_meq_r.len); for (int __vf_meq_k = 0; __vf_meq && __vf_meq_k < __vf_meq_l.len; __vf_meq_k++) { if (!${inner_comparison}) { __vf_meq = false; break; } } __vf_meq; })'
 }
 
 fn (g &Parser) render_membership_candidate(tokens []FastcExpressionToken, expected_type string) ?string {

--- a/vlib/v3/gen/fastc/c_abi.v
+++ b/vlib/v3/gen/fastc/c_abi.v
@@ -229,6 +229,26 @@ fn fastc_c_abi_functions(target_os string, target_arch string) []FastcCAbiFuncti
 	return fns
 }
 
+// fastc_macos_system_tbd returns a compact libSystem text stub containing the
+// complete macOS ABI table used by header-free FastC self-host builds. Passing
+// this to TinyCC avoids parsing the SDK's much larger umbrella stub at link
+// time while retaining the same libSystem install name.
+pub fn fastc_macos_system_tbd(target_arch string) string {
+	targets := if target_arch == 'amd64' {
+		'x86_64-macos, x86_64-maccatalyst'
+	} else {
+		'arm64-macos, arm64e-macos'
+	}
+	mut symbols := ['___stdinp', '___stdoutp', '___stderrp', '_environ', '_mach_task_self_',
+		'_clonefile', '_posix_spawn', '_posix_spawn_file_actions_addclose',
+		'_posix_spawn_file_actions_adddup2', '_posix_spawn_file_actions_destroy',
+		'_posix_spawn_file_actions_init', '_posix_spawnp']
+	for f in fastc_c_abi_functions('macos', target_arch) {
+		symbols << if f.asm_label != '' { f.asm_label } else { '_' + f.name }
+	}
+	return '--- !tapi-tbd\n' + 'tbd-version:     4\n' + 'targets:         [ ${targets} ]\n' + "install-name:    '/usr/lib/libSystem.B.dylib'\n" + 'exports:\n' + '  - targets:         [ ${targets} ]\n' + '    symbols:         [ ${symbols.join(', ')} ]\n' + '...\n'
+}
+
 // fastc_c_abi_prelude renders the header-free prelude for a target. `p`
 // prefixes every name the prelude introduces (types, struct tags, macros,
 // functions, globals); it is '' for generation and lets c_abi_test.v compile
@@ -303,6 +323,7 @@ fn fastc_c_abi_prelude(target_os string, target_arch string, p string) string {
 		b.writeln('#define ${p}O_NOCTTY 0x20000')
 		b.writeln('#define ${p}F_SETLK 8')
 		b.writeln('#define ${p}F_SETLKW 9')
+		b.writeln('#define ${p}F_SETNOSIGPIPE 73')
 		b.writeln('#define ${p}F_RDLCK 1')
 		b.writeln('#define ${p}F_UNLCK 2')
 		b.writeln('#define ${p}F_WRLCK 3')

--- a/vlib/v3/gen/fastc/c_abi_test.v
+++ b/vlib/v3/gen/fastc/c_abi_test.v
@@ -60,6 +60,19 @@ fn test_c_abi_prelude_requires_glibc_on_linux() {
 	assert !fastc_c_abi_supported('linux', 'x86', true)
 }
 
+fn test_fastc_macos_system_tbd_uses_abi_symbols() {
+	arm := fastc_macos_system_tbd('arm64')
+	assert arm.contains("install-name:    '/usr/lib/libSystem.B.dylib'")
+	assert arm.contains('targets:         [ arm64-macos, arm64e-macos ]')
+	assert arm.contains('_malloc')
+	assert arm.contains(r'_realpath$DARWIN_EXTSN')
+	assert arm.contains('___stdoutp')
+	assert arm.contains('_posix_spawn_file_actions_init')
+	amd64 := fastc_macos_system_tbd('amd64')
+	assert amd64.contains('targets:         [ x86_64-macos, x86_64-maccatalyst ]')
+	assert amd64.contains(r'_stat$INODE64')
+}
+
 // fastc_c_abi_check_source renders the C program that compares the prefixed
 // prelude with the real headers: static assertions for layouts, values and
 // prototypes, and runtime checks for the initializers and fd_set macros.

--- a/vlib/v3/gen/fastc/comptime.v
+++ b/vlib/v3/gen/fastc/comptime.v
@@ -1739,7 +1739,7 @@ fn (mut g Parser) parse_veb_html_return() !bool {
 		}
 	}
 	ctx_name := g.fastc_veb_context_name()
-	bname := '__v_fastc_veb_tmpl'
+	bname := '__vf_veb_tmpl'
 	mut lowering := fastc_veb_compile_template(tmpl_path, bname, ctx_name) or {
 		return g.unsupported('veb template `${tmpl_path}`: ${err.msg()}')
 	}

--- a/vlib/v3/gen/fastc/comptime.v
+++ b/vlib/v3/gen/fastc/comptime.v
@@ -1137,7 +1137,11 @@ fn (g &Parser) dollar_keyword_is(keyword string) bool {
 }
 
 fn (g &Parser) comptime_pseudo_expression(name string) ?string {
-	line, column := fastc_line_column(g.s.src, g.s.pos)
+	mut line, mut column := fastc_line_column(g.s.src, g.s.pos)
+	if line == 1 {
+		column += g.source_column_offset
+	}
+	line += g.source_line_offset
 	module_name := if g.module_name == '' { 'main' } else { g.module_name }
 	function_name := g.current_function
 	receiver_name := g.current_receiver.all_after_last('.')

--- a/vlib/v3/gen/fastc/decl.v
+++ b/vlib/v3/gen/fastc/decl.v
@@ -1192,11 +1192,21 @@ fn fastc_constant_candidates(ordered_sources []FastcSourceFile, constant_sources
 }
 
 // fastc_seed_constant_types parses constants in source order only to make their
-// types available to struct field defaults. It is used conditionally when a
-// default references a constant; the authoritative parallel pass still renders
-// and emits the declarations after the defaults are available.
-fn fastc_seed_constant_types(ctx &FastcConstantGenContext, candidates []FastcSourceFile, mut constant_types map[string]string) {
-	for candidate in candidates {
+// types available to struct field defaults. Independent results from the
+// authoritative parallel pass are reused; only order-dependent candidates are
+// parsed again before the defaults are rendered.
+fn fastc_seed_constant_types(ctx &FastcConstantGenContext, candidates []FastcSourceFile, parallel_results []FastcConstantFileResult, mut constant_types map[string]string) {
+	for index, candidate in candidates {
+		if index < parallel_results.len {
+			result := parallel_results[index]
+			if !result.failed && !result.used_field_defaults
+				&& fastc_constant_file_is_independent(result) {
+				for value in result.values {
+					constant_types[value.key] = value.typ
+				}
+				continue
+			}
+		}
 		mut result := fastc_parse_constant_file(ctx, candidate, constant_types)
 		if result.failed {
 			return
@@ -1222,7 +1232,7 @@ fn fastc_field_defaults_reference_constants(struct_field_info map[string][]Fastc
 	return false
 }
 
-fn fastc_generate_constant_declarations(ordered_sources []FastcSourceFile, constant_sources map[string]string, constant_spans map[string][]int, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, sum_types map[string]bool, sum_type_variants map[string]bool, mut pending_defaults FastcPendingFieldDefaults, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, globals map[string]string, public_globals map[string]bool, mut constant_types map[string]string) !FastcConstantDeclarations {
+fn fastc_generate_constant_declarations(candidates []FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, sum_types map[string]bool, sum_type_variants map[string]bool, mut pending_defaults FastcPendingFieldDefaults, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, globals map[string]string, public_globals map[string]bool, initial_parallel_results []FastcConstantFileResult, mut constant_types map[string]string) !FastcConstantDeclarations {
 	mut values := []FastcConstantValue{}
 	mut composite_types := map[string]bool{}
 	mut fixed_array_types := map[string]string{}
@@ -1247,12 +1257,12 @@ fn fastc_generate_constant_declarations(ordered_sources []FastcSourceFile, const
 		globals: globals
 		public_globals: public_globals
 	}
-	// Candidates carry their filtered constant source as `source`, in module
-	// dependency order, so both the parallel pre-pass and the in-order merge
-	// below see the same files.
-	candidates := fastc_constant_candidates(ordered_sources, constant_sources, constant_spans)
 	sw := time.new_stopwatch()
-	parallel_results := fastc_parse_constant_files_parallel(&ctx, candidates, constant_types)
+	parallel_results := if initial_parallel_results.len > 0 {
+		initial_parallel_results
+	} else {
+		fastc_parse_constant_files_parallel(&ctx, candidates, constant_types)
+	}
 	parallel_us := sw.elapsed().microseconds()
 	// The rendered defaults are needed from here on: for the in-order parse of
 	// the files that consulted them, and by the phases after this one.

--- a/vlib/v3/gen/fastc/decl.v
+++ b/vlib/v3/gen/fastc/decl.v
@@ -600,7 +600,7 @@ fn fastc_merge_declaration_partial(partial FastcDeclarationPartial, mut declared
 	}
 }
 
-fn fastc_generate_global_declarations(ordered_sources []FastcSourceFile, global_sources map[string]string, prefs &pref.Preferences, header_free bool, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, constant_values map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, mut global_types map[string]string) !FastcGlobalDeclarations {
+fn fastc_generate_global_declarations(ordered_sources []FastcSourceFile, global_sources map[string]string, prefs &pref.Preferences, header_free bool, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, function_c_names map[string]string, constants map[string]string, constant_values map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, mut global_types map[string]string) !FastcGlobalDeclarations {
 	declared_type_key_by_name := fastc_declared_type_key_by_name(declared_types)
 	mut out := strings.new_builder(1024)
 	mut module_initializers := map[string]string{}
@@ -651,6 +651,7 @@ fn fastc_generate_global_declarations(ordered_sources []FastcSourceFile, global_
 			out: strings.new_builder(0)
 			protos: strings.new_builder(0)
 			functions: functions
+			function_c_names: function_c_names
 			constant_types: constant_types
 			global_types: global_types
 			composite_types: map[string]bool{}
@@ -878,9 +879,9 @@ struct FastcFieldDefaultsResult {
 
 // fastc_run_field_defaults renders the field defaults into a copy of the
 // field table (the renderer replaces each type's entry) and indexes it.
-fn fastc_run_field_defaults(source_imports map[string]map[string]string, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, enum_field_names map[string][]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, global_types map[string]string, sum_types map[string]bool) FastcFieldDefaultsResult {
+fn fastc_run_field_defaults(source_imports map[string]map[string]string, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, enum_field_names map[string][]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, function_c_names map[string]string, constants map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, global_types map[string]string, sum_types map[string]bool) FastcFieldDefaultsResult {
 	mut rendered := struct_field_info.clone()
-	fastc_render_struct_field_defaults(source_imports, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, enum_field_names, alias_base_types, struct_fields, mut rendered, functions, constants, public_constants, constant_types, globals, public_globals, global_types, sum_types) or {
+	fastc_render_struct_field_defaults(source_imports, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, enum_field_names, alias_base_types, struct_fields, mut rendered, functions, function_c_names, constants, public_constants, constant_types, globals, public_globals, global_types, sum_types) or {
 		return FastcFieldDefaultsResult{
 			failed: true
 			error_message: err.msg()
@@ -892,7 +893,7 @@ fn fastc_run_field_defaults(source_imports map[string]map[string]string, prefs &
 	}
 }
 
-fn fastc_render_struct_field_defaults(source_imports map[string]map[string]string, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, enum_field_names map[string][]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, global_types map[string]string, sum_types map[string]bool) ! {
+fn fastc_render_struct_field_defaults(source_imports map[string]map[string]string, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, enum_field_names map[string][]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, mut struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, function_c_names map[string]string, constants map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, global_types map[string]string, sum_types map[string]bool) ! {
 	declared_type_key_by_name := fastc_declared_type_key_by_name(declared_types)
 	helper_has_c_functions := fastc_functions_declare_c(functions)
 	mut type_names := struct_field_info.keys()
@@ -978,6 +979,7 @@ fn fastc_render_struct_field_defaults(source_imports map[string]map[string]strin
 				out: strings.new_builder(0)
 				protos: strings.new_builder(0)
 				functions: functions
+				function_c_names: function_c_names
 				constant_types: constant_types
 				global_types: global_types
 				fixed_array_types: map[string]string{}
@@ -1039,6 +1041,7 @@ struct FastcConstantGenContext {
 	sum_types                 map[string]bool
 	sum_type_variants         map[string]bool
 	functions                 map[string]FastcFunctionSignature
+	function_c_names          map[string]string
 	constants                 map[string]string
 	public_constants          map[string]bool
 	globals                   map[string]string
@@ -1111,6 +1114,7 @@ fn fastc_parse_constant_file(ctx &FastcConstantGenContext, source_file FastcSour
 		out: strings.new_builder(256)
 		protos: strings.new_builder(0)
 		functions: ctx.functions
+		function_c_names: ctx.function_c_names
 		constant_types: constant_types
 		composite_types: map[string]bool{}
 		fixed_array_types: map[string]string{}
@@ -1232,7 +1236,7 @@ fn fastc_field_defaults_reference_constants(struct_field_info map[string][]Fastc
 	return false
 }
 
-fn fastc_generate_constant_declarations(candidates []FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, sum_types map[string]bool, sum_type_variants map[string]bool, mut pending_defaults FastcPendingFieldDefaults, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, globals map[string]string, public_globals map[string]bool, initial_parallel_results []FastcConstantFileResult, mut constant_types map[string]string) !FastcConstantDeclarations {
+fn fastc_generate_constant_declarations(candidates []FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, sum_types map[string]bool, sum_type_variants map[string]bool, mut pending_defaults FastcPendingFieldDefaults, functions map[string]FastcFunctionSignature, function_c_names map[string]string, constants map[string]string, public_constants map[string]bool, globals map[string]string, public_globals map[string]bool, initial_parallel_results []FastcConstantFileResult, mut constant_types map[string]string) !FastcConstantDeclarations {
 	mut values := []FastcConstantValue{}
 	mut composite_types := map[string]bool{}
 	mut fixed_array_types := map[string]string{}
@@ -1252,6 +1256,7 @@ fn fastc_generate_constant_declarations(candidates []FastcSourceFile, prefs &pre
 		sum_types: sum_types
 		sum_type_variants: sum_type_variants
 		functions: functions
+		function_c_names: function_c_names
 		constants: constants
 		public_constants: public_constants
 		globals: globals
@@ -1283,6 +1288,7 @@ fn fastc_generate_constant_declarations(candidates []FastcSourceFile, prefs &pre
 		sum_types: sum_types
 		sum_type_variants: sum_type_variants
 		functions: functions
+		function_c_names: function_c_names
 		constants: constants
 		public_constants: public_constants
 		globals: globals
@@ -2779,9 +2785,9 @@ fn fastc_generate_enum_string_helpers(infos []FastcEnumInfo) ([]string, []string
 		mut from_out := strings.new_builder(256)
 		// `Enum.from_string(s)` maps a field-name string back to its value, returning
 		// `?Enum` (none when no field name matches).
-		from_out.writeln('Option ${info.c_name}__from_string(string __v_fastc_from) {')
+		from_out.writeln('Option ${info.c_name}__from_string(string __vf_from) {')
 		for field in info.fields {
-			from_out.writeln('\tif (builtin__string_eq(__v_fastc_from, _S("${field}"))) { ${info.c_name} __v_fastc_value = ${info.c_name}__${field}; return (Option){.data=v_fastc_interface_box(&__v_fastc_value, sizeof(${info.c_name})), .state=0}; }')
+			from_out.writeln('\tif (builtin__string_eq(__vf_from, _S("${field}"))) { ${info.c_name} __vf_value = ${info.c_name}__${field}; return (Option){.data=v_fastc_interface_box(&__vf_value, sizeof(${info.c_name})), .state=0}; }')
 		}
 		from_out.writeln('\treturn (Option){.state=2};')
 		from_out.writeln('}')

--- a/vlib/v3/gen/fastc/expr.v
+++ b/vlib/v3/gen/fastc/expr.v
@@ -476,7 +476,7 @@ fn (mut g Parser) lower_higher_order_expression(mut result strings.Builder, mut 
 			if cmp_name !in g.spawn_helpers {
 				// The same rendered comparison in two blocks with swapped element
 				// bindings yields the -1 / +1 / 0 ordering without re-rendering it.
-				g.spawn_helpers[cmp_name] = 'static int ${cmp_name}(void *__v_fastc_a, void *__v_fastc_b) { { ${norm_element} a = *(${norm_element} *)__v_fastc_a; ${norm_element} b = *(${norm_element} *)__v_fastc_b; if (${condition}) { return -1; } } { ${norm_element} a = *(${norm_element} *)__v_fastc_b; ${norm_element} b = *(${norm_element} *)__v_fastc_a; if (${condition}) { return 1; } } return 0; }'
+				g.spawn_helpers[cmp_name] = 'static int ${cmp_name}(void *__vf_a, void *__vf_b) { { ${norm_element} a = *(${norm_element} *)__vf_a; ${norm_element} b = *(${norm_element} *)__vf_b; if (${condition}) { return -1; } } { ${norm_element} a = *(${norm_element} *)__vf_b; ${norm_element} b = *(${norm_element} *)__vf_a; if (${condition}) { return 1; } } return 0; }'
 			}
 			lowered := '({ builtin__array_sort_with_compare((array *)&(${receiver_source}), ${cmp_name}); })'
 			result.write_string(lowered)
@@ -4007,7 +4007,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 				inner_source = defaulted_call.source
 			}
 			value_type := g.option_value_type_for_expression(inner_tokens)
-			temporary := '__v_fastc_option_propagate'
+			temporary := '__vf_op'
 			failure := if g.in_main {
 				deferred := g.deferred_scopes_source()
 				'${deferred} builtin__panic_result_not_set(builtin__IError_msg(${temporary}.err));'
@@ -4047,7 +4047,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 				} else if item.tok in [.rpar, .rsbr, .rcbr] {
 					depth--
 				} else if depth == 0 && item.tok in [.key_in, .not_in] && i > 0 && i + 1 < tokens.len {
-					temporary_namespace := g.temporary_namespace('membership')
+					temporary_namespace := g.temporary_namespace('m')
 					right_tokens := tokens[i + 1..]
 					// `x in [Type1, Type2, …]` where `x` is a boxed sum type is a membership
 					// over the runtime type tag (V's `x is Type1 || x is Type2 || …`), not a
@@ -4067,7 +4067,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 									return none
 								}
 								access := if left_boxed_type.ends_with('*') { '->' } else { '.' }
-								subject_name := '${temporary_namespace}_subject'
+								subject_name := '${temporary_namespace}_s'
 								mut checks := []string{}
 								for type_id in type_ids {
 									checks << '(${subject_name}${access}_typ == __v_typeid_${type_id})'
@@ -4108,8 +4108,8 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 						value := g.render_call_argument_expression(right_tokens, right_type) or {
 							return none
 						}
-						substring_name := '${temporary_namespace}_substring'
-						value_name := '${temporary_namespace}_value'
+						substring_name := '${temporary_namespace}_s'
+						value_name := '${temporary_namespace}_v'
 						found := 'v_fastc_string_contains(${value_name}, ${substring_name})'
 						predicate := if item.tok == .not_in { '!(${found})' } else { found }
 						return FastcRenderedExpression{
@@ -4128,7 +4128,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 						} else {
 							'&(${map_source})'
 						}
-						key_name := '${temporary_namespace}_map_key'
+						key_name := '${temporary_namespace}_k'
 						found := 'builtin__map_get_check((map *)${map_expression}, &${key_name}) != NULL'
 						predicate := if item.tok == .not_in { '!(${found})' } else { found }
 						return FastcRenderedExpression{
@@ -4145,10 +4145,10 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 						collection := g.render_call_argument_expression(right_tokens, right_type) or {
 							return none
 						}
-						item_name := '${temporary_namespace}_item'
-						collection_name := '${temporary_namespace}_collection'
-						found_name := '${temporary_namespace}_found'
-						index_name := '${temporary_namespace}_index'
+						item_name := '${temporary_namespace}_x'
+						collection_name := '${temporary_namespace}_a'
+						found_name := '${temporary_namespace}_f'
+						index_name := '${temporary_namespace}_i'
 						access := if right_type.ends_with('*') { '->' } else { '.' }
 						collection_length := if fixed_length := fastc_fixed_array_length(right_layout) {
 							fixed_length
@@ -4172,10 +4172,12 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 						// selfhost parser renders nested `${if ... { '${...}' }}` blocks
 						// literally, corrupting the emitted membership expression.
 						predicate := if item.tok == .not_in { '!${found_name}' } else { found_name }
-						// A collection lowered to a `({ … for … })` statement-expression (e.g.
-						// `arr.map(it.f)`) cannot be `__typeof__`'d by TinyCC; name its known array
-						// type directly instead.
-						collection_c_type := if collection.starts_with('({') {
+						// The membership collection was already inferred. In a self-host, naming
+						// that type directly avoids duplicating large inline array literals and
+						// also handles statement expressions that TinyCC cannot inspect.
+						collection_c_type := if g.selfhost && right_type != '' {
+							fastc_normalize_inferred_type(right_type)
+						} else if collection.starts_with('({') {
 							right_type
 						} else {
 							'__typeof__((${collection}))'
@@ -4202,7 +4204,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 					lhs_source := g.render_membership_candidate(tokens[..i], lhs_type) or {
 						return none
 					}
-					lhs_name := '${temporary_namespace}_subject'
+					lhs_name := '${temporary_namespace}_s'
 					value_type := fastc_runtime_c_type(fastc_normalize_inferred_type(lhs_type))
 					mut initializers := []string{cap: items.len}
 					mut comparisons := []string{cap: items.len}
@@ -4210,7 +4212,7 @@ fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered
 						candidate_source := g.render_membership_candidate(candidate, lhs_type) or {
 							return none
 						}
-						candidate_name := '${temporary_namespace}_candidate_${candidate_index}'
+						candidate_name := '${temporary_namespace}_c${candidate_index}'
 						initializers << '${value_type} ${candidate_name} = (${candidate_source});'
 						comparison := if g.underlying_alias_type(lhs_type).trim_right('*') == 'string' {
 							'builtin__string_eq(${lhs_name}, ${candidate_name})'

--- a/vlib/v3/gen/fastc/expr.v
+++ b/vlib/v3/gen/fastc/expr.v
@@ -1089,10 +1089,10 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 			return g.unsupported('ORM `sql` select is only supported as `x := sql db { select ... }`')
 		}
 	}
-	mut result := strings.new_builder(32)
+	mut result := strings.new_builder(64)
 	// Most expressions are a handful of tokens; start with room for them so
 	// the token buffer is not regrown several times per expression.
-	mut expression_tokens := []FastcExpressionToken{cap: 8}
+	mut expression_tokens := []FastcExpressionToken{cap: 16}
 	if prefix.len > 0 {
 		result.write_string(g.resolved_expression_name(prefix, .unknown))
 		expression_tokens << FastcExpressionToken{
@@ -2093,6 +2093,10 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 		previous_token_end = g.s.offset
 		g.next()
 	}
+	return g.finish_read_expression(mut result, mut expression_tokens, saved_expected_expression_type, paren_depth, bracket_depth, brace_depth, unsafe_expression_depth, mutation_operator, tokens_before_mutation)
+}
+
+fn (mut g Parser) finish_read_expression(mut result strings.Builder, mut expression_tokens []FastcExpressionToken, saved_expected_expression_type string, paren_depth int, bracket_depth int, brace_depth int, unsafe_expression_depth int, mutation_operator token.Token, tokens_before_mutation int) !string {
 	g.expected_expression_type = saved_expected_expression_type
 	if paren_depth != 0 {
 		return g.unsupported('unbalanced expression')

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -2539,16 +2539,15 @@ fn fastc_unit_group_starts(unit_sizes []int, groups int, first_overhead int, sha
 	return starts
 }
 
-// fastc_write_c_units writes the translation units of a generation for
-// `jobs` parallel TinyCC processes: `prefix.unit<k>.c` files, each with the
-// shared head (the globals as extern declarations after the first), the
-// first also with the startup, cleanup and main pieces, and consecutive body
-// units grouped to balance their sizes. It returns the paths, or none when
-// the program does not split.
-pub fn fastc_write_c_units(prefix string, pieces []string, units FastcUnitLayout, jobs int) ![]string {
+struct FastcCUnitPlan {
+	paths       []string
+	first_units []int
+}
+
+fn fastc_c_unit_plan(prefix string, pieces []string, units FastcUnitLayout, jobs int) FastcCUnitPlan {
 	unit_count := units.unit_starts.len - 1
 	if jobs < 2 || unit_count < 2 || units.head_end <= 0 || units.solo_end > pieces.len {
-		return []string{}
+		return FastcCUnitPlan{}
 	}
 	mut unit_sizes := []int{cap: unit_count}
 	for u in 0 .. unit_count {
@@ -2559,7 +2558,6 @@ pub fn fastc_write_c_units(prefix string, pieces []string, units FastcUnitLayout
 		unit_sizes << size
 	}
 	groups := if jobs < unit_count { jobs } else { unit_count }
-	mut paths := []string{cap: groups}
 	mut first_overhead := 1
 	mut shared_overhead := 1
 	for k in 0 .. units.head_end {
@@ -2584,17 +2582,35 @@ pub fn fastc_write_c_units(prefix string, pieces []string, units FastcUnitLayout
 	}
 	first_units := fastc_unit_group_starts(unit_sizes, groups, first_overhead, shared_overhead)
 	if first_units.len == 0 {
-		return []string{}
+		return FastcCUnitPlan{}
 	}
+	mut paths := []string{cap: groups}
 	for g in 0 .. groups {
 		paths << '${prefix}.unit${g}.c'
 	}
+	return FastcCUnitPlan{
+		paths: paths
+		first_units: first_units
+	}
+}
+
+// fastc_write_c_units writes the translation units of a generation for
+// `jobs` parallel TinyCC processes: `prefix.unit<k>.c` files, each with the
+// shared head (the globals as extern declarations after the first), the
+// first also with the startup, cleanup and main pieces, and consecutive body
+// units grouped to balance their sizes. It returns the paths, or none when
+// the program does not split.
+pub fn fastc_write_c_units(prefix string, pieces []string, units FastcUnitLayout, jobs int) ![]string {
+	plan := fastc_c_unit_plan(prefix, pieces, units, jobs)
+	if plan.paths.len == 0 {
+		return []string{}
+	}
 	// The files are written concurrently; they add up to several megabytes.
 	mut writers := [
-		spawn fastc_write_c_unit(paths[0], pieces, &units, 0, first_units[0], first_units[1]),
+		spawn fastc_write_c_unit(plan.paths[0], pieces, &units, 0, plan.first_units[0], plan.first_units[1]),
 	]
-	for g in 1 .. groups {
-		writers << spawn fastc_write_c_unit(paths[g], pieces, &units, g, first_units[g], first_units[g + 1])
+	for g in 1 .. plan.paths.len {
+		writers << spawn fastc_write_c_unit(plan.paths[g], pieces, &units, g, plan.first_units[g], plan.first_units[g + 1])
 	}
 	mut failure := ''
 	for writer in writers {
@@ -2606,7 +2622,7 @@ pub fn fastc_write_c_units(prefix string, pieces []string, units FastcUnitLayout
 	if failure != '' {
 		return error(failure)
 	}
-	return paths
+	return plan.paths
 }
 
 // fastc_write_c_unit writes one translation unit: the head (with the shared
@@ -2615,7 +2631,24 @@ pub fn fastc_write_c_units(prefix string, pieces []string, units FastcUnitLayout
 // units `first_unit` to `end_unit`. It returns an error message or ''.
 fn fastc_write_c_unit(path string, pieces []string, units &FastcUnitLayout, g int, first_unit int, end_unit int) string {
 	mut file := os.create(path) or { return 'could not create ${path}: ${err.msg()}' }
-	// One buffered write per unit: piecewise writes cost several times more.
+	text := fastc_render_c_unit(pieces, units, g, first_unit, end_unit)
+	file.write_string(text) or {
+		file.close()
+		return 'could not write ${path}: ${err.msg()}'
+	}
+	file.close()
+	return ''
+}
+
+// FastcRenderedCUnits holds split translation units in memory so an uncached
+// build can stream them to TinyCC without temporary C files.
+pub struct FastcRenderedCUnits {
+pub:
+	paths   []string
+	sources []string
+}
+
+fn fastc_render_c_unit(pieces []string, units &FastcUnitLayout, g int, first_unit int, end_unit int) string {
 	mut out := strings.new_builder(1024 * 1024)
 	for k in 0 .. units.head_end {
 		if units.prototype_start < units.prototype_end && k >= units.prototype_start
@@ -2663,12 +2696,27 @@ fn fastc_write_c_unit(path string, pieces []string, units &FastcUnitLayout, g in
 	for k in units.unit_starts[first_unit] .. units.unit_starts[end_unit] {
 		out.write_string(pieces[k])
 	}
-	file.write(out) or {
-		file.close()
-		return 'could not write ${path}: ${err.msg()}'
+	return out.str()
+}
+
+// fastc_render_c_units renders balanced split translation units in parallel.
+pub fn fastc_render_c_units(prefix string, pieces []string, units FastcUnitLayout, jobs int) FastcRenderedCUnits {
+	plan := fastc_c_unit_plan(prefix, pieces, units, jobs)
+	if plan.paths.len == 0 {
+		return FastcRenderedCUnits{}
 	}
-	file.close()
-	return ''
+	mut workers := []thread string{cap: plan.paths.len}
+	for g in 0 .. plan.paths.len {
+		workers << spawn fastc_render_c_unit(pieces, &units, g, plan.first_units[g], plan.first_units[g + 1])
+	}
+	mut sources := []string{cap: plan.paths.len}
+	for worker in workers {
+		sources << worker.wait()
+	}
+	return FastcRenderedCUnits{
+		paths: plan.paths
+		sources: sources
+	}
 }
 
 struct FastcUnitCacheEntry {
@@ -2825,7 +2873,15 @@ pub fn fastc_generation_link_cache_key(tcc string, compile_args []string, final_
 	if !enabled || pieces.len == 0 {
 		return ''
 	}
-	configuration := 'fastc-generation-link-v1\x00${fastc_unit_cache_configuration(tcc, compile_args)}\x00${final_args.join('\x00')}\x00${jobs}\x00${units.head_end}\x00${units.solo_end}\x00${units.prototype_start}\x00${units.prototype_end}\x00${units.unit_starts}\x00${units.extern_indexes}\x00${units.unit_ref_starts}\x00${units.unit_ref_ids}\x00${units.solo_prototype_ids}\x00${units.tail_prototype_ids}'
+	mut stable_final_args := []string{cap: final_args.len}
+	for arg in final_args {
+		if arg.ends_with('.tbd') && os.is_file(arg) {
+			stable_final_args << 'tbd-content:' + (os.read_file(arg) or { arg })
+		} else {
+			stable_final_args << arg
+		}
+	}
+	configuration := 'fastc-generation-link-v1\x00${fastc_unit_cache_configuration(tcc, compile_args)}\x00${stable_final_args.join('\x00')}\x00${jobs}\x00${units.head_end}\x00${units.solo_end}\x00${units.prototype_start}\x00${units.prototype_end}\x00${units.unit_starts}\x00${units.extern_indexes}\x00${units.unit_ref_starts}\x00${units.unit_ref_ids}\x00${units.solo_prototype_ids}\x00${units.tail_prototype_ids}'
 	mut hash := fastc_unit_cache_hash(configuration, u64(0x510e527fade682d1))
 	for piece in pieces {
 		hash = fastc_unit_cache_hash(piece, hash ^ u64(piece.len))
@@ -3308,36 +3364,40 @@ fn fastc_c_identifier_start_byte(value u8) bool {
 
 // fastc_collect_c_name_ids appends the ids of the indexed functions named in
 // text[start..end]. Every indexed C name carries a module or type separator
-// (`__`), so only such identifiers are looked up, through a view of the text.
+// (`__`) or the `v_fastc_` prefix, so only underscores can begin a candidate.
+// Expanding from those markers avoids classifying every ordinary identifier.
 @[direct_array_access]
 fn fastc_collect_c_name_ids(text string, start int, end int, ids map[string]int, mut out []int) {
 	mut i := start
 	for i < end {
-		if !fastc_c_identifier_start_byte(text[i]) {
+		if text[i] != `_` {
 			i++
 			continue
 		}
-		word_start := i
-		mut separated := false
-		i++
-		for i < end && fastc_identifier_byte(text[i]) {
-			if text[i] == `_` && text[i - 1] == `_` {
-				separated = true
-			}
+		mut word_start := i
+		mut indexed := i + 1 < end && text[i + 1] == `_`
+		if !indexed && i > start && text[i - 1] == `v` && i + 6 < end && text[i + 1] == `f`
+			&& text[i + 2] == `a` && text[i + 3] == `s` && text[i + 4] == `t`
+			&& text[i + 5] == `c` && text[i + 6] == `_` {
+			word_start = i - 1
+			indexed = word_start == start || !fastc_identifier_byte(text[word_start - 1])
+		}
+		if !indexed {
 			i++
+			continue
 		}
-		if !separated && i - word_start > 8 && text[word_start] == `v` && text[word_start + 1] == `_`
-			&& text[word_start + 2] == `f` && text[word_start + 3] == `a` && text[word_start + 4] == `s`
-			&& text[word_start + 5] == `t` && text[word_start + 6] == `c` && text[word_start + 7] == `_` {
-			// The enum helpers are indexed too.
-			separated = true
+		for word_start > start && fastc_identifier_byte(text[word_start - 1]) {
+			word_start--
 		}
-		if separated {
-			candidate := unsafe { tos(text.str + word_start, i - word_start) }
-			if id := ids[candidate] {
-				out << id
-			}
+		mut word_end := i + 2
+		for word_end < end && fastc_identifier_byte(text[word_end]) {
+			word_end++
 		}
+		candidate := unsafe { tos(text.str + word_start, word_end - word_start) }
+		if id := ids[candidate] {
+			out << id
+		}
+		i = word_end
 	}
 }
 

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -2256,11 +2256,11 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	fastc_collect_c_piece_ranges(mut pieces, prototype_pieces, kept_proto_ranges)
 	prototype_end := pieces.len
 	if startup_initializers.len > 0 {
-		pieces << 'static void v_fastc_init_globals(void);'
+		pieces << 'void v_fastc_init_globals(void);'
 		pieces << '\n'
 	}
 	if module_cleanup_calls.len > 0 {
-		pieces << 'static void v_fastc_cleanup_modules(void);'
+		pieces << 'void v_fastc_cleanup_modules(void);'
 		pieces << '\n'
 	}
 	pieces << '\n'
@@ -2279,7 +2279,7 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	}
 	pieces << fastc_piece(interface_dispatches)
 	if startup_initializers.len > 0 {
-		pieces << 'static void v_fastc_init_globals(void) {'
+		pieces << 'void v_fastc_init_globals(void) {'
 		pieces << '\n'
 		pieces << fastc_piece(startup_initializers)
 		pieces << '}'
@@ -2287,7 +2287,7 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 		pieces << '\n'
 	}
 	if module_cleanup_calls.len > 0 {
-		pieces << 'static void v_fastc_cleanup_modules(void) {'
+		pieces << 'void v_fastc_cleanup_modules(void) {'
 		pieces << '\n'
 		for cleanup_call in module_cleanup_calls {
 			pieces << '\t${cleanup_call}();'
@@ -2479,8 +2479,8 @@ fn fastc_parallel_worker_limit(prefs &pref.Preferences) int {
 // program's translation units with.
 pub fn fastc_tcc_job_count(prefs &pref.Preferences) int {
 	mut jobs := fastc_parallel_worker_limit(prefs)
-	if jobs > 18 {
-		jobs = 18
+	if jobs > 16 {
+		jobs = 16
 	}
 	if jobs < 1 {
 		jobs = 1
@@ -2492,7 +2492,7 @@ pub fn fastc_tcc_job_count(prefs &pref.Preferences) int {
 // for the C text prepended to each translation unit. The first unit also owns
 // the runtime/startup/main definitions, so balancing only the bodies makes it
 // the slowest TinyCC job. Dynamic programming finds the partition whose
-// largest emitted source is smallest; there are at most 18 groups and a few
+// largest emitted source is smallest; there are at most 16 groups and a few
 // hundred source files, so this costs much less than writing one unit.
 fn fastc_unit_group_starts(unit_sizes []int, groups int, first_overhead int, shared_overhead int) []int {
 	unit_count := unit_sizes.len
@@ -2684,6 +2684,31 @@ pub struct FastcPreparedUnits {
 pub:
 	objects   []string
 	cache_key string
+}
+
+// fastc_unit_compile_order returns the indexes of uncached C units largest
+// first. TinyCC processes start one at a time, so launching longer jobs first
+// reduces the time spent waiting for the final unit.
+fn fastc_unit_compile_order(unit_paths []string, prepared FastcPreparedUnits) []int {
+	mut order := []int{cap: unit_paths.len}
+	mut sizes := []u64{cap: unit_paths.len}
+	for i, path in unit_paths {
+		if prepared.entries[i].hit {
+			continue
+		}
+		size := os.file_size(path)
+		order << i
+		sizes << size
+		mut at := order.len - 1
+		for at > 0 && sizes[at - 1] < size {
+			order[at] = order[at - 1]
+			sizes[at] = sizes[at - 1]
+			at--
+		}
+		order[at] = i
+		sizes[at] = size
+	}
+	return order
 }
 
 fn fastc_unit_cache_entry(unit_path string, configuration string, cache_dir string) FastcUnitCacheEntry {

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -912,10 +912,12 @@ struct FastcSourceHeader {
 }
 
 struct FastcSourceFile {
-	path          string
-	source        string
-	source_offset int
-	header        FastcSourceHeader
+	path                 string
+	source               string
+	source_offset        int
+	source_line_offset   int
+	source_column_offset int
+	header               FastcSourceHeader
 }
 
 struct FastcQueuedSource {
@@ -1224,15 +1226,17 @@ struct Parser {
 	has_startup_inits bool
 	has_cleanup_hooks bool
 mut:
-	path          string
-	source_offset int
-	module_name   string
-	imports       map[string]string
-	s             scanner.Scanner
-	tok           token.Token
-	lit           string
-	out           strings.Builder
-	protos        strings.Builder
+	path                 string
+	source_offset        int
+	source_line_offset   int
+	source_column_offset int
+	module_name          string
+	imports              map[string]string
+	s                    scanner.Scanner
+	tok                  token.Token
+	lit                  string
+	out                  strings.Builder
+	protos               strings.Builder
 	// The function definitions of this file, recorded for the reachability
 	// prune: see FastcFileGenOutput.
 	function_id_table    map[string]int
@@ -1570,6 +1574,8 @@ fn fastc_generate_single_file(ctx &FastcFileGenContext, source_file FastcSourceF
 		declared_type_key_memo: map[string]FastcMemoEntry{}
 		path: source_file.path
 		source_offset: source_file.source_offset
+		source_line_offset: source_file.source_line_offset
+		source_column_offset: source_file.source_column_offset
 		module_name: source_file.header.module_name
 		imports: source_file.header.imports
 		declared_types: ctx.declared_types
@@ -1786,6 +1792,11 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	for source_file in sources {
 		source_imports[source_file.path] = source_file.header.imports.clone()
 	}
+	// Candidates carry their filtered constant source as `source`, in module
+	// dependency order, so both the parallel pre-pass and the in-order merge
+	// see the same files.
+	constant_candidates := fastc_constant_candidates(ordered_sources, constant_sources, constant_spans)
+	mut parallel_constant_results := []FastcConstantFileResult{}
 	if fastc_field_defaults_reference_constants(struct_field_info, constants) {
 		seed_ctx := FastcConstantGenContext{
 			prefs: unsafe { prefs }
@@ -1808,13 +1819,13 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 			globals: globals
 			public_globals: public_globals
 		}
-		constant_candidates := fastc_constant_candidates(ordered_sources, constant_sources, constant_spans)
-		fastc_seed_constant_types(&seed_ctx, constant_candidates, mut constant_types)
+		parallel_constant_results = fastc_parse_constant_files_parallel(&seed_ctx, constant_candidates, constant_types)
+		fastc_seed_constant_types(&seed_ctx, constant_candidates, parallel_constant_results, mut constant_types)
 	}
 	// The struct field defaults render on a worker while the constants are
 	// pre-parsed; a constant file that consulted them is re-parsed after.
 	mut pending_defaults := fastc_start_field_defaults(source_imports, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.enum_field_names, type_output.alias_base_types, struct_fields, struct_field_info, functions, constants, public_constants, constant_types, globals, public_globals, global_types, type_output.sum_types)
-	constant_output := fastc_generate_constant_declarations(ordered_sources, constant_sources, constant_spans, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info, type_output.sum_types, type_output.sum_type_variants, mut pending_defaults, functions, constants, public_constants, globals, public_globals, mut constant_types)!
+	constant_output := fastc_generate_constant_declarations(constant_candidates, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info, type_output.sum_types, type_output.sum_type_variants, mut pending_defaults, functions, constants, public_constants, globals, public_globals, parallel_constant_results, mut constant_types)!
 	struct_field_info = constant_output.struct_field_info.clone()
 	timer.mark('constant_declarations')
 	for name, _ in constant_output.composite_types {
@@ -2707,6 +2718,11 @@ fn fastc_unit_cache_entry(unit_path string, configuration string, cache_dir stri
 	}
 }
 
+fn fastc_unit_cache_configuration(tcc string, base_args []string) string {
+	build_hash := os.read_file(os.join_path_single(os.dir(tcc), 'build_source_hash.txt')) or { '' }
+	return 'fastc-unit-v1\x00${tcc}\x00${os.file_size(tcc)}\x00${os.file_last_mod_unix(tcc)}\x00${build_hash}\x00${base_args.join('\x00')}'
+}
+
 fn fastc_unit_cache_entries(tcc string, base_args []string, unit_paths []string, enabled bool) []FastcUnitCacheEntry {
 	mut entries := []FastcUnitCacheEntry{len: unit_paths.len}
 	for i, unit_path in unit_paths {
@@ -2719,8 +2735,7 @@ fn fastc_unit_cache_entries(tcc string, base_args []string, unit_paths []string,
 	}
 	cache_dir := os.join_path_single(os.vtmp_dir(), 'v3_fastc_unit_cache')
 	os.mkdir_all(cache_dir) or { return entries }
-	build_hash := os.read_file(os.join_path_single(os.dir(tcc), 'build_source_hash.txt')) or { '' }
-	configuration := 'fastc-unit-v1\x00${tcc}\x00${os.file_size(tcc)}\x00${os.file_last_mod_unix(tcc)}\x00${build_hash}\x00${base_args.join('\x00')}'
+	configuration := fastc_unit_cache_configuration(tcc, base_args)
 	mut workers := []thread FastcUnitCacheEntry{cap: unit_paths.len}
 	for unit_path in unit_paths {
 		workers << spawn fastc_unit_cache_entry(unit_path, configuration, cache_dir)
@@ -2775,6 +2790,31 @@ pub fn fastc_link_cache_key(unit_key string, final_args []string) string {
 	}
 	text := 'fastc-link-v1\x00${unit_key}\x00${final_args.join('\x00')}'
 	return fastc_unit_cache_hash(text, u64(0x3c6ef372fe94f82b)).hex()
+}
+
+// fastc_generation_link_cache_key identifies the final executable directly
+// from the generated pieces and every input that affects unit compilation or
+// linking. A warm build can therefore restore the executable before writing
+// and re-reading the split C files.
+pub fn fastc_generation_link_cache_key(tcc string, compile_args []string, final_args []string, pieces []string, units FastcUnitLayout, jobs int, enabled bool) string {
+	if !enabled || pieces.len == 0 {
+		return ''
+	}
+	configuration := 'fastc-generation-link-v1\x00${fastc_unit_cache_configuration(tcc, compile_args)}\x00${final_args.join('\x00')}\x00${jobs}\x00${units.head_end}\x00${units.solo_end}\x00${units.prototype_start}\x00${units.prototype_end}\x00${units.unit_starts}\x00${units.extern_indexes}\x00${units.unit_ref_starts}\x00${units.unit_ref_ids}\x00${units.solo_prototype_ids}\x00${units.tail_prototype_ids}'
+	mut hash := fastc_unit_cache_hash(configuration, u64(0x510e527fade682d1))
+	for piece in pieces {
+		hash = fastc_unit_cache_hash(piece, hash ^ u64(piece.len))
+	}
+	for text in units.extern_texts {
+		hash = fastc_unit_cache_hash(text, hash ^ u64(text.len))
+	}
+	for text in units.define_texts {
+		hash = fastc_unit_cache_hash(text, hash ^ u64(text.len))
+	}
+	for text in units.prototype_texts {
+		hash = fastc_unit_cache_hash(text, hash ^ u64(text.len))
+	}
+	return hash.hex()
 }
 
 fn fastc_link_cache_path(key string) string {

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -2477,6 +2477,57 @@ pub fn fastc_tcc_job_count(prefs &pref.Preferences) int {
 	return jobs
 }
 
+// fastc_unit_group_starts partitions consecutive body units while accounting
+// for the C text prepended to each translation unit. The first unit also owns
+// the runtime/startup/main definitions, so balancing only the bodies makes it
+// the slowest TinyCC job. Dynamic programming finds the partition whose
+// largest emitted source is smallest; there are at most 18 groups and a few
+// hundred source files, so this costs much less than writing one unit.
+fn fastc_unit_group_starts(unit_sizes []int, groups int, first_overhead int, shared_overhead int) []int {
+	unit_count := unit_sizes.len
+	if groups < 1 || unit_count < groups {
+		return []int{}
+	}
+	mut prefix := []int{len: unit_count + 1}
+	for i, size in unit_sizes {
+		prefix[i + 1] = prefix[i] + size
+	}
+	mut previous := []int{len: unit_count + 1, init: max_int}
+	previous[0] = 0
+	mut splits := [][]int{len: groups + 1}
+	for count in 1 .. groups + 1 {
+		mut current := []int{len: unit_count + 1, init: max_int}
+		splits[count] = []int{len: unit_count + 1, init: -1}
+		overhead := if count == 1 { first_overhead } else { shared_overhead }
+		for end in count .. unit_count + 1 {
+			for start in count - 1 .. end {
+				if previous[start] == max_int {
+					continue
+				}
+				group_size := overhead + prefix[end] - prefix[start]
+				largest := if previous[start] > group_size { previous[start] } else { group_size }
+				if largest < current[end] {
+					current[end] = largest
+					splits[count][end] = start
+				}
+			}
+		}
+		previous = current.clone()
+	}
+	mut starts := []int{len: groups + 1}
+	starts[groups] = unit_count
+	mut end := unit_count
+	for count := groups; count > 0; count-- {
+		start := splits[count][end]
+		if start < 0 {
+			return []int{}
+		}
+		starts[count - 1] = start
+		end = start
+	}
+	return starts
+}
+
 // fastc_write_c_units writes the translation units of a generation for
 // `jobs` parallel TinyCC processes: `prefix.unit<k>.c` files, each with the
 // shared head (the globals as extern declarations after the first), the
@@ -2488,7 +2539,6 @@ pub fn fastc_write_c_units(prefix string, pieces []string, units FastcUnitLayout
 	if jobs < 2 || unit_count < 2 || units.head_end <= 0 || units.solo_end > pieces.len {
 		return []string{}
 	}
-	mut total := 0
 	mut unit_sizes := []int{cap: unit_count}
 	for u in 0 .. unit_count {
 		mut size := 0
@@ -2496,40 +2546,38 @@ pub fn fastc_write_c_units(prefix string, pieces []string, units FastcUnitLayout
 			size += pieces[k].len
 		}
 		unit_sizes << size
-		total += size
 	}
 	groups := if jobs < unit_count { jobs } else { unit_count }
 	mut paths := []string{cap: groups}
-	mut first_units := []int{cap: groups + 1}
-	mut u := 0
-	mut remaining := total
-	for g in 0 .. groups {
-		// Every group aims at an equal share of what is left, so the last
-		// one does not end up with the remainder of the rounding.
-		target := (remaining + groups - g - 1) / (groups - g)
-		paths << '${prefix}.unit${g}.c'
-		first_units << u
-		mut size := 0
-		remaining_groups := groups - g - 1
-		for u < unit_count {
-			// Leave one unit for every later group; the last group takes the
-			// rest, the others stop at the size target.
-			if unit_count - u <= remaining_groups {
+	mut first_overhead := 1
+	mut shared_overhead := 1
+	for k in 0 .. units.head_end {
+		if units.prototype_start < units.prototype_end && k >= units.prototype_start
+			&& k < units.prototype_end {
+			continue
+		}
+		mut first_text := pieces[k]
+		mut shared_text := pieces[k]
+		for e, index in units.extern_indexes {
+			if index == k {
+				first_text = units.define_texts[e]
+				shared_text = units.extern_texts[e]
 				break
 			}
-			if size > 0 && remaining_groups > 0 && size + unit_sizes[u] > target {
-				under_target := target - size
-				over_target := size + unit_sizes[u] - target
-				if under_target <= over_target {
-					break
-				}
-			}
-			size += unit_sizes[u]
-			remaining -= unit_sizes[u]
-			u++
 		}
+		first_overhead += first_text.len
+		shared_overhead += shared_text.len
 	}
-	first_units << unit_count
+	for k in units.head_end .. units.solo_end {
+		first_overhead += pieces[k].len
+	}
+	first_units := fastc_unit_group_starts(unit_sizes, groups, first_overhead, shared_overhead)
+	if first_units.len == 0 {
+		return []string{}
+	}
+	for g in 0 .. groups {
+		paths << '${prefix}.unit${g}.c'
+	}
 	// The files are written concurrently; they add up to several megabytes.
 	mut writers := [
 		spawn fastc_write_c_unit(paths[0], pieces, &units, 0, first_units[0], first_units[1]),
@@ -2610,6 +2658,155 @@ fn fastc_write_c_unit(path string, pieces []string, units &FastcUnitLayout, g in
 	}
 	file.close()
 	return ''
+}
+
+struct FastcUnitCacheEntry {
+	object       string
+	cache_object string
+	hit          bool
+}
+
+// FastcPreparedUnits holds the ordered TinyCC objects and their content cache
+// entries. Preparing them restores object-cache hits before compilation starts.
+pub struct FastcPreparedUnits {
+	entries []FastcUnitCacheEntry
+pub:
+	objects   []string
+	cache_key string
+}
+
+fn fastc_unit_cache_entry(unit_path string, configuration string, cache_dir string) FastcUnitCacheEntry {
+	object := unit_path[..unit_path.len - 2] + '.o'
+	source := os.read_file(unit_path) or {
+		return FastcUnitCacheEntry{
+			object: object
+		}
+	}
+	configuration_hash := fastc_unit_cache_hash(configuration, u64(0x6a09e667f3bcc909))
+	source_hash := fastc_unit_cache_hash(source, configuration_hash)
+	cache_object := os.join_path_single(cache_dir, '${source_hash.hex()}.o')
+	if os.is_file(cache_object) && os.file_size(cache_object) > 0 {
+		os.rm(object) or {}
+		os.link(cache_object, object) or {
+			os.cp(cache_object, object) or {
+				return FastcUnitCacheEntry{
+					object: object
+					cache_object: cache_object
+				}
+			}
+		}
+		return FastcUnitCacheEntry{
+			object: object
+			cache_object: cache_object
+			hit: true
+		}
+	}
+	return FastcUnitCacheEntry{
+		object: object
+		cache_object: cache_object
+	}
+}
+
+fn fastc_unit_cache_entries(tcc string, base_args []string, unit_paths []string, enabled bool) []FastcUnitCacheEntry {
+	mut entries := []FastcUnitCacheEntry{len: unit_paths.len}
+	for i, unit_path in unit_paths {
+		entries[i] = FastcUnitCacheEntry{
+			object: unit_path[..unit_path.len - 2] + '.o'
+		}
+	}
+	if !enabled || unit_paths.len == 0 {
+		return entries
+	}
+	cache_dir := os.join_path_single(os.vtmp_dir(), 'v3_fastc_unit_cache')
+	os.mkdir_all(cache_dir) or { return entries }
+	build_hash := os.read_file(os.join_path_single(os.dir(tcc), 'build_source_hash.txt')) or { '' }
+	configuration := 'fastc-unit-v1\x00${tcc}\x00${os.file_size(tcc)}\x00${os.file_last_mod_unix(tcc)}\x00${build_hash}\x00${base_args.join('\x00')}'
+	mut workers := []thread FastcUnitCacheEntry{cap: unit_paths.len}
+	for unit_path in unit_paths {
+		workers << spawn fastc_unit_cache_entry(unit_path, configuration, cache_dir)
+	}
+	for i, worker in workers {
+		entries[i] = worker.wait()
+	}
+	return entries
+}
+
+fn fastc_publish_unit_cache(entry FastcUnitCacheEntry) {
+	if entry.hit || entry.cache_object == '' || !os.is_file(entry.object)
+		|| os.file_size(entry.object) == 0 || os.is_file(entry.cache_object) {
+		return
+	}
+	os.link(entry.object, entry.cache_object) or {
+		if os.is_file(entry.cache_object) {
+			return
+		}
+		staged := '${entry.cache_object}.tmp.${os.getpid()}'
+		os.cp(entry.object, staged) or { return }
+		os.mv(staged, entry.cache_object) or { os.rm(staged) or {} }
+	}
+}
+
+fn fastc_unit_cache_key(entries []FastcUnitCacheEntry) string {
+	mut text := strings.new_builder(entries.len * 24)
+	for entry in entries {
+		if entry.cache_object == '' {
+			return ''
+		}
+		text.write_string(os.file_name(entry.cache_object))
+		text.write_u8(0)
+	}
+	return fastc_unit_cache_hash(text.str(), u64(0xbb67ae8584caa73b)).hex()
+}
+
+// fastc_prepare_c_units calculates the object cache keys and restores hits.
+pub fn fastc_prepare_c_units(tcc string, base_args []string, unit_paths []string, cache_enabled bool) FastcPreparedUnits {
+	entries := fastc_unit_cache_entries(tcc, base_args, unit_paths, cache_enabled)
+	return FastcPreparedUnits{
+		entries: entries
+		objects: entries.map(it.object)
+		cache_key: fastc_unit_cache_key(entries)
+	}
+}
+
+// fastc_link_cache_key identifies a link of content-addressed unit objects.
+pub fn fastc_link_cache_key(unit_key string, final_args []string) string {
+	if unit_key == '' {
+		return ''
+	}
+	text := 'fastc-link-v1\x00${unit_key}\x00${final_args.join('\x00')}'
+	return fastc_unit_cache_hash(text, u64(0x3c6ef372fe94f82b)).hex()
+}
+
+fn fastc_link_cache_path(key string) string {
+	return os.join_path(os.vtmp_dir(), 'v3_fastc_link_cache', '${key}.bin')
+}
+
+// fastc_restore_link_cache copies a cached linked self-host to output.
+pub fn fastc_restore_link_cache(key string, output string) bool {
+	if key == '' {
+		return false
+	}
+	cached := fastc_link_cache_path(key)
+	if !os.is_file(cached) || os.file_size(cached) == 0 {
+		return false
+	}
+	fastc_copy_cached_link(cached, output) or { return false }
+	return os.is_executable(output)
+}
+
+// fastc_publish_link_cache atomically caches a linked and signed self-host.
+pub fn fastc_publish_link_cache(key string, output string) {
+	if key == '' || !os.is_executable(output) {
+		return
+	}
+	cached := fastc_link_cache_path(key)
+	if os.is_file(cached) {
+		return
+	}
+	os.mkdir_all(os.dir(cached)) or { return }
+	staged := '${cached}.tmp.${os.getpid()}'
+	fastc_copy_cached_link(output, staged) or { return }
+	os.mv(staged, cached) or { os.rm(staged) or {} }
 }
 
 // FastcUnitCompile is one TinyCC process compiling a translation unit.

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -47,7 +47,7 @@ typedef struct { void *data; void *err; unsigned char state; } Option;
    overflow the slot. */
 typedef union { uintptr_t word; long double alignment; void *ptr; unsigned char data[32]; } MultiReturnValue;
 typedef struct { MultiReturnValue values[8]; } MultiReturn;
-#define V_FASTC_MULTI_VALUE(expression) ({ __typeof__(expression) __v_fastc_multi_value = (expression); MultiReturnValue __v_fastc_multi_result; if (sizeof(__v_fastc_multi_value) <= sizeof(__v_fastc_multi_result.data)) memcpy(__v_fastc_multi_result.data, &__v_fastc_multi_value, sizeof(__v_fastc_multi_value)); else __v_fastc_multi_result.ptr = v_fastc_interface_box(&__v_fastc_multi_value, sizeof(__v_fastc_multi_value)); __v_fastc_multi_result; })
+#define V_FASTC_MULTI_VALUE(expression) ({ __typeof__(expression) __vf_multi_value = (expression); MultiReturnValue __vf_multi_result; if (sizeof(__vf_multi_value) <= sizeof(__vf_multi_result.data)) memcpy(__vf_multi_result.data, &__vf_multi_value, sizeof(__vf_multi_value)); else __vf_multi_result.ptr = v_fastc_interface_box(&__vf_multi_value, sizeof(__vf_multi_value)); __vf_multi_result; })
 #define V_FASTC_MULTI_SOURCE(slot, size) (((size) <= sizeof((slot).data)) ? (const void *)(slot).data : (const void *)(slot).ptr)
 
 static void v_fastc_print_string(const char *value) { fputs(value ? value : "", stdout); }
@@ -315,7 +315,7 @@ fn fastc_c_identifier(name string) string {
 		return name
 	}
 	return if name in fastc_c_reserved_identifiers {
-		'__v_fastc_keyword_${name}'
+		'__vf_keyword_${name}'
 	} else {
 		name
 	}
@@ -394,7 +394,7 @@ typedef void *chan;
    overflow the slot. */
 typedef union { uintptr_t word; long double alignment; void *ptr; unsigned char data[32]; } MultiReturnValue;
 typedef struct { MultiReturnValue values[8]; } MultiReturn;
-#define V_FASTC_MULTI_VALUE(expression) ({ __typeof__(expression) __v_fastc_multi_value = (expression); MultiReturnValue __v_fastc_multi_result; if (sizeof(__v_fastc_multi_value) <= sizeof(__v_fastc_multi_result.data)) memcpy(__v_fastc_multi_result.data, &__v_fastc_multi_value, sizeof(__v_fastc_multi_value)); else __v_fastc_multi_result.ptr = v_fastc_interface_box(&__v_fastc_multi_value, sizeof(__v_fastc_multi_value)); __v_fastc_multi_result; })
+#define V_FASTC_MULTI_VALUE(expression) ({ __typeof__(expression) __vf_multi_value = (expression); MultiReturnValue __vf_multi_result; if (sizeof(__vf_multi_value) <= sizeof(__vf_multi_result.data)) memcpy(__vf_multi_result.data, &__vf_multi_value, sizeof(__vf_multi_value)); else __vf_multi_result.ptr = v_fastc_interface_box(&__vf_multi_value, sizeof(__vf_multi_value)); __vf_multi_result; })
 #define V_FASTC_MULTI_SOURCE(slot, size) (((size) <= sizeof((slot).data)) ? (const void *)(slot).data : (const void *)(slot).ptr)
 
 #define _S(s) ((string){.str=(byteptr)("" s), .len=(sizeof(s)-1), .is_lit=1})
@@ -742,11 +742,11 @@ struct FastcFunctionSignature {
 // designated compound literal would perform on the whole aggregate.
 fn fastc_multi_return_literal(packed_values []string) string {
 	mut out := strings.new_builder(64)
-	out.write_string('({ MultiReturn __v_fastc_multi; ')
+	out.write_string('({ MultiReturn __vf_multi; ')
 	for i, value in packed_values {
-		out.write_string('__v_fastc_multi.values[${i}] = ${value}; ')
+		out.write_string('__vf_multi.values[${i}] = ${value}; ')
 	}
-	out.write_string('__v_fastc_multi; })')
+	out.write_string('__vf_multi; })')
 	return out.str()
 }
 
@@ -1193,7 +1193,7 @@ struct Parser {
 	// (see fastc_declared_type_c_names); semantic_type_key resolves through it.
 	declared_type_c_names     map[string]string
 	declared_type_key_by_name map[string]string
-	// `__v_fastc_`-prefixed generated C names, the only possible collisions for
+	// `__vf_`-prefixed generated C names, the only possible collisions for
 	// temporary_namespace candidates (see fastc_reserved_temporary_c_names).
 	fastc_prefixed_c_names []string
 	declared_kinds         map[string]FastcDeclaredTypeKind
@@ -1217,8 +1217,11 @@ struct Parser {
 	globals             map[string]string
 	public_globals      map[string]bool
 	used_function_names map[string]bool
-	selfhost            bool
-	header_free         bool
+	// function_c_names overrides the conventional C spelling for selected
+	// source-level functions. It is immutable and shared by file generators.
+	function_c_names map[string]string
+	selfhost         bool
+	header_free      bool
 	// source_has_select is false only when the file provably holds no `select`
 	// word (see fastc_source_scan_flags), so block pre-scans for channel
 	// select statements can be skipped.
@@ -1490,6 +1493,7 @@ struct FastcFileGenContext {
 	has_startup_inits         bool
 	has_cleanup_hooks         bool
 	functions                 map[string]FastcFunctionSignature
+	function_c_names          map[string]string
 	constant_types            map[string]string
 	global_types              map[string]string
 	fixed_array_types         map[string]string
@@ -1616,6 +1620,7 @@ fn fastc_generate_single_file(ctx &FastcFileGenContext, source_file FastcSourceF
 		globals: ctx.globals
 		public_globals: ctx.public_globals
 		used_function_names: ctx.used_function_names
+		function_c_names: ctx.function_c_names
 		selfhost: prefs.building_v
 		source_has_select: source_file.header.has_select
 		has_startup_inits: ctx.has_startup_inits
@@ -1712,6 +1717,12 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	// The `int` C spelling is fixed before any source is generated, so the
 	// generation workers below all read the same width.
 	fastc_set_platform_int_bits(prefs.target.pointer_bits)
+	fastc_set_compact_v3_type_names(prefs.building_v)
+	defer {
+		// The compact spellings are private to a V3 self-host. Keep the module
+		// generator's global target state from leaking into a later generation.
+		fastc_set_compact_v3_type_names(false)
+	}
 	// Source-level generic monomorphization runs first; it is a no-op when the
 	// program has no generic function definitions (so the self-host is untouched).
 	mut timer := fastc_new_phase_timer()
@@ -1754,14 +1765,15 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	// methods. Copy them onto B (with the receiver re-keyed to B) so calls on a B
 	// value resolve and B gets its own dispatch table entries.
 	fastc_promote_embedded_interface_methods(embed_embedders, embed_embeddeds, mut functions, mut interface_methods)
+	function_c_names := fastc_compact_function_c_names(functions, prefs.building_v)
 	mut pending_references := fastc_start_referenced_function_names(sources, prefs, functions)
 	has_c_functions := fastc_functions_declare_c(functions)
 	fastc_prefixed_c_names := fastc_reserved_temporary_c_names(functions, globals)
 	// Module dependency order is shared by the lifecycle, constant, global, and
 	// startup-initializer passes below.
 	ordered_sources := fastc_sources_in_dependency_order(sources)!
-	module_init_calls := fastc_module_init_calls(ordered_sources, functions)!
-	module_cleanup_calls := fastc_module_cleanup_calls(ordered_sources, functions)!
+	module_init_calls := fastc_module_init_calls(ordered_sources, functions, function_c_names)!
+	module_cleanup_calls := fastc_module_cleanup_calls(ordered_sources, functions, function_c_names)!
 	timer.mark('lifecycle_calls')
 	mut composite_types := map[string]bool{}
 	if prefs.building_v {
@@ -1815,6 +1827,7 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 			sum_types: type_output.sum_types
 			sum_type_variants: type_output.sum_type_variants
 			functions: functions
+			function_c_names: function_c_names
 			constants: constants
 			public_constants: public_constants
 			globals: globals
@@ -1825,8 +1838,8 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	}
 	// The struct field defaults render on a worker while the constants are
 	// pre-parsed; a constant file that consulted them is re-parsed after.
-	mut pending_defaults := fastc_start_field_defaults(source_imports, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.enum_field_names, type_output.alias_base_types, struct_fields, struct_field_info, functions, constants, public_constants, constant_types, globals, public_globals, global_types, type_output.sum_types)
-	constant_output := fastc_generate_constant_declarations(constant_candidates, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info, type_output.sum_types, type_output.sum_type_variants, mut pending_defaults, functions, constants, public_constants, globals, public_globals, parallel_constant_results, mut constant_types)!
+	mut pending_defaults := fastc_start_field_defaults(source_imports, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.enum_field_names, type_output.alias_base_types, struct_fields, struct_field_info, functions, function_c_names, constants, public_constants, constant_types, globals, public_globals, global_types, type_output.sum_types)
+	constant_output := fastc_generate_constant_declarations(constant_candidates, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info, type_output.sum_types, type_output.sum_type_variants, mut pending_defaults, functions, function_c_names, constants, public_constants, globals, public_globals, parallel_constant_results, mut constant_types)!
 	struct_field_info = constant_output.struct_field_info.clone()
 	timer.mark('constant_declarations')
 	for name, _ in constant_output.composite_types {
@@ -1838,7 +1851,7 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	header_free := prefs.building_v
 		&& ('fastc_real_builtin' !in prefs.user_defines || prefs.target.os == 'macos')
 		&& fastc_c_abi_supported(prefs.target.os, prefs.target.arch, fastc_host_uses_glibc())
-	global_output := fastc_generate_global_declarations(ordered_sources, global_sources, prefs, header_free, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info, functions, constants, constant_output.compile_time_values, public_constants, constant_types, globals, public_globals, mut global_types)!
+	global_output := fastc_generate_global_declarations(ordered_sources, global_sources, prefs, header_free, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, type_output.alias_base_types, struct_fields, struct_field_info, functions, function_c_names, constants, constant_output.compile_time_values, public_constants, constant_types, globals, public_globals, mut global_types)!
 	timer.mark('global_declarations')
 	for name, _ in global_output.composite_types {
 		composite_types[name] = true
@@ -1849,11 +1862,11 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	for global_type in global_types.values() {
 		fastc_register_composite_type(global_type, mut composite_types)
 	}
-	startup_initializers := fastc_generate_startup_initializers(ordered_sources, constant_output.module_initializers, global_output.module_initializers, module_init_calls)!
+	startup_initializers := fastc_generate_startup_initializers(ordered_sources, constant_output.module_initializers, global_output.module_initializers, module_init_calls, function_c_names)!
 	timer.mark('startup_initializers')
 	used_function_names := fastc_wait_referenced_function_names(mut pending_references)
 	timer.mark('wait_references')
-	mut pending_interface_dispatches := fastc_start_interface_dispatches(declared_kinds, functions, interface_methods, used_function_names, prefs.building_v, prefs)
+	mut pending_interface_dispatches := fastc_start_interface_dispatches(declared_kinds, functions, function_c_names, interface_methods, used_function_names, prefs.building_v, prefs)
 	struct_field_lookup := constant_output.struct_field_lookup.clone()
 	// The per-file prototype blocks are emitted as pieces too, so they are
 	// never concatenated into one buffer.
@@ -1887,7 +1900,7 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	// the source-level reachability keeps every function sharing a used name.
 	prune_unreachable := prefs.building_v
 	function_ids := if prune_unreachable {
-		fastc_function_id_table(functions, declared_kinds)
+		fastc_function_id_table(functions, function_c_names, declared_kinds)
 	} else {
 		map[string]int{}
 	}
@@ -1924,6 +1937,7 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 		has_startup_inits: startup_initializers.len > 0
 		has_cleanup_hooks: module_cleanup_calls.len > 0
 		functions: functions
+		function_c_names: function_c_names
 		constant_types: constant_types
 		global_types: global_types
 		fixed_array_types: fixed_array_types
@@ -2523,12 +2537,8 @@ fn fastc_parallel_worker_limit(prefs &pref.Preferences) int {
 // program's translation units with.
 pub fn fastc_tcc_job_count(prefs &pref.Preferences) int {
 	mut jobs := fastc_parallel_worker_limit(prefs)
-	benchmark_jobs := os.getenv('V3_FASTC_TCC_JOBS').int()
-	if benchmark_jobs > 0 {
-		jobs = benchmark_jobs
-	}
-	if jobs > 16 {
-		jobs = 16
+	if jobs > 12 {
+		jobs = 12
 	}
 	if jobs < 1 {
 		jobs = 1
@@ -2713,6 +2723,37 @@ pub:
 mut:
 	workers []thread string
 	order   []int
+}
+
+// FastcPrestartedCUnits holds TinyCC processes started before FastC generation
+// completes. They wait on stdin until the balanced translation units are ready.
+pub struct FastcPrestartedCUnits {
+pub:
+	build_dir  string
+	base_args  []string
+	unit_count int
+mut:
+	paths     []string
+	objects   []string
+	pids      []int
+	read_fds  []int
+	write_fds []int
+	active    bool
+}
+
+// FastcFeedingCUnits holds the workers that copy rendered translation units
+// into prestarted TinyCC processes.
+pub struct FastcFeedingCUnits {
+pub:
+	paths []string
+mut:
+	writers []thread
+}
+
+// fastc_prestarted_c_units_match reports whether `units` can consume a build
+// with the final compile arguments and translation-unit count.
+pub fn fastc_prestarted_c_units_match(units &FastcPrestartedCUnits, base_args []string, unit_count int) bool {
+	return units.active && units.unit_count == unit_count && units.base_args == base_args
 }
 
 fn fastc_render_c_unit(pieces []string, units &FastcUnitLayout, g int, first_unit int, end_unit int) string {
@@ -3149,7 +3190,7 @@ fn fastc_promote_embedded_interface_methods(embed_embedders []string, embed_embe
 	}
 }
 
-fn fastc_generate_interface_dispatches(declared_kinds map[string]FastcDeclaredTypeKind, functions map[string]FastcFunctionSignature, interface_methods map[string]bool, used_function_names map[string]bool, selfhost bool) string {
+fn fastc_generate_interface_dispatches(declared_kinds map[string]FastcDeclaredTypeKind, functions map[string]FastcFunctionSignature, function_c_names map[string]string, interface_methods map[string]bool, used_function_names map[string]bool, selfhost bool) string {
 	mut out := strings.new_builder(1024)
 	mut function_keys := functions.keys()
 	function_keys.sort()
@@ -3183,7 +3224,11 @@ fn fastc_generate_interface_dispatches(declared_kinds map[string]FastcDeclaredTy
 				parameters << '${interface_signature.parameter_types[i]} arg${i}'
 				arguments << 'arg${i}'
 			}
-			c_name := fastc_method_c_name(interface_signature.module_name, interface_type, method_name)
+			c_name := if compact_name := function_c_names[interface_method_key] {
+				compact_name
+			} else {
+				fastc_method_c_name(interface_signature.module_name, interface_type, method_name)
+			}
 			out.writeln('${interface_signature.return_type} ${c_name}(${parameters.join(', ')}) {')
 			out.writeln('\tswitch (value._typ) {')
 			candidate_count := if selfhost && method_name !in used_function_names {
@@ -3216,7 +3261,12 @@ fn fastc_generate_interface_dispatches(declared_kinds map[string]FastcDeclaredTy
 				} else {
 					''
 				}
-				call := '${fastc_method_c_name(candidate_signature.module_name, receiver_type, method_name)}(${receiver_argument}${call_arguments})'
+				candidate_c_name := if compact_name := function_c_names[candidate_key] {
+					compact_name
+				} else {
+					fastc_method_c_name(candidate_signature.module_name, receiver_type, method_name)
+				}
+				call := '${candidate_c_name}(${receiver_argument}${call_arguments})'
 				out.writeln('\tcase __v_typeid_${receiver_type}: ${if interface_signature.return_type == 'void' {
 					call + '; return;'
 				} else {
@@ -3414,19 +3464,17 @@ fn fastc_inlined_c_header(path string) string {
 // fastc_function_id_table numbers the C names of the indexed functions and
 // methods (the keys of the signature index), as the emitted definitions and
 // calls spell them.
-fn fastc_function_id_table(functions map[string]FastcFunctionSignature, declared_kinds map[string]FastcDeclaredTypeKind) map[string]int {
+fn fastc_function_id_table(functions map[string]FastcFunctionSignature, function_c_names map[string]string, declared_kinds map[string]FastcDeclaredTypeKind) map[string]int {
 	mut ids := map[string]int{}
 	ids.reserve(u32(functions.len))
 	for key, signature in functions {
 		if key.starts_with('C.') {
 			continue
 		}
-		name := key.all_after_last('.')
-		prefix := key.all_before_last('.')
-		c_name := if prefix == '' || prefix == signature.module_name {
-			fastc_c_function_name(signature.module_name, name)
+		c_name := if compact_name := function_c_names[key] {
+			compact_name
 		} else {
-			fastc_method_c_name(signature.module_name, fastc_c_declared_type_name(prefix), name)
+			fastc_signature_c_name(key, signature)
 		}
 		// Only names the reference scan recognizes (a `__` separator or the
 		// `v_fastc_` prefix) are indexed; a bare main-module name stays out
@@ -3453,10 +3501,11 @@ fn fastc_function_id_table(functions map[string]FastcFunctionSignature, declared
 }
 
 // fastc_c_name_is_indexed reports whether a C name carries a module or type
-// separator (`__`) or the helper prefix, the spellings the reference scan
-// looks up.
+// separator (`__`) or one of the generated helper prefixes, the spellings the
+// reference scan looks up.
 fn fastc_c_name_is_indexed(c_name string) bool {
 	return fastc_contains(c_name, '__') || c_name.starts_with('v_fastc_')
+		|| c_name.starts_with('v_f')
 }
 
 fn fastc_c_identifier_start_byte(value u8) bool {
@@ -3465,7 +3514,7 @@ fn fastc_c_identifier_start_byte(value u8) bool {
 
 // fastc_collect_c_name_ids appends the ids of the indexed functions named in
 // text[start..end]. Every indexed C name carries a module or type separator
-// (`__`) or the `v_fastc_` prefix, so only underscores can begin a candidate.
+// (`__`), `v_fastc_`, or compact `v_f` prefix, so only underscores can begin a candidate.
 // Expanding from those markers avoids classifying every ordinary identifier.
 @[direct_array_access]
 fn fastc_collect_c_name_ids(text string, start int, end int, ids map[string]int, mut out []int) {
@@ -3480,6 +3529,10 @@ fn fastc_collect_c_name_ids(text string, start int, end int, ids map[string]int,
 		if !indexed && i > start && text[i - 1] == `v` && i + 6 < end && text[i + 1] == `f`
 			&& text[i + 2] == `a` && text[i + 3] == `s` && text[i + 4] == `t`
 			&& text[i + 5] == `c` && text[i + 6] == `_` {
+			word_start = i - 1
+			indexed = word_start == start || !fastc_identifier_byte(text[word_start - 1])
+		} else if !indexed && i > start && text[i - 1] == `v` && i + 1 < end
+			&& text[i + 1] == `f` {
 			word_start = i - 1
 			indexed = word_start == start || !fastc_identifier_byte(text[word_start - 1])
 		}

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -1565,6 +1565,7 @@ mut:
 fn fastc_generate_single_file(ctx &FastcFileGenContext, source_file FastcSourceFile) FastcFileGenOutput {
 	file := token.File.unindexed(source_file.path, source_file.source.len)
 	prefs := ctx.prefs
+	body_capacity := source_file.source.len * (if prefs.building_v { 4 } else { 2 }) + 1024
 	mut gen := Parser{
 		prefs: unsafe { prefs }
 		unqualified_key_memo: map[string]string{}
@@ -1620,7 +1621,7 @@ fn fastc_generate_single_file(ctx &FastcFileGenContext, source_file FastcSourceF
 		has_startup_inits: ctx.has_startup_inits
 		has_cleanup_hooks: ctx.has_cleanup_hooks
 		s: scanner.new_scanner(prefs, .normal)
-		out: strings.new_builder(source_file.source.len * 2 + 1024)
+		out: strings.new_builder(body_capacity)
 		protos: strings.new_builder(4096)
 		functions: ctx.functions
 		function_id_table: ctx.function_ids
@@ -2178,11 +2179,14 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 		unit_ref_starts << unit_ref_ids.len
 	}
 	mut pieces := []string{cap: 64 + body_pieces.len * 3}
-	pieces << fastc_piece(preamble)
+	mut extern_indexes := []int{}
+	mut extern_texts := []string{}
+	mut define_texts := []string{}
+	fastc_append_split_head_piece(mut pieces, mut extern_indexes, mut extern_texts, mut define_texts, preamble)
 	for header_path in inlined_header_paths {
-		pieces << fastc_inlined_c_header(header_path)
+		fastc_append_split_head_piece(mut pieces, mut extern_indexes, mut extern_texts, mut define_texts, fastc_inlined_c_header(header_path))
 	}
-	pieces << fastc_piece(c_integer_comparison_helpers)
+	fastc_append_split_head_piece(mut pieces, mut extern_indexes, mut extern_texts, mut define_texts, c_integer_comparison_helpers)
 	fastc_collect_c_piece_ranges(mut pieces, body_pieces, hoisted_body.directive_ranges)
 	timer.mark('assemble.directives')
 	if hoisted_body.final_kind == 1 {
@@ -2192,7 +2196,7 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 		pieces << '\n'
 	}
 	if prefs.building_v {
-		pieces << fastc_piece(c_selfhost_post_directives)
+		fastc_append_split_head_piece(mut pieces, mut extern_indexes, mut extern_texts, mut define_texts, c_selfhost_post_directives)
 	}
 	if spawn_typedefs.len > 0 {
 		if !header_free {
@@ -2217,9 +2221,6 @@ fn generate_source_pieces(input_sources []FastcSourceFile, module_aliases map[st
 	pieces << late_composite_declarations.str()
 	pieces << fastc_piece(fixed_array_declarations)
 	pieces << fastc_c_extern_prototypes(functions)
-	mut extern_indexes := []int{}
-	mut extern_texts := []string{}
-	mut define_texts := []string{}
 	extern_indexes << pieces.len
 	extern_texts << fastc_extern_declarations(constant_output.declarations, true)
 	define_texts << fastc_extern_declarations(constant_output.declarations, false)
@@ -2429,17 +2430,58 @@ fn fastc_range_is_kept(ranges []int, start int, end int) bool {
 	return false
 }
 
-// fastc_extern_declarations rewrites the `static` variable definitions of a
-// declaration block for a split build: as `extern` declarations (`as_extern`)
-// for the units that share the globals, or as external definitions (without
-// `static`) for the unit that holds them. Static functions and multi-line
-// initializers are left as they are (they stay per unit).
+fn fastc_append_split_head_piece(mut pieces []string, mut extern_indexes []int, mut extern_texts []string, mut define_texts []string, text string) {
+	// TinyCC recognizes its private atomic helpers only while compiling these
+	// static-inline wrappers; keep that header local to every translation unit.
+	if text.contains('__atomic_exchange_4') {
+		pieces << fastc_piece(text)
+		return
+	}
+	definitions := fastc_extern_declarations(text, false)
+	declarations := fastc_extern_declarations(text, true)
+	if definitions != text || declarations != text {
+		extern_indexes << pieces.len
+		extern_texts << declarations
+		define_texts << definitions
+	}
+	pieces << fastc_piece(text)
+}
+
+fn fastc_external_function_header(line string, as_extern bool) string {
+	body_start := line.index(') {') or { return line }
+	mut header := line['static '.len..body_start + 1]
+	if header.starts_with('inline ') {
+		header = header['inline '.len..]
+	}
+	return if as_extern { 'extern ${header};' } else { header + line[body_start + 1..] }
+}
+
+// fastc_extern_declarations rewrites top-level `static` definitions for a
+// split build: as `extern` declarations (`as_extern`) for units that share
+// them, or as external definitions in the first unit. TinyCC does not inline,
+// so emitting helper bodies once avoids parsing and generating them per unit.
 fn fastc_extern_declarations(text string, as_extern bool) string {
 	if !fastc_contains(text, 'static ') {
 		return text
 	}
 	mut out := strings.new_builder(text.len)
-	for line in text.split_into_lines() {
+	lines := text.split_into_lines()
+	mut i := 0
+	for i < lines.len {
+		line := lines[i]
+		if line.starts_with('static ') && line.contains(') {') {
+			out.writeln(fastc_external_function_header(line, as_extern))
+			mut depth := line.count('{') - line.count('}')
+			i++
+			for i < lines.len && depth > 0 {
+				if !as_extern {
+					out.writeln(lines[i])
+				}
+				depth += lines[i].count('{') - lines[i].count('}')
+				i++
+			}
+			continue
+		}
 		if line.starts_with('static ') && !fastc_contains(line, '(') && line.ends_with(';') {
 			mut declaration := line['static '.len..]
 			if as_extern {
@@ -2450,9 +2492,11 @@ fn fastc_extern_declarations(text string, as_extern bool) string {
 			} else {
 				out.writeln(declaration)
 			}
+			i++
 			continue
 		}
 		out.writeln(line)
+		i++
 	}
 	return out.str()
 }
@@ -2479,6 +2523,10 @@ fn fastc_parallel_worker_limit(prefs &pref.Preferences) int {
 // program's translation units with.
 pub fn fastc_tcc_job_count(prefs &pref.Preferences) int {
 	mut jobs := fastc_parallel_worker_limit(prefs)
+	benchmark_jobs := os.getenv('V3_FASTC_TCC_JOBS').int()
+	if benchmark_jobs > 0 {
+		jobs = benchmark_jobs
+	}
 	if jobs > 16 {
 		jobs = 16
 	}
@@ -2542,6 +2590,7 @@ fn fastc_unit_group_starts(unit_sizes []int, groups int, first_overhead int, sha
 struct FastcCUnitPlan {
 	paths       []string
 	first_units []int
+	sizes       []int
 }
 
 fn fastc_c_unit_plan(prefix string, pieces []string, units FastcUnitLayout, jobs int) FastcCUnitPlan {
@@ -2585,12 +2634,19 @@ fn fastc_c_unit_plan(prefix string, pieces []string, units FastcUnitLayout, jobs
 		return FastcCUnitPlan{}
 	}
 	mut paths := []string{cap: groups}
+	mut sizes := []int{cap: groups}
 	for g in 0 .. groups {
 		paths << '${prefix}.unit${g}.c'
+		mut size := if g == 0 { first_overhead } else { shared_overhead }
+		for u in first_units[g] .. first_units[g + 1] {
+			size += unit_sizes[u]
+		}
+		sizes << size
 	}
 	return FastcCUnitPlan{
 		paths: paths
 		first_units: first_units
+		sizes: sizes
 	}
 }
 
@@ -2648,6 +2704,17 @@ pub:
 	sources []string
 }
 
+// FastcRenderingCUnits holds translation-unit render workers. Keeping the
+// workers live lets an uncached build start TinyCC while the C text is still
+// being assembled.
+pub struct FastcRenderingCUnits {
+pub:
+	paths []string
+mut:
+	workers []thread string
+	order   []int
+}
+
 fn fastc_render_c_unit(pieces []string, units &FastcUnitLayout, g int, first_unit int, end_unit int) string {
 	mut out := strings.new_builder(1024 * 1024)
 	for k in 0 .. units.head_end {
@@ -2699,24 +2766,58 @@ fn fastc_render_c_unit(pieces []string, units &FastcUnitLayout, g int, first_uni
 	return out.str()
 }
 
-// fastc_render_c_units renders balanced split translation units in parallel.
-pub fn fastc_render_c_units(prefix string, pieces []string, units FastcUnitLayout, jobs int) FastcRenderedCUnits {
+fn fastc_descending_size_order(sizes []int) []int {
+	mut order := []int{cap: sizes.len}
+	mut ordered_sizes := []int{cap: sizes.len}
+	for i, size in sizes {
+		order << i
+		ordered_sizes << size
+		mut at := order.len - 1
+		for at > 0 && ordered_sizes[at - 1] < size {
+			order[at] = order[at - 1]
+			ordered_sizes[at] = ordered_sizes[at - 1]
+			at--
+		}
+		order[at] = i
+		ordered_sizes[at] = size
+	}
+	return order
+}
+
+// fastc_begin_render_c_units starts rendering balanced split translation
+// units and returns immediately, so their consumers can start concurrently.
+pub fn fastc_begin_render_c_units(prefix string, pieces []string, units FastcUnitLayout, jobs int) FastcRenderingCUnits {
 	plan := fastc_c_unit_plan(prefix, pieces, units, jobs)
 	if plan.paths.len == 0 {
-		return FastcRenderedCUnits{}
+		return FastcRenderingCUnits{}
 	}
 	mut workers := []thread string{cap: plan.paths.len}
 	for g in 0 .. plan.paths.len {
 		workers << spawn fastc_render_c_unit(pieces, &units, g, plan.first_units[g], plan.first_units[g + 1])
 	}
-	mut sources := []string{cap: plan.paths.len}
-	for worker in workers {
+	return FastcRenderingCUnits{
+		paths: plan.paths
+		workers: workers
+		order: fastc_descending_size_order(plan.sizes)
+	}
+}
+
+// fastc_finish_render_c_units waits for an in-progress unit render.
+pub fn fastc_finish_render_c_units(mut rendering FastcRenderingCUnits) FastcRenderedCUnits {
+	mut sources := []string{cap: rendering.paths.len}
+	for worker in rendering.workers {
 		sources << worker.wait()
 	}
 	return FastcRenderedCUnits{
-		paths: plan.paths
+		paths: rendering.paths
 		sources: sources
 	}
+}
+
+// fastc_render_c_units renders balanced split translation units in parallel.
+pub fn fastc_render_c_units(prefix string, pieces []string, units FastcUnitLayout, jobs int) FastcRenderedCUnits {
+	mut rendering := fastc_begin_render_c_units(prefix, pieces, units, jobs)
+	return fastc_finish_render_c_units(mut rendering)
 }
 
 struct FastcUnitCacheEntry {
@@ -3370,9 +3471,9 @@ fn fastc_c_identifier_start_byte(value u8) bool {
 fn fastc_collect_c_name_ids(text string, start int, end int, ids map[string]int, mut out []int) {
 	mut i := start
 	for i < end {
-		if text[i] != `_` {
-			i++
-			continue
+		i = fastc_next_underscore(text, i, end)
+		if i >= end {
+			break
 		}
 		mut word_start := i
 		mut indexed := i + 1 < end && text[i + 1] == `_`

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -682,6 +682,41 @@ fn test_fastc_tcc_job_count_respects_parallel_controls() {
 	assert fastc_tcc_job_count(prefs) == 1
 }
 
+fn test_fastc_unit_group_starts_accounts_for_prepended_text() {
+	unit_sizes := [90, 90, 90, 300]
+	assert fastc_unit_group_starts(unit_sizes, 2, 0, 0) == [0, 3, 4]
+	// The extra first-unit runtime makes a smaller first body optimal.
+	assert fastc_unit_group_starts(unit_sizes, 2, 250, 0) == [0, 2, 4]
+	// Common text is part of every later unit too.
+	assert fastc_unit_group_starts([100, 100, 100, 100], 2, 0, 300) == [0, 3, 4]
+}
+
+fn test_fastc_link_cache_restores_an_independent_executable() {
+	$if !windows {
+		key := 'test-${os.getpid()}'
+		cached := fastc_link_cache_path(key)
+		root := os.join_path(os.vtmp_dir(), 'v3_fastc_link_cache_test_${os.getpid()}')
+		source := os.join_path_single(root, 'source')
+		first := os.join_path_single(root, 'first')
+		second := os.join_path_single(root, 'second')
+		os.mkdir_all(root) or { panic(err) }
+		os.rm(cached) or {}
+		defer {
+			os.rmdir_all(root) or {}
+			os.rm(cached) or {}
+		}
+		os.write_file(source, 'cached executable') or { panic(err) }
+		os.chmod(source, 0o700) or { panic(err) }
+		fastc_publish_link_cache(key, source)
+		os.write_file(source, 'changed source') or { panic(err) }
+		assert fastc_restore_link_cache(key, first)
+		assert os.read_file(first) or { panic(err) } == 'cached executable'
+		os.write_file(first, 'changed output') or { panic(err) }
+		assert fastc_restore_link_cache(key, second)
+		assert os.read_file(second) or { panic(err) } == 'cached executable'
+	}
+}
+
 fn test_fastc_fragmented_generation_matches_serial_output() {
 	large_comment := '// ' + 'x'.repeat(fastc_generation_fragment_size + 1024)
 	sources := [

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -675,6 +675,9 @@ fn test_fastc_tcc_job_count_respects_parallel_controls() {
 	os.unsetenv('V3_FASTC_NO_PARALLEL')
 	mut prefs := pref.new_preferences()
 	assert fastc_tcc_job_count(prefs) == 4
+	os.setenv('VJOBS', '100', true)
+	assert fastc_tcc_job_count(prefs) == 16
+	os.setenv('VJOBS', '4', true)
 	prefs.no_parallel = true
 	assert fastc_tcc_job_count(prefs) == 1
 	prefs.no_parallel = false
@@ -689,6 +692,24 @@ fn test_fastc_unit_group_starts_accounts_for_prepended_text() {
 	assert fastc_unit_group_starts(unit_sizes, 2, 250, 0) == [0, 2, 4]
 	// Common text is part of every later unit too.
 	assert fastc_unit_group_starts([100, 100, 100, 100], 2, 0, 300) == [0, 3, 4]
+}
+
+fn test_fastc_unit_compile_order_starts_largest_cache_misses_first() {
+	root := os.join_path_single(os.vtmp_dir(), 'fastc_unit_order_${os.getpid()}')
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	paths := [os.join_path_single(root, 'small.c'), os.join_path_single(root, 'cached.c'),
+		os.join_path_single(root, 'large.c'), os.join_path_single(root, 'medium.c')]
+	for i, size in [10, 100, 80, 40] {
+		os.write_file(paths[i], 'x'.repeat(size)) or { panic(err) }
+	}
+	prepared := FastcPreparedUnits{
+		entries: [FastcUnitCacheEntry{}, FastcUnitCacheEntry{ hit: true }, FastcUnitCacheEntry{},
+			FastcUnitCacheEntry{}]
+	}
+	assert fastc_unit_compile_order(paths, prepared) == [2, 3, 0]
 }
 
 fn test_fastc_link_cache_restores_an_independent_executable() {
@@ -3753,6 +3774,8 @@ fn main() {
 	assert c_source.contains('static int answer;'), c_source
 	assert c_source.contains('\tanswer = 42;'), c_source
 	assert c_source.contains('v_fastc_init_globals();'), c_source
+	assert c_source.contains('void v_fastc_init_globals(void) {'), c_source
+	assert !c_source.contains('static void v_fastc_init_globals'), c_source
 }
 
 fn test_script_main_initializes_globals_before_statements() {
@@ -3769,7 +3792,7 @@ fn init() {
 println(answer)
 ', 'initialized_script_global.v', prefs) or { panic(err) }
 	main_source := c_source.all_after('int main(void) {')
-	startup_source := c_source.all_after('static void v_fastc_init_globals(void) {')
+	startup_source := c_source.all_after('void v_fastc_init_globals(void) {')
 	initializer := startup_source.index('answer = 42;') or { -1 }
 	module_initializer := startup_source.index('\n\tinit();') or { -1 }
 	startup_call := main_source.index('v_fastc_init_globals();') or { -1 }
@@ -3961,7 +3984,7 @@ pub fn value() int {
 	prefs.module_search_paths = [root]
 	c_source := generate_files([main_file], prefs) or { panic(err) }
 	main_source := c_source.all_after('int main(void) {')
-	startup_source := c_source.all_after('static void v_fastc_init_globals(void) {')
+	startup_source := c_source.all_after('void v_fastc_init_globals(void) {')
 	dependency_initializer := startup_source.index('dep__state = 1;') or { -1 }
 	dependency_init := startup_source.index('\tdep__init();') or { -1 }
 	importer_initializer := startup_source.index('main__copied = dep__value();') or { -1 }
@@ -4040,7 +4063,8 @@ pub fn ping() {}
 	mut prefs := pref.new_preferences()
 	prefs.module_search_paths = [root]
 	c_source := generate_files([main_file], prefs) or { panic(err) }
-	cleanup_source := c_source.all_after('static void v_fastc_cleanup_modules(void) {')
+	assert !c_source.contains('static void v_fastc_cleanup_modules'), c_source
+	cleanup_source := c_source.all_after('void v_fastc_cleanup_modules(void) {')
 	main_cleanup := cleanup_source.index('\n\tcleanup();') or { -1 }
 	dependency_cleanup := cleanup_source.index('\n\tdep__cleanup();') or { -1 }
 	assert main_cleanup >= 0, c_source
@@ -4161,12 +4185,12 @@ pub fn ping() {}
 	}
 	assert header.import_order == ['zed', 'alpha']
 	c_source := generate_files([main_file], prefs) or { panic(err) }
-	startup_source := c_source.all_after('static void v_fastc_init_globals(void) {')
+	startup_source := c_source.all_after('void v_fastc_init_globals(void) {')
 	zed_init := startup_source.index('\tzed__init();') or { -1 }
 	alpha_init := startup_source.index('\talpha__init();') or { -1 }
 	assert zed_init >= 0, c_source
 	assert alpha_init > zed_init, c_source
-	cleanup_source := c_source.all_after('static void v_fastc_cleanup_modules(void) {')
+	cleanup_source := c_source.all_after('void v_fastc_cleanup_modules(void) {')
 	alpha_cleanup := cleanup_source.index('\talpha__cleanup();') or { -1 }
 	zed_cleanup := cleanup_source.index('\tzed__cleanup();') or { -1 }
 	assert alpha_cleanup >= 0, c_source

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -694,6 +694,14 @@ fn test_fastc_unit_group_starts_accounts_for_prepended_text() {
 	assert fastc_unit_group_starts([100, 100, 100, 100], 2, 0, 300) == [0, 3, 4]
 }
 
+fn test_fastc_extern_declarations_extracts_static_helpers() {
+	text := 'static int count = 3;\nstatic inline int add(int a, int b) { return a + b; }\nstatic void clear(void) {\n\tcount = 0;\n}\n#define COUNT count\n'
+	definitions := fastc_extern_declarations(text, false)
+	assert definitions == 'int count = 3;\nint add(int a, int b) { return a + b; }\nvoid clear(void) {\n\tcount = 0;\n}\n#define COUNT count\n'
+	declarations := fastc_extern_declarations(text, true)
+	assert declarations == 'extern int count;\nextern int add(int a, int b);\nextern void clear(void);\n#define COUNT count\n'
+}
+
 fn test_fastc_rendered_units_match_temporary_files() {
 	root := os.join_path_single(os.vtmp_dir(), 'fastc_rendered_units_${os.getpid()}')
 	os.mkdir_all(root) or { panic(err) }

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -49,6 +49,40 @@ fn test_parse_resolve_memo_rejects_short_listings() {
 	assert memo.dir_files[0].len == 0
 }
 
+fn test_resolve_memo_unchanged_sources_use_preloaded_stamps() {
+	stamp := FastcFileStamp{
+		size: 12
+		mtime: 20
+		ctime: 21
+		inode: 22
+	}
+	memo := FastcResolveMemo{
+		files: ['/tmp/a.v']
+		stamps: [stamp]
+	}
+	sources := [FastcSourceFile{
+		path: '/tmp/a.v'
+	}]
+	preloaded := {
+		'/tmp/a.v': FastcLoadedSource{
+			path: '/tmp/a.v'
+			stamp: stamp
+		}
+	}
+	assert fastc_resolve_memo_sources_unchanged(memo, sources, preloaded)
+	mut changed := preloaded.clone()
+	changed['/tmp/a.v'] = FastcLoadedSource{
+		path: '/tmp/a.v'
+		stamp: FastcFileStamp{
+			size: 13
+			mtime: 20
+			ctime: 21
+			inode: 22
+		}
+	}
+	assert !fastc_resolve_memo_sources_unchanged(memo, sources, changed)
+}
+
 fn test_fastc_index_of_and_replace() {
 	text := 'abc_call(x) + abc_call(y) - ab'
 	assert fastc_index_of(text, 'abc_call(', 0) == text.index_after_('abc_call(', 0)
@@ -235,8 +269,8 @@ fn main() {
 	assert c_source.contains('return shared+other;'), c_source
 	assert c_source.contains('return shared^2;'), c_source
 	assert !c_source.contains('return &shared'), c_source
-	assert c_source.contains('Option __v_fastc_option_0 = (shared);'), c_source
-	assert c_source.contains('__v_fastc_membership_item = (shared);'), c_source
+	assert c_source.contains('Option __v0 = (shared);'), c_source
+	assert c_source.contains('__vf_m_x = (shared);'), c_source
 	assert c_source.count('return shared;') == 3, c_source
 	assert c_source.contains('if (shared)'), c_source
 	assert c_source.contains('total+=shared;'), c_source
@@ -393,7 +427,7 @@ fn main() {
 	_ := propagate() or { 0 }
 }
 ', 'selfhost_multiline_shared_result_propagation.v', prefs) or { panic(err) }
-	assert c_source.contains('Option __v_fastc_option_propagate = (shared);'), c_source
+	assert c_source.contains('Option __vf_op = (shared);'), c_source
 	assert !c_source.contains('shared!'), c_source
 }
 
@@ -424,7 +458,7 @@ fn main() {
 }
 ', 'selfhost_static_shared_local.v', prefs) or { panic(err) }
 	assert c_source.contains('static ${fastc_platform_int_c_type} shared;'), c_source
-	assert c_source.contains('static bool __v_fastc_static_init_'), c_source
+	assert c_source.contains('static bool __v'), c_source
 	assert c_source.contains('shared = (1);'), c_source
 	assert c_source.contains('println(shared)'), c_source
 }
@@ -451,7 +485,7 @@ fn main() {
 }
 ', 'selfhost_mut_static_pointer.v', prefs) or { panic(err) }
 	assert c_source.contains('static __typeof__((((Item*)(NULL)))) saved;'), c_source
-	assert c_source.contains('static bool __v_fastc_static_init_'), c_source
+	assert c_source.contains('static bool __v'), c_source
 	assert c_source.contains('saved = (((Item*)(NULL)));'), c_source
 }
 
@@ -676,7 +710,7 @@ fn test_fastc_tcc_job_count_respects_parallel_controls() {
 	mut prefs := pref.new_preferences()
 	assert fastc_tcc_job_count(prefs) == 4
 	os.setenv('VJOBS', '100', true)
-	assert fastc_tcc_job_count(prefs) == 16
+	assert fastc_tcc_job_count(prefs) == 14
 	os.setenv('VJOBS', '4', true)
 	prefs.no_parallel = true
 	assert fastc_tcc_job_count(prefs) == 1
@@ -942,7 +976,7 @@ fn test_fastc_overlap_workers_honor_serial_preferences() {
 	for name in ['a', 'b', 'c', 'd'] {
 		functions[name] = FastcFunctionSignature{}
 	}
-	mut pending_dispatches := fastc_start_interface_dispatches(map[string]FastcDeclaredTypeKind{}, functions, map[string]bool{}, map[string]bool{}, false, prefs)
+	mut pending_dispatches := fastc_start_interface_dispatches(map[string]FastcDeclaredTypeKind{}, functions, map[string]string{}, map[string]bool{}, map[string]bool{}, false, prefs)
 	assert pending_dispatches.workers.len == 0
 	assert fastc_wait_interface_dispatches(mut pending_dispatches) == ''
 }
@@ -1128,8 +1162,8 @@ fn main() {
 }
 ', 'spawn_params_struct.v', prefs) or { panic(err) }
 	assert c_source.contains('args->result = configured(args->arg0, args->arg1);'), c_source
-	assert c_source.contains('__v_fastc_struct_default.value=(default_value());'), c_source
-	assert c_source.contains('.value=(__v_fastc_struct_field_0)'), c_source
+	assert c_source.contains('__vf_sd.value=(default_value());'), c_source
+	assert c_source.contains('.value=(__vf_sf_0)'), c_source
 	assert c_source.contains('v_fastc_interface_box(&(PointerConfig){0}, sizeof(PointerConfig))'), c_source
 }
 
@@ -1155,7 +1189,7 @@ fn main() {
 	println(handle.wait())
 }
 ', 'spawn_shared_named_params_field.v', prefs) or { panic(err) }
-	assert c_source.contains('.shared=(__v_fastc_struct_field_0)'), c_source
+	assert c_source.contains('.shared=(__vf_sf_0)'), c_source
 }
 
 fn test_generate_and_compile_without_flat_ast() {
@@ -1183,8 +1217,8 @@ fn twice(value int) int {
 	c_source := generate(source, 'fastc_test.v', prefs) or { panic(err) }
 	assert c_source.contains('i64 total = (0);')
 	assert c_source.contains('string label = ("total=");')
-	assert c_source.contains('__v_fastc_range_start_0 = (0);')
-	assert c_source.contains('__v_fastc_range_end_1 = (3);')
+	assert c_source.contains('__v0 = (0);')
+	assert c_source.contains('__v1 = (3);')
 	assert c_source.contains('i64 twice(i64 value);')
 	assert c_source.contains('setvbuf(stdout, NULL, _IONBF, 0);')
 	assert !c_source.contains('v3.flat')
@@ -1296,7 +1330,7 @@ fn main() {
 	assert c_source.count('builtin__string_plus_many(2, (string[]){') >= 4, c_source
 	assert c_source.contains('combined=builtin__string_plus_many(2, (string[]){combined,"b"});'), c_source
 	assert c_source.contains('alias_combined=builtin__string_plus_many(2, (string[]){alias_combined,((Str)("y"))});'), c_source
-	assert c_source.count('builtin__string_eq(__v_fastc_match_') >= 2, c_source
+	assert c_source.count('builtin__string_eq(__v') >= 2, c_source
 
 	root := os.join_path(os.vtmp_dir(), 'v3_fastc_string_concat_${os.getpid()}')
 	os.rmdir_all(root) or {}
@@ -2424,7 +2458,7 @@ fn test_real_builtin_path_provided_params_struct_named_args() {
 	// separate arguments.
 	source := generate("module main\n@[params]\nstruct Opts {\n\ta int\n\tb bool\n}\nfn foo(x int, opts Opts) int {\n\treturn x + opts.a\n}\nfn main() {\n\tr := foo(1, a: 2, b: true)\n\tif r > 0 {\n\t\tprintln('ok')\n\t}\n}\n", 'params_named_args.v', prefs) or { panic(err) }
 	assert source.contains('foo(1,({'), source
-	assert source.contains('__v_fastc_struct_field_'), source
+	assert source.contains('__vf_sf_'), source
 }
 
 fn test_real_builtin_path_embedded_method_promotion() {
@@ -2538,8 +2572,8 @@ fn main() {
 	_ := text
 }
 ', 'embedded_option_method.v', prefs) or { panic(err) }
-	assert source.contains('*((string *)__v_fastc_option_'), source
-	assert !source.contains('*((int *)__v_fastc_option_'), source
+	assert source.contains('*((string *)__v'), source
+	assert !source.contains('*((int *)__v'), source
 }
 
 fn test_real_builtin_path_inferred_enum_keyed_map() {
@@ -2567,8 +2601,8 @@ fn test_selfhost_map_literal_call_argument_uses_runtime_map() {
 	mut prefs := pref.new_preferences()
 	prefs.building_v = true
 	source := generate("module main\nfn use_headers(headers map[string]string) {}\nfn main() {\n\tuse_headers({\n\t\t'Server': 'veb'\n\t})\n}\n", 'map_literal_argument.v', prefs) or { panic(err) }
-	assert source.contains('use_headers(({ map __v_fastc_argument_map = builtin__new_map'), source
-	assert source.contains('builtin__map_set(&__v_fastc_argument_map'), source
+	assert source.contains('use_headers(({ map __vf_argument_map = builtin__new_map'), source
+	assert source.contains('builtin__map_set(&__vf_argument_map'), source
 }
 
 fn test_selfhost_empty_inferred_map_uses_expected_return_type() {
@@ -2695,11 +2729,11 @@ fn main() {
 ', 'higher_order_nested_regressions.v', prefs) or { panic(err) }
 	// Mutable array receivers are pointers in C. Both lowerers iterate a value copy of the
 	// header, nested bare callbacks are invoked, and legal V names are escaped for C.
-	assert c_source.contains('Array_int __v_fastc_collection_'), c_source
+	assert c_source.contains('Array_int __v'), c_source
 	assert c_source.contains('= (*(values));'), c_source
-	assert !c_source.contains('Array_int* __v_fastc_collection_'), c_source
+	assert !c_source.contains('Array_int* __v'), c_source
 	assert c_source.contains('convert(it)'), c_source
-	assert c_source.count('int __v_fastc_keyword_short =') == 2, c_source
+	assert c_source.count('int __vf_keyword_short =') == 2, c_source
 	assert !c_source.contains('int short ='), c_source
 }
 
@@ -2928,7 +2962,7 @@ fn main() {
 }
 ', 'struct_field_default.v', prefs) or { panic(err) }
 	assert c_source.contains('int default_retries(void)'), c_source
-	assert c_source.contains('__v_fastc_struct_default.retries=(default_retries());'), c_source
+	assert c_source.contains('__vf_sd.retries=(default_retries());'), c_source
 }
 
 fn test_required_struct_fields_must_be_initialized() {
@@ -3026,7 +3060,7 @@ pub fn make() Settings {
 			header: fastc_scan_source_header(module_source, module_file, prefs) or { panic(err) }
 		},
 	], map[string]string{}, prefs) or { panic(err) }
-	assert c_source.contains('.visible=(__v_fastc_struct_field_0)'), c_source
+	assert c_source.contains('.visible=(__vf_sf_0)'), c_source
 }
 
 fn test_imported_public_field_mutability_is_preserved() {
@@ -3132,10 +3166,10 @@ fn main() {
 	println(config.value)
 }
 ', 'valid_struct_literal.v', prefs) or { panic(err) }
-	assert c_source.contains('__v_fastc_struct_field_0 = (enabled);'), c_source
-	assert c_source.contains('__v_fastc_struct_field_1 = (2);'), c_source
-	assert c_source.contains('.enabled=(__v_fastc_struct_field_0)'), c_source
-	assert c_source.contains('.value=(__v_fastc_struct_field_1)'), c_source
+	assert c_source.contains('__vf_sf_0 = (enabled);'), c_source
+	assert c_source.contains('__vf_sf_1 = (2);'), c_source
+	assert c_source.contains('.enabled=(__vf_sf_0)'), c_source
+	assert c_source.contains('.value=(__vf_sf_1)'), c_source
 
 	update_source := generate('module main
 
@@ -3149,7 +3183,7 @@ fn main() {
 	println(config.value)
 }
 ', 'valid_struct_update.v', prefs) or { panic(err) }
-	assert update_source.contains('__v_fastc_struct_update'), update_source
+	assert update_source.contains('__vf_struct_update'), update_source
 
 	pointer_update_source := generate('module main
 
@@ -3166,8 +3200,8 @@ fn main() {
 	_ := clone_config(base)
 }
 ', 'valid_pointer_struct_update.v', prefs) or { panic(err) }
-	assert pointer_update_source.contains('Config __v_fastc_struct_update = *(base);'), pointer_update_source
-	assert pointer_update_source.contains('v_fastc_interface_box(&__v_fastc_struct_update, sizeof(Config))'), pointer_update_source
+	assert pointer_update_source.contains('Config __vf_struct_update = *(base);'), pointer_update_source
+	assert pointer_update_source.contains('v_fastc_interface_box(&__vf_struct_update, sizeof(Config))'), pointer_update_source
 }
 
 fn test_selfhost_struct_field_initializers_preserve_source_order() {
@@ -3191,11 +3225,11 @@ fn main() {
 }
 '
 	c_source := generate(source, 'struct_field_initializer_order.v', prefs) or { panic(err) }
-	second_initializer := c_source.index('__v_fastc_struct_field_0 = (next(2));') or { -1 }
-	first_initializer := c_source.index('__v_fastc_struct_field_1 = (next(1));') or { -1 }
+	second_initializer := c_source.index('__vf_sf_0 = (next(2));') or { -1 }
+	first_initializer := c_source.index('__vf_sf_1 = (next(1));') or { -1 }
 	assert second_initializer >= 0, c_source
 	assert first_initializer > second_initializer, c_source
-	assert c_source.contains('(Pair){.first=(__v_fastc_struct_field_1),.second=(__v_fastc_struct_field_0)}'), c_source
+	assert c_source.contains('(Pair){.first=(__vf_sf_1),.second=(__vf_sf_0)}'), c_source
 }
 
 fn test_embedded_struct_fields_use_storage_paths() {
@@ -3239,8 +3273,8 @@ fn main() {
 	println(outer.number)
 }
 ', 'embedded_struct_fields.v', prefs) or { panic(err) }
-	assert c_source.contains('.__embedded_0.value=(__v_fastc_struct_field_0)'), c_source
-	assert c_source.contains('.__embedded_0.__embedded_0.number=(__v_fastc_struct_field_1)'), c_source
+	assert c_source.contains('.__embedded_0.value=(__vf_sf_0)'), c_source
+	assert c_source.contains('.__embedded_0.__embedded_0.number=(__vf_sf_1)'), c_source
 	assert c_source.contains('outer.__embedded_0.value'), c_source
 	assert c_source.contains('outer.__embedded_0.child.count'), c_source
 	assert c_source.contains('outer.__embedded_0.__embedded_0.number'), c_source
@@ -3783,7 +3817,7 @@ fn main() {
 	assert c_source.contains('union Payload {\n\tint number;'), c_source
 	assert c_source.contains('struct Named { void *_object; u32 _typ; void *_methods; };'), c_source
 	assert c_source.contains('Named_name(Named value) {'), c_source
-	assert c_source.contains('__typeof__((({ __typeof__((42)) __v_fastc_struct_field_0 = (42); (Choice){.value=(__v_fastc_struct_field_0)}; }))) choice'), c_source
+	assert c_source.contains('__typeof__((({ __typeof__((42)) __vf_sf_0 = (42); (Choice){.value=(__vf_sf_0)}; }))) choice'), c_source
 }
 
 fn test_selected_top_level_comptime_constants_are_collected_and_emitted() {
@@ -5142,10 +5176,10 @@ fn parenthesized(left Pair, right Pair) bool {
 	return !(left == right)
 }
 ', 'struct_equality.v', prefs) or { panic(err) }
-	assert c_source.contains('Pair __v_fastc_eq_left = (left);'), c_source
-	assert c_source.contains('Pair __v_fastc_eq_right = (right);'), c_source
-	assert c_source.contains('((__v_fastc_eq_left).inner).value'), c_source
-	assert c_source.contains('builtin__string_eq((__v_fastc_eq_left).label, (__v_fastc_eq_right).label)'), c_source
+	assert c_source.contains('Pair __vf_eq_left = (left);'), c_source
+	assert c_source.contains('Pair __vf_eq_right = (right);'), c_source
+	assert c_source.contains('((__vf_eq_left).inner).value'), c_source
+	assert c_source.contains('builtin__string_eq((__vf_eq_left).label, (__vf_eq_right).label)'), c_source
 	assert c_source.contains('!('), c_source
 
 	root := os.join_path(os.vtmp_dir(), 'v3_fastc_struct_equality_${os.getpid()}')
@@ -5174,8 +5208,8 @@ fn equal(left Values, right Values) bool {
 	return left == right
 }
 ', 'struct_array_equality.v', prefs) or { panic(err) }
-	assert c_source.contains('__v_fastc_array_eq_left.len == __v_fastc_array_eq_right.len'), c_source
-	assert c_source.contains('((int *)__v_fastc_array_eq_left.data)'), c_source
+	assert c_source.contains('__vf_array_eq_left.len == __vf_array_eq_right.len'), c_source
+	assert c_source.contains('((int *)__vf_array_eq_left.data)'), c_source
 }
 
 fn test_literal_membership_evaluates_subject_once() {
@@ -5183,7 +5217,7 @@ fn test_literal_membership_evaluates_subject_once() {
 	prefs.building_v = true
 	for operator in ['in', '!in'] {
 		c_source := generate('module main\n\nfn next() int {\n\treturn 1\n}\n\nfn main() {\n\tif next() ${operator} [0, 2] {}\n}\n', 'membership_subject_once.v', prefs) or { panic(err) }
-		assert c_source.contains('__v_fastc_membership_item = (next());'), c_source
+		assert c_source.contains('__vf_m_x = (next());'), c_source
 		assert c_source.count('next()') == 1, c_source
 	}
 }
@@ -5193,14 +5227,14 @@ fn test_array_membership_evaluates_candidate_before_collection() {
 	prefs.building_v = true
 	for operator in ['in', '!in'] {
 		c_source := generate('module main\n\nfn candidate() int {\n\treturn 1\n}\n\nfn collection() []int {\n\treturn [1, 2]\n}\n\nfn main() {\n\tif candidate() ${operator} collection() {}\n}\n', 'array_membership_order.v', prefs) or { panic(err) }
-		candidate_index := c_source.index('__v_fastc_membership_item = (candidate());') or { -1 }
-		collection_index := c_source.index('__v_fastc_membership_collection = (collection());') or {
+		candidate_index := c_source.index('__vf_m_x = (candidate());') or { -1 }
+		collection_index := c_source.index('__vf_m_a = (collection());') or {
 			-1
 		}
 		assert candidate_index >= 0, c_source
 		assert collection_index > candidate_index, c_source
 		assert c_source.count('candidate()') == 1, c_source
-		assert c_source.count('__v_fastc_membership_collection = (collection());') == 1, c_source
+		assert c_source.count('__vf_m_a = (collection());') == 1, c_source
 	}
 }
 
@@ -5246,9 +5280,9 @@ fn test_literal_membership_materializes_candidates_before_comparison() {
 		rendered := g.render_special_expression(tokens, '') or {
 			panic('membership was not rendered')
 		}
-		first_assignment := '__v_fastc_membership_candidate_0 = (candidate(1));'
-		second_assignment := '__v_fastc_membership_candidate_1 = (candidate(2));'
-		comparison := '__v_fastc_membership_subject) == (__v_fastc_membership_candidate_0)'
+		first_assignment := '__vf_m_c0 = (candidate(1));'
+		second_assignment := '__vf_m_c1 = (candidate(2));'
+		comparison := '__vf_m_s) == (__vf_m_c0)'
 		first_index := rendered.source.index(first_assignment) or { -1 }
 		second_index := rendered.source.index(second_assignment) or { -1 }
 		comparison_index := rendered.source.index(comparison) or { -1 }
@@ -5266,13 +5300,13 @@ fn test_membership_temporaries_do_not_collide_with_user_names() {
 	c_source := generate('module main
 
 fn main() {
-	__v_fastc_membership_candidate_0 := 1
-	if 1 in [__v_fastc_membership_candidate_0] {}
+	__vf_m_c0 := 1
+	if 1 in [__vf_m_c0] {}
 }
 ', 'membership_temporary_collision.v', prefs) or { panic(err) }
-	assert c_source.contains('int __v_fastc_membership_1_item = (1);'), c_source
-	assert c_source.contains('__v_fastc_membership_1_collection'), c_source
-	assert !c_source.contains('int __v_fastc_membership_item = (1);'), c_source
+	assert c_source.contains('int __vf_m_1_x = (1);'), c_source
+	assert c_source.contains('__vf_m_1_a'), c_source
+	assert !c_source.contains('int __vf_m_x = (1);'), c_source
 }
 
 fn test_selfhost_string_membership_uses_substring_semantics() {
@@ -5293,19 +5327,19 @@ fn main() {
 	if 'xyz' !in 'hello' {}
 }
 ", 'string_membership.v', prefs) or { panic(err) }
-	substring_assignment := 'string __v_fastc_membership_substring = (substring());'
-	value_assignment := 'string __v_fastc_membership_value = (value());'
+	substring_assignment := 'string __vf_m_s = (substring());'
+	value_assignment := 'string __vf_m_v = (value());'
 	assert c_source.contains('static bool v_fastc_string_contains(string value, string substring)'), c_source
 	assert c_source.contains(substring_assignment), c_source
 	assert c_source.contains(value_assignment), c_source
 	substring_index := c_source.index(substring_assignment) or { -1 }
 	value_index := c_source.index(value_assignment) or { -1 }
 	assert substring_index < value_index, c_source
-	assert c_source.contains('v_fastc_string_contains(__v_fastc_membership_value, __v_fastc_membership_substring)'), c_source
-	assert c_source.contains('!(v_fastc_string_contains(__v_fastc_membership_value, __v_fastc_membership_substring))'), c_source
+	assert c_source.contains('v_fastc_string_contains(__vf_m_v, __vf_m_s)'), c_source
+	assert c_source.contains('!(v_fastc_string_contains(__vf_m_v, __vf_m_s))'), c_source
 	assert c_source.count('substring()') == 1, c_source
 	assert c_source.count('value()') == 1, c_source
-	assert !c_source.contains('u8 __v_fastc_membership_item'), c_source
+	assert !c_source.contains('u8 __vf_m_x'), c_source
 }
 
 fn test_string_alias_membership_uses_string_equality() {
@@ -5323,7 +5357,7 @@ fn main() {
 	if value in values {}
 }
 ", 'string_alias_membership.v', prefs) or { panic(err) }
-	assert c_source.count('builtin__string_eq(__v_fastc_membership_item, ((Str *)__v_fastc_membership_collection.data)') == 2, c_source
+	assert c_source.count('builtin__string_eq(__vf_m_x, ((Str *)__vf_m_a.data)') == 2, c_source
 }
 
 fn test_mixed_integer_comparisons_preserve_signed_semantics() {
@@ -5385,7 +5419,7 @@ fn main() {
 	}
 }
 ', 'valid_match_branch_types.v', prefs) or { panic(err) }
-	assert c_source.contains('if (((__v_fastc_match_'), c_source
+	assert c_source.contains('if (((__v'), c_source
 	assert c_source.contains('== (0)) || '), c_source
 	assert c_source.contains('== (1))'), c_source
 }
@@ -5555,9 +5589,9 @@ fn main() {
 	println(value())
 }
 ', 'return_before_defer.v', prefs) or { panic(err) }
-	evaluation := c_source.index('__typeof__((x)) __v_fastc_return_') or { panic(c_source) }
+	evaluation := c_source.index('__typeof__((x)) __v') or { panic(c_source) }
 	deferred_assignment := c_source.index_after('x=2;', evaluation) or { panic(c_source) }
-	returned_temporary := c_source.index_after('return __v_fastc_return_', deferred_assignment) or {
+	returned_temporary := c_source.index_after('return __v', deferred_assignment) or {
 		panic(c_source)
 	}
 	assert evaluation < deferred_assignment
@@ -5829,15 +5863,15 @@ fn main() {
 	println(auto + v_auto)
 }
 ', 'reserved_identifiers.v', prefs) or { panic(err) }
-	assert c_source.contains('int __v_fastc_keyword_auto;'), c_source
+	assert c_source.contains('int __vf_keyword_auto;'), c_source
 	assert c_source.contains('int v_auto;'), c_source
-	assert c_source.contains('int calculate(Holder holder, int __v_fastc_keyword_register, int v_register)'), c_source
-	assert c_source.contains('__typeof__((__v_fastc_keyword_register)) __v_fastc_keyword_restrict = (__v_fastc_keyword_register);'), c_source
+	assert c_source.contains('int calculate(Holder holder, int __vf_keyword_register, int v_register)'), c_source
+	assert c_source.contains('__typeof__((__vf_keyword_register)) __vf_keyword_restrict = (__vf_keyword_register);'), c_source
 	assert c_source.contains('__typeof__((v_register)) v_restrict = (v_register);'), c_source
-	assert c_source.contains('return holder.__v_fastc_keyword_auto+holder.v_auto+__v_fastc_keyword_restrict+v_restrict;'), c_source
-	assert c_source.contains('int __v_fastc_function_auto(void)'), c_source
+	assert c_source.contains('return holder.__vf_keyword_auto+holder.v_auto+__vf_keyword_restrict+v_restrict;'), c_source
+	assert c_source.contains('int __vf_function_auto(void)'), c_source
 	assert c_source.contains('int v_auto(void)'), c_source
-	assert c_source.contains(' __v_fastc_keyword_auto = (result);'), c_source
+	assert c_source.contains(' __vf_keyword_auto = (result);'), c_source
 	assert c_source.contains(' v_auto = (v_result);'), c_source
 
 	root := os.join_path(os.vtmp_dir(), 'v3_fastc_reserved_names_${os.getpid()}')
@@ -5882,12 +5916,12 @@ fn main() {
 }
 ', 'libc_function_collisions.v', prefs) or { panic(err) }
 	for name in ['strlen', 'printf', 'open', 'close'] {
-		assert c_source.contains('int __v_fastc_function_${name}(void)'), c_source
+		assert c_source.contains('int __vf_function_${name}(void)'), c_source
 	}
-	assert c_source.contains('return __v_fastc_function_strlen();'), c_source
-	assert c_source.contains('return __v_fastc_function_printf();'), c_source
-	assert c_source.contains('return __v_fastc_function_open();'), c_source
-	assert c_source.contains('println(__v_fastc_function_close());'), c_source
+	assert c_source.contains('return __vf_function_strlen();'), c_source
+	assert c_source.contains('return __vf_function_printf();'), c_source
+	assert c_source.contains('return __vf_function_open();'), c_source
+	assert c_source.contains('println(__vf_function_close());'), c_source
 
 	root := os.join_path(os.vtmp_dir(), 'v3_fastc_libc_names_${os.getpid()}')
 	os.rmdir_all(root) or {}
@@ -5922,8 +5956,8 @@ fn main() {
 }
 ", 'fastc_runtime_function_collision.v', prefs) or { panic(err) }
 	assert c_source.contains('static string v_fastc_bool_str(bool value)'), c_source
-	assert c_source.contains('string __v_fastc_function_v_fastc_bool_str(bool value)'), c_source
-	assert c_source.contains('println(__v_fastc_function_v_fastc_bool_str(((bool)true)))'), c_source
+	assert c_source.contains('string __vf_function_v_fastc_bool_str(bool value)'), c_source
+	assert c_source.contains('println(__vf_function_v_fastc_bool_str(((bool)true)))'), c_source
 
 	root := os.join_path(os.vtmp_dir(), 'v3_fastc_runtime_names_${os.getpid()}')
 	os.rmdir_all(root) or {}
@@ -6047,10 +6081,10 @@ fn main() {
 	println(second)
 }
 ', 'valid_parallel_assignment.v', prefs) or { panic(err) }
-	assert c_source.contains('first = __v_fastc_parallel_'), c_source
-	assert c_source.contains('second = __v_fastc_parallel_'), c_source
-	assert c_source.contains('memcpy(&first, V_FASTC_MULTI_SOURCE(__v_fastc_multi_return_'), c_source
-	assert c_source.contains('memcpy(&second, V_FASTC_MULTI_SOURCE(__v_fastc_multi_return_'), c_source
+	assert c_source.contains('first = __v'), c_source
+	assert c_source.contains('second = __v'), c_source
+	assert c_source.contains('memcpy(&first, V_FASTC_MULTI_SOURCE(__v'), c_source
+	assert c_source.contains('memcpy(&second, V_FASTC_MULTI_SOURCE(__v'), c_source
 }
 
 fn test_parallel_member_assignment_uses_pointer_backed_multi_return_storage() {
@@ -6080,7 +6114,7 @@ fn main() {
 	assign(mut holder)
 }
 ', 'parallel_member_large_multi_return.v', prefs) or { panic(err) }
-	assert c_source.contains('memcpy(&holder->value, V_FASTC_MULTI_SOURCE(__v_fastc_multi_return_'), c_source
+	assert c_source.contains('memcpy(&holder->value, V_FASTC_MULTI_SOURCE(__v'), c_source
 	assert !c_source.contains('.values[1].data, sizeof(holder->value)'), c_source
 }
 
@@ -6103,7 +6137,7 @@ fn main() {
 	swap(mut holder)
 }
 ', 'parallel_aggregate_assignment.v', prefs) or { panic(err) }
-	assert c_source.count('__v_fastc_parallel_') >= 4, c_source
+	assert c_source.count('__v') >= 4, c_source
 }
 
 fn test_selfhost_parallel_declaration_from_if_expression() {
@@ -6126,7 +6160,7 @@ fn main() {
 	_ := choose(true)
 }
 ', 'selfhost_parallel_if_expression.v', prefs) or { panic(err) }
-	assert c_source.contains('MultiReturn __v_fastc_multi_return_'), c_source
+	assert c_source.contains('MultiReturn __v'), c_source
 	assert c_source.contains('int a = (int){0};'), c_source
 	assert c_source.contains('int b = (int){0};'), c_source
 }
@@ -6160,7 +6194,7 @@ fn main() {
 }
 ', 'selfhost_nested_receiver_option_multireturn.v', prefs) or { panic(err) }
 	assert c_source.contains('Data data = (Data){0};'), c_source
-	assert c_source.contains('memcpy(&data, __v_fastc_multi_return_'), c_source
+	assert c_source.contains('memcpy(&data, __v'), c_source
 }
 
 fn test_selfhost_option_multireturn_guard_from_nested_mut_receiver() {
@@ -6195,7 +6229,7 @@ fn main() {
 }
 ', 'selfhost_nested_mut_receiver_option_multireturn_guard.v', prefs) or { panic(err) }
 	assert c_source.contains('u64 first = (u64){0};'), c_source
-	assert c_source.contains('memcpy(&first, __v_fastc_multi_return_'), c_source
+	assert c_source.contains('memcpy(&first, __v'), c_source
 	assert !c_source.contains(';);'), c_source
 }
 
@@ -6467,10 +6501,10 @@ fn main() {
 	iterate(map[string]int{})
 }
 ', 'map_pointer_iteration.v', prefs) or { panic(err) }
-	assert c_source.count('builtin__map_keys((map *)&__v_fastc_map_collection_') == 1, c_source
-	assert c_source.count('builtin__map_values((map *)&__v_fastc_map_collection_') == 1, c_source
-	assert c_source.count('builtin__map_keys((map *)__v_fastc_map_collection_') == 1, c_source
-	assert c_source.count('builtin__map_values((map *)__v_fastc_map_collection_') == 1, c_source
+	assert c_source.count('builtin__map_keys((map *)&__v') == 1, c_source
+	assert c_source.count('builtin__map_values((map *)&__v') == 1, c_source
+	assert c_source.count('builtin__map_keys((map *)__v') == 1, c_source
+	assert c_source.count('builtin__map_values((map *)__v') == 1, c_source
 }
 
 fn test_map_pointer_sized_callbacks_follow_target_width() {
@@ -6565,7 +6599,7 @@ fn main() {
 	}
 }
 ', 'array_pointer_iteration.v', prefs) or { panic(err) }
-	assert c_source.count('int *value = &(((int *)__v_fastc_collection_') == 2, c_source
+	assert c_source.count('int *value = &(((int *)__v') == 2, c_source
 	assert c_source.count('take(value);') == 2, c_source
 }
 
@@ -6977,7 +7011,7 @@ fn main() {
 	add(mut groups, 'x', 1)
 }
 ", 'selfhost_append_to_map_array.v', prefs) or { panic(err) }
-	assert c_source.contains('__v_fastc_append_map_target'), c_source
+	assert c_source.contains('__vf_append_map_target'), c_source
 	assert c_source.contains('builtin__map_get_check'), c_source
 	assert !c_source.contains('groups[key]'), c_source
 }
@@ -6996,10 +7030,10 @@ fn main() {
 	add(mut groups, 0, 42)
 }
 ', 'selfhost_append_to_nested_array.v', prefs) or { panic(err) }
-	assert c_source.contains('__v_fastc_append_array_target'), c_source
+	assert c_source.contains('__vf_append_array_target'), c_source
 	assert c_source.contains('builtin__array_get(*(groups), index)'), c_source
 	assert c_source.contains('builtin____new_array(0,0,sizeof(int))'), c_source
-	assert c_source.contains('((Array_int *)__v_fastc_array_init.data)[__v_fastc_array_index]'), c_source
+	assert c_source.contains('((Array_int *)__vf_array_init.data)[__vf_array_index]'), c_source
 	assert !c_source.contains('groups[index]'), c_source
 }
 
@@ -7029,12 +7063,12 @@ fn test_selfhost_fixed_array_elements_skip_dynamic_inner_array_initialization() 
 	fixed := g.render_struct_literal_expression(tokens) or { panic('fixed array literal was not rendered') }
 	assert fixed.source.contains('sizeof(' + 'FixedArray_2_int' + ')'), fixed.source
 	assert !fixed.source.contains('builtin____new_array(0,0,sizeof(int))'), fixed.source
-	assert !fixed.source.contains('((FixedArray_2_int *)__v_fastc_array_init.data)'), fixed.source
+	assert !fixed.source.contains('((FixedArray_2_int *)__vf_array_init.data)'), fixed.source
 
 	tokens[0].typ = 'Array_Array_int'
 	dynamic := g.render_struct_literal_expression(tokens) or { panic('dynamic array literal was not rendered') }
 	assert dynamic.source.contains('builtin____new_array(0,0,sizeof(int))'), dynamic.source
-	assert dynamic.source.contains('((Array_int *)__v_fastc_array_init.data)'), dynamic.source
+	assert dynamic.source.contains('((Array_int *)__vf_array_init.data)'), dynamic.source
 }
 
 fn test_selfhost_append_array_result_to_struct_field() {
@@ -7127,7 +7161,7 @@ fn main() {}
 	// did not set `expected_expression_type` to the field type and a stale `Option`
 	// leaked in).
 	assert c_source.contains('_S("a")'), c_source
-	assert !c_source.contains('__v_fastc_box_value = (_S("a"))'), c_source
+	assert !c_source.contains('__vf_bv = (_S("a"))'), c_source
 }
 
 fn test_selfhost_result_method_or_block_is_a_statement() {
@@ -7154,7 +7188,7 @@ fn main() {
 	pad(mut writer)
 }
 ', 'result_method_or_statement.v', prefs) or { panic(err) }
-	assert c_source.contains('Option __v_fastc_option_'), c_source
+	assert c_source.contains('Option __v'), c_source
 }
 
 fn test_selfhost_comptime_if_starts_or_block_statement() {
@@ -7176,7 +7210,7 @@ fn main() {
 	use()
 }
 ', 'selfhost_comptime_if_or_statement.v', prefs) or { panic(err) }
-	assert c_source.contains('Option __v_fastc_option_'), c_source
+	assert c_source.contains('Option __v'), c_source
 	assert !c_source.contains('_S("trace")'), c_source
 }
 
@@ -7193,8 +7227,8 @@ fn main() {
 	_ := first([]string{})
 }
 ", 'array_lookup_or_block.v', prefs) or { panic(err) }
-	assert c_source.contains('bool __v_fastc_array_missing = __v_fastc_array_index < 0 || __v_fastc_array_index >= __v_fastc_array.len;'), c_source
-	assert c_source.contains('(Option){.data=__v_fastc_array_value, .state=__v_fastc_array_missing ? 2 : 0}'), c_source
+	assert c_source.contains('bool __vf_array_missing = __vf_array_index < 0 || __vf_array_index >= __vf_array.len;'), c_source
+	assert c_source.contains('(Option){.data=__vf_array_value, .state=__vf_array_missing ? 2 : 0}'), c_source
 }
 
 fn test_selfhost_array_slices_use_the_runtime_helper() {
@@ -7264,16 +7298,16 @@ fn main() {
 }
 ', 'array_slice.v', prefs) or { panic(err) }
 	assert c_source.contains('return builtin__array_slice(values, start, end);'), c_source
-	assert c_source.contains('__typeof__((make_values())) __v_fastc_slice_receiver = (make_values()); builtin__array_slice(__v_fastc_slice_receiver, 1, __v_fastc_slice_receiver.len);'), c_source
-	assert c_source.contains('__typeof__((make_text())) __v_fastc_slice_receiver = (make_text()); builtin__string_substr((__v_fastc_slice_receiver), 1, __v_fastc_slice_receiver.len);'), c_source
+	assert c_source.contains('__typeof__((make_values())) __vf_slice_receiver = (make_values()); builtin__array_slice(__vf_slice_receiver, 1, __vf_slice_receiver.len);'), c_source
+	assert c_source.contains('__typeof__((make_text())) __vf_slice_receiver = (make_text()); builtin__string_substr((__vf_slice_receiver), 1, __vf_slice_receiver.len);'), c_source
 	assert c_source.contains('return builtin__string_substr((value), 1, 2);'), c_source
 	assert c_source.contains('return builtin__string_substr((value), 1, value.len);'), c_source
 	assert !c_source.contains('builtin__array_slice(value, 1'), c_source
 	assert !c_source.contains('make_values().len'), c_source
 	assert !c_source.contains('make_text().len'), c_source
 	assert !c_source.contains('__v_slice.flags |= ArrayFlags__is_slice'), c_source
-	assert c_source.contains('__v_fastc_mut_argument = (({ __typeof__((buffer->bytes)) __v_fastc_slice_receiver'), c_source
-	assert !c_source.contains('__v_fastc_slice_receiver->len'), c_source
+	assert c_source.contains('__vf_mut_argument = (({ __typeof__((buffer->bytes)) __vf_slice_receiver'), c_source
+	assert !c_source.contains('__vf_slice_receiver->len'), c_source
 	assert c_source.contains('write_bytes(({ __typeof__(('), c_source
 	assert c_source.contains('builtin__array_clone(&(builtin__array_slice(*(values), 0, 1)))'), c_source
 }
@@ -7328,7 +7362,7 @@ fn test_literal_range_must_not_be_empty() {
 	}
 
 	c_source := generate('module main\nfn main() { for i in 2 .. 4 { println(i) } }\n', 'valid_literal_range.v', prefs) or { panic(err) }
-	assert c_source.contains('for (__typeof__((__v_fastc_range_start_0)) i = (__v_fastc_range_start_0); i < (__v_fastc_range_end_1); i++) {'), c_source
+	assert c_source.contains('for (__typeof__((__v0)) i = (__v0); i < (__v1); i++) {'), c_source
 }
 
 fn test_arithmetic_operand_types_are_not_validated() {
@@ -7487,7 +7521,7 @@ fn main() {
 	make() or { return }
 }
 ', 'selfhost_static_option_constructor.v', prefs) or { panic(err) }
-	assert c_source.contains('*((Key *)__v_fastc_option_propagate.data)'), c_source
+	assert c_source.contains('*((Key *)__vf_op.data)'), c_source
 	assert c_source.contains('Key_use(key);'), c_source
 }
 
@@ -7580,7 +7614,7 @@ fn main() {
 	use() or { return }
 }
 ', 'selfhost_nested_propagation_cast.v', prefs) or { panic(err) }
-	assert c_source.contains('Option __v_fastc_option_propagate = (maybe())'), c_source
+	assert c_source.contains('Option __vf_op = (maybe())'), c_source
 	assert !c_source.contains('maybe()!'), c_source
 }
 
@@ -7642,7 +7676,7 @@ fn main() {
 	run() or { return }
 }
 ', 'selfhost_nested_argument_and_outer_propagation.v', prefs) or { panic(err) }
-	assert c_source.contains('Option __v_fastc_option_propagate = (outer('), c_source
+	assert c_source.contains('Option __vf_op = (outer('), c_source
 	assert !c_source.contains('outer(inner()!)!'), c_source
 }
 
@@ -7775,9 +7809,9 @@ fn main() {
 	}
 }
 ', 'range_bounds.v', prefs) or { panic(err) }
-	assert c_source.contains('__v_fastc_range_start_0 = (start());')
-	assert c_source.contains('__v_fastc_range_end_1 = (limit());')
-	assert c_source.contains('i < (__v_fastc_range_end_1)')
+	assert c_source.contains('__v0 = (start());')
+	assert c_source.contains('__v1 = (limit());')
+	assert c_source.contains('i < (__v1)')
 	assert !c_source.contains('i < (limit())')
 }
 
@@ -7952,10 +7986,10 @@ fn main() {
 }
 ', 'unsigned_right_shift_assignment.v', prefs) or { panic(err) }
 	assert !c_source.contains('>>>='), c_source
-	assert c_source.count('u64 __v_fastc_unsigned_shift_count =') == 3, c_source
-	assert c_source.count('u64 __v_fastc_unsigned_shift_value =') == 3, c_source
-	assert c_source.count('__v_fastc_unsigned_shift_count >= 64') == 3, c_source
-	assert c_source.count('__v_fastc_unsigned_shift_value >> __v_fastc_unsigned_shift_count') == 3, c_source
+	assert c_source.count('u64 __vf_unsigned_shift_count =') == 3, c_source
+	assert c_source.count('u64 __vf_unsigned_shift_value =') == 3, c_source
+	assert c_source.count('__vf_unsigned_shift_count >= 64') == 3, c_source
+	assert c_source.count('__vf_unsigned_shift_value >> __vf_unsigned_shift_count') == 3, c_source
 }
 
 fn test_selfhost_main_result_propagation_panics_and_runs_defers() {
@@ -7972,11 +8006,11 @@ fn main() {
 	fail()!
 }
 ", 'main_result_propagation.v', prefs) or { panic(err) }
-	panic_call := 'builtin__panic_result_not_set(builtin__IError_msg(__v_fastc_option_propagate.err));'
+	panic_call := 'builtin__panic_result_not_set(builtin__IError_msg(__vf_op.err));'
 	assert c_source.contains(panic_call), c_source
-	assert c_source.contains('if (__v_fastc_option_propagate.state) {'), c_source
+	assert c_source.contains('if (__vf_op.state) {'), c_source
 	assert c_source.count('println(_S("cleanup"));') == 2, c_source
-	assert !c_source.contains('if (__v_fastc_option_propagate.state) { return 1; }'), c_source
+	assert !c_source.contains('if (__vf_op.state) { return 1; }'), c_source
 	used := fastc_collect_referenced_function_names([], prefs, map[string]FastcFunctionSignature{})
 	assert used['panic_result_not_set']
 }
@@ -7997,9 +8031,9 @@ fn main() {
 	ordinary_c := generate(source, 'ordinary_string_alias_iteration.v', ordinary_prefs) or {
 		panic(err)
 	}
-	assert ordinary_c.contains('string __v_fastc_collection_'), ordinary_c
-	assert ordinary_c.contains('strlen(__v_fastc_collection_'), ordinary_c
-	assert ordinary_c.contains('((const unsigned char *)__v_fastc_collection_'), ordinary_c
+	assert ordinary_c.contains('string __v'), ordinary_c
+	assert ordinary_c.contains('strlen(__v'), ordinary_c
+	assert ordinary_c.contains('((const unsigned char *)__v'), ordinary_c
 
 	root := os.join_path(os.vtmp_dir(), 'v3_fastc_string_alias_iteration_${os.getpid()}')
 	os.rmdir_all(root) or {}
@@ -8022,9 +8056,9 @@ fn main() {
 	selfhost_c := generate(source, 'selfhost_string_alias_iteration.v', selfhost_prefs) or {
 		panic(err)
 	}
-	assert selfhost_c.contains('__typeof__((value)) __v_fastc_collection_'), selfhost_c
-	assert selfhost_c.contains('__v_fastc_collection_0.len'), selfhost_c
-	assert selfhost_c.contains('__v_fastc_collection_0.str'), selfhost_c
+	assert selfhost_c.contains('__typeof__((value)) __v'), selfhost_c
+	assert selfhost_c.contains('__v0.len'), selfhost_c
+	assert selfhost_c.contains('__v0.str'), selfhost_c
 }
 
 fn test_interface_argument_boxing_at_call_site() {
@@ -8069,8 +8103,8 @@ fn main() {
 	assert c_source.contains('._object='), c_source
 	assert c_source.contains('._typ=__v_typeid_Dog'), c_source
 	assert c_source.contains('case __v_typeid_Dog:'), c_source
-	assert c_source.contains('__v_fastc_box_value = (d)'), c_source
-	assert c_source.contains('__v_fastc_box_value = ((Dog){})'), c_source
+	assert c_source.contains('__vf_bv = (d)'), c_source
+	assert c_source.contains('__vf_bv = ((Dog){})'), c_source
 	// Assignment to an interface variable boxes rather than emitting `cur=(Dog){}`.
 	assert c_source.contains('cur=(Animal){._object='), c_source
 }
@@ -8108,16 +8142,16 @@ fn main() {
 	assert c_source.contains('typedef struct { void *_object; u32 _typ; void *_methods; } Animal;'), c_source
 	// Construction boxes the concrete variant with its type id.
 	assert c_source.contains('._typ=__v_typeid_Dog'), c_source
-	assert c_source.contains('Dog __v_fastc_box_value ='), c_source
+	assert c_source.contains('Dog __vf_bv ='), c_source
 	assert !c_source.contains('Dog{sound:'), c_source
 	// `match` dispatches on the boxed `_typ` tag rather than comparing structs.
 	assert c_source.contains('_typ == __v_typeid_Dog'), c_source
 	assert c_source.contains('_typ == __v_typeid_Cat'), c_source
 	// The matched branch smart-casts the subject to the concrete variant so field
 	// access (`a.sound`) resolves through the uniquely named narrowed temporary.
-	assert c_source.contains('Dog __v_fastc_match_cast_'), c_source
-	assert c_source.contains('Cat __v_fastc_match_cast_'), c_source
-	assert c_source.contains('return __v_fastc_match_cast_'), c_source
+	assert c_source.contains('Dog __v'), c_source
+	assert c_source.contains('Cat __v'), c_source
+	assert c_source.contains('return __v'), c_source
 	assert !c_source.contains('return a.sound'), c_source
 }
 
@@ -8148,7 +8182,7 @@ fn main() {
 	assert c_source.contains('#define __v_typeid_int 1073741824'), c_source
 	assert c_source.contains('#define __v_typeid_bool '), c_source
 	// A primitive is boxed into the sum type with its type id on construction.
-	assert c_source.contains('int __v_fastc_box_value = (42)'), c_source
+	assert c_source.contains('int __vf_bv = (42)'), c_source
 	assert c_source.contains('._typ=__v_typeid_int'), c_source
 	// `match` dispatches on the tag and smart-casts to the primitive C type.
 	assert c_source.contains('_typ == __v_typeid_int'), c_source
@@ -8182,7 +8216,7 @@ fn main() {
 	// composite range and is registered so it also gets a typedef.
 	assert c_source.contains('#define __v_typeid_Array_int '), c_source
 	// The array literal is boxed as a real construction, not raw `[1,2,3]`.
-	assert c_source.contains('Array_int __v_fastc_box_value = (((Array_int)builtin__new_array_from_c_array'), c_source
+	assert c_source.contains('Array_int __vf_bv = (((Array_int)builtin__new_array_from_c_array'), c_source
 	assert c_source.contains('._typ=__v_typeid_Array_int'), c_source
 	// `match []int` dispatches on the composite tag and smart-casts to the array.
 	assert c_source.contains('_typ == __v_typeid_Array_int'), c_source
@@ -8210,10 +8244,10 @@ fn main() {
 ', 'sum_type_match_expr.v', prefs) or { panic(err) }
 	// A `match` used as an expression over a sum type dispatches on the boxed tag
 	// (not a struct-vs-type comparison) and smart-casts inside each branch value.
-	assert c_source.contains('__v_fastc_match_0._typ == __v_typeid_int'), c_source
-	assert c_source.contains('int v = *(int *)__v_fastc_match_0._object'), c_source
-	assert c_source.contains('bool v = *(bool *)__v_fastc_match_0._object'), c_source
-	assert !c_source.contains('(__v_fastc_match_0) == (int)'), c_source
+	assert c_source.contains('__v0._typ == __v_typeid_int'), c_source
+	assert c_source.contains('int v = *(int *)__v0._object'), c_source
+	assert c_source.contains('bool v = *(bool *)__v0._object'), c_source
+	assert !c_source.contains('(__v0) == (int)'), c_source
 }
 
 fn test_sum_type_map_and_nested_variants() {
@@ -8313,7 +8347,7 @@ fn retain_items(nodes []Node) []Node {
 
 fn main() {}
 ', 'sum_type_smartcast_append.v', prefs) or { panic(err) }
-	assert c_source.contains('main__Node __v_fastc_push_value_'), c_source
+	assert c_source.contains('main__Node __v'), c_source
 	assert c_source.contains('__v_typeid_main__Item'), c_source
 	assert c_source.contains('builtin__array_push((array *)&result'), c_source
 }
@@ -8339,7 +8373,7 @@ fn update(node Node) {
 
 fn main() {}
 ', 'mut_sum_type_smartcast.v', prefs) or { panic(err) }
-	assert c_source.contains('Item* __v_fastc_if_cast_'), c_source
+	assert c_source.contains('Item* __v'), c_source
 	assert c_source.contains('->value=2'), c_source
 }
 
@@ -8372,7 +8406,7 @@ fn main() {
 ', 'condition_loop_smartcast_once.v', prefs) or { panic(err) }
 	// The rewritten type-test conjunct owns evaluation of the subject. Its temporary must not
 	// evaluate the indexed expression again in the per-iteration prelude.
-	assert c_source.contains('Expr __v_fastc_smartcast_subject_'), c_source
+	assert c_source.contains('Expr __v'), c_source
 	assert c_source.contains('= (Expr){0};'), c_source
 	assert c_source.count('next_index()') == 1, c_source
 }
@@ -8396,10 +8430,13 @@ fn inspect(mut node Node) {
 	}
 }
 
-fn main() {}
+fn main() {
+	mut node := Node(Item{})
+	inspect(mut node)
+}
 ', 'mut_sum_type_smartcast_argument.v', prefs) or { panic(err) }
-	assert c_source.contains('inspect(__v_fastc_smartcast_subject_'), c_source
-	assert !c_source.contains('inspect(__v_fastc_if_cast_'), c_source
+	assert c_source.contains('inspect(__v0)'), c_source
+	assert !c_source.contains('inspect(__v3)'), c_source
 }
 
 fn test_mut_match_sum_type_smartcast_passes_original_box_to_mut_parameter() {
@@ -8424,10 +8461,13 @@ fn inspect(mut node Node) {
 	}
 }
 
-fn main() {}
+fn main() {
+	mut node := Node(Item{})
+	inspect(mut node)
+}
 ', 'mut_match_sum_type_smartcast_argument.v', prefs) or { panic(err) }
 	assert c_source.contains('inspect(node)'), c_source
-	assert !c_source.contains('inspect(__v_fastc_match_cast_'), c_source
+	assert !c_source.contains('inspect(__v'), c_source
 }
 
 fn test_selfhost_string_array_index_uses_value_equality() {
@@ -8441,9 +8481,9 @@ fn locate(names []string, wanted string) (int, int) {
 
 fn main() {}
 ', 'string_array_index.v', prefs) or { panic(err) }
-	assert c_source.count('builtin__string_eq(__v_fastc_index_item') == 2, c_source
-	assert c_source.contains('int __v_fastc_index_cursor = 0;'), c_source
-	assert c_source.contains('int __v_fastc_index_cursor = __v_fastc_index_collection.len - 1;'), c_source
+	assert c_source.count('builtin__string_eq(__vitem') == 2, c_source
+	assert c_source.contains('int __vcursor = 0;'), c_source
+	assert c_source.contains('int __vcursor = __vcollection.len - 1;'), c_source
 }
 
 fn test_mut_match_member_smartcast_reads_current_boxed_payload() {
@@ -8484,7 +8524,7 @@ fn value(mut holder Holder) int {
 
 fn main() {}
 ', 'mut_match_current_payload.v', prefs) or { panic(err) }
-	assert c_source.contains('((First *)__v_fastc_match_'), c_source
+	assert c_source.contains('((First *)__v'), c_source
 	assert c_source.contains('->_object)->value'), c_source
 }
 
@@ -8503,8 +8543,8 @@ fn boxed_pointer() &Value {
 
 fn main() {}
 ', 'boxed_interface_pointer.v', prefs) or { panic(err) }
-	assert c_source.contains('(Value *)v_fastc_interface_box(&__v_fastc_iface_ref, sizeof(Value))'), c_source
-	assert !c_source.contains('&__v_fastc_iface_ref;'), c_source
+	assert c_source.contains('(Value *)v_fastc_interface_box(&__vf_iface_ref, sizeof(Value))'), c_source
+	assert !c_source.contains('&__vf_iface_ref;'), c_source
 }
 
 fn test_boxed_address_payload_has_heap_lifetime() {
@@ -8961,8 +9001,8 @@ fn main() {
 	_ = Holder{}
 }
 ', 'selfhost_sum_constant_field_default.v', prefs) or { panic(err) }
-	assert c_source.contains('__v_fastc_struct_default.expr=(main__empty_expr);'), c_source
-	assert !c_source.contains('__v_fastc_box_value = (main__empty_expr)'), c_source
+	assert c_source.contains('__vf_sd.expr=(main__empty_expr);'), c_source
+	assert !c_source.contains('__vf_bv = (main__empty_expr)'), c_source
 	assert c_source.contains('static Expr main__empty_expr;'), c_source
 	assert c_source.contains('main__empty_expr = (Expr){._object='), c_source
 	assert c_source.contains('._typ=__v_typeid_Empty'), c_source
@@ -9273,8 +9313,8 @@ fn main() {
 	c_source := generate(source, 'selfhost_or_value.v', prefs) or { panic(err) }
 	// The or-block runs its leading statement (`flag = 9`), then uses the trailing value
 	// (`42`) on failure and the unwrapped option value on success, via an
-	// `__v_fastc_or_result` temp.
-	assert c_source.contains('__v_fastc_or_result'), c_source
+	// `__vf_or_result` temp.
+	assert c_source.contains('__vf_or_result'), c_source
 	assert c_source.contains('flag=9'), c_source
 	assert c_source.contains(' = (42)'), c_source
 }
@@ -9297,7 +9337,7 @@ fn main() {
 }
 ', 'selfhost_multiline_struct_fallback.v', prefs) or { panic(err) }
 	assert c_source.contains('? ((Item){}) : *((Item *)'), c_source
-	assert !c_source.contains('if (__v_fastc_option_'), c_source
+	assert !c_source.contains('if (__v'), c_source
 }
 
 fn test_veb_template_compiles_to_builder() {
@@ -10015,7 +10055,7 @@ fn main() {
 ', 'selfhost_blank_for.v', prefs) or { panic(err) }
 	// `_` is the blank identifier: nested `for _ in ...` loops must not be rejected as
 	// a redeclaration, and the range counter for `_` gets a private name, not `_`.
-	assert c_source.contains('__v_fastc_range_index'), c_source
+	assert c_source.contains('__vf_range_index'), c_source
 }
 
 fn test_selfhost_if_is_smartcast_field_access() {
@@ -10088,8 +10128,8 @@ fn main() {
 ', 'selfhost_member_is_smartcast.v', prefs) or { panic(err) }
 	// A member smart-cast keeps a pointer to the boxed concrete value, and the nested
 	// member chain is rendered through it so both type inference and C access use File.
-	assert c_source.contains('File *__v_fastc_smartcast_member_'), c_source
-	assert c_source.contains('__v_fastc_smartcast_member_'), c_source
+	assert c_source.contains('File *__v'), c_source
+	assert c_source.contains('__v'), c_source
 	assert c_source.contains('->fd'), c_source
 }
 
@@ -10151,7 +10191,7 @@ fn main() {
 	_ := choose(true)
 }
 ', 'if_expression_large_multi_return_guard.v', prefs) or { panic(err) }
-	assert c_source.contains('memcpy(&value, V_FASTC_MULTI_SOURCE(__v_fastc_multi_return_'), c_source
+	assert c_source.contains('memcpy(&value, V_FASTC_MULTI_SOURCE(__v'), c_source
 	assert !c_source.contains('.values[0].data, sizeof(value)'), c_source
 }
 
@@ -10264,8 +10304,8 @@ fn size(decoded Decoded) int {
 
 fn main() {}
 ', 'selfhost_match_member_smartcast.v', prefs) or { panic(err) }
-	assert c_source.contains('DataFrame *__v_fastc_smartcast_member_'), c_source
-	assert c_source.contains('__v_fastc_smartcast_member_'), c_source
+	assert c_source.contains('DataFrame *__v'), c_source
+	assert c_source.contains('__v'), c_source
 	assert c_source.contains('->data.len'), c_source
 	assert !c_source.contains('decoded.frame.data'), c_source
 }
@@ -10312,8 +10352,8 @@ fn classify(ok bool) ?Kind {
 
 fn main() {}
 ', 'selfhost_optional_enum_shorthand_return.v', prefs) or { panic(err) }
-	assert c_source.contains('Kind __v_fastc_box_value = (Kind__one)'), c_source
-	assert !c_source.contains('__v_fastc_box_value = (.one)'), c_source
+	assert c_source.contains('Kind __vf_bv = (Kind__one)'), c_source
+	assert !c_source.contains('__vf_bv = (.one)'), c_source
 	assert !c_source.contains('sizeof()'), c_source
 }
 
@@ -10403,8 +10443,8 @@ fn (mut p Pool) take(key string) {
 
 fn main() {}
 ', 'selfhost_map_array_ptr.v', prefs) or { panic(err) }
-	assert c_source.contains('Array_main__Item_ptr *__v_fastc_map_value'), c_source
-	assert !c_source.contains('Array_main__Item* *__v_fastc_map_value'), c_source
+	assert c_source.contains('Array_main__Item_ptr *__vf_mv'), c_source
+	assert !c_source.contains('Array_main__Item* *__vf_mv'), c_source
 }
 
 fn test_selfhost_map_lookup_or_return_uses_option_value_type() {
@@ -10429,9 +10469,9 @@ fn main() {
 	write(.item)
 }
 ', 'selfhost_map_lookup_or_return.v', prefs) or { panic(err) }
-	assert c_source.contains('string *__v_fastc_map_value'), c_source
-	assert c_source.contains('*((string *)__v_fastc_option_'), c_source
-	assert !c_source.contains('Option __v_fastc_option_0 = (main__labels[kind])'), c_source
+	assert c_source.contains('string *__vf_mv'), c_source
+	assert c_source.contains('*((string *)__v'), c_source
+	assert !c_source.contains('Option __v0 = (main__labels[kind])'), c_source
 }
 
 fn test_selfhost_address_of_map_lookup_or_returns_stored_value_pointer() {
@@ -10449,8 +10489,8 @@ fn find_ptr(items map[string]Item, key string) &Item {
 
 fn main() {}
 ', 'selfhost_map_lookup_address.v', prefs) or { panic(err) }
-	assert c_source.contains('Item *__v_fastc_map_value'), c_source
-	assert c_source.contains('Item* __v_fastc_box_value = (__v_fastc_map_value)'), c_source
+	assert c_source.contains('Item *__vf_mv'), c_source
+	assert c_source.contains('Item* __vf_bv = (__vf_mv)'), c_source
 	assert !c_source.contains('&({ Option'), c_source
 }
 
@@ -10606,8 +10646,8 @@ fn main() {
 ', 'selfhost_as_cast.v', prefs) or { panic(err) }
 	// `a as Loud` (interface -> interface) re-boxes the same object under the target
 	// type; `b as Dog` (sum -> concrete) unboxes the stored object.
-	assert c_source.contains('._object = __v_fastc_as_src'), c_source
-	assert c_source.contains('*((Dog *)__v_fastc_as_src'), c_source
+	assert c_source.contains('._object = __vf_as_src'), c_source
+	assert c_source.contains('*((Dog *)__vf_as_src'), c_source
 }
 
 fn test_selfhost_as_cast_to_module_qualified_concrete_type() {
@@ -10648,7 +10688,7 @@ pub fn (d Dog) sound() int {
 			}
 		},
 	], map[string]string{}, prefs) or { panic(err) }
-	assert c_source.contains('*((animals__Dog *)__v_fastc_as_src'), c_source
+	assert c_source.contains('*((animals__Dog *)__vf_as_src'), c_source
 	assert !c_source.contains(' as animals__Dog'), c_source
 }
 
@@ -10740,7 +10780,7 @@ fn main() {
 	assert c_source.contains('builtin__chan_try_push'), c_source
 	assert c_source.contains('builtin__chan_try_pop'), c_source
 	assert c_source.contains('builtin__chan_close(ch,(Array_IError){0})'), c_source
-	assert c_source.contains('Item __v_fastc_chan_recv'), c_source
+	assert c_source.contains('Item __vf_chan_recv'), c_source
 	assert !c_source.contains('items.closed'), c_source
 }
 
@@ -11097,7 +11137,7 @@ fn main() {
 	_ := choose(Limits{}, true)
 }
 ', 'selfhost_option_if_expression.v', prefs) or { panic(err) }
-	assert c_source.contains('Option __v_fastc_if_guard'), c_source
+	assert c_source.contains('Option __v'), c_source
 	assert c_source.contains('u64 value = *((u64 *)'), c_source
 	assert !c_source.contains('value:=selected'), c_source
 }
@@ -11235,7 +11275,7 @@ fn main() {
 ', 'selfhost_bang_method.v', prefs) or { panic(err) }
 	// `decode(raw)!.len`: the receiver `decode(raw)!` unwraps the result (propagating
 	// its error) before `.len` is taken.
-	assert c_source.contains('__v_fastc_option_propagate'), c_source
+	assert c_source.contains('__vf_op'), c_source
 }
 
 fn test_selfhost_mut_method_on_pointer_field() {
@@ -11295,7 +11335,7 @@ fn main() {
 }
 ', 'selfhost_spawn_mut.v', prefs) or { panic(err) }
 	// `spawn bump(mut c)`: the `mut` parameter is a pointer, so c is passed by address.
-	assert c_source.contains('__v_fastc_spawn_start'), c_source
+	assert c_source.contains('__vf_spawn_start'), c_source
 }
 
 fn test_selfhost_mut_map_option_guard() {
@@ -11390,10 +11430,10 @@ fn main() {
 	_ := total(Holder{})
 }
 ', 'fixed_array_field_iteration.v', prefs) or { panic(err) }
-	assert c_source.contains('Item *__v_fastc_collection_'), c_source
+	assert c_source.contains('Item *__v'), c_source
 	assert c_source.contains('= &((holder.items)[0]);'), c_source
-	assert !c_source.contains('__typeof__((holder.items)) __v_fastc_collection_'), c_source
-	assert !c_source.contains('__v_fastc_collection_0.data'), c_source
+	assert !c_source.contains('__typeof__((holder.items)) __v'), c_source
+	assert !c_source.contains('__v0.data'), c_source
 }
 
 fn test_selfhost_fixed_array_struct_field_copy_uses_memcpy() {
@@ -11417,9 +11457,9 @@ fn main() {
 	_ := copy(Holder{})
 }
 ', 'fixed_array_struct_field_copy.v', prefs) or { panic(err) }
-	assert c_source.contains('memcpy(__v_fastc_struct_fixed.items, source.items, sizeof(__v_fastc_struct_fixed.items));'), c_source
+	assert c_source.contains('memcpy(__vf_struct_fixed.items, source.items, sizeof(__vf_struct_fixed.items));'), c_source
 
-	assert !c_source.contains('__typeof__((source.items)) __v_fastc_struct_field_'), c_source
+	assert !c_source.contains('__typeof__((source.items)) __vf_sf_'), c_source
 }
 
 fn test_selfhost_panic_argument_uses_string_concatenation_lowering() {
@@ -11475,7 +11515,7 @@ fn main() {
 	_ := call(map[string]Handler{})
 }
 ', 'map_guard_function_alias.v', prefs) or { panic(err) }
-	assert c_source.contains('Handler handler = *((Handler *)__v_fastc_if_guard_'), c_source
+	assert c_source.contains('Handler handler = *((Handler *)__v'), c_source
 	assert c_source.contains('return handler(1);'), c_source
 	assert !c_source.contains('sizeof());'), c_source
 }
@@ -11499,7 +11539,7 @@ fn main() {
 	_ := call(Server{})
 }
 ', 'function_field_result_payload.v', prefs) or { panic(err) }
-	assert c_source.contains('*((string *)__v_fastc_option_'), c_source
+	assert c_source.contains('*((string *)__v'), c_source
 	assert !c_source.contains('return; } 0;'), c_source
 }
 
@@ -11525,7 +11565,7 @@ fn main() {
 ', 'optional_function_field_guard.v', prefs) or { panic(err) }
 	assert c_source.contains('config.callback != NULL'), c_source
 	assert c_source.contains('Option (*callback)(int)'), c_source
-	assert !c_source.contains('Option __v_fastc_if_guard_'), c_source
+	assert !c_source.contains('Option __v'), c_source
 }
 
 fn test_selfhost_derived_overloaded_comparisons() {
@@ -11613,8 +11653,8 @@ fn main() {
 	value *= Count{ value: 3 }
 }
 ', 'overloaded_compound_assignment.v', prefs) or { panic(err) }
-	assert c_source.contains('Count *__v_fastc_overloaded_assignment_target = &(value)'), c_source
-	assert c_source.contains('main__Count_mul(*__v_fastc_overloaded_assignment_target'), c_source
+	assert c_source.contains('Count *__vf_overloaded_assignment_target = &(value)'), c_source
+	assert c_source.contains('main__Count_mul(*__vf_overloaded_assignment_target'), c_source
 	assert !c_source.contains('value*='), c_source
 }
 
@@ -11695,10 +11735,10 @@ fn main() {
 	_ := different(["a"], ["b"])
 }
 ', 'dynamic_array_equality.v', prefs) or { panic(err) }
-	assert c_source.contains('__v_fastc_array_eq_left.len == __v_fastc_array_eq_right.len'), c_source
-	assert c_source.contains('((u64 *)__v_fastc_array_eq_left.data)'), c_source
-	assert c_source.contains('builtin__string_eq(((string *)__v_fastc_array_eq_left.data)'), c_source
-	assert c_source.contains('!__v_fastc_array_equal'), c_source
+	assert c_source.contains('__vf_array_eq_left.len == __vf_array_eq_right.len'), c_source
+	assert c_source.contains('((u64 *)__vf_array_eq_left.data)'), c_source
+	assert c_source.contains('builtin__string_eq(((string *)__vf_array_eq_left.data)'), c_source
+	assert c_source.contains('!__vf_array_equal'), c_source
 	assert !c_source.contains('left==right'), c_source
 }
 
@@ -11717,8 +11757,8 @@ fn missing(value Preferred) bool {
 
 fn main() {}
 ', 'fixed_array_field_equality.v', prefs) or { panic(err) }
-	assert c_source.contains('u8 *__v_fastc_array_eq_left = (u8 *)(value.ipv4)'), c_source
-	assert c_source.contains('__v_fastc_array_eq_index < 4'), c_source
+	assert c_source.contains('u8 *__vf_array_eq_left = (u8 *)(value.ipv4)'), c_source
+	assert c_source.contains('__vf_array_eq_index < 4'), c_source
 	assert !c_source.contains('==[4]u8{}'), c_source
 }
 
@@ -11932,7 +11972,7 @@ fn slice(address Address) []u8 {
 fn main() {}
 ', 'selfhost_fixed_field_slice.v', prefs) or { panic(err) }
 	assert c_source.contains('&(((address.bytes))[0])'), c_source
-	assert !c_source.contains('__typeof__((address.bytes)) __v_fastc_slice_receiver'), c_source
+	assert !c_source.contains('__typeof__((address.bytes)) __vf_slice_receiver'), c_source
 }
 
 fn test_selfhost_embedded_union_fixed_array_slice_promotes_member() {
@@ -12041,7 +12081,7 @@ fn main() {
 	// balanced (`Option t = (make_box(x))`, not `((make_box(x))`) and the grouped operand`s
 	// value type (Box) flows into the result token so the method binds to the unwrapped Box.
 	assert c_source.contains('Box_doubled'), c_source
-	assert c_source.contains('__v_fastc_option'), c_source
+	assert c_source.contains('__v'), c_source
 	assert !c_source.contains('= ((make_box'), c_source
 }
 
@@ -12064,7 +12104,7 @@ fn main() {
 ', 'selfhost_parenthesized_or_comparison.v', prefs) or { panic(err) }
 	// The synthetic option-unwrapping atom must retain its full statement expression
 	// when the surrounding string equality re-renders the comparison operands.
-	assert c_source.contains('Option __v_fastc_option_'), c_source
+	assert c_source.contains('Option __v'), c_source
 	assert c_source.contains('= (maybe_role())'), c_source
 	assert c_source.contains('builtin__string_eq'), c_source
 }
@@ -12111,8 +12151,8 @@ fn main() {
 	append_value(mut values, "compiler", Text{ value: " initializer" })
 }
 ', 'selfhost_map_assignment_overloaded_operation.v', prefs) or { panic(err) }
-	assert c_source.contains('Text __v_fastc_map_value = (Text_plus(previous,suffix))'), c_source
-	assert !c_source.contains('Text_plus(({ string __v_fastc_map_key'), c_source
+	assert c_source.contains('Text __vf_mv = (Text_plus(previous,suffix))'), c_source
+	assert !c_source.contains('Text_plus(({ string __vf_k'), c_source
 }
 
 fn test_selfhost_map_assignment_with_propagated_result() {
@@ -12138,7 +12178,7 @@ fn main() {
 }
 ', 'selfhost_map_assignment_propagated_result.v', prefs) or { panic(err) }
 	assert c_source.contains('builtin__map_set'), c_source
-	assert c_source.contains('__v_fastc_option_propagate'), c_source
+	assert c_source.contains('__vf_op'), c_source
 	assert !c_source.contains('items[_S("answer")]'), c_source
 }
 
@@ -12156,7 +12196,7 @@ fn main() {
 	insert(mut values, "group", "key", "value")
 }
 ', 'selfhost_nested_map_assignment.v', prefs) or { panic(err) }
-	assert c_source.contains('Map_string_string *__v_fastc_nested_map_value'), c_source
+	assert c_source.contains('Map_string_string *__vf_nested_map_value'), c_source
 	assert c_source.contains('builtin__new_map(sizeof(string), sizeof(string)'), c_source
 	assert c_source.contains('builtin__map_set((map *)({'), c_source
 	assert !c_source.contains('&values[group]'), c_source
@@ -12176,7 +12216,7 @@ fn main() {
 }
 ', 'selfhost_array_any.v', prefs) or { panic(err) }
 	assert c_source.contains('string it ='), c_source
-	assert c_source.contains('bool __v_fastc_mapped_'), c_source
+	assert c_source.contains('bool __v'), c_source
 	assert !c_source.contains('builtin__array_any'), c_source
 }
 
@@ -12223,7 +12263,7 @@ fn main() {
 	_ := use_number()
 }
 ', 'selfhost_arithmetic_or_method.v', prefs) or { panic(err) }
-	assert c_source.contains('__v_fastc_option'), c_source
+	assert c_source.contains('__v'), c_source
 	assert c_source.contains('100+('), c_source
 	assert !c_source.contains('.doubled()'), c_source
 }
@@ -12260,7 +12300,7 @@ fn main() {
 ', 'selfhost_pointer_struct_or_call.v', prefs) or { panic(err) }
 	assert c_source.contains('(Conn*)v_fastc_interface_box'), c_source
 	assert c_source.contains('Conn_use(c)'), c_source
-	assert c_source.contains('take(({ Option __v_fastc_option_'), c_source
+	assert c_source.contains('take(({ Option __v'), c_source
 }
 
 fn test_selfhost_method_on_parenthesized_or_in_struct_field() {
@@ -12330,7 +12370,7 @@ fn main() {
 ', 'selfhost_or_binop.v', prefs) or { panic(err) }
 	// `maybe(x) or { return -1 } + 10`: the diverging or-block returns on failure, and the
 	// `+ 10` binds to the unwrapped success value rather than orphaning as its own statement.
-	assert c_source.contains('__v_fastc_option'), c_source
+	assert c_source.contains('__v'), c_source
 	assert c_source.contains('+ 10') || c_source.contains('+10'), c_source
 }
 
@@ -12355,11 +12395,11 @@ fn main() {
 	_ := use_it()
 }
 ', 'selfhost_option_if_guard_err.v', prefs) or { panic(err) }
-	assert c_source.contains('IError err = __v_fastc_if_guard_'), c_source
+	assert c_source.contains('IError err = __v'), c_source
 }
 
 fn test_selfhost_multi_return_macro_uses_collision_safe_temporaries() {
-	assert c_selfhost_preamble.contains('__v_fastc_multi_value')
+	assert c_selfhost_preamble.contains('__vf_multi_value')
 	assert !c_selfhost_preamble.contains('__typeof__(expression) value =')
 }
 
@@ -12421,8 +12461,8 @@ fn main() {
 	_ := remove(Stream{})
 }
 ', 'option_field_local_guard.v', prefs) or { panic(err) }
-	assert c_source.contains('Option __v_fastc_if_guard_'), c_source
-	assert c_source.contains('u64 id = *((u64 *)__v_fastc_if_guard_'), c_source
+	assert c_source.contains('Option __v'), c_source
+	assert c_source.contains('u64 id = *((u64 *)__v'), c_source
 	assert !c_source.contains('if (id:=stream_id)'), c_source
 }
 
@@ -12448,7 +12488,7 @@ fn main() {
 ', 'explicit_option_casts.v', prefs) or { panic(err) }
 	assert c_source.contains('(Option){.state=2}'), c_source
 	assert c_source.contains('(Option){.data='), c_source
-	assert c_source.contains('u64 unwrapped = *((u64 *)__v_fastc_if_guard_'), c_source
+	assert c_source.contains('u64 unwrapped = *((u64 *)__v'), c_source
 	assert !c_source.contains('?((u64)'), c_source
 }
 

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -694,6 +694,36 @@ fn test_fastc_unit_group_starts_accounts_for_prepended_text() {
 	assert fastc_unit_group_starts([100, 100, 100, 100], 2, 0, 300) == [0, 3, 4]
 }
 
+fn test_fastc_rendered_units_match_temporary_files() {
+	root := os.join_path_single(os.vtmp_dir(), 'fastc_rendered_units_${os.getpid()}')
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	pieces := ['ignored definition', 'ignored prototypes', 'solo\n', 'body_a\n', 'body_b\n']
+	units := FastcUnitLayout{
+		head_end: 2
+		solo_end: 3
+		prototype_start: 1
+		prototype_end: 2
+		unit_starts: [3, 4, 5]
+		extern_indexes: [0]
+		extern_texts: ['extern shared;\n']
+		define_texts: ['int shared;\n']
+		prototype_texts: ['void first(void);\n', 'void second(void);\n']
+		unit_ref_starts: [0, 1, 2]
+		unit_ref_ids: [0, 1]
+		solo_prototype_ids: [1]
+	}
+	prefix := os.join_path_single(root, 'unit')
+	rendered := fastc_render_c_units(prefix, pieces, units, 2)
+	written_paths := fastc_write_c_units(prefix, pieces, units, 2) or { panic(err) }
+	assert rendered.paths == written_paths
+	for i, path in written_paths {
+		assert rendered.sources[i] == os.read_file(path) or { panic(err) }
+	}
+}
+
 fn test_fastc_unit_compile_order_starts_largest_cache_misses_first() {
 	root := os.join_path_single(os.vtmp_dir(), 'fastc_unit_order_${os.getpid()}')
 	os.mkdir_all(root) or { panic(err) }
@@ -750,6 +780,41 @@ fn test_fastc_generation_link_cache_key_covers_generated_inputs() {
 	assert key != fastc_generation_link_cache_key(tcc, ['-g'], ['-lm'], ['head', 'body'], units, 2, true)
 	assert key != fastc_generation_link_cache_key(tcc, ['-c'], ['-lm'], ['head', 'changed'], units, 2, true)
 	assert fastc_generation_link_cache_key(tcc, ['-c'], ['-lm'], ['head', 'body'], units, 2, false) == ''
+}
+
+fn test_fastc_generation_link_cache_key_uses_tbd_contents() {
+	root := os.join_path_single(os.vtmp_dir(), 'fastc_tbd_key_${os.getpid()}')
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	first := os.join_path_single(root, 'first.tbd')
+	second := os.join_path_single(root, 'second.tbd')
+	os.write_file(first, 'same stub') or { panic(err) }
+	os.write_file(second, 'same stub') or { panic(err) }
+	tcc := os.join_path(@VMODROOT, 'thirdparty', 'tcc', 'tcc.exe')
+	units := FastcUnitLayout{
+		head_end: 1
+		solo_end: 1
+		unit_starts: [1, 2]
+	}
+	first_key := fastc_generation_link_cache_key(tcc, [], [first], ['head', 'body'], units, 2, true)
+	second_key := fastc_generation_link_cache_key(tcc, [], [second], ['head', 'body'], units, 2, true)
+	assert first_key == second_key
+	os.write_file(second, 'changed stub') or { panic(err) }
+	assert first_key != fastc_generation_link_cache_key(tcc, [], [second], ['head', 'body'], units, 2, true)
+}
+
+fn test_fastc_collect_c_name_ids_scans_index_markers() {
+	ids := {
+		'alpha__one':     1
+		'v_fastc_helper': 2
+		'_leading__name': 3
+	}
+	text := 'ordinary(alpha__one()); v_fastc_helper(); _leading__name(); foov_fastc_helper();'
+	mut found := []int{}
+	fastc_collect_c_name_ids(text, 0, text.len, ids, mut found)
+	assert found == [1, 2, 3]
 }
 
 fn test_parallel_constant_seed_preserves_constant_field_defaults() {

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -717,12 +717,46 @@ fn test_fastc_link_cache_restores_an_independent_executable() {
 	}
 }
 
+fn test_fastc_generation_link_cache_key_covers_generated_inputs() {
+	tcc := os.join_path(@VMODROOT, 'thirdparty', 'tcc', 'tcc.exe')
+	units := FastcUnitLayout{
+		head_end: 1
+		solo_end: 1
+		unit_starts: [1, 2]
+	}
+	key := fastc_generation_link_cache_key(tcc, ['-c'], ['-lm'], ['head', 'body'], units, 2, true)
+	assert key != ''
+	assert key != fastc_generation_link_cache_key(tcc, ['-g'], ['-lm'], ['head', 'body'], units, 2, true)
+	assert key != fastc_generation_link_cache_key(tcc, ['-c'], ['-lm'], ['head', 'changed'], units, 2, true)
+	assert fastc_generation_link_cache_key(tcc, ['-c'], ['-lm'], ['head', 'body'], units, 2, false) == ''
+}
+
+fn test_parallel_constant_seed_preserves_constant_field_defaults() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	sources := [
+		FastcSourceFile{
+			path: 'constant_default.v'
+			source: 'module fastc\nconst default_retries = 3\nstruct Config {\n\tretries int = default_retries\n}\nfn main() { _ = Config{} }\n'
+			header: FastcSourceHeader{ module_name: 'v3.gen.fastc' }
+		},
+		FastcSourceFile{
+			path: 'other_constant.v'
+			source: 'module fastc\nconst other_constant = 4\n'
+			header: FastcSourceHeader{ module_name: 'v3.gen.fastc' }
+		},
+	]
+	c_source, _, _ := generate_source_files(sources, map[string]string{}, prefs) or { panic(err) }
+	assert c_source.contains('#define v3__gen__fastc__default_retries (3)'), c_source
+	assert c_source.contains('.retries=(v3__gen__fastc__default_retries)'), c_source
+}
+
 fn test_fastc_fragmented_generation_matches_serial_output() {
 	large_comment := '// ' + 'x'.repeat(fastc_generation_fragment_size + 1024)
 	sources := [
 		FastcSourceFile{
 			path: 'large.v'
-			source: 'module fastc\nfn fastc_fragment_first() {\n${large_comment}\n}\nfn fastc_fragment_second() {}\n'
+			source: 'module fastc\nfn fastc_fragment_first() {\n${large_comment}\n}\nfn fastc_fragment_second() {\n\tprintln(@LINE)\n\tprintln(@COLUMN)\n\tprintln(@FILE_LINE)\n\tprintln(@LOCATION)\n}\n'
 			header: FastcSourceHeader{
 				module_name: 'v3.gen.fastc'
 			}
@@ -755,6 +789,12 @@ fn test_fastc_fragmented_generation_matches_serial_output() {
 		panic(err)
 	}
 	assert parallel == serial
+	fragments := fastc_source_generation_fragments(sources[0], parallel_prefs)
+	mut fragmented_length := 0
+	for fragment in fragments {
+		fragmented_length += fragment.source.len
+	}
+	assert fragmented_length == sources[0].source.len
 }
 
 fn test_fastc_generation_fragments_keep_top_level_comptime_chain_together() {

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -710,13 +710,25 @@ fn test_fastc_tcc_job_count_respects_parallel_controls() {
 	mut prefs := pref.new_preferences()
 	assert fastc_tcc_job_count(prefs) == 4
 	os.setenv('VJOBS', '100', true)
-	assert fastc_tcc_job_count(prefs) == 14
+	assert fastc_tcc_job_count(prefs) == 12
 	os.setenv('VJOBS', '4', true)
 	prefs.no_parallel = true
 	assert fastc_tcc_job_count(prefs) == 1
 	prefs.no_parallel = false
 	os.setenv('V3_FASTC_NO_PARALLEL', '1', true)
 	assert fastc_tcc_job_count(prefs) == 1
+}
+
+fn test_fastc_prestart_skips_single_unit() {
+	build_dir := os.join_path_single(os.vtmp_dir(), 'fastc_prestart_single_${os.getpid()}')
+	os.rmdir_all(build_dir) or {}
+	defer {
+		os.rmdir_all(build_dir) or {}
+	}
+	mut units := fastc_prestart_c_units('', [], build_dir, 1)
+	assert !fastc_prestarted_c_units_match(&units, [], 1)
+	assert !os.exists(build_dir)
+	fastc_discard_prestarted_c_units(mut units)
 }
 
 fn test_fastc_unit_group_starts_accounts_for_prepended_text() {

--- a/vlib/v3/gen/fastc/fn.v
+++ b/vlib/v3/gen/fastc/fn.v
@@ -759,7 +759,7 @@ fn (mut g Parser) parse_function(enabled bool) ! {
 		return
 	}
 	is_fastc_source := name.starts_with('fastc_') || g.path.ends_with('/fastc/fastc.v') || g.module_name.ends_with('fastc')
-	if g.selfhost && name != 'fastc_collect_referenced_function_names' && !is_fastc_source && name !in [
+	if g.selfhost && name != 'fastc_collect_referenced_function_names' && name !in [
 		'main',
 		'init',
 		'cleanup',
@@ -1032,7 +1032,7 @@ fn (mut g Parser) emit_generic_body_stub(out_checkpoint int, saved_indent int, b
 // record_function_span notes the C definition the last parse_function wrote
 // to `out` (and its prototype in `protos`) for the reachability prune.
 fn (mut g Parser) record_function_span(out_start int, proto_start int) {
-	if g.last_function_c_name == '' || g.in_mono_drain {
+	if g.last_function_c_name == '' || g.in_mono_drain || g.function_id_table.len == 0 {
 		return
 	}
 	g.function_ids << g.function_id_table[g.last_function_c_name] or { -1 }

--- a/vlib/v3/gen/fastc/fn.v
+++ b/vlib/v3/gen/fastc/fn.v
@@ -460,8 +460,8 @@ fn (mut g Parser) next() {
 	g.lit = g.s.lit
 }
 
-fn (mut g Parser) temporary_name(kind string) string {
-	name := '__v_fastc_${kind}_${g.temp_id}'
+fn (mut g Parser) temporary_name(_ string) string {
+	name := '__v${g.temp_id}'
 	g.temp_id++
 	return name
 }
@@ -469,7 +469,7 @@ fn (mut g Parser) temporary_name(kind string) string {
 fn (g &Parser) temporary_namespace(kind string) string {
 	mut index := 0
 	for {
-		namespace := '__v_fastc_${kind}' + if index == 0 { '' } else { '_${index}' }
+		namespace := '__vf_${kind}' + if index == 0 { '' } else { '_${index}' }
 		prefix := namespace + '_'
 		mut collision := false
 		for local_name in g.locals.keys() {
@@ -479,8 +479,8 @@ fn (g &Parser) temporary_namespace(kind string) string {
 			}
 		}
 		if !collision {
-			// Every candidate prefix starts with `__v_fastc_`, so only the
-			// program's few `__v_fastc_`-prefixed function and global C names
+			// Every candidate prefix starts with `__vf_`, so only the
+			// program's few `__vf_`-prefixed function and global C names
 			// can collide (see fastc_reserved_temporary_c_names); rescanning
 			// every function key here made each temporary O(program).
 			for c_name in g.fastc_prefixed_c_names {
@@ -499,24 +499,24 @@ fn (g &Parser) temporary_namespace(kind string) string {
 }
 
 // fastc_reserved_temporary_c_names collects the generated function and global
-// C names that begin with the `__v_fastc_` temporary namespace prefix. Only
+// C names that begin with the `__vf_` temporary namespace prefix. Only
 // these can collide with a temporary_namespace candidate.
 fn fastc_reserved_temporary_c_names(functions map[string]FastcFunctionSignature, globals map[string]string) []string {
 	mut names := []string{}
 	for function_key in functions.keys() {
 		// Only an unqualified key can collide with a C keyword or libc name and
-		// so be renamed into the `__v_fastc_` namespace: a module-qualified key
+		// so be renamed into the `__vf_` namespace: a module-qualified key
 		// keeps its `module__name` spelling, and `C.` keys are emitted verbatim.
 		if function_key.contains('.') {
 			continue
 		}
 		function_c_name := fastc_c_function_name_for_key(function_key)
-		if function_c_name.starts_with('__v_fastc_') {
+		if function_c_name.starts_with('__vf_') {
 			names << function_c_name
 		}
 	}
 	for c_name in globals.values() {
-		if c_name.starts_with('__v_fastc_') {
+		if c_name.starts_with('__vf_') {
 			names << c_name
 		}
 	}
@@ -781,11 +781,12 @@ fn (mut g Parser) parse_function(enabled bool) ! {
 		g.skip_balanced(.lcbr, .rcbr)!
 		return
 	}
-	c_name := if receiver_type == '' {
+	conventional_c_name := if receiver_type == '' {
 		fastc_c_function_name(g.module_name, name)
 	} else {
 		fastc_method_c_name(g.module_name, fastc_c_declared_type_name(receiver_key), name)
 	}
+	c_name := g.c_function_name_or(function_key, conventional_c_name)
 	g.last_function_c_name = c_name
 	c_return_type := if is_main { 'int' } else { fastc_output_c_type(return_type) }
 	c_params := if is_main && g.selfhost {

--- a/vlib/v3/gen/fastc/for.v
+++ b/vlib/v3/gen/fastc/for.v
@@ -77,6 +77,7 @@ fn (mut g Parser) parse_for() !bool {
 				}
 				g.next()
 				end := g.read_expression([token.Token.lcbr])!
+				end_expression_type := g.last_expression_type
 				end_expression := g.last_expression
 				if start_value := fastc_integer_literal_value(start_expression) {
 					if end_value := fastc_integer_literal_value(end_expression) {
@@ -96,9 +97,11 @@ fn (mut g Parser) parse_for() !bool {
 					fastc_c_identifier(name)
 				}
 				// V evaluates both range bounds exactly once, from left to right.
-				g.write_line('__typeof__((${start})) ${start_name} = (${start});')
-				g.write_line('__typeof__((${end})) ${end_name} = (${end});')
-				g.write_line('for (__typeof__((${start_name})) ${c_name} = (${start_name}); ${c_name} < (${end_name}); ${c_name}++) {')
+				start_type := g.declaration_c_type(start_expression_type, start)
+				end_type := g.declaration_c_type(end_expression_type, end)
+				g.write_line('${start_type} ${start_name} = (${start});')
+				g.write_line('${end_type} ${end_name} = (${end});')
+				g.write_line('for (${start_type} ${c_name} = (${start_name}); ${c_name} < (${end_name}); ${c_name}++) {')
 				if name != '_' {
 					g.locals[name] = FastcLocal{
 						typ: fastc_normalize_inferred_type(start_expression_type)
@@ -135,7 +138,8 @@ fn (mut g Parser) parse_for() !bool {
 				keys_name := g.temporary_name('map_keys')
 				values_name := g.temporary_name('map_values')
 				index_name := g.temporary_name('map_index')
-				g.write_line('__typeof__((${start})) ${collection_name} = (${start});')
+				collection_c_type := g.declaration_c_type(start_expression_type, start)
+				g.write_line('${collection_c_type} ${collection_name} = (${start});')
 				map_pointer := if collection_layout_type.ends_with('*') {
 					collection_name
 				} else {
@@ -208,7 +212,8 @@ fn (mut g Parser) parse_for() !bool {
 			} else if is_ordinary_string {
 				g.write_line('string ${collection_name} = (${start});')
 			} else {
-				g.write_line('__typeof__((${start})) ${collection_name} = (${start});')
+				collection_c_type := g.declaration_c_type(start_expression_type, start)
+				g.write_line('${collection_c_type} ${collection_name} = (${start});')
 			}
 			collection_length := if is_ordinary_string {
 				'strlen(${collection_name} ? ${collection_name} : "")'
@@ -306,7 +311,7 @@ fn (mut g Parser) parse_for() !bool {
 			update := g.read_statement_expression([token.Token.lcbr])!
 			g.expect(.lcbr)!
 			initializer := if is_declaration {
-				'__typeof__((${initial})) ${fastc_c_identifier(name)} = (${initial})'
+				'${g.declaration_c_type(initial_type, initial)} ${fastc_c_identifier(name)} = (${initial})'
 			} else {
 				'${fastc_c_identifier(name)} = (${initial})'
 			}

--- a/vlib/v3/gen/fastc/if.v
+++ b/vlib/v3/gen/fastc/if.v
@@ -1355,7 +1355,7 @@ fn fastc_option_success_expression(value_type string, expression string) string 
 }
 
 fn fastc_box_expression(value_type string, expression string) string {
-	return '({ ${value_type} __v_fastc_box_value = (${expression}); v_fastc_interface_box(&__v_fastc_box_value, sizeof(${value_type})); })'
+	return '({ ${value_type} __vf_bv = (${expression}); v_fastc_interface_box(&__vf_bv, sizeof(${value_type})); })'
 }
 
 // read_if_expression_multi_return_guard lowers `if a, b := opt_multi() { x } else { y }`

--- a/vlib/v3/gen/fastc/link.v
+++ b/vlib/v3/gen/fastc/link.v
@@ -37,6 +37,26 @@ pub fn fastc_prepared_link_skips_codesign(link &FastcPreparedLink) bool {
 	}
 }
 
+// fastc_prepared_link_accepts_inputs reports whether object files can be
+// loaded into this linker before the final output step.
+pub fn fastc_prepared_link_accepts_inputs(link &FastcPreparedLink) bool {
+	$if macos && !tinyc && !fastc_selfhost ?&& !v3_backend ? {
+		return !isnil(link.state)
+	} $else {
+		return false
+	}
+}
+
+// fastc_add_prepared_link_input loads one completed object into the macOS
+// in-process linker. Callers preserve the original object order.
+pub fn fastc_add_prepared_link_input(mut link FastcPreparedLink, input_path string) ! {
+	$if macos && !tinyc && !fastc_selfhost ?&& !v3_backend ? {
+		fastc_libtcc_add_input(mut link, input_path)!
+	} $else {
+		return error('prepared FastC linker does not accept inputs')
+	}
+}
+
 // fastc_finish_link adds the compiled inputs to a prepared linker and writes
 // the executable. `final_args` contains libraries and other link-only flags.
 pub fn fastc_finish_link(mut link FastcPreparedLink, input_paths []string, final_args []string, output string) os.Result {

--- a/vlib/v3/gen/fastc/link_darwin.c.v
+++ b/vlib/v3/gen/fastc/link_darwin.c.v
@@ -188,6 +188,17 @@ fn fastc_libtcc_add_library(state &C.TCCState, name string, diagnostics &FastcLi
 	return none
 }
 
+fn fastc_libtcc_add_input(mut link FastcPreparedLink, input_path string) ! {
+	state := fastc_libtcc_state(&link)
+	if isnil(state) || isnil(link.diagnostics) {
+		return error('prepared TinyCC linker is unavailable')
+	}
+	mut diagnostics := unsafe { &FastcLibtccDiagnostics(link.diagnostics) }
+	if C.tcc_add_file(state, input_path.str) != 0 {
+		return error(fastc_libtcc_diagnostics(diagnostics, 'could not add `${input_path}` to the TinyCC link'))
+	}
+}
+
 fn fastc_finish_libtcc_link(mut link FastcPreparedLink, input_paths []string, final_args []string, output string) os.Result {
 	state := fastc_libtcc_state(&link)
 	if isnil(state) || isnil(link.diagnostics) {
@@ -204,10 +215,10 @@ fn fastc_finish_libtcc_link(mut link FastcPreparedLink, input_paths []string, fi
 		link.diagnostics = unsafe { nil }
 	}
 	for input_path in input_paths {
-		if C.tcc_add_file(state, input_path.str) != 0 {
+		fastc_libtcc_add_input(mut link, input_path) or {
 			return os.Result{
 				exit_code: 1
-				output: fastc_libtcc_diagnostics(diagnostics, 'could not add `${input_path}` to the TinyCC link')
+				output: err.msg()
 			}
 		}
 	}

--- a/vlib/v3/gen/fastc/link_darwin.c.v
+++ b/vlib/v3/gen/fastc/link_darwin.c.v
@@ -95,7 +95,7 @@ fn fastc_libtcc_is_link_input(arg string) bool {
 	lower := arg.to_lower()
 	return lower.ends_with('.o') || lower.ends_with('.obj') || lower.ends_with('.a')
 		|| lower.ends_with('.lib') || lower.ends_with('.dylib') || lower.ends_with('.so')
-		|| lower.contains('.so.')
+		|| lower.ends_with('.tbd') || lower.contains('.so.')
 }
 
 fn fastc_libtcc_apply_options(state &C.TCCState, args []string) int {

--- a/vlib/v3/gen/fastc/macho_sign.v
+++ b/vlib/v3/gen/fastc/macho_sign.v
@@ -97,7 +97,11 @@ fn fastc_macho_sign_capacity(original_len int, ident string) int {
 // empty requirements blob and an empty CMS wrapper), replacing any signature
 // it has. The identifier is the file name, as `codesign -s -` uses.
 pub fn fastc_sign_macho_adhoc(path string) ! {
-	fastc_sign_macho_adhoc_buffered(path)!
+	$if macos {
+		fastc_sign_macho_adhoc_mapped(path)!
+	} $else {
+		fastc_sign_macho_adhoc_buffered(path)!
+	}
 }
 
 fn fastc_sign_macho_adhoc_buffered(path string) ! {

--- a/vlib/v3/gen/fastc/macho_sign.v
+++ b/vlib/v3/gen/fastc/macho_sign.v
@@ -79,14 +79,68 @@ pub fn fastc_remove_codesign_shim_dir(shim FastcCodesignShim) {
 	}
 }
 
+struct FastcMachoPatch {
+mut:
+	original_len int
+	tail_start   int
+	load_end     int
+	final_len    int
+}
+
+fn fastc_macho_sign_capacity(original_len int, ident string) int {
+	code_limit := (original_len + 15) & ~15
+	return code_limit + fastc_adhoc_signature_size(ident, code_limit)
+}
+
 // fastc_sign_macho_adhoc gives the 64-bit Mach-O executable at `path` an
 // ad-hoc code signature (a SHA-256 code directory over 4 KiB pages, an
 // empty requirements blob and an empty CMS wrapper), replacing any signature
 // it has. The identifier is the file name, as `codesign -s -` uses.
 pub fn fastc_sign_macho_adhoc(path string) ! {
-	mut file := os.read_bytes(path)!
-	original_len := file.len
-	if file.len < macho_header_size || fastc_read_u32_le(file, 0) != macho_magic_64 {
+	fastc_sign_macho_adhoc_buffered(path)!
+}
+
+fn fastc_sign_macho_adhoc_buffered(path string) ! {
+	original_len := int(os.file_size(path))
+	capacity := fastc_macho_sign_capacity(original_len, path.all_after_last('/'))
+	mut file := []u8{len: capacity}
+	mut out := os.open_file(path, 'r+')!
+	read := out.read_into_ptr(file.data, original_len) or {
+		out.close()
+		return err
+	}
+	if read != original_len {
+		out.close()
+		return error('`${path}`: could not read the complete Mach-O file')
+	}
+	patch := fastc_patch_macho_signature(mut file, original_len, path) or {
+		out.close()
+		return err
+	}
+	out.write_to(0, file[..patch.load_end]) or {
+		out.close()
+		return err
+	}
+	out.write_to(u64(patch.tail_start), file[patch.tail_start..patch.final_len]) or {
+		out.close()
+		return err
+	}
+	if patch.original_len > patch.final_len {
+		// A larger old signature is cut off.
+		out.flush()
+		if C.ftruncate(i32(out.fd), u64(patch.final_len)) != 0 {
+			out.close()
+			return error('`${path}`: could not truncate the old signature')
+		}
+	}
+	out.close()
+}
+
+// fastc_patch_macho_signature validates and patches a buffer whose length is
+// large enough for the replacement signature. It returns the ranges that a
+// buffered caller must publish; the macOS path patches a shared mapping.
+fn fastc_patch_macho_signature(mut file []u8, original_len int, path string) !FastcMachoPatch {
+	if original_len < macho_header_size || fastc_read_u32_le(file, 0) != macho_magic_64 {
 		return error('`${path}` is not a 64-bit Mach-O file')
 	}
 	mut ncmds := int(fastc_read_u32_le(file, 16))
@@ -96,12 +150,12 @@ pub fn fastc_sign_macho_adhoc(path string) ! {
 	mut signature_cmd := -1
 	mut offset := macho_header_size
 	for _ in 0 .. ncmds {
-		if offset + 8 > file.len {
+		if offset + 8 > original_len {
 			return error('`${path}`: truncated load commands')
 		}
 		cmd := fastc_read_u32_le(file, offset)
 		cmdsize := int(fastc_read_u32_le(file, offset + 4))
-		if cmdsize < 8 || offset + cmdsize > file.len {
+		if cmdsize < 8 || offset + cmdsize > original_len {
 			return error('`${path}`: bad load command size')
 		}
 		if cmd == macho_lc_segment_64 {
@@ -121,16 +175,15 @@ pub fn fastc_sign_macho_adhoc(path string) ! {
 	}
 	// The signed range ends where the signature starts: at the old signature
 	// when there is one, else at the (16-byte padded) end of the file.
-	mut code_limit := file.len
+	mut code_limit := original_len
 	if signature_cmd >= 0 {
 		code_limit = int(fastc_read_u32_le(file, signature_cmd + 8))
-		if code_limit > file.len {
+		if code_limit > original_len {
 			return error('`${path}`: signature past the end of the file')
 		}
-		file.trim(code_limit)
 	} else {
 		load_end := macho_header_size + sizeofcmds
-		if load_end + 16 > file.len {
+		if load_end + 16 > original_len {
 			return error('`${path}`: no room for a signature load command')
 		}
 		for k in 0 .. 16 {
@@ -148,9 +201,9 @@ pub fn fastc_sign_macho_adhoc(path string) ! {
 	}
 	// Only the load commands and the tail from here (padding and signature)
 	// change; they are patched into the file rather than rewriting it all.
-	tail_start := file.len
+	tail_start := code_limit
 	for code_limit % 16 != 0 {
-		file << 0
+		file[code_limit] = 0
 		code_limit++
 	}
 	ident := path.all_after_last('/')
@@ -168,26 +221,14 @@ pub fn fastc_sign_macho_adhoc(path string) ! {
 	if signature.len != signature_size {
 		return error('`${path}`: signature size mismatch')
 	}
-	file << signature
+	unsafe { vmemcpy(&u8(file.data) + code_limit, signature.data, signature.len) }
 	load_end := macho_header_size + sizeofcmds
-	mut out := os.open_file(path, 'r+')!
-	out.write_to(0, file[..load_end]) or {
-		out.close()
-		return err
+	return FastcMachoPatch{
+		original_len: original_len
+		tail_start: tail_start
+		load_end: load_end
+		final_len: code_limit + signature.len
 	}
-	out.write_to(u64(tail_start), file[tail_start..]) or {
-		out.close()
-		return err
-	}
-	if original_len > file.len {
-		// A larger old signature is cut off.
-		out.flush()
-		if C.ftruncate(i32(out.fd), u64(file.len)) != 0 {
-			out.close()
-			return error('`${path}`: could not truncate the old signature')
-		}
-	}
-	out.close()
 }
 
 fn fastc_adhoc_signature_size(ident string, code_limit int) int {

--- a/vlib/v3/gen/fastc/macho_sign_darwin.c.v
+++ b/vlib/v3/gen/fastc/macho_sign_darwin.c.v
@@ -1,8 +1,62 @@
 module fastc
 
+import os
+
 #include <CommonCrypto/CommonDigest.h>
 
+#include <sys/mman.h>
+
 fn C.CC_SHA256(data voidptr, len u32, md &u8) &u8
+
+// fastc_sign_macho_adhoc_mapped extends and patches the linker output through
+// a private mapping. The page hashes can read that mapping directly, avoiding a
+// four-megabyte read and a second copy back through write syscalls per self-host.
+fn fastc_sign_macho_adhoc_mapped(path string) ! {
+	original_len := int(os.file_size(path))
+	capacity := fastc_macho_sign_capacity(original_len, path.all_after_last('/'))
+	mut out := os.open_file(path, 'r+')!
+	if C.ftruncate(i32(out.fd), u64(capacity)) != 0 {
+		out.close()
+		return error('`${path}`: could not extend the Mach-O file for signing')
+	}
+	mapped := unsafe {
+		C.mmap(nil, usize(capacity), C.PROT_READ | C.PROT_WRITE, C.MAP_PRIVATE, out.fd, 0)
+	}
+	if mapped == voidptr(-1) {
+		_ = C.ftruncate(i32(out.fd), u64(original_len))
+		out.close()
+		return error('`${path}`: could not map the Mach-O file for signing')
+	}
+	mut file := unsafe { mapped.vbytes(capacity) }
+	patch := fastc_patch_macho_signature(mut file, original_len, path) or {
+		unsafe { C.munmap(mapped, usize(capacity)) }
+		_ = C.ftruncate(i32(out.fd), u64(original_len))
+		out.close()
+		return err
+	}
+	load_commands := file[..patch.load_end].clone()
+	tail := file[patch.tail_start..patch.final_len].clone()
+	if unsafe { C.munmap(mapped, usize(capacity)) } != 0 {
+		out.close()
+		return error('`${path}`: could not release the mapped Mach-O image')
+	}
+	// Drop the old signature before publishing the new tail. Besides avoiding a
+	// whole-file rewrite, this size transition invalidates macOS's cached signing
+	// state so the executable can be launched immediately.
+	if C.ftruncate(i32(out.fd), u64(patch.tail_start)) != 0 {
+		out.close()
+		return error('`${path}`: could not remove the old Mach-O signature')
+	}
+	out.write_to(0, load_commands) or {
+		out.close()
+		return err
+	}
+	out.write_to(u64(patch.tail_start), tail) or {
+		out.close()
+		return err
+	}
+	out.close()
+}
 
 // fastc_hash_code_pages_native writes the SHA-256 of the pages [0, page_count)
 // of `data` (the last one ending at `code_limit`) to `hashes`, with the
@@ -14,7 +68,8 @@ fn fastc_hash_code_pages_native(data &u8, hashes &u8, page_count int, code_limit
 		fastc_hash_native_range(data, hashes, 0, page_count, code_limit)
 		return
 	}
-	worker_count := 6
+	available_workers := fastc_nr_cpus()
+	worker_count := if available_workers < 16 { available_workers } else { 16 }
 	mut workers := [
 		spawn fastc_hash_native_range(data, hashes, 0, page_count / worker_count, code_limit),
 	]

--- a/vlib/v3/gen/fastc/macho_sign_darwin.c.v
+++ b/vlib/v3/gen/fastc/macho_sign_darwin.c.v
@@ -14,7 +14,7 @@ fn fastc_hash_code_pages_native(data &u8, hashes &u8, page_count int, code_limit
 		fastc_hash_native_range(data, hashes, 0, page_count, code_limit)
 		return
 	}
-	worker_count := 4
+	worker_count := 6
 	mut workers := [
 		spawn fastc_hash_native_range(data, hashes, 0, page_count / worker_count, code_limit),
 	]

--- a/vlib/v3/gen/fastc/macho_sign_test.v
+++ b/vlib/v3/gen/fastc/macho_sign_test.v
@@ -143,7 +143,9 @@ fn test_fastc_prepared_libtcc_preserves_archive_option_order() {
 	final_args := ['-Wl,--whole-archive', archive_path, '-Wl,--no-whole-archive']
 	mut prepared := fastc_prepare_link(tcc, tcc_lib, base_args, final_args)
 	assert fastc_prepared_link_skips_codesign(&prepared)
-	link_result := fastc_finish_link(mut prepared, [main_object], final_args, exe_path)
+	assert fastc_prepared_link_accepts_inputs(&prepared)
+	fastc_add_prepared_link_input(mut prepared, main_object) or { panic(err) }
+	link_result := fastc_finish_link(mut prepared, [], final_args, exe_path)
 	assert link_result.exit_code == 0, link_result.output
 	nm_result := os.execute('/usr/bin/nm -g ${exe_path}')
 	assert nm_result.exit_code == 0, nm_result.output

--- a/vlib/v3/gen/fastc/match.v
+++ b/vlib/v3/gen/fastc/match.v
@@ -305,7 +305,8 @@ fn (mut g Parser) read_match_expression() !string {
 	}
 	g.last_expression_type = if result_type == '' { outer_expected_type } else { result_type }
 	g.last_expression = []FastcExpressionToken{}
-	return '({ __typeof__((${subject})) ${temporary} = (${subject}); ${expression}; })'
+	subject_decl_type := g.declaration_c_type(subject_type, subject)
+	return '({ ${subject_decl_type} ${temporary} = (${subject}); ${expression}; })'
 }
 
 fn (g &Parser) normalized_match_case_key(tokens []FastcExpressionToken, rendered string) string {

--- a/vlib/v3/gen/fastc/names.v
+++ b/vlib/v3/gen/fastc/names.v
@@ -10,7 +10,34 @@ fn fastc_type_key(module_name string, name string) string {
 }
 
 fn fastc_c_declared_type_name(type_key string) string {
+	if fastc_compact_v3_type_names {
+		if type_key.starts_with('v3.gen.fastc.') {
+			return 'F__' + type_key[13..].replace('.', '__')
+		}
+		if type_key.starts_with('v3.token.') {
+			return 'T__' + type_key[9..].replace('.', '__')
+		}
+		if type_key.starts_with('v3.pref.') {
+			return 'P__' + type_key[8..].replace('.', '__')
+		}
+		if type_key.starts_with('v3.scanner.') {
+			return 'S__' + type_key[11..].replace('.', '__')
+		}
+	}
 	return type_key.replace('.', '__')
+}
+
+fn fastc_c_module_name(module_name string) string {
+	if fastc_compact_v3_type_names {
+		return match module_name {
+			'v3.gen.fastc' { 'F' }
+			'v3.token' { 'T' }
+			'v3.pref' { 'P' }
+			'v3.scanner' { 'S' }
+			else { module_name.replace('.', '__') }
+		}
+	}
+	return module_name.replace('.', '__')
 }
 
 // fastc_declared_type_c_names indexes declared type keys by their generated C
@@ -102,13 +129,53 @@ fn (g &Parser) unqualified_function_key(name string) string {
 // site. The mapping does not depend on the parser's context, so the memo
 // is never reset.
 fn (g &Parser) c_function_name_for_key(key string) string {
+	return g.c_function_name_or(key, fastc_c_function_name_for_key(key))
+}
+
+fn (g &Parser) c_function_name_or(key string, conventional string) string {
 	if cached := g.c_function_name_memo[key] {
 		return cached
 	}
-	c_name := fastc_c_function_name_for_key(key)
+	c_name := if compact_name := g.function_c_names[key] {
+		compact_name
+	} else {
+		conventional
+	}
 	mut w := unsafe { &Parser(g) }
 	w.c_function_name_memo[key] = c_name
 	return c_name
+}
+
+fn fastc_compact_function_c_names(functions map[string]FastcFunctionSignature, compact bool) map[string]string {
+	mut names := map[string]string{}
+	if !compact {
+		return names
+	}
+	mut keys := functions.keys()
+	keys.sort()
+	mut compact_id := 0
+	for key in keys {
+		signature := functions[key]
+		if !key.starts_with('C.') && key != 'main' && !key.starts_with('main.')
+			&& signature.module_name !in ['', 'main', 'builtin'] && !signature.module_name.starts_with('math') {
+			names[key] = 'v_f${compact_id}'
+			compact_id++
+		}
+	}
+	return names
+}
+
+fn fastc_signature_c_name(key string, signature FastcFunctionSignature) string {
+	if key.starts_with('C.') {
+		return fastc_c_function_name_for_key(key)
+	}
+	name := key.all_after_last('.')
+	prefix := key.all_before_last('.')
+	return if prefix == '' || prefix == signature.module_name {
+		fastc_c_function_name(signature.module_name, name)
+	} else {
+		fastc_method_c_name(signature.module_name, fastc_c_declared_type_name(prefix), name)
+	}
 }
 
 fn fastc_c_function_name_for_key(key string) string {
@@ -118,7 +185,7 @@ fn fastc_c_function_name_for_key(key string) string {
 	sanitized := naming.sanitize(key)
 	c_name := naming.c_name(key)
 	if c_name != sanitized || sanitized.starts_with('v_fastc_') {
-		return '__v_fastc_function_${sanitized}'
+		return '__vf_function_${sanitized}'
 	}
 	return c_name
 }

--- a/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_d_v3_no_parallel.v
@@ -20,9 +20,9 @@ fn fastc_wait_referenced_function_names(mut pending FastcPendingReferences) map[
 	return pending.references
 }
 
-fn fastc_start_interface_dispatches(declared_kinds map[string]FastcDeclaredTypeKind, functions map[string]FastcFunctionSignature, interface_methods map[string]bool, used_function_names map[string]bool, selfhost bool, _prefs &pref.Preferences) FastcPendingInterfaceDispatches {
+fn fastc_start_interface_dispatches(declared_kinds map[string]FastcDeclaredTypeKind, functions map[string]FastcFunctionSignature, function_c_names map[string]string, interface_methods map[string]bool, used_function_names map[string]bool, selfhost bool, _prefs &pref.Preferences) FastcPendingInterfaceDispatches {
 	return FastcPendingInterfaceDispatches{
-		dispatches: fastc_generate_interface_dispatches(declared_kinds, functions, interface_methods, used_function_names, selfhost)
+		dispatches: fastc_generate_interface_dispatches(declared_kinds, functions, function_c_names, interface_methods, used_function_names, selfhost)
 	}
 }
 
@@ -109,9 +109,9 @@ mut:
 	result FastcFieldDefaultsResult
 }
 
-fn fastc_start_field_defaults(source_imports map[string]map[string]string, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, enum_field_names map[string][]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, global_types map[string]string, sum_types map[string]bool) FastcPendingFieldDefaults {
+fn fastc_start_field_defaults(source_imports map[string]map[string]string, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, enum_field_names map[string][]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, function_c_names map[string]string, constants map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, global_types map[string]string, sum_types map[string]bool) FastcPendingFieldDefaults {
 	return FastcPendingFieldDefaults{
-		result: fastc_run_field_defaults(source_imports, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, enum_field_names, alias_base_types, struct_fields, struct_field_info, functions, constants, public_constants, constant_types, globals, public_globals, global_types, sum_types)
+		result: fastc_run_field_defaults(source_imports, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, enum_field_names, alias_base_types, struct_fields, struct_field_info, functions, function_c_names, constants, public_constants, constant_types, globals, public_globals, global_types, sum_types)
 	}
 }
 

--- a/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
@@ -743,11 +743,16 @@ fn fastc_source_generation_fragments(source_file FastcSourceFile, prefs &pref.Pr
 			}
 			position_offset++
 		}
-		prefix := '\n'.repeat(position_lines) + ' '.repeat(position_column)
 		fragments << FastcSourceFile{
 			path: source_file.path
-			source: prefix + source_file.source[start..cuts[i + 1]]
-			source_offset: source_file.source_offset + start - prefix.len
+			source: source_file.source[start..cuts[i + 1]]
+			source_offset: source_file.source_offset + start
+			source_line_offset: source_file.source_line_offset + position_lines
+			source_column_offset: if position_lines == 0 {
+				source_file.source_column_offset + position_column
+			} else {
+				position_column
+			}
 			header: source_file.header
 		}
 	}

--- a/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
@@ -745,7 +745,9 @@ fn fastc_source_generation_fragments(source_file FastcSourceFile, prefs &pref.Pr
 		}
 		fragments << FastcSourceFile{
 			path: source_file.path
-			source: source_file.source[start..cuts[i + 1]]
+			// The original source array remains alive throughout generation; share
+			// its bytes instead of copying every fragment before the parallel pass.
+			source: unsafe { source_file.source[start..cuts[i + 1]] }
 			source_offset: source_file.source_offset + start
 			source_line_offset: source_file.source_line_offset + position_lines
 			source_column_offset: if position_lines == 0 {

--- a/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/fastc/parallel_notd_v3_no_parallel.v
@@ -36,15 +36,15 @@ fn fastc_wait_referenced_function_names(mut pending FastcPendingReferences) map[
 	return pending.workers[0].wait()
 }
 
-fn fastc_start_interface_dispatches(declared_kinds map[string]FastcDeclaredTypeKind, functions map[string]FastcFunctionSignature, interface_methods map[string]bool, used_function_names map[string]bool, selfhost bool, prefs &pref.Preferences) FastcPendingInterfaceDispatches {
+fn fastc_start_interface_dispatches(declared_kinds map[string]FastcDeclaredTypeKind, functions map[string]FastcFunctionSignature, function_c_names map[string]string, interface_methods map[string]bool, used_function_names map[string]bool, selfhost bool, prefs &pref.Preferences) FastcPendingInterfaceDispatches {
 	if fastc_parallel_job_count(functions.len, prefs) <= 1 {
 		return FastcPendingInterfaceDispatches{
-			dispatches: fastc_generate_interface_dispatches(declared_kinds, functions, interface_methods, used_function_names, selfhost)
+			dispatches: fastc_generate_interface_dispatches(declared_kinds, functions, function_c_names, interface_methods, used_function_names, selfhost)
 		}
 	}
 	return FastcPendingInterfaceDispatches{
 		workers: [
-			spawn fastc_generate_interface_dispatches(declared_kinds, functions, interface_methods, used_function_names, selfhost),
+			spawn fastc_generate_interface_dispatches(declared_kinds, functions, function_c_names, interface_methods, used_function_names, selfhost),
 		]
 	}
 }
@@ -657,7 +657,7 @@ fn fastc_generate_file_steal(ctx &FastcFileGenContext, sources []FastcSourceFile
 	}
 }
 
-const fastc_generation_fragment_size = 28 * 1024
+const fastc_generation_fragment_size = 16 * 1024
 
 fn fastc_generation_fragment_is_followed_by_comptime_else(scan scanner.Scanner) bool {
 	mut lookahead := scan
@@ -693,7 +693,8 @@ fn fastc_source_generation_fragments(source_file FastcSourceFile, prefs &pref.Pr
 			}
 			.rcbr {
 				brace_depth--
-				if brace_depth == 0 && paren_depth == 0 && bracket_depth == 0 && scan.offset >= next_target {
+				if brace_depth == 0 && paren_depth == 0 && bracket_depth == 0
+					&& scan.offset >= next_target {
 					pending_cut = true
 				}
 			}
@@ -714,7 +715,8 @@ fn fastc_source_generation_fragments(source_file FastcSourceFile, prefs &pref.Pr
 				bracket_depth--
 			}
 			.semicolon {
-				if pending_cut && brace_depth == 0 && paren_depth == 0 && bracket_depth == 0 && !fastc_generation_fragment_is_followed_by_comptime_else(scan) {
+				if pending_cut && brace_depth == 0 && paren_depth == 0 && bracket_depth == 0
+					&& !fastc_generation_fragment_is_followed_by_comptime_else(scan) {
 					cuts << scan.offset
 					next_target = source_file.source.len * cuts.len / part_count
 					pending_cut = false
@@ -868,15 +870,15 @@ mut:
 	result  FastcFieldDefaultsResult
 }
 
-fn fastc_start_field_defaults(source_imports map[string]map[string]string, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, enum_field_names map[string][]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, constants map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, global_types map[string]string, sum_types map[string]bool) FastcPendingFieldDefaults {
+fn fastc_start_field_defaults(source_imports map[string]map[string]string, prefs &pref.Preferences, declared_types map[string]bool, declared_type_c_names map[string]string, fastc_prefixed_c_names []string, declared_kinds map[string]FastcDeclaredTypeKind, enum_flags map[string]bool, enum_field_types map[string]string, enum_field_names map[string][]string, alias_base_types map[string]string, struct_fields map[string]map[string]string, struct_field_info map[string][]FastcStructField, functions map[string]FastcFunctionSignature, function_c_names map[string]string, constants map[string]string, public_constants map[string]bool, constant_types map[string]string, globals map[string]string, public_globals map[string]bool, global_types map[string]string, sum_types map[string]bool) FastcPendingFieldDefaults {
 	if fastc_parallel_worker_limit(prefs) <= 1 {
 		return FastcPendingFieldDefaults{
-			result: fastc_run_field_defaults(source_imports, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, enum_field_names, alias_base_types, struct_fields, struct_field_info, functions, constants, public_constants, constant_types, globals, public_globals, global_types, sum_types)
+			result: fastc_run_field_defaults(source_imports, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, enum_field_names, alias_base_types, struct_fields, struct_field_info, functions, function_c_names, constants, public_constants, constant_types, globals, public_globals, global_types, sum_types)
 		}
 	}
 	return FastcPendingFieldDefaults{
 		workers: [
-			spawn fastc_run_field_defaults(source_imports, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, enum_field_names, alias_base_types, struct_fields, struct_field_info, functions, constants, public_constants, constant_types, globals, public_globals, global_types, sum_types),
+			spawn fastc_run_field_defaults(source_imports, prefs, declared_types, declared_type_c_names, fastc_prefixed_c_names, declared_kinds, enum_flags, enum_field_types, enum_field_names, alias_base_types, struct_fields, struct_field_info, functions, function_c_names, constants, public_constants, constant_types, globals, public_globals, global_types, sum_types),
 		]
 	}
 }

--- a/vlib/v3/gen/fastc/platform_int.v
+++ b/vlib/v3/gen/fastc/platform_int.v
@@ -8,6 +8,7 @@ module fastc
 // generator is usable before a target is configured; generation calls
 // `fastc_set_platform_int_bits` with the target pointer width first.
 __global fastc_platform_int_c_type = 'i64'
+__global fastc_compact_v3_type_names = false
 
 // fastc_set_platform_int_bits selects the C spelling for the platform `int`
 // from the target pointer width. Generation calls this once, before any worker
@@ -16,4 +17,8 @@ __global fastc_platform_int_c_type = 'i64'
 // correct, and matches `types.set_platform_int_bits` in the C backend.
 fn fastc_set_platform_int_bits(bits int) {
 	fastc_platform_int_c_type = if bits == 32 { 'i32' } else { 'i64' }
+}
+
+fn fastc_set_compact_v3_type_names(compact bool) {
+	fastc_compact_v3_type_names = compact
 }

--- a/vlib/v3/gen/fastc/render.v
+++ b/vlib/v3/gen/fastc/render.v
@@ -107,11 +107,11 @@ fn fastc_resolve_enum_shorthands_in_source(source string, enum_c string, fields 
 
 fn (g &Parser) render_map_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {
 	if lookup := g.render_map_lookup_option_expression(tokens) {
-		// The Option temp uses the reserved `__v_fastc_` prefix, NOT a plain name like `lookup`: a
+		// The Option temp uses the reserved `__vf_` prefix, NOT a plain name like `lookup`: a
 		// source variable of that name used in the key (`m[lookup]`) would otherwise be shadowed by
 		// this declaration and read uninitialized inside its own initializer.
 		return FastcRenderedExpression{
-			source: '({ Option __v_fastc_map_lookup = (${lookup.source}); __v_fastc_map_lookup.state ? (${lookup.typ}){0} : *((${lookup.typ} *)__v_fastc_map_lookup.data); })'
+			source: '({ Option __vf_ml = (${lookup.source}); __vf_ml.state ? (${lookup.typ}){0} : *((${lookup.typ} *)__vf_ml.data); })'
 			typ: lookup.typ
 		}
 	}
@@ -189,7 +189,7 @@ fn (g &Parser) render_map_expression(tokens []FastcExpressionToken) ?FastcRender
 			map_address = if map_type.ends_with('*') { map_source } else { '&${map_source}' }
 		}
 		return FastcRenderedExpression{
-			source: '({ ${key_type} __v_fastc_map_key = (${key_source}); ${value_type} __v_fastc_map_value = (${value_source}); builtin__map_set((map *)${map_address}, &__v_fastc_map_key, &__v_fastc_map_value); __v_fastc_map_value; })'
+			source: '({ ${key_type} __vf_k = (${key_source}); ${value_type} __vf_mv = (${value_source}); builtin__map_set((map *)${map_address}, &__vf_k, &__vf_mv); __vf_mv; })'
 			typ: value_type
 		}
 	}
@@ -207,7 +207,7 @@ fn (g &Parser) render_map_expression(tokens []FastcExpressionToken) ?FastcRender
 		map_source := g.globals[global_key] or { tokens[0].lit }
 		map_address := if map_type.ends_with('*') { map_source } else { '&${map_source}' }
 		return FastcRenderedExpression{
-			source: '({ ${key_type} __v_fastc_map_key = (${key_source}); ${value_type} __v_fastc_map_zero = (${value_type}){0}; *((${value_type} *)builtin__map_get((map *)${map_address}, &__v_fastc_map_key, &__v_fastc_map_zero)); })'
+			source: '({ ${key_type} __vf_k = (${key_source}); ${value_type} __vf_map_zero = (${value_type}){0}; *((${value_type} *)builtin__map_get((map *)${map_address}, &__vf_k, &__vf_map_zero)); })'
 			typ: value_type
 		}
 	}
@@ -282,7 +282,7 @@ fn (g &Parser) render_map_value_field_assignment(tokens []FastcExpressionToken) 
 		return none
 	}
 	return FastcRenderedExpression{
-		source: '({ ${value_type} *__v_fastc_map_field_ptr = (${ptr.source}); __v_fastc_map_field_ptr${field_access} = (${value_source}); (void)0; })'
+		source: '({ ${value_type} *__vf_map_field_ptr = (${ptr.source}); __vf_map_field_ptr${field_access} = (${value_source}); (void)0; })'
 		typ: 'void'
 	}
 }
@@ -337,7 +337,7 @@ fn (g &Parser) render_map_value_field_inc_dec(tokens []FastcExpressionToken) ?Fa
 		current_type = field.typ
 	}
 	return FastcRenderedExpression{
-		source: '({ ${value_type} *__v_fastc_map_field_ptr = (${ptr.source}); __v_fastc_map_field_ptr${field_access}${op}; (void)0; })'
+		source: '({ ${value_type} *__vf_map_field_ptr = (${ptr.source}); __vf_map_field_ptr${field_access}${op}; (void)0; })'
 		typ: 'void'
 	}
 }
@@ -488,8 +488,8 @@ fn (g &Parser) render_map_index_assignment_wrapping(left_tokens []FastcExpressio
 		map_address = if map_type.ends_with('*') { map_source } else { '&${map_source}' }
 	}
 	return FastcMapAssignmentWrap{
-		prefix: '({ ${key_type} __v_fastc_map_key = (${key_source}); ${value_type} __v_fastc_map_value = ('
-		suffix: '); builtin__map_set((map *)${map_address}, &__v_fastc_map_key, &__v_fastc_map_value); __v_fastc_map_value; })'
+		prefix: '({ ${key_type} __vf_k = (${key_source}); ${value_type} __vf_mv = ('
+		suffix: '); builtin__map_set((map *)${map_address}, &__vf_k, &__vf_mv); __vf_mv; })'
 		value_type: value_type
 	}
 }
@@ -621,7 +621,8 @@ fn (g &Parser) render_selfhost_print_expression(tokens []FastcExpressionToken) ?
 	} else {
 		argument
 	}
-	string_value := '${fastc_method_c_name(signature.module_name, expected_receiver, 'str')}(${receiver_argument})'
+	method_c_name := g.c_function_name_or(method_key, fastc_method_c_name(signature.module_name, expected_receiver, 'str'))
+	string_value := '${method_c_name}(${receiver_argument})'
 	return FastcRenderedExpression{
 		source: 'builtin__${tokens[0].lit}(${string_value})'
 		typ: 'void'
@@ -646,7 +647,7 @@ fn (g &Parser) render_struct_literal_with_defaults(c_type string, layout_type st
 		if field in initialized_fields {
 			continue
 		}
-		assignments << '__v_fastc_struct_default${field};'
+		assignments << '__vf_sd${field};'
 	}
 	initializer := if initializers.len > 0 {
 		'(${base_type}){${initializers.join(',')}}'
@@ -654,12 +655,12 @@ fn (g &Parser) render_struct_literal_with_defaults(c_type string, layout_type st
 		'(${base_type}){0}'
 	}
 	result := if c_type.ends_with('*') {
-		'(${c_type})v_fastc_interface_box(&__v_fastc_struct_default, sizeof(${base_type}))'
+		'(${c_type})v_fastc_interface_box(&__vf_sd, sizeof(${base_type}))'
 	} else {
-		'__v_fastc_struct_default'
+		'__vf_sd'
 	}
 	return FastcRenderedExpression{
-		source: '({ ${explicit_initializers.join(' ')} ${base_type} __v_fastc_struct_default = ${initializer}; ${assignments.join(' ')} ${result}; })'
+		source: '({ ${explicit_initializers.join(' ')} ${base_type} __vf_sd = ${initializer}; ${assignments.join(' ')} ${result}; })'
 		typ: c_type
 	}
 }
@@ -703,7 +704,7 @@ fn (g &Parser) struct_field_initializer_default(field FastcStructField) string {
 	if !field.is_shared_pointer {
 		return value
 	}
-	return '({ ${field.typ} __v_fastc_shared_field_value = (${value}); (${field.typ}*)v_fastc_interface_box(&__v_fastc_shared_field_value, sizeof(${field.typ})); })'
+	return '({ ${field.typ} __vf_shared_field_value = (${value}); (${field.typ}*)v_fastc_interface_box(&__vf_shared_field_value, sizeof(${field.typ})); })'
 }
 
 fn (g &Parser) struct_type_has_initializer_defaults(c_type string) bool {
@@ -1013,9 +1014,8 @@ fn (g &Parser) render_overloaded_assignment(target string, value string, target_
 	if signature.parameter_types.len < 2 || signature.is_disabled {
 		return none
 	}
-	receiver_type := signature.parameter_types[0]
-	method_name := fastc_method_c_name(signature.module_name, receiver_type, operator)
-	return '({ ${target_type} *__v_fastc_overloaded_assignment_target = &(${target}); *__v_fastc_overloaded_assignment_target = ${method_name}(*__v_fastc_overloaded_assignment_target,${value}); })'
+	method_name := g.c_function_name_or(method_key, fastc_method_c_name(signature.module_name, signature.parameter_types[0], operator))
+	return '({ ${target_type} *__vf_overloaded_assignment_target = &(${target}); *__vf_overloaded_assignment_target = ${method_name}(*__vf_overloaded_assignment_target,${value}); })'
 }
 
 fn (g &Parser) render_unsigned_right_shift_assignment(target string, value string, target_type string) ?string {
@@ -1030,7 +1030,7 @@ fn (g &Parser) render_unsigned_right_shift_assignment(target string, value strin
 			return none
 		}
 	}
-	return '({ ${target_type} *__v_fastc_unsigned_shift_target = &(${target}); ${unsigned_type} __v_fastc_unsigned_shift_value = (${unsigned_type})(*__v_fastc_unsigned_shift_target); u64 __v_fastc_unsigned_shift_count = (u64)(${value}); *__v_fastc_unsigned_shift_target = (${target_type})(__v_fastc_unsigned_shift_count >= ${bits} ? (${unsigned_type})0 : (__v_fastc_unsigned_shift_value >> __v_fastc_unsigned_shift_count)); })'
+	return '({ ${target_type} *__vf_unsigned_shift_target = &(${target}); ${unsigned_type} __vf_unsigned_shift_value = (${unsigned_type})(*__vf_unsigned_shift_target); u64 __vf_unsigned_shift_count = (u64)(${value}); *__vf_unsigned_shift_target = (${target_type})(__vf_unsigned_shift_count >= ${bits} ? (${unsigned_type})0 : (__vf_unsigned_shift_value >> __vf_unsigned_shift_count)); })'
 }
 
 fn fastc_overloaded_binary_precedence(tok token.Token) int {
@@ -1130,7 +1130,8 @@ fn (g &Parser) render_overloaded_comparison_expression(left_tokens []FastcExpres
 	argument := g.render_call_argument_expression(argument_tokens, signature.parameter_types[1]) or {
 		return none
 	}
-	call := '${fastc_method_c_name(signature.module_name, signature.parameter_types[0], method_operator)}(${receiver},${argument})'
+	method_c_name := g.c_function_name_or(method_key, fastc_method_c_name(signature.module_name, signature.parameter_types[0], method_operator))
+	call := '${method_c_name}(${receiver},${argument})'
 	return FastcRenderedExpression{
 		source: if negate { '!(${call})' } else { call }
 		typ: 'bool'
@@ -1164,26 +1165,26 @@ fn (g &Parser) render_array_equality_comparison(left_tokens []FastcExpressionTok
 			return none
 		}
 		element_comparison := if resolved_element == 'string' {
-			'builtin__string_eq(__v_fastc_array_eq_left[__v_fastc_array_eq_index], __v_fastc_array_eq_right[__v_fastc_array_eq_index])'
+			'builtin__string_eq(__vf_array_eq_left[__vf_array_eq_index], __vf_array_eq_right[__vf_array_eq_index])'
 		} else {
-			'(__v_fastc_array_eq_left[__v_fastc_array_eq_index] == __v_fastc_array_eq_right[__v_fastc_array_eq_index])'
+			'(__vf_array_eq_left[__vf_array_eq_index] == __vf_array_eq_right[__vf_array_eq_index])'
 		}
-		result := if operator == .ne { '!__v_fastc_array_equal' } else { '__v_fastc_array_equal' }
+		result := if operator == .ne { '!__vf_array_equal' } else { '__vf_array_equal' }
 		return FastcRenderedExpression{
-			source: '({ ${element_type} *__v_fastc_array_eq_left = (${element_type} *)(${left_data}); ${element_type} *__v_fastc_array_eq_right = (${element_type} *)(${right_data}); bool __v_fastc_array_equal = true; for (int __v_fastc_array_eq_index = 0; __v_fastc_array_eq_index < ${length}; __v_fastc_array_eq_index++) { if (!(${element_comparison})) { __v_fastc_array_equal = false; break; } } ${result}; })'
+			source: '({ ${element_type} *__vf_array_eq_left = (${element_type} *)(${left_data}); ${element_type} *__vf_array_eq_right = (${element_type} *)(${right_data}); bool __vf_array_equal = true; for (int __vf_array_eq_index = 0; __vf_array_eq_index < ${length}; __vf_array_eq_index++) { if (!(${element_comparison})) { __vf_array_equal = false; break; } } ${result}; })'
 			typ: 'bool'
 		}
 	}
 	left := g.render_call_argument_expression(left_tokens, left_type) or { return none }
 	right := g.render_call_argument_expression(right_tokens, right_type) or { return none }
 	element_comparison := if resolved_element == 'string' {
-		'builtin__string_eq(((${element_type} *)__v_fastc_array_eq_left.data)[__v_fastc_array_eq_index], ((${element_type} *)__v_fastc_array_eq_right.data)[__v_fastc_array_eq_index])'
+		'builtin__string_eq(((${element_type} *)__vf_array_eq_left.data)[__vf_array_eq_index], ((${element_type} *)__vf_array_eq_right.data)[__vf_array_eq_index])'
 	} else {
-		'(((${element_type} *)__v_fastc_array_eq_left.data)[__v_fastc_array_eq_index] == ((${element_type} *)__v_fastc_array_eq_right.data)[__v_fastc_array_eq_index])'
+		'(((${element_type} *)__vf_array_eq_left.data)[__vf_array_eq_index] == ((${element_type} *)__vf_array_eq_right.data)[__vf_array_eq_index])'
 	}
-	result := if operator == .ne { '!__v_fastc_array_equal' } else { '__v_fastc_array_equal' }
+	result := if operator == .ne { '!__vf_array_equal' } else { '__vf_array_equal' }
 	return FastcRenderedExpression{
-		source: '({ ${left_type} __v_fastc_array_eq_left = (${left}); ${right_type} __v_fastc_array_eq_right = (${right}); bool __v_fastc_array_equal = __v_fastc_array_eq_left.len == __v_fastc_array_eq_right.len; if (__v_fastc_array_equal) { for (int __v_fastc_array_eq_index = 0; __v_fastc_array_eq_index < __v_fastc_array_eq_left.len; __v_fastc_array_eq_index++) { if (!(${element_comparison})) { __v_fastc_array_equal = false; break; } } } ${result}; })'
+		source: '({ ${left_type} __vf_array_eq_left = (${left}); ${right_type} __vf_array_eq_right = (${right}); bool __vf_array_equal = __vf_array_eq_left.len == __vf_array_eq_right.len; if (__vf_array_equal) { for (int __vf_array_eq_index = 0; __vf_array_eq_index < __vf_array_eq_left.len; __vf_array_eq_index++) { if (!(${element_comparison})) { __vf_array_equal = false; break; } } } ${result}; })'
 		typ: 'bool'
 	}
 }
@@ -1379,8 +1380,9 @@ fn (g &Parser) render_overloaded_binary_expression(tokens []FastcExpressionToken
 	right := g.render_call_argument_expression(right_tokens, signature.parameter_types[1]) or {
 		return none
 	}
+	method_c_name := g.c_function_name_or(method_key, fastc_method_c_name(signature.module_name, signature.parameter_types[0], operator))
 	return FastcRenderedExpression{
-		source: '${fastc_method_c_name(signature.module_name, signature.parameter_types[0], operator)}(${left},${right})'
+		source: '${method_c_name}(${left},${right})'
 		typ: signature.return_type
 	}
 }
@@ -1682,7 +1684,7 @@ fn (g &Parser) render_chained_array_access_expression(tokens []FastcExpressionTo
 		}
 		// The buffer holds the render_raw spelling of the base, so match that first; using the
 		// member-receiver `base_source` as the primary needle lets a shorter un-mangled name
-		// (`short[0]`) match INSIDE the mangled buffer text (`__v_fastc_keyword_short[0]`) and
+		// (`short[0]`) match INSIDE the mangled buffer text (`__vf_keyword_short[0]`) and
 		// splice the replacement after the keyword prefix.
 		mut needle := '${raw_base}[${index_source}]'
 		if !fastc_contains(rendered, needle) {
@@ -1922,10 +1924,10 @@ fn (g &Parser) struct_equality_source(left string, right string, typ string, see
 		return if comparisons.len == 0 { 'true' } else { '(${comparisons.join(' && ')})' }
 	}
 	if element_type := g.array_element_type(layout_type) {
-		left_array := '__v_fastc_array_eq_left'
-		right_array := '__v_fastc_array_eq_right'
-		equal := '__v_fastc_array_eq_equal'
-		index := '__v_fastc_array_eq_index'
+		left_array := '__vf_array_eq_left'
+		right_array := '__vf_array_eq_right'
+		equal := '__vf_array_eq_equal'
+		index := '__vf_array_eq_index'
 		left_element := '((${element_type} *)${left_array}.data)[${index}]'
 		right_element := '((${element_type} *)${right_array}.data)[${index}]'
 		element_equality := g.struct_equality_source(left_element, right_element, element_type, seen)
@@ -2086,10 +2088,10 @@ fn (g &Parser) render_struct_comparison_expression_impl(tokens []FastcExpression
 			}
 			left := g.render_comparison_operand(left_tokens, left_type) or { return none }
 			right := g.render_comparison_operand(right_tokens, right_type) or { return none }
-			equality := g.struct_equality_source('__v_fastc_eq_left', '__v_fastc_eq_right', left_type, []string{})
+			equality := g.struct_equality_source('__vf_eq_left', '__vf_eq_right', left_type, []string{})
 			result := if item.tok == .ne { '!(${equality})' } else { equality }
 			return FastcRenderedExpression{
-				source: '({ ${left_type} __v_fastc_eq_left = (${left}); ${right_type} __v_fastc_eq_right = (${right}); ${result}; })'
+				source: '({ ${left_type} __vf_eq_left = (${left}); ${right_type} __vf_eq_right = (${right}); ${result}; })'
 				typ: 'bool'
 			}
 		}
@@ -2125,7 +2127,7 @@ fn (g &Parser) render_sum_type_equality(left_tokens []FastcExpressionToken, righ
 		return none
 	}
 	left := g.render_comparison_operand(left_tokens, sum_type) or { return none }
-	left_temp := '__v_fastc_sum_left'
+	left_temp := '__vf_sum_left'
 	tag := '${left_temp}._typ == __v_typeid_${variant_type}'
 	mut comparison := tag
 	if variant_type == 'string' {
@@ -2150,8 +2152,8 @@ fn (g &Parser) render_sum_type_equality(left_tokens []FastcExpressionToken, righ
 fn (g &Parser) render_sum_type_value_equality(left_tokens []FastcExpressionToken, right_tokens []FastcExpressionToken, sum_type string) ?string {
 	left := g.render_comparison_operand(left_tokens, sum_type) or { return none }
 	right := g.render_comparison_operand(right_tokens, sum_type) or { return none }
-	a := '__v_fastc_sv_a'
-	b := '__v_fastc_sv_b'
+	a := '__vf_sv_a'
+	b := '__vf_sv_b'
 	mut cases := []string{}
 	for variant in g.sum_type_leaf_variants(sum_type) {
 		mut concrete := 'true'
@@ -2162,12 +2164,12 @@ fn (g &Parser) render_sum_type_value_equality(left_tokens []FastcExpressionToken
 		} else if fastc_primitive_c_type(variant) != none {
 			concrete = '(*(${variant} *)${a}._object == *(${variant} *)${b}._object)'
 		}
-		cases << 'case __v_typeid_${variant}: __v_fastc_sv_eq = (${concrete}); break;'
+		cases << 'case __v_typeid_${variant}: __vf_sv_eq = (${concrete}); break;'
 	}
 	if cases.len == 0 {
 		return none
 	}
-	return '({ ${sum_type} ${a} = (${left}); ${sum_type} ${b} = (${right}); bool __v_fastc_sv_eq; if (${a}._typ != ${b}._typ) { __v_fastc_sv_eq = false; } else { switch (${a}._typ) { ${cases.join(' ')} default: __v_fastc_sv_eq = true; break; } } __v_fastc_sv_eq; })'
+	return '({ ${sum_type} ${a} = (${left}); ${sum_type} ${b} = (${right}); bool __vf_sv_eq; if (${a}._typ != ${b}._typ) { __vf_sv_eq = false; } else { switch (${a}._typ) { ${cases.join(' ')} default: __vf_sv_eq = true; break; } } __vf_sv_eq; })'
 }
 
 // render_as_cast_expression lowers `<boxed> as Type`. A boxed sum-type / interface
@@ -2424,7 +2426,7 @@ fn (g &Parser) render_as_cast_expression(tokens []FastcExpressionToken) ?FastcRe
 	}
 	left_source := g.render_call_argument_expression(left_tokens, left_type) or { return none }
 	access := if left_type.ends_with('*') { '->' } else { '.' }
-	src := '__v_fastc_as_src'
+	src := '__vf_as_src'
 	if g.is_boxed_type(target_c) {
 		return FastcRenderedExpression{
 			source: '({ ${left_type} ${src} = (${left_source}); (${target_c}){._object = ${src}${access}_object, ._typ = ${src}${access}_typ, ._methods = ${src}${access}_methods}; })'
@@ -3117,7 +3119,7 @@ fn (g &Parser) render_call_argument_expression(tokens []FastcExpressionToken, ex
 		// non-synthetic path below does; otherwise a struct value is passed where `void*` is wanted.
 		if g.selfhost && expected_type == 'voidptr' && tokens[0].typ !in ['', 'voidptr', 'nil'] && !fastc_is_pointer_type(tokens[0].typ) {
 			actual := fastc_normalize_inferred_type(g.underlying_alias_type(tokens[0].typ))
-			return '({ ${actual} __v_fastc_generic_argument = (${tokens[0].source}); v_fastc_interface_box(&__v_fastc_generic_argument, sizeof(${actual})); })'
+			return '({ ${actual} __vf_generic_argument = (${tokens[0].source}); v_fastc_interface_box(&__vf_generic_argument, sizeof(${actual})); })'
 		}
 		// An if/match-expression argument was pre-rendered to a ternary during streaming with the
 		// call-argument expected type cleared, so its branches may still hold raw `.member` enum
@@ -3148,7 +3150,8 @@ fn (g &Parser) render_call_argument_expression(tokens []FastcExpressionToken, ex
 			return none
 		}
 		if fastc_expression_tokens_contain(tokens[1..], .dotdot) {
-			return '({ __typeof__((${inner})) __v_fastc_mut_argument = (${inner}); &__v_fastc_mut_argument; })'
+			declaration_type := g.declaration_c_type(inner_expected_type, inner)
+			return '({ ${declaration_type} __vf_mut_argument = (${inner}); &__vf_mut_argument; })'
 		}
 		return '&(${inner})'
 	}
@@ -3280,7 +3283,7 @@ fn (g &Parser) render_call_argument_expression(tokens []FastcExpressionToken, ex
 		fastc_normalize_inferred_type(g.infer_expression_type(tokens) or { '' })
 	}
 	if expected_type == 'voidptr' && actual_type !in ['', 'voidptr', 'nil'] && !fastc_expression_is_zero(tokens) && !fastc_is_pointer_type(actual_type) {
-		box_value := '__v_fastc_generic_argument'
+		box_value := '__vf_generic_argument'
 		return '({ ${actual_type} ${box_value} = (${rendered}); v_fastc_interface_box(&${box_value}, sizeof(${actual_type})); })'
 	}
 	if actual_type == 'voidptr' && !expected_type.ends_with('*') && (expected_type.trim_right('*') in g.struct_fields || expected_type.trim_right('*').starts_with('Array_') || expected_type.trim_right('*').starts_with('Map_') || expected_type.trim_right('*').starts_with('FixedArray_')) {
@@ -3318,7 +3321,7 @@ fn (g &Parser) render_call_argument_expression(tokens []FastcExpressionToken, ex
 		// address of a statement-expression local would immediately dangle.
 		iface_type := expected_type.trim_right('*')
 		boxed := g.interface_value_expression(iface_type, actual_type, rendered)
-		return '({ ${iface_type} __v_fastc_iface_ref = ${boxed}; (${iface_type} *)v_fastc_interface_box(&__v_fastc_iface_ref, sizeof(${iface_type})); })'
+		return '({ ${iface_type} __vf_iface_ref = ${boxed}; (${iface_type} *)v_fastc_interface_box(&__vf_iface_ref, sizeof(${iface_type})); })'
 	}
 	if g.should_box_variant(expected_type, actual_type) {
 		return g.interface_value_expression(expected_type, actual_type, rendered)
@@ -3472,7 +3475,8 @@ fn (g &Parser) render_method_value_expression(tokens []FastcExpressionToken) ?st
 	if signature.parameter_types.len == 0 {
 		return none
 	}
-	return '&${fastc_method_c_name(signature.module_name, signature.parameter_types[0], tokens.last().lit)}'
+	method_c_name := g.c_function_name_or(method_key, fastc_method_c_name(signature.module_name, signature.parameter_types[0], tokens.last().lit))
+	return '&${method_c_name}'
 }
 
 fn (g &Parser) render_map_literal_argument(tokens []FastcExpressionToken, expected_type string) ?FastcRenderedExpression {
@@ -3488,7 +3492,7 @@ fn (g &Parser) render_map_literal_argument(tokens []FastcExpressionToken, expect
 	entries := fastc_map_literal_entries(tokens, 1, close) or { return none }
 	hash_fn, eq_fn, clone_fn, free_fn := g.map_runtime_functions(key_type)
 	mut statements := [
-		'map __v_fastc_argument_map = builtin__new_map(sizeof(${fastc_runtime_c_type(key_type)}), sizeof(${fastc_runtime_c_type(value_type)}), &${hash_fn}, &${eq_fn}, &${clone_fn}, &${free_fn});',
+		'map __vf_argument_map = builtin__new_map(sizeof(${fastc_runtime_c_type(key_type)}), sizeof(${fastc_runtime_c_type(value_type)}), &${hash_fn}, &${eq_fn}, &${clone_fn}, &${free_fn});',
 	]
 	for entry_index, entry in entries {
 		mut colon := -1
@@ -3531,14 +3535,14 @@ fn (g &Parser) render_map_literal_argument(tokens []FastcExpressionToken, expect
 		value := g.render_call_argument_expression(entry[colon + 1..], value_type) or {
 			return none
 		}
-		key_name := '__v_fastc_argument_map_key_${entry_index}'
-		value_name := '__v_fastc_argument_map_value_${entry_index}'
+		key_name := '__vf_argument_map_key_${entry_index}'
+		value_name := '__vf_argument_map_value_${entry_index}'
 		statements << '${fastc_runtime_c_type(key_type)} ${key_name} = (${key});'
 		statements << '${fastc_runtime_c_type(value_type)} ${value_name} = (${value});'
-		statements << 'builtin__map_set(&__v_fastc_argument_map, &${key_name}, &${value_name});'
+		statements << 'builtin__map_set(&__vf_argument_map, &${key_name}, &${value_name});'
 	}
 	return FastcRenderedExpression{
-		source: '({ ${statements.join(' ')} __v_fastc_argument_map; })'
+		source: '({ ${statements.join(' ')} __vf_argument_map; })'
 		typ: map_type
 	}
 }
@@ -3675,7 +3679,7 @@ fn (g &Parser) render_map_index_inc_dec_expression(tokens []FastcExpressionToken
 		map_source = '*(${map_source})'
 	}
 	return FastcRenderedExpression{
-		source: '({ ${key_type} __v_fastc_inc_key = (${key_source}); ${value_type} *__v_fastc_inc_value = (${value_type} *)builtin__map_get_check((map *)&(${map_source}), &__v_fastc_inc_key); if (__v_fastc_inc_value == NULL) { ${value_type} __v_fastc_inc_zero = (${value_type}){0}; builtin__map_set((map *)&(${map_source}), &__v_fastc_inc_key, &__v_fastc_inc_zero); __v_fastc_inc_value = (${value_type} *)builtin__map_get_check((map *)&(${map_source}), &__v_fastc_inc_key); } (*__v_fastc_inc_value)${op}; })'
+		source: '({ ${key_type} __vf_inc_key = (${key_source}); ${value_type} *__vf_inc_value = (${value_type} *)builtin__map_get_check((map *)&(${map_source}), &__vf_inc_key); if (__vf_inc_value == NULL) { ${value_type} __vf_inc_zero = (${value_type}){0}; builtin__map_set((map *)&(${map_source}), &__vf_inc_key, &__vf_inc_zero); __vf_inc_value = (${value_type} *)builtin__map_get_check((map *)&(${map_source}), &__vf_inc_key); } (*__vf_inc_value)${op}; })'
 		typ: value_type
 	}
 }
@@ -3775,18 +3779,18 @@ fn (g &Parser) render_map_lookup_option_expression(tokens []FastcExpressionToken
 	key_source := g.render_membership_candidate(lookup_tokens[open + 1..lookup_tokens.len - 1], key_type) or { return none }
 	option_value_type := if address_of_value { '${value_type}*' } else { value_type }
 	option_result := if address_of_value {
-		'__v_fastc_map_value == NULL ? (Option){.state=2} : ${fastc_option_success_expression(option_value_type, '__v_fastc_map_value')}'
+		'__vf_mv == NULL ? (Option){.state=2} : ${fastc_option_success_expression(option_value_type, '__vf_mv')}'
 	} else {
-		'(Option){.data=__v_fastc_map_value, .state=__v_fastc_map_value == NULL ? 2 : 0}'
+		'(Option){.data=__vf_mv, .state=__vf_mv == NULL ? 2 : 0}'
 	}
 	if needs_receiver_temp {
 		return FastcRenderedExpression{
-			source: '({ ${map_type.trim_right('*')} __v_fastc_map_receiver = (${map_source}); ${key_type} __v_fastc_map_key = (${key_source}); ${value_type} *__v_fastc_map_value = (${value_type} *)builtin__map_get_check((map *)&(__v_fastc_map_receiver), &__v_fastc_map_key); ${option_result}; })'
+			source: '({ ${map_type.trim_right('*')} __vf_map_receiver = (${map_source}); ${key_type} __vf_k = (${key_source}); ${value_type} *__vf_mv = (${value_type} *)builtin__map_get_check((map *)&(__vf_map_receiver), &__vf_k); ${option_result}; })'
 			typ: option_value_type
 		}
 	}
 	return FastcRenderedExpression{
-		source: '({ ${key_type} __v_fastc_map_key = (${key_source}); ${value_type} *__v_fastc_map_value = (${value_type} *)builtin__map_get_check((map *)&(${map_source}), &__v_fastc_map_key); ${option_result}; })'
+		source: '({ ${key_type} __vf_k = (${key_source}); ${value_type} *__vf_mv = (${value_type} *)builtin__map_get_check((map *)&(${map_source}), &__vf_k); ${option_result}; })'
 		typ: option_value_type
 	}
 }
@@ -3855,17 +3859,17 @@ fn (g &Parser) render_slice_option_expression(tokens []FastcExpressionToken) ?Fa
 		g.render_membership_candidate(slice_tokens[open + 1..range_index], 'int') or { return none }
 	}
 	high := if range_index + 1 == close {
-		'__v_fastc_slice_receiver.len'
+		'__vf_slice_receiver.len'
 	} else {
 		g.render_membership_candidate(slice_tokens[range_index + 1..close], 'int') or { return none }
 	}
 	slice_value := if is_string {
-		'builtin__string_substr(__v_fastc_slice_receiver, __v_fastc_slice_low, __v_fastc_slice_high)'
+		'builtin__string_substr(__vf_slice_receiver, __vf_slice_low, __vf_slice_high)'
 	} else {
-		'builtin__array_slice(__v_fastc_slice_receiver, __v_fastc_slice_low, __v_fastc_slice_high)'
+		'builtin__array_slice(__vf_slice_receiver, __vf_slice_low, __vf_slice_high)'
 	}
 	return FastcRenderedExpression{
-		source: '({ ${value_type} __v_fastc_slice_receiver = (${receiver_source}); int __v_fastc_slice_low = (${low}); int __v_fastc_slice_high = (${high}); bool __v_fastc_slice_ok = __v_fastc_slice_low >= 0 && __v_fastc_slice_low <= __v_fastc_slice_high && __v_fastc_slice_high <= __v_fastc_slice_receiver.len; ${value_type} __v_fastc_slice_value = __v_fastc_slice_ok ? (${slice_value}) : (${value_type}){0}; (Option){.data=__v_fastc_slice_ok ? v_fastc_interface_box(&__v_fastc_slice_value, sizeof(${value_type})) : NULL, .state=__v_fastc_slice_ok ? 0 : 2}; })'
+		source: '({ ${value_type} __vf_slice_receiver = (${receiver_source}); int __vf_slice_low = (${low}); int __vf_slice_high = (${high}); bool __vf_slice_ok = __vf_slice_low >= 0 && __vf_slice_low <= __vf_slice_high && __vf_slice_high <= __vf_slice_receiver.len; ${value_type} __vf_slice_value = __vf_slice_ok ? (${slice_value}) : (${value_type}){0}; (Option){.data=__vf_slice_ok ? v_fastc_interface_box(&__vf_slice_value, sizeof(${value_type})) : NULL, .state=__vf_slice_ok ? 0 : 2}; })'
 		typ: value_type
 	}
 }
@@ -3905,7 +3909,7 @@ fn (g &Parser) render_array_lookup_option_expression(tokens []FastcExpressionTok
 		// `at_with_check`), read from the `string`'s `.str`/`.len` payload.
 		string_source := if base_type.ends_with('*') { '*(${base_source})' } else { base_source }
 		return FastcRenderedExpression{
-			source: '({ int __v_fastc_str_index = (${index_source}); string __v_fastc_str = (${string_source}); bool __v_fastc_str_missing = __v_fastc_str_index < 0 || __v_fastc_str_index >= __v_fastc_str.len; u8 *__v_fastc_str_value = __v_fastc_str_missing ? NULL : (u8 *)(__v_fastc_str.str + __v_fastc_str_index); (Option){.data=__v_fastc_str_value, .state=__v_fastc_str_missing ? 2 : 0}; })'
+			source: '({ int __vf_str_index = (${index_source}); string __vf_str = (${string_source}); bool __vf_str_missing = __vf_str_index < 0 || __vf_str_index >= __vf_str.len; u8 *__vf_str_value = __vf_str_missing ? NULL : (u8 *)(__vf_str.str + __vf_str_index); (Option){.data=__vf_str_value, .state=__vf_str_missing ? 2 : 0}; })'
 			typ: 'u8'
 		}
 	}
@@ -3915,7 +3919,7 @@ fn (g &Parser) render_array_lookup_option_expression(tokens []FastcExpressionTok
 	element_type := g.array_element_type(base_type) or { return none }
 	array_source := if base_type.ends_with('*') { '*(${base_source})' } else { base_source }
 	return FastcRenderedExpression{
-		source: '({ int __v_fastc_array_index = (${index_source}); ${base_type.trim_right('*')} __v_fastc_array = (${array_source}); bool __v_fastc_array_missing = __v_fastc_array_index < 0 || __v_fastc_array_index >= __v_fastc_array.len; ${element_type} *__v_fastc_array_value = __v_fastc_array_missing ? NULL : (${element_type} *)((byteptr)__v_fastc_array.data + (usize)__v_fastc_array_index * (usize)__v_fastc_array.element_size); (Option){.data=__v_fastc_array_value, .state=__v_fastc_array_missing ? 2 : 0}; })'
+		source: '({ int __vf_array_index = (${index_source}); ${base_type.trim_right('*')} __vf_array = (${array_source}); bool __vf_array_missing = __vf_array_index < 0 || __vf_array_index >= __vf_array.len; ${element_type} *__vf_array_value = __vf_array_missing ? NULL : (${element_type} *)((byteptr)__vf_array.data + (usize)__vf_array_index * (usize)__vf_array.element_size); (Option){.data=__vf_array_value, .state=__vf_array_missing ? 2 : 0}; })'
 		typ: element_type
 	}
 }
@@ -4014,7 +4018,7 @@ fn (g &Parser) render_append_expression(tokens []FastcExpressionToken, rendered_
 	if rerendered := g.render_call_argument_expression(right_tokens, expected_right_type) {
 		right_source = rerendered
 	}
-	temporary := '__v_fastc_append_value'
+	temporary := '__vf_append_value'
 	if left_tokens.len >= 4 && left_tokens.last().tok == .rsbr {
 		mut open := -1
 		mut bracket_depth := 0
@@ -4066,11 +4070,11 @@ fn (g &Parser) render_append_expression(tokens []FastcExpressionToken, rendered_
 					} else {
 						'(${value_type}){0}'
 					}
-					left_source = '({ map *__v_fastc_append_map_addr = ${map_address}; ${key_type} __v_fastc_append_map_key = (${key_source}); ${value_type} *__v_fastc_append_map_value = (${value_type} *)builtin__map_get_check(__v_fastc_append_map_addr, &__v_fastc_append_map_key); if (__v_fastc_append_map_value == NULL) { ${value_type} __v_fastc_append_map_empty = ${map_empty}; builtin__map_set(__v_fastc_append_map_addr, &__v_fastc_append_map_key, &__v_fastc_append_map_empty); __v_fastc_append_map_value = (${value_type} *)builtin__map_get_check(__v_fastc_append_map_addr, &__v_fastc_append_map_key); } __v_fastc_append_map_value; })'
+					left_source = '({ map *__vf_append_map_addr = ${map_address}; ${key_type} __vf_append_map_key = (${key_source}); ${value_type} *__vf_append_map_value = (${value_type} *)builtin__map_get_check(__vf_append_map_addr, &__vf_append_map_key); if (__vf_append_map_value == NULL) { ${value_type} __vf_append_map_empty = ${map_empty}; builtin__map_set(__vf_append_map_addr, &__vf_append_map_key, &__vf_append_map_empty); __vf_append_map_value = (${value_type} *)builtin__map_get_check(__vf_append_map_addr, &__vf_append_map_key); } __vf_append_map_value; })'
 					map_push := if is_array_append {
-						'${value_type} ${temporary} = (${right_source}); ${value_type} *__v_fastc_append_map_target = ${left_source}; builtin__array_push_many((array *)__v_fastc_append_map_target, ${temporary}.data, ${temporary}.len);'
+						'${value_type} ${temporary} = (${right_source}); ${value_type} *__vf_append_map_target = ${left_source}; builtin__array_push_many((array *)__vf_append_map_target, ${temporary}.data, ${temporary}.len);'
 					} else {
-						'${element_type} ${temporary} = (${right_source}); ${value_type} *__v_fastc_append_map_target = ${left_source}; builtin__array_push((array *)__v_fastc_append_map_target, &${temporary});'
+						'${element_type} ${temporary} = (${right_source}); ${value_type} *__vf_append_map_target = ${left_source}; builtin__array_push((array *)__vf_append_map_target, &${temporary});'
 					}
 					return FastcRenderedExpression{
 						source: '({ ${map_push} 0; })'
@@ -4101,12 +4105,12 @@ fn (g &Parser) render_append_expression(tokens []FastcExpressionToken, rendered_
 					target := '(${left_type.trim_right('*')} *)builtin__array_get(${array_value}, ${index_source})'
 					if is_array_append {
 						return FastcRenderedExpression{
-							source: '({ ${left_type.trim_right('*')} ${temporary} = (${right_source}); ${left_type.trim_right('*')} *__v_fastc_append_array_target = ${target}; builtin__array_push_many((array *)__v_fastc_append_array_target, ${temporary}.data, ${temporary}.len); 0; })'
+							source: '({ ${left_type.trim_right('*')} ${temporary} = (${right_source}); ${left_type.trim_right('*')} *__vf_append_array_target = ${target}; builtin__array_push_many((array *)__vf_append_array_target, ${temporary}.data, ${temporary}.len); 0; })'
 							typ: 'void'
 						}
 					}
 					return FastcRenderedExpression{
-						source: '({ ${element_type} ${temporary} = (${right_source}); ${left_type.trim_right('*')} *__v_fastc_append_array_target = ${target}; builtin__array_push((array *)__v_fastc_append_array_target, &${temporary}); 0; })'
+						source: '({ ${element_type} ${temporary} = (${right_source}); ${left_type.trim_right('*')} *__vf_append_array_target = ${target}; builtin__array_push((array *)__vf_append_array_target, &${temporary}); 0; })'
 						typ: 'void'
 					}
 				}
@@ -4157,8 +4161,8 @@ fn (g &Parser) render_append_expression(tokens []FastcExpressionToken, rendered_
 				} else {
 					base_source
 				}
-				arr_tmp := '__v_fastc_append_last_array'
-				elem_tmp := '__v_fastc_append_last_elem'
+				arr_tmp := '__vf_append_last_array'
+				elem_tmp := '__vf_append_last_elem'
 				norm_elem := fastc_normalize_inferred_type(elem_type)
 				index := if method == 'last' { '${arr_tmp}.len - 1' } else { '0' }
 				// No trailing field: the element itself is the array; otherwise the target is the
@@ -4200,7 +4204,7 @@ fn (g &Parser) render_append_expression(tokens []FastcExpressionToken, rendered_
 		}
 	}
 	return FastcRenderedExpression{
-		source: '({ __typeof__((${right_source})) ${temporary} = (${right_source}); builtin__array_push((array *)&(${left_source}), &${temporary}); 0; })'
+		source: '({ ${g.declaration_c_type(element_type, right_source)} ${temporary} = (${right_source}); builtin__array_push((array *)&(${left_source}), &${temporary}); 0; })'
 		typ: 'void'
 	}
 }
@@ -4337,7 +4341,7 @@ fn (g &Parser) render_option_propagation(inner_tokens []FastcExpressionToken) ?F
 		inner_source = pointer_members.source
 	}
 	value_type := g.option_value_type_for_expression(inner_tokens)
-	temporary := '__v_fastc_option_propagate'
+	temporary := '__vf_op'
 	failure := if g.in_main {
 		deferred := g.deferred_scopes_source()
 		'${deferred} builtin__panic_result_not_set(builtin__IError_msg(${temporary}.err));'
@@ -4520,8 +4524,8 @@ fn (g &Parser) render_method_receiver_expression(tokens []FastcExpressionToken) 
 // `receiver_type` (already rendered as `receiver_source`).
 fn (g &Parser) fastc_sumtype_field_switch_source(receiver_type string, receiver_source string, field_name string, field_type string) ?string {
 	access := if receiver_type.ends_with('*') { '->' } else { '.' }
-	subject := '__v_fastc_sumfield'
-	result_var := '__v_fastc_sumfield_result'
+	subject := '__vf_sumfield'
+	result_var := '__vf_sumfield_result'
 	mut cases := []string{}
 	for variant in g.sum_type_leaf_variants(receiver_type) {
 		field := g.struct_field_metadata(variant, field_name) or { return none }
@@ -4538,8 +4542,8 @@ fn (g &Parser) fastc_sumtype_field_switch_source(receiver_type string, receiver_
 // occur at runtime, so any coincidental extra case is dead. Mirrors the sum-type field switch.
 fn (g &Parser) fastc_interface_field_switch_source(receiver_type string, receiver_source string, field_name string, field_type string) ?string {
 	access := if receiver_type.ends_with('*') { '->' } else { '.' }
-	subject := '__v_fastc_ifacefield'
-	result_var := '__v_fastc_ifacefield_result'
+	subject := '__vf_ifacefield'
+	result_var := '__vf_ifacefield_result'
 	normalized_field_type := fastc_normalize_inferred_type(field_type)
 	mut cases := []string{}
 	for type_key, kind in g.declared_kinds {
@@ -4702,8 +4706,8 @@ fn (g &Parser) render_sumtype_common_field_assignment(tokens []FastcExpressionTo
 		return none
 	}
 	access := if receiver_type.ends_with('*') { '->' } else { '.' }
-	subject := '__v_fastc_sumfield_assign'
-	value_var := '__v_fastc_sumfield_assign_value'
+	subject := '__vf_sumfield_assign'
+	value_var := '__vf_sumfield_assign_value'
 	mut cases := []string{}
 	for variant in g.sum_type_leaf_variants(receiver_type) {
 		field := g.struct_field_metadata(variant, field_name) or { return none }

--- a/vlib/v3/gen/fastc/render_calls.v
+++ b/vlib/v3/gen/fastc/render_calls.v
@@ -325,7 +325,7 @@ fn (g &Parser) render_flag_method_expression(tokens []FastcExpressionToken, rend
 		for argument_index < call_end {
 			if tokens[argument_index].tok == .dot && argument_index + 1 < call_end && tokens[argument_index + 1].tok == .name {
 				// The raw renderer mangles a `.member` shorthand whose name is a C keyword
-				// (`.unsigned` -> `.__v_fastc_keyword_unsigned`); match that spelling so the
+				// (`.unsigned` -> `.__vf_keyword_unsigned`); match that spelling so the
 				// needle still finds the call. The enum constant itself keeps the raw name.
 				raw_argument.write_string('.${fastc_c_identifier(tokens[argument_index + 1].lit)}')
 				c_argument.write_string('${fastc_c_declared_type_name(receiver_key)}__${tokens[argument_index + 1].lit}')
@@ -418,6 +418,7 @@ fn (g &Parser) render_static_call_expression(tokens []FastcExpressionToken, rend
 		}
 		type_key := function_key.all_before_last('.')
 		owner := fastc_c_declared_type_name(type_key)
+		method_c_name := g.c_function_name_or(function_key, fastc_method_c_name_for_key(type_key, tokens[i].lit))
 		call_start := if i >= 4 && tokens[i - 4].tok == .name && tokens[i - 3].tok == .dot {
 			i - 4
 		} else {
@@ -445,7 +446,7 @@ fn (g &Parser) render_static_call_expression(tokens []FastcExpressionToken, rend
 				named_initializer := g.render_named_struct_initializer(signature.parameter_types[named_start], call_args[named_start..]) or { '' }
 				if named_initializer != '' {
 					rendered_arguments << named_initializer
-					call_source := '${fastc_method_c_name_for_key(type_key, tokens[i].lit)}(${rendered_arguments.join(',')})'
+					call_source := '${method_c_name}(${rendered_arguments.join(',')})'
 					if call_start == 0 && call_end == tokens.len - 1 {
 						return FastcRenderedExpression{
 							source: call_source
@@ -475,7 +476,7 @@ fn (g &Parser) render_static_call_expression(tokens []FastcExpressionToken, rend
 				rendered_arguments << rendered_argument
 			}
 			if arguments_ok {
-				call_source := '${fastc_method_c_name_for_key(type_key, tokens[i].lit)}(${rendered_arguments.join(',')})'
+				call_source := '${method_c_name}(${rendered_arguments.join(',')})'
 				if call_start == 0 && call_end == tokens.len - 1 {
 					return FastcRenderedExpression{
 						source: call_source
@@ -500,7 +501,7 @@ fn (g &Parser) render_static_call_expression(tokens []FastcExpressionToken, rend
 		if !rendered.contains(needle) {
 			continue
 		}
-		rendered = rendered.replace(needle, '${fastc_method_c_name_for_key(type_key, tokens[i].lit)}(')
+		rendered = rendered.replace(needle, '${method_c_name}(')
 		result_type = signature.return_type
 		changed = true
 	}
@@ -760,7 +761,7 @@ fn (g &Parser) render_mutable_map_value_pointer(tokens []FastcExpressionToken) ?
 		empty_value = '(${value_type})builtin__new_map(sizeof(${fastc_runtime_c_type(nested_key_type)}), sizeof(${fastc_runtime_c_type(nested_value_type)}), &${hash_fn}, &${eq_fn}, &${clone_fn}, &${free_fn})'
 	}
 	return FastcRenderedExpression{
-		source: '({ ${key_type} __v_fastc_nested_map_key = (${key_source}); ${value_type} *__v_fastc_nested_map_value = (${value_type} *)builtin__map_get_check((map *)(${map_address}), &__v_fastc_nested_map_key); if (__v_fastc_nested_map_value == NULL) { ${value_type} __v_fastc_nested_map_empty = ${empty_value}; builtin__map_set((map *)(${map_address}), &__v_fastc_nested_map_key, &__v_fastc_nested_map_empty); __v_fastc_nested_map_value = (${value_type} *)builtin__map_get_check((map *)(${map_address}), &__v_fastc_nested_map_key); } __v_fastc_nested_map_value; })'
+		source: '({ ${key_type} __vf_nested_map_key = (${key_source}); ${value_type} *__vf_nested_map_value = (${value_type} *)builtin__map_get_check((map *)(${map_address}), &__vf_nested_map_key); if (__vf_nested_map_value == NULL) { ${value_type} __vf_nested_map_empty = ${empty_value}; builtin__map_set((map *)(${map_address}), &__vf_nested_map_key, &__vf_nested_map_empty); __vf_nested_map_value = (${value_type} *)builtin__map_get_check((map *)(${map_address}), &__vf_nested_map_key); } __vf_nested_map_value; })'
 		typ: value_type
 	}
 }

--- a/vlib/v3/gen/fastc/render_method_calls.v
+++ b/vlib/v3/gen/fastc/render_method_calls.v
@@ -88,7 +88,7 @@ fn (g &Parser) render_missing_call_arguments(tokens []FastcExpressionToken) ?Fas
 			spread := g.render_call_argument_expression(call_args[fixed_arguments][1..], variadic_type) or { return none }
 			c_arguments << spread
 			return FastcRenderedExpression{
-				source: '${fastc_c_function_name_for_key(function_key)}(${c_arguments.join(',')})'
+				source: '${g.c_function_name_for_key(function_key)}(${c_arguments.join(',')})'
 				typ: signature.return_type
 			}
 		}
@@ -240,11 +240,12 @@ fn (g &Parser) render_method_call_expression(tokens []FastcExpressionToken, rend
 			}
 			access := if receiver_type.ends_with('*') { '->' } else { '.' }
 			comparison := if fastc_trim_pointer_suffix(g.underlying_alias_type(element_type)) == 'string' {
-				'builtin__string_eq(__v_fastc_contains_item, ((${element_type} *)__v_fastc_contains_collection${access}data)[__v_fastc_contains_index])'
+				'builtin__string_eq(__vf_contains_item, ((${element_type} *)__vf_contains_collection${access}data)[__vf_contains_index])'
 			} else {
-				'(__v_fastc_contains_item == ((${element_type} *)__v_fastc_contains_collection${access}data)[__v_fastc_contains_index])'
+				'(__vf_contains_item == ((${element_type} *)__vf_contains_collection${access}data)[__vf_contains_index])'
 			}
-			call_source := '({ ${element_type} __v_fastc_contains_item = (${argument}); __typeof__((${receiver.source})) __v_fastc_contains_collection = (${receiver.source}); bool __v_fastc_contains_found = false; for (int __v_fastc_contains_index = 0; __v_fastc_contains_index < __v_fastc_contains_collection${access}len; __v_fastc_contains_index++) { if (${comparison}) { __v_fastc_contains_found = true; break; } } __v_fastc_contains_found; })'
+			receiver_decl_type := g.declaration_c_type(receiver_type, receiver.source)
+			call_source := '({ ${element_type} __vf_contains_item = (${argument}); ${receiver_decl_type} __vf_contains_collection = (${receiver.source}); bool __vf_contains_found = false; for (int __vf_contains_index = 0; __vf_contains_index < __vf_contains_collection${access}len; __vf_contains_index++) { if (${comparison}) { __vf_contains_found = true; break; } } __vf_contains_found; })'
 			if receiver_start == 0 && call_end == tokens.len - 1 {
 				return FastcRenderedExpression{
 					source: call_source
@@ -274,21 +275,22 @@ fn (g &Parser) render_method_call_expression(tokens []FastcExpressionToken, rend
 				}
 				access := if receiver_type.ends_with('*') { '->' } else { '.' }
 				loop_init := if tokens[i].lit == 'last_index' {
-					'__v_fastc_index_collection${access}len - 1'
+					'__vf_index_collection${access}len - 1'
 				} else {
 					'0'
 				}
 				loop_condition := if tokens[i].lit == 'last_index' {
-					'__v_fastc_index_cursor >= 0'
+					'__vf_index_cursor >= 0'
 				} else {
-					'__v_fastc_index_cursor < __v_fastc_index_collection${access}len'
+					'__vf_index_cursor < __vf_index_collection${access}len'
 				}
 				loop_step := if tokens[i].lit == 'last_index' {
-					'__v_fastc_index_cursor--'
+					'__vf_index_cursor--'
 				} else {
-					'__v_fastc_index_cursor++'
+					'__vf_index_cursor++'
 				}
-				call_source := '({ ${element_type} __v_fastc_index_item = (${argument}); __typeof__((${receiver.source})) __v_fastc_index_collection = (${receiver.source}); int __v_fastc_index_result = -1; for (int __v_fastc_index_cursor = ${loop_init}; ${loop_condition}; ${loop_step}) { if (builtin__string_eq(__v_fastc_index_item, ((${element_type} *)__v_fastc_index_collection${access}data)[__v_fastc_index_cursor])) { __v_fastc_index_result = __v_fastc_index_cursor; break; } } __v_fastc_index_result; })'
+				receiver_decl_type := g.declaration_c_type(receiver_type, receiver.source)
+				call_source := '({ ${element_type} __vf_index_item = (${argument}); ${receiver_decl_type} __vf_index_collection = (${receiver.source}); int __vf_index_result = -1; for (int __vf_index_cursor = ${loop_init}; ${loop_condition}; ${loop_step}) { if (builtin__string_eq(__vf_index_item, ((${element_type} *)__vf_index_collection${access}data)[__vf_index_cursor])) { __vf_index_result = __vf_index_cursor; break; } } __vf_index_result; })'
 				if receiver_start == 0 && call_end == tokens.len - 1 {
 					return FastcRenderedExpression{
 						source: call_source
@@ -321,7 +323,8 @@ fn (g &Parser) render_method_call_expression(tokens []FastcExpressionToken, rend
 				} else {
 					receiver.source
 				}
-				wait_all := '({ __typeof__((${recv_src})) __v_fastc_threads = (${recv_src}); ${result_type} __v_fastc_results = (${result_type})builtin____new_array(0, __v_fastc_threads.len, sizeof(${value_type})); for (int __v_fastc_ti = 0; __v_fastc_ti < __v_fastc_threads.len; __v_fastc_ti++) { ${value_type} __v_fastc_tv = ${wait_helper}(((${element} *)__v_fastc_threads.data)[__v_fastc_ti]); builtin__array_push((array *)&__v_fastc_results, &__v_fastc_tv); } __v_fastc_results; })'
+				receiver_decl_type := g.declaration_c_type(receiver_type.trim_right('*'), recv_src)
+				wait_all := '({ ${receiver_decl_type} __vf_threads = (${recv_src}); ${result_type} __vf_results = (${result_type})builtin____new_array(0, __vf_threads.len, sizeof(${value_type})); for (int __vf_ti = 0; __vf_ti < __vf_threads.len; __vf_ti++) { ${value_type} __vf_tv = ${wait_helper}(((${element} *)__vf_threads.data)[__vf_ti]); builtin__array_push((array *)&__vf_results, &__vf_tv); } __vf_results; })'
 				if receiver_start == 0 && wait_end == tokens.len - 1 {
 					return FastcRenderedExpression{
 						source: wait_all
@@ -677,7 +680,7 @@ fn (g &Parser) render_method_call_expression(tokens []FastcExpressionToken, rend
 			effective_receiver_source
 		}
 		has_arguments := call_end > i + 2
-		method_c_name := fastc_method_c_name(signature.module_name, expected_receiver, tokens[i].lit)
+		method_c_name := g.c_function_name_or(method_key, fastc_method_c_name(signature.module_name, expected_receiver, tokens[i].lit))
 		mut direct_arguments := []string{}
 		if has_arguments {
 			call_args := fastc_call_arguments(tokens, i + 1, call_end) or { continue }

--- a/vlib/v3/gen/fastc/render_struct_literal.v
+++ b/vlib/v3/gen/fastc/render_struct_literal.v
@@ -34,8 +34,9 @@ fn (g &Parser) render_struct_literal_field_value(value_tokens []FastcExpressionT
 				rendered_item := g.render_call_argument_expression(item, fixed_element_type) or {
 					return none
 				}
-				temporary := '__v_fastc_struct_field_${temporary_start + initializers.len}'
-				initializers << '__typeof__((${rendered_item})) ${temporary} = (${rendered_item});'
+				temporary := '__vf_sf_${temporary_start + initializers.len}'
+				declaration_type := g.declaration_c_type(fixed_element_type, rendered_item)
+				initializers << '${declaration_type} ${temporary} = (${rendered_item});'
 				values << temporary
 			}
 			joined_values := values.join(',')
@@ -57,7 +58,7 @@ fn (g &Parser) render_struct_literal_field_value(value_tokens []FastcExpressionT
 		}
 		return FastcStructLiteralFieldValue{
 			field_value: value
-			fixed_array_copy: 'memcpy(__v_fastc_struct_fixed.${c_field_name}, ${copy_source}, sizeof(__v_fastc_struct_fixed.${c_field_name}));'
+			fixed_array_copy: 'memcpy(__vf_struct_fixed.${c_field_name}, ${copy_source}, sizeof(__vf_struct_fixed.${c_field_name}));'
 			is_fixed_array: true
 		}
 	}
@@ -68,11 +69,11 @@ fn (g &Parser) render_struct_literal_field_value(value_tokens []FastcExpressionT
 	} else {
 		g.render_call_argument_expression(value_tokens, expected_type) or { return none }
 	}
-	temporary := '__v_fastc_struct_field_${temporary_start}'
-	// TinyCC cannot `__typeof__` a statement-expression that declares locals or ends in a
-	// designated compound literal (`chan T{cap: …}`, an `or`-block); the field type is known, so
-	// name it directly in that case rather than inferring it back from the value.
-	field_decl_type := if expected_type != '' && value.starts_with('({') {
+	temporary := '__vf_sf_${temporary_start}'
+	// Prefer the declared field type. Besides handling statement expressions that
+	// TinyCC cannot inspect with `__typeof__`, this avoids spelling a potentially
+	// large initializer twice in the generated C.
+	field_decl_type := if expected_type != '' {
 		fastc_normalize_inferred_type(expected_type)
 	} else {
 		'__typeof__((${value}))'
@@ -164,7 +165,7 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 				}
 				rendered_item := g.render_call_argument_expression(item, field.typ) or { return none }
 				values << if field.is_shared_pointer {
-					'({ ${field.typ} __v_fastc_shared_field_value = (${rendered_item}); (${field.typ}*)v_fastc_interface_box(&__v_fastc_shared_field_value, sizeof(${field.typ})); })'
+					'({ ${field.typ} __vf_shared_field_value = (${rendered_item}); (${field.typ}*)v_fastc_interface_box(&__vf_shared_field_value, sizeof(${field.typ})); })'
 				} else {
 					rendered_item
 				}
@@ -386,18 +387,18 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 			}
 			// `index` names the current element position inside an `init:` closure; bind it
 			// to the loop counter so an expression like `init: index` fills 0, 1, 2, ….
-			value_source = '({ ${explicit_initializers.join(' ')} ${array_type} __v_fastc_array_init = ${base}; for (int __v_fastc_array_index = 0; __v_fastc_array_index < __v_fastc_array_init.len; __v_fastc_array_index++) { int index = __v_fastc_array_index; (void)index; ((${element_type} *)__v_fastc_array_init.data)[__v_fastc_array_index] = (${inner}); } __v_fastc_array_init; })'
+			value_source = '({ ${explicit_initializers.join(' ')} ${array_type} __vf_array_init = ${base}; for (int __vf_array_index = 0; __vf_array_index < __vf_array_init.len; __vf_array_index++) { int index = __vf_array_index; (void)index; ((${element_type} *)__vf_array_init.data)[__vf_array_index] = (${inner}); } __vf_array_init; })'
 		} else if inner_array_element_type != '' {
 			// A zeroed inner dynamic array has element_size == 0, so appending to an
 			// element of `[][]T{len: n}` copies no data. Construct a valid empty inner
 			// array for every outer element, as the main C backend does.
 			inner_default := '((${element_type})builtin____new_array(0,0,sizeof(${inner_array_element_type})))'
-			value_source = '({ ${explicit_initializers.join(' ')} ${array_type} __v_fastc_array_init = ${base}; for (int __v_fastc_array_index = 0; __v_fastc_array_index < __v_fastc_array_init.len; __v_fastc_array_index++) { ((${element_type} *)__v_fastc_array_init.data)[__v_fastc_array_index] = ${inner_default}; } __v_fastc_array_init; })'
+			value_source = '({ ${explicit_initializers.join(' ')} ${array_type} __vf_array_init = ${base}; for (int __vf_array_index = 0; __vf_array_index < __vf_array_init.len; __vf_array_index++) { ((${element_type} *)__vf_array_init.data)[__vf_array_index] = ${inner_default}; } __vf_array_init; })'
 		} else if explicit_initializers.len > 0 {
 			value_source = '({ ${explicit_initializers.join(' ')} ${base}; })'
 		}
 		if c_type.ends_with('*') {
-			value_source = '({ ${array_type} __v_fastc_array_pointer_value = (${value_source}); (${c_type})v_fastc_interface_box(&__v_fastc_array_pointer_value, sizeof(${array_type})); })'
+			value_source = '({ ${array_type} __vf_array_pointer_value = (${value_source}); (${c_type})v_fastc_interface_box(&__vf_array_pointer_value, sizeof(${array_type})); })'
 		}
 		return FastcRenderedExpression{
 			source: value_source
@@ -407,19 +408,19 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 	if update_source != '' {
 		mut assignments := []string{cap: rendered_fields.len}
 		for field in rendered_fields {
-			assignments << '__v_fastc_struct_update${field};'
+			assignments << '__vf_struct_update${field};'
 		}
 		if c_type.ends_with('*') {
 			base_type := c_type.trim_right('*')
 			copy_statements := fixed_array_copies.join(' ')
 			return FastcRenderedExpression{
-				source: '({ ${base_type} __v_fastc_struct_update = *(${update_source}); ${explicit_initializers.join(' ')} ${assignments.join(' ')} ${copy_statements.replace('__v_fastc_struct_fixed', '__v_fastc_struct_update')} (${c_type})v_fastc_interface_box(&__v_fastc_struct_update, sizeof(${base_type})); })'
+				source: '({ ${base_type} __vf_struct_update = *(${update_source}); ${explicit_initializers.join(' ')} ${assignments.join(' ')} ${copy_statements.replace('__vf_struct_fixed', '__vf_struct_update')} (${c_type})v_fastc_interface_box(&__vf_struct_update, sizeof(${base_type})); })'
 				typ: c_type
 			}
 		}
 		copy_statements := fixed_array_copies.join(' ')
 		return FastcRenderedExpression{
-			source: '({ ${c_type} __v_fastc_struct_update = (${update_source}); ${explicit_initializers.join(' ')} ${assignments.join(' ')} ${copy_statements.replace('__v_fastc_struct_fixed', '__v_fastc_struct_update')} __v_fastc_struct_update; })'
+			source: '({ ${c_type} __vf_struct_update = (${update_source}); ${explicit_initializers.join(' ')} ${assignments.join(' ')} ${copy_statements.replace('__vf_struct_fixed', '__vf_struct_update')} __vf_struct_update; })'
 			typ: c_type
 		}
 	}
@@ -429,9 +430,9 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 			return rendered
 		}
 		access := if c_type.ends_with('*') { '->' } else { '.' }
-		copies := fixed_array_copies.join(' ').replace('__v_fastc_struct_fixed.', '__v_fastc_struct_with_fixed${access}')
+		copies := fixed_array_copies.join(' ').replace('__vf_struct_fixed.', '__vf_struct_with_fixed${access}')
 		return FastcRenderedExpression{
-			source: '({ ${c_type} __v_fastc_struct_with_fixed = (${rendered.source}); ${copies} __v_fastc_struct_with_fixed; })'
+			source: '({ ${c_type} __vf_struct_with_fixed = (${rendered.source}); ${copies} __vf_struct_with_fixed; })'
 			typ: c_type
 		}
 	}
@@ -444,12 +445,12 @@ fn (g &Parser) render_struct_literal_expression(tokens []FastcExpressionToken) ?
 		base_type := c_type.trim_right('*')
 		copies := fixed_array_copies.join(' ')
 		result := if c_type.ends_with('*') {
-			'(${c_type})v_fastc_interface_box(&__v_fastc_struct_fixed, sizeof(${base_type}))'
+			'(${c_type})v_fastc_interface_box(&__vf_struct_fixed, sizeof(${base_type}))'
 		} else {
-			'__v_fastc_struct_fixed'
+			'__vf_struct_fixed'
 		}
 		return FastcRenderedExpression{
-			source: '({ ${explicit_initializers.join(' ')} ${base_type} __v_fastc_struct_fixed = (${base_type}){${rendered_fields.join(',')}}; ${copies} ${result}; })'
+			source: '({ ${explicit_initializers.join(' ')} ${base_type} __vf_struct_fixed = (${base_type}){${rendered_fields.join(',')}}; ${copies} ${result}; })'
 			typ: c_type
 		}
 	}

--- a/vlib/v3/gen/fastc/scan.c.v
+++ b/vlib/v3/gen/fastc/scan.c.v
@@ -1,0 +1,17 @@
+module fastc
+
+// fastc_next_underscore uses libc's vectorized byte search to skip ordinary
+// generated C text while collecting reachable function names.
+@[inline]
+fn fastc_next_underscore(text string, start int, end int) int {
+	if start >= end {
+		return end
+	}
+	unsafe {
+		found := C.memchr(text.str + start, `_`, end - start)
+		if found == voidptr(0) {
+			return end
+		}
+		return int(&u8(found) - text.str)
+	}
+}

--- a/vlib/v3/gen/fastc/signatures.v
+++ b/vlib/v3/gen/fastc/signatures.v
@@ -1518,7 +1518,7 @@ fn fastc_collect_veb_template_references(source_file FastcSourceFile, function_n
 		explicit_path = lookahead.lit.trim('\'"')
 	}
 	template_path := fastc_referenced_veb_template_path(source_file.path, function_name, explicit_path) or { return }
-	generated := fastc_veb_compile_template(template_path, '__v_fastc_reachability_template', 'ctx') or {
+	generated := fastc_veb_compile_template(template_path, '__vf_reachability_template', 'ctx') or {
 		return
 	}
 	fastc_collect_generated_template_references(generated, template_path, prefs, available_names, mut references)

--- a/vlib/v3/gen/fastc/source.v
+++ b/vlib/v3/gen/fastc/source.v
@@ -348,11 +348,35 @@ fn fastc_resolve_source_files_deferring_memo(paths []string, prefs &pref.Prefere
 	}
 	timer.mark('resolve.imports')
 	if memo_path != '' {
-		memo_entry_paths := if prefs.building_v { paths } else { []string{} }
-		pending_memo_store = fastc_start_memo_store(memo_path, memo_text, sources, builtin_dir, memo_lookup_modules, memo_lookup_sources, prefs, module_path_cache, module_dir_files, memo_entry_paths, real_path_cache, entry_files, preloaded)
+		// An unchanged source set would serialize the same memo body and return
+		// without writing it. Recognize that common warm path from the stamps the
+		// preload already collected, avoiding a second walk and string build.
+		if !fastc_resolve_memo_sources_unchanged(memo, sources, preloaded) {
+			memo_entry_paths := if prefs.building_v { paths } else { []string{} }
+			pending_memo_store = fastc_start_memo_store(memo_path, memo_text, sources, builtin_dir, memo_lookup_modules, memo_lookup_sources, prefs, module_path_cache, module_dir_files, memo_entry_paths, real_path_cache, entry_files, preloaded)
+		}
 		timer.mark('resolve.memo_store')
 	}
 	return sources, module_aliases
+}
+
+// fastc_resolve_memo_sources_unchanged reports whether the resolved files and
+// their versions are exactly the source sequence already recorded by `memo`.
+fn fastc_resolve_memo_sources_unchanged(memo FastcResolveMemo, sources []FastcSourceFile, preloaded map[string]FastcLoadedSource) bool {
+	if memo.files.len == 0 || memo.files.len != sources.len || memo.stamps.len != sources.len {
+		return false
+	}
+	for i, source_file in sources {
+		if memo.files[i] != source_file.path {
+			return false
+		}
+		loaded := preloaded[source_file.path] or { return false }
+		if loaded.stamp.size == 0 || loaded.stamp.mtime == 0
+			|| !fastc_same_stamp(memo.stamps[i], loaded.stamp) {
+			return false
+		}
+	}
+	return true
 }
 
 // FastcResolveMemo records what an earlier resolution of the same entry
@@ -1288,15 +1312,15 @@ fn fastc_sources_in_dependency_order(sources []FastcSourceFile) ![]FastcSourceFi
 
 // fastc_module_init_calls lists the `init` hooks of `ordered_sources`, which
 // must already be in module dependency order.
-fn fastc_module_init_calls(ordered_sources []FastcSourceFile, functions map[string]FastcFunctionSignature) ![]string {
-	return fastc_module_lifecycle_calls(ordered_sources, functions, 'init', false)
+fn fastc_module_init_calls(ordered_sources []FastcSourceFile, functions map[string]FastcFunctionSignature, function_c_names map[string]string) ![]string {
+	return fastc_module_lifecycle_calls(ordered_sources, functions, function_c_names, 'init', false)
 }
 
-fn fastc_module_cleanup_calls(ordered_sources []FastcSourceFile, functions map[string]FastcFunctionSignature) ![]string {
-	return fastc_module_lifecycle_calls(ordered_sources, functions, 'cleanup', true)
+fn fastc_module_cleanup_calls(ordered_sources []FastcSourceFile, functions map[string]FastcFunctionSignature, function_c_names map[string]string) ![]string {
+	return fastc_module_lifecycle_calls(ordered_sources, functions, function_c_names, 'cleanup', true)
 }
 
-fn fastc_module_lifecycle_calls(ordered_sources []FastcSourceFile, functions map[string]FastcFunctionSignature, hook_name string, reverse bool) ![]string {
+fn fastc_module_lifecycle_calls(ordered_sources []FastcSourceFile, functions map[string]FastcFunctionSignature, function_c_names map[string]string, hook_name string, reverse bool) ![]string {
 	mut seen_modules := map[string]bool{}
 	mut ordered_modules := []string{}
 	for source_file in ordered_sources {
@@ -1315,13 +1339,17 @@ fn fastc_module_lifecycle_calls(ordered_sources []FastcSourceFile, functions map
 			if signature.parameter_types.len > 0 {
 				return error('fastc parser does not support module `${hook_name}` with parameters in ${signature.path}')
 			}
-			calls << fastc_c_function_name(module_name, hook_name)
+			calls << if c_name := function_c_names[function_key] {
+				c_name
+			} else {
+				fastc_c_function_name(module_name, hook_name)
+			}
 		}
 	}
 	return calls
 }
 
-fn fastc_generate_startup_initializers(ordered_sources []FastcSourceFile, constant_initializers map[string]string, global_initializers map[string]string, module_init_calls []string) !string {
+fn fastc_generate_startup_initializers(ordered_sources []FastcSourceFile, constant_initializers map[string]string, global_initializers map[string]string, module_init_calls []string, function_c_names map[string]string) !string {
 	mut seen_modules := map[string]bool{}
 	mut out := strings.new_builder(1024)
 	for source_file in ordered_sources {
@@ -1334,7 +1362,12 @@ fn fastc_generate_startup_initializers(ordered_sources []FastcSourceFile, consta
 		global_initializer := global_initializers[module_name] or { '' }
 		out.write_string(constant_initializer)
 		out.write_string(global_initializer)
-		init_call := fastc_c_function_name(module_name, 'init')
+		function_key := fastc_function_key(module_name, 'init')
+		init_call := if c_name := function_c_names[function_key] {
+			c_name
+		} else {
+			fastc_c_function_name(module_name, 'init')
+		}
 		if init_call in module_init_calls {
 			out.writeln('\t${init_call}();')
 		}

--- a/vlib/v3/gen/fastc/spawn.v
+++ b/vlib/v3/gen/fastc/spawn.v
@@ -9,19 +9,26 @@ import v3.token
 // returns the packed result. Helpers are registered per call target and
 // deduplicated program-wide; the pthread runtime block is emitted only when a
 // program spawns.
-const fastc_thread_type_prefix = '__v_fastc_thread_'
+const fastc_thread_type_prefix = '__vf_thread_'
 
 const c_spawn_runtime = r'#include <pthread.h>
 '
 
-// fastc_name_key hex-encodes the original UTF-8 bytes. The readable sanitized
-// part of a generated name is lossy, so this C-safe key keeps names injective.
+// fastc_name_key preserves ASCII letters and digits and hex-escapes every
+// other UTF-8 byte. Escaping underscores too makes the result injective while
+// keeping ordinary type and function names much shorter than full hex.
 fn fastc_name_key(text string) string {
 	hex_digits := '0123456789abcdef'
-	mut encoded := strings.new_builder(text.len * 2)
+	mut encoded := strings.new_builder(text.len + 8)
 	for value in text.bytes() {
-		encoded.write_u8(hex_digits[value >> 4])
-		encoded.write_u8(hex_digits[value & 0x0f])
+		if (value >= `a` && value <= `z`) || (value >= `A` && value <= `Z`)
+			|| (value >= `0` && value <= `9`) {
+			encoded.write_u8(value)
+		} else {
+			encoded.write_u8(`_`)
+			encoded.write_u8(hex_digits[value >> 4])
+			encoded.write_u8(hex_digits[value & 0x0f])
+		}
 	}
 	return encoded.str()
 }
@@ -30,12 +37,11 @@ fn fastc_thread_type_name(value_type string) string {
 	if value_type in ['', 'void'] {
 		return '${fastc_thread_type_prefix}void'
 	}
-	sanitized := value_type.replace('*', '_ptr').replace(' ', '_').replace('.', '__')
-	return '${fastc_thread_type_prefix}k${fastc_name_key(value_type)}_${sanitized}'
+	return '${fastc_thread_type_prefix}k${fastc_name_key(value_type)}'
 }
 
 fn fastc_thread_wait_name(thread_type string) string {
-	return '__v_fastc_thread_wait_${thread_type.all_after(fastc_thread_type_prefix)}'
+	return '__vf_thread_wait_${thread_type.all_after(fastc_thread_type_prefix)}'
 }
 
 // read_spawn_expression parses `spawn callee(arguments)` eagerly at an
@@ -110,8 +116,7 @@ fn (mut g Parser) read_spawn_expression() !string {
 			} else {
 				receiver.source
 			}
-			method_target = fastc_method_c_name(method_signature.module_name, expected_receiver,
-				method_name)
+			method_target = g.c_function_name_or(method_key, fastc_method_c_name(method_signature.module_name, expected_receiver, method_name))
 			function_key = method_key
 			callee = method_name
 		} else {
@@ -272,9 +277,8 @@ fn (mut g Parser) read_spawn_expression() !string {
 		signature.return_type
 	}
 	thread_type := g.fastc_unclaimed_generated_name(fastc_thread_type_name(value_type))
-	start_name := g.fastc_unclaimed_generated_name(fastc_spawn_start_name(function_key))
-	g.register_spawn_helpers(function_key, thread_type, value_type, signature.parameter_types,
-		start_name, method_target)
+	start_name := g.fastc_unclaimed_generated_name('__vf_spawn_start_${g.fastc_spawn_target_stem(function_key)}')
+	g.register_spawn_helpers(function_key, thread_type, value_type, signature.parameter_types, start_name, method_target)
 	g.last_expression = []FastcExpressionToken{}
 	g.last_expression_type = thread_type
 	g.last_multi_return_types = []string{}
@@ -282,19 +286,25 @@ fn (mut g Parser) read_spawn_expression() !string {
 }
 
 fn fastc_spawn_start_name(function_key string) string {
-	return '__v_fastc_spawn_start_${fastc_spawn_target_stem(function_key)}'
+	return '__vf_spawn_start_${fastc_spawn_target_stem(function_key)}'
 }
 
-// fastc_spawn_target_stem puts the injective target key before the readable C
-// name. A collision suffix on one target therefore cannot equal another
-// target's natural generated name, and parallel file parsers choose alike.
+// fastc_spawn_target_stem uses an injective target key, so a collision suffix
+// on one target cannot equal another target's natural generated name and
+// parallel file parsers choose alike.
 fn fastc_spawn_target_stem(function_key string) string {
-	readable := fastc_c_identifier(fastc_c_function_name_for_key(function_key))
-	return 'k${fastc_name_key(function_key)}_${readable}'
+	return 'k${fastc_name_key(function_key)}'
+}
+
+fn (g &Parser) fastc_spawn_target_stem(function_key string) string {
+	if compact_name := g.function_c_names[function_key] {
+		return compact_name
+	}
+	return fastc_spawn_target_stem(function_key)
 }
 
 // fastc_unclaimed_generated_name screens a deterministic generated name
-// against the program's collected `__v_fastc_`-prefixed function and global C
+// against the program's collected `__vf_`-prefixed function and global C
 // names and its declared type spellings, suffixing until free. Both inputs
 // are frozen program-wide, so every file resolves the same name.
 fn (g &Parser) fastc_unclaimed_generated_name(base string) string {
@@ -367,9 +377,9 @@ fn (mut g Parser) register_spawn_helpers(function_key string, thread_type string
 	} else {
 		g.c_function_name_for_key(function_key)
 	}
-	target_stem := fastc_spawn_target_stem(function_key)
-	args_struct := g.fastc_unclaimed_generated_name('__v_fastc_spawn_args_${target_stem}')
-	run_name := g.fastc_unclaimed_generated_name('__v_fastc_spawn_run_${target_stem}')
+	target_stem := g.fastc_spawn_target_stem(function_key)
+	args_struct := g.fastc_unclaimed_generated_name('__vf_spawn_args_${target_stem}')
+	run_name := g.fastc_unclaimed_generated_name('__vf_spawn_run_${target_stem}')
 	mut fields := ''
 	if value_type != '' {
 		fields += '\t${value_type} result;\n'

--- a/vlib/v3/gen/fastc/stmt.v
+++ b/vlib/v3/gen/fastc/stmt.v
@@ -558,7 +558,8 @@ fn (mut g Parser) parse_match_statement() !bool {
 	smartcast_is_reference := subject_is_mut || subject_type.ends_with('*')
 	g.expect(.lcbr)!
 	subject_name := g.temporary_name('match')
-	g.write_line('__typeof__((${subject})) ${subject_name} = (${subject});')
+	subject_decl_type := g.declaration_c_type(subject_type, subject)
+	g.write_line('${subject_decl_type} ${subject_name} = (${subject});')
 	is_string := g.underlying_alias_type(subject_type).trim_right('*') == 'string'
 	// A sum type or interface subject dispatches on the boxed `_typ` tag; each
 	// branch names a variant/implementer type. When the subject is a plain local,
@@ -900,13 +901,14 @@ fn (mut g Parser) parse_return() !bool {
 		}
 		g.consume_statement_end()
 		mut evaluated_values := []string{cap: values.len}
-		for value in values {
+		for i, value in values {
 			if !g.has_deferred_blocks() {
 				evaluated_values << value
 				continue
 			}
 			temporary := g.temporary_name('return')
-			g.write_line('__typeof__((${value})) ${temporary} = (${value});')
+			declaration_type := g.declaration_c_type(value_types[i], value)
+			g.write_line('${declaration_type} ${temporary} = (${value});')
 			evaluated_values << temporary
 		}
 		g.write_all_deferred_scopes()
@@ -948,7 +950,7 @@ fn (mut g Parser) parse_return() !bool {
 	mut actual_type := g.last_expression_type
 	if g.selfhost && g.return_type == '' {
 		g.consume_statement_end()
-		g.write_return_expression(expression)
+		g.write_return_expression(expression, actual_type)
 		return true
 	}
 	contextual_return_type := if g.return_type == 'Option' && g.option_return_type != '' {
@@ -964,7 +966,7 @@ fn (mut g Parser) parse_return() !bool {
 		// A struct-field/global/`__global` fixed array is stored as a raw C array, but the
 		// by-value return type is the `struct { T data[N]; }` wrapper; copy the raw array into
 		// its `.data` so the value can be returned.
-		expression = '({ ${g.return_type} __v_fastc_fixed_ret; memcpy(__v_fastc_fixed_ret.data, ${expression}, sizeof(__v_fastc_fixed_ret.data)); __v_fastc_fixed_ret; })'
+		expression = '({ ${g.return_type} __vf_fixed_ret; memcpy(__vf_fixed_ret.data, ${expression}, sizeof(__vf_fixed_ret.data)); __vf_fixed_ret; })'
 		actual_type = g.return_type
 	}
 	if g.selfhost && actual_type.ends_with('*') && !g.return_type.ends_with('*') && g.return_type == actual_type.trim_right('*') {
@@ -1013,17 +1015,18 @@ fn (mut g Parser) parse_return() !bool {
 		actual_type = 'Option'
 	}
 	g.consume_statement_end()
-	g.write_return_expression(expression)
+	g.write_return_expression(expression, actual_type)
 	return true
 }
 
-fn (mut g Parser) write_return_expression(expression string) {
+fn (mut g Parser) write_return_expression(expression string, expression_type string) {
 	if !g.has_deferred_blocks() {
 		g.write_line('return ${expression};')
 		return
 	}
 	temporary := g.temporary_name('return')
-	g.write_line('__typeof__((${expression})) ${temporary} = (${expression});')
+	declaration_type := g.declaration_c_type(expression_type, expression)
+	g.write_line('${declaration_type} ${temporary} = (${expression});')
 	g.write_all_deferred_scopes()
 	g.write_line('return ${temporary};')
 }
@@ -1209,7 +1212,8 @@ fn (mut g Parser) parse_simple_statement() ! {
 				g.write_line('${element_type} ${value_name} = (${boxed});')
 				g.write_line('builtin__array_push(${array_target}, &${value_name});')
 			} else if is_array_append {
-				g.write_line('__typeof__((${value})) ${value_name} = (${value});')
+				value_decl_type := g.declaration_c_type(value_type, value)
+				g.write_line('${value_decl_type} ${value_name} = (${value});')
 				g.write_line('builtin__array_push_many(${array_target}, ${value_name}.data, ${value_name}.len);')
 			} else {
 				// A `.member` enum-shorthand element needs its target enum type to lower; re-render it
@@ -1229,10 +1233,10 @@ fn (mut g Parser) parse_simple_statement() ! {
 				// TinyCC cannot `__typeof__` a statement expression that runs a `return`/`for`/
 				// `switch` (an `or { return … }`-unwrap element); name the element type directly, as
 				// the declaration path does. Gated on `({` so a compound-literal value is unaffected.
-				push_decl_type := if boxes_variant || (element_type != '' && push_value.contains('({') && (push_value.contains('return ') || push_value.contains('for (') || push_value.contains('switch ('))) {
+				push_decl_type := if boxes_variant {
 					element_type
 				} else {
-					'__typeof__((${push_value}))'
+					g.declaration_c_type(element_type, push_value)
 				}
 				g.write_line('${push_decl_type} ${value_name} = (${push_value});')
 				g.write_line('builtin__array_push(${array_target}, &${value_name});')
@@ -1545,9 +1549,10 @@ fn (mut g Parser) parse_parallel_assignment(initial_names []string, initial_mut 
 			g.validate_parallel_assignment_targets(names)!
 		}
 		mut temporaries := []string{cap: values.len}
-		for item in values {
+		for i, item in values {
 			temporary := g.temporary_name('parallel')
-			g.write_line('__typeof__((${item})) ${temporary} = (${item});')
+			declaration_type := g.declaration_c_type(value_types[i], item)
+			g.write_line('${declaration_type} ${temporary} = (${item});')
 			temporaries << temporary
 		}
 		if is_declaration {
@@ -1628,12 +1633,14 @@ fn (mut g Parser) finish_parallel_member_assignment(names []string, member_targe
 	}
 	g.last_multi_return_types = []string{}
 	mut values := []string{}
+	mut value_types := []string{}
 	for {
 		value := g.read_expression([token.Token.comma, token.Token.semicolon, token.Token.rcbr])!
 		if value == '' {
 			return g.unsupported('empty parallel assignment')
 		}
 		values << value
+		value_types << g.last_expression_type
 		if g.tok != .comma {
 			break
 		}
@@ -1645,9 +1652,10 @@ fn (mut g Parser) finish_parallel_member_assignment(names []string, member_targe
 			return g.unsupported('parallel assignment with ${targets.len} targets and ${values.len} values')
 		}
 		mut temporaries := []string{cap: values.len}
-		for value in values {
+		for i, value in values {
 			temporary := g.temporary_name('parallel')
-			g.write_line('__typeof__((${value})) ${temporary} = (${value});')
+			declaration_type := g.declaration_c_type(value_types[i], value)
+			g.write_line('${declaration_type} ${temporary} = (${value});')
 			temporaries << temporary
 		}
 		for i, target in targets {
@@ -1902,12 +1910,14 @@ fn (mut g Parser) parse_parallel_expression_assignment(first_source string, firs
 	g.next()
 	g.last_multi_return_types = []string{}
 	mut values := []string{}
+	mut value_types := []string{}
 	for {
 		value := g.read_expression([token.Token.comma, token.Token.semicolon, token.Token.rcbr])!
 		if value == '' {
 			return g.unsupported('empty parallel assignment')
 		}
 		values << value
+		value_types << g.last_expression_type
 		if g.tok != .comma {
 			break
 		}
@@ -1919,9 +1929,10 @@ fn (mut g Parser) parse_parallel_expression_assignment(first_source string, firs
 			return g.unsupported('parallel assignment with ${targets.len} targets and ${values.len} values')
 		}
 		mut temporaries := []string{cap: values.len}
-		for value in values {
+		for i, value in values {
 			temporary := g.temporary_name('parallel')
-			g.write_line('__typeof__((${value})) ${temporary} = (${value});')
+			declaration_type := g.declaration_c_type(value_types[i], value)
+			g.write_line('${declaration_type} ${temporary} = (${value});')
 			temporaries << temporary
 		}
 		for i, target in targets {
@@ -2338,6 +2349,8 @@ fn (mut g Parser) parse_declaration_after_name(name string, is_mut bool, is_stat
 	g.consume_statement_end()
 	// GNU typeof is unevaluated and is supported by bundled TinyCC. It lets the
 	// direct path preserve V's `:=` without running any inference or type checker.
+	// A self-host has already inferred the C type, so spelling that type directly
+	// avoids duplicating large statement expressions in the generated source.
 	c_name := fastc_c_identifier(name)
 	normalized_type := fastc_normalize_inferred_type(g.last_expression_type)
 	local_type := if g.selfhost && g.last_expression_type == '' {
@@ -2345,7 +2358,11 @@ fn (mut g Parser) parse_declaration_after_name(name string, is_mut bool, is_stat
 	} else {
 		normalized_type
 	}
-	mut declaration_type := '__typeof__((${expression}))'
+	mut declaration_type := if g.selfhost && local_type != '' && !local_type.starts_with('fn (') {
+		local_type
+	} else {
+		'__typeof__((${expression}))'
+	}
 	if expression.starts_with('"') {
 		// C's typeof preserves a literal's array type instead of applying the usual
 		// pointer decay. The spelling alone is enough to lower this case.
@@ -2389,6 +2406,18 @@ fn fastc_normalize_inferred_type(typ string) string {
 		'nil' { 'voidptr' }
 		else { typ }
 	}
+}
+
+fn (g &Parser) declaration_c_type(inferred_type string, expression string) string {
+	if g.selfhost && inferred_type != '' {
+		normalized := fastc_normalize_inferred_type(inferred_type)
+		if !normalized.starts_with('fn (') {
+			mut w := unsafe { &Parser(g) }
+			fastc_register_composite_type(normalized, mut w.composite_types)
+			return if normalized == 'int' { fastc_platform_int_c_type } else { normalized }
+		}
+	}
+	return '__typeof__((${expression}))'
 }
 
 fn (mut g Parser) consume_statement_end() {

--- a/vlib/v3/gen/fastc/unit_cache.c.v
+++ b/vlib/v3/gen/fastc/unit_cache.c.v
@@ -1,0 +1,25 @@
+module fastc
+
+import os
+
+fn C.wyhash(&u8, u64, u64, &u64) u64
+
+@[c_extern]
+fn C.clonefile(&char, &char, int) int
+
+@[inline]
+fn fastc_unit_cache_hash(text string, seed u64) u64 {
+	return C.wyhash(text.str, u64(text.len), seed, &u64(voidptr(C._wyp)))
+}
+
+fn fastc_copy_cached_link(source string, destination string) ! {
+	$if macos {
+		// clonefile creates a copy-on-write executable, avoiding both the cost of
+		// copying a self-host and the cache corruption risk of a hard link.
+		os.rm(destination) or {}
+		if C.clonefile(source.str, destination.str, 0) == 0 {
+			return
+		}
+	}
+	os.cp(source, destination)!
+}

--- a/vlib/v3/gen/fastc/unit_compile_nix.c.v
+++ b/vlib/v3/gen/fastc/unit_compile_nix.c.v
@@ -99,6 +99,149 @@ fn fastc_render_unit_stdin(fd int, worker thread string) {
 	fastc_write_unit_stdin(fd, source)
 }
 
+fn fastc_render_c_unit_stdin(fd int, pieces []string, units &FastcUnitLayout, g int, first_unit int, end_unit int) {
+	source := fastc_render_c_unit(pieces, units, g, first_unit, end_unit)
+	fastc_write_unit_stdin(fd, source)
+}
+
+// fastc_prestart_c_units starts TinyCC processes that wait for their source on
+// stdin. Starting this on a worker lets source generation hide process launch.
+pub fn fastc_prestart_c_units(tcc string, base_args []string, build_dir string, unit_count int) FastcPrestartedCUnits {
+	os.mkdir_all(build_dir) or { return FastcPrestartedCUnits{} }
+	mut units := FastcPrestartedCUnits{
+		build_dir: build_dir
+		base_args: base_args.clone()
+		unit_count: unit_count
+		paths: []string{len: unit_count}
+		objects: []string{len: unit_count}
+		pids: []int{len: unit_count}
+		read_fds: []int{len: unit_count, init: -1}
+		write_fds: []int{len: unit_count, init: -1}
+		active: true
+	}
+	for i in 0 .. unit_count {
+		path := os.join_path_single(build_dir, 'src.unit${i}.c')
+		object := path[..path.len - 2] + '.o'
+		mut args := [tcc]
+		args << base_args
+		args << ['-c', '-', '-o', object]
+		mut pid := 0
+		mut read_fd := -1
+		mut write_fd := -1
+		if !fastc_start_capture_input(args, &pid, &read_fd, &write_fd) {
+			fastc_discard_prestarted_c_units(mut units)
+			return FastcPrestartedCUnits{}
+		}
+		units.paths[i] = path
+		units.objects[i] = object
+		units.pids[i] = pid
+		units.read_fds[i] = read_fd
+		units.write_fds[i] = write_fd
+	}
+	return units
+}
+
+// fastc_discard_prestarted_c_units closes and reaps unused prestarted TinyCC
+// processes, then removes their private build directory.
+pub fn fastc_discard_prestarted_c_units(mut units FastcPrestartedCUnits) {
+	if !units.active {
+		return
+	}
+	for fd in units.write_fds {
+		if fd >= 0 {
+			C.close(fd)
+		}
+	}
+	for i, pid in units.pids {
+		if pid <= 0 {
+			continue
+		}
+		if i < units.read_fds.len && units.read_fds[i] >= 0 {
+			_ = os.fd_slurp(units.read_fds[i])
+			os.fd_close(units.read_fds[i])
+		}
+		fastc_wait_exit_code(pid)
+	}
+	units.active = false
+	os.rmdir_all(units.build_dir) or {}
+}
+
+// fastc_begin_feed_prestarted_c_units starts copying rendered source to TinyCC
+// processes that were launched while FastC generation was still running.
+pub fn fastc_begin_feed_prestarted_c_units(mut prestarted FastcPrestartedCUnits, mut rendering FastcRenderingCUnits) !FastcFeedingCUnits {
+	if !prestarted.active || rendering.paths != prestarted.paths
+		|| rendering.workers.len != prestarted.unit_count {
+		return error('invalid prestarted FastC unit layout')
+	}
+	mut writers := []thread{len: prestarted.unit_count}
+	for i in rendering.order {
+		writers[i] = spawn fastc_render_unit_stdin(prestarted.write_fds[i], rendering.workers[i])
+		prestarted.write_fds[i] = -1
+	}
+	return FastcFeedingCUnits{
+		paths: rendering.paths
+		writers: writers
+	}
+}
+
+// fastc_begin_render_prestarted_c_units renders directly into prestarted
+// TinyCC processes, avoiding a second set of threads just to hand strings off.
+pub fn fastc_begin_render_prestarted_c_units(mut prestarted FastcPrestartedCUnits, prefix string, pieces []string, units FastcUnitLayout, jobs int) !FastcFeedingCUnits {
+	plan := fastc_c_unit_plan(prefix, pieces, units, jobs)
+	if !prestarted.active || plan.paths != prestarted.paths
+		|| plan.paths.len != prestarted.unit_count {
+		return error('invalid prestarted FastC unit layout')
+	}
+	mut writers := []thread{len: prestarted.unit_count}
+	for g in 0 .. plan.paths.len {
+		writers[g] = spawn fastc_render_c_unit_stdin(prestarted.write_fds[g], pieces, &units, g, plan.first_units[g], plan.first_units[g + 1])
+		prestarted.write_fds[g] = -1
+	}
+	return FastcFeedingCUnits{
+		paths: plan.paths
+		writers: writers
+	}
+}
+
+// fastc_finish_prestarted_c_units waits for TinyCC and optionally loads each
+// completed object into the prepared linker in translation-unit order.
+pub fn fastc_finish_prestarted_c_units(mut prestarted FastcPrestartedCUnits, mut feeding FastcFeedingCUnits, prepared FastcPreparedUnits, mut prepared_link FastcPreparedLink, preload_link bool) ![]string {
+	if !prestarted.active || feeding.paths != prestarted.paths
+		|| feeding.writers.len != prestarted.unit_count
+		|| prepared.entries.len != prestarted.unit_count {
+		return error('invalid prestarted FastC unit layout')
+	}
+	mut failure := ''
+	for i in 0 .. prestarted.unit_count {
+		output := os.fd_slurp(prestarted.read_fds[i]).join('')
+		os.fd_close(prestarted.read_fds[i])
+		prestarted.read_fds[i] = -1
+		feeding.writers[i].wait()
+		code := fastc_wait_exit_code(prestarted.pids[i])
+		prestarted.pids[i] = 0
+		if code != 0 && failure == '' {
+			failure = if output.len > 0 { output } else { 'tcc failed on ${prestarted.objects[i]}' }
+		} else if code == 0 && preload_link && failure == '' {
+			fastc_add_prepared_link_input(mut prepared_link, prestarted.objects[i]) or {
+				failure = err.msg()
+			}
+		}
+	}
+	prestarted.active = false
+	if failure != '' {
+		return error(failure)
+	}
+	return prepared.objects
+}
+
+// fastc_compile_prestarted_rendering_c_units feeds and waits for translation
+// units in one call. Callers with independent setup work can use the split
+// begin/finish API to overlap that work with rendering and compilation.
+pub fn fastc_compile_prestarted_rendering_c_units(mut prestarted FastcPrestartedCUnits, mut rendering FastcRenderingCUnits, prepared FastcPreparedUnits, mut prepared_link FastcPreparedLink, preload_link bool) ![]string {
+	mut feeding := fastc_begin_feed_prestarted_c_units(mut prestarted, mut rendering)!
+	return fastc_finish_prestarted_c_units(mut prestarted, mut feeding, prepared, mut prepared_link, preload_link)
+}
+
 // fastc_compile_rendering_c_units starts concurrent TinyCC processes while
 // their translation units are still being rendered, then streams each unit
 // as soon as its render worker completes.

--- a/vlib/v3/gen/fastc/unit_compile_nix.c.v
+++ b/vlib/v3/gen/fastc/unit_compile_nix.c.v
@@ -5,6 +5,10 @@ import time
 
 fn C.v_os_exec_capture_start(argv &&char, child_pid &int, read_fd &int) int
 
+fn C.v_os_exec_capture_input_start(argv &&char, child_pid &int, read_fd &int, write_fd &int) int
+
+fn C.v_os_fd_write_all(fd int, data &char, len usize)
+
 fn C.waitpid(pid int, status &int, options int) int
 
 struct FastcUnitCompile {
@@ -67,6 +71,82 @@ pub fn fastc_compile_c_units(tcc string, base_args []string, unit_paths []string
 	return prepared.objects
 }
 
+fn fastc_stream_unit_compile_order(sources []string) []int {
+	mut order := []int{cap: sources.len}
+	mut sizes := []int{cap: sources.len}
+	for i, source in sources {
+		order << i
+		sizes << source.len
+		mut at := order.len - 1
+		for at > 0 && sizes[at - 1] < source.len {
+			order[at] = order[at - 1]
+			sizes[at] = sizes[at - 1]
+			at--
+		}
+		order[at] = i
+		sizes[at] = source.len
+	}
+	return order
+}
+
+fn fastc_write_unit_stdin(fd int, source string) {
+	C.v_os_fd_write_all(fd, &char(source.str), usize(source.len))
+	C.close(fd)
+}
+
+// fastc_compile_c_unit_texts streams in-memory translation units to concurrent
+// TinyCC processes. This avoids a temporary-file write/read round trip and
+// overlaps feeding earlier processes with starting the remaining ones.
+pub fn fastc_compile_c_unit_texts(tcc string, base_args []string, unit_paths []string, sources []string, prepared FastcPreparedUnits) ![]string {
+	if unit_paths.len != sources.len || prepared.entries.len != sources.len {
+		return error('invalid streamed FastC unit layout')
+	}
+	bench_phases := os.getenv('FASTC_BENCH_PHASES') != ''
+	sw := time.new_stopwatch()
+	mut compiles := []FastcUnitCompile{cap: unit_paths.len}
+	mut writers := []thread{cap: unit_paths.len}
+	mut start_error := ''
+	for i in fastc_stream_unit_compile_order(sources) {
+		object := prepared.entries[i].object
+		mut args := [tcc]
+		args << base_args
+		args << ['-c', '-', '-o', object]
+		mut pid := 0
+		mut read_fd := -1
+		mut write_fd := -1
+		if !fastc_start_capture_input(args, &pid, &read_fd, &write_fd) {
+			start_error = 'could not start ${tcc} for ${unit_paths[i]}'
+			break
+		}
+		compiles << FastcUnitCompile{
+			pid: pid
+			read_fd: read_fd
+			object: object
+		}
+		writers << spawn fastc_write_unit_stdin(write_fd, sources[i])
+	}
+	if bench_phases {
+		eprintln('fastc-phase tcc.units_started ${sw.elapsed().microseconds()}us streamed=1')
+	}
+	mut failure := start_error
+	for i, compile in compiles {
+		output := os.fd_slurp(compile.read_fd).join('')
+		os.fd_close(compile.read_fd)
+		writers[i].wait()
+		code := fastc_wait_exit_code(compile.pid)
+		if bench_phases {
+			eprintln('fastc-phase tcc.unit_done ${sw.elapsed().microseconds()}us ${os.file_name(compile.object)}')
+		}
+		if code != 0 && failure == '' {
+			failure = if output.len > 0 { output } else { 'tcc failed on ${compile.object}' }
+		}
+	}
+	if failure != '' {
+		return error(failure)
+	}
+	return prepared.objects
+}
+
 // fastc_run_command runs the program with the argument vector and returns
 // its exit code and merged output, like cmdexec.run, but through posix_spawn
 // and a blocking wait rather than a fork of this (large) process and a
@@ -99,6 +179,19 @@ fn fastc_start_capture(argv []string, pid &int, read_fd &int) bool {
 	}
 	cargs << &char(unsafe { nil })
 	return C.v_os_exec_capture_start(cargs.data, pid, read_fd) == 0
+}
+
+fn fastc_start_capture_input(argv []string, pid &int, read_fd &int, write_fd &int) bool {
+	$if macos {
+		mut cargs := []&char{cap: argv.len + 1}
+		for arg in argv {
+			cargs << &char(arg.str)
+		}
+		cargs << &char(unsafe { nil })
+		return C.v_os_exec_capture_input_start(cargs.data, pid, read_fd, write_fd) == 0
+	} $else {
+		return false
+	}
 }
 
 // fastc_wait_exit_code waits for the process and returns its exit code; a

--- a/vlib/v3/gen/fastc/unit_compile_nix.c.v
+++ b/vlib/v3/gen/fastc/unit_compile_nix.c.v
@@ -22,11 +22,9 @@ pub fn fastc_compile_c_units(tcc string, base_args []string, unit_paths []string
 	sw := time.new_stopwatch()
 	mut compiles := []FastcUnitCompile{cap: unit_paths.len}
 	mut start_error := ''
-	for i, unit_path in unit_paths {
+	for i in fastc_unit_compile_order(unit_paths, prepared) {
+		unit_path := unit_paths[i]
 		entry := prepared.entries[i]
-		if entry.hit {
-			continue
-		}
 		object := entry.object
 		mut args := [tcc]
 		args << base_args

--- a/vlib/v3/gen/fastc/unit_compile_nix.c.v
+++ b/vlib/v3/gen/fastc/unit_compile_nix.c.v
@@ -17,13 +17,17 @@ struct FastcUnitCompile {
 // concurrent TinyCC processes (started with posix_spawn, which is cheaper
 // than forking the compiler process), and returns the object paths, or the
 // output of the first compile that failed.
-pub fn fastc_compile_c_units(tcc string, base_args []string, unit_paths []string) ![]string {
+pub fn fastc_compile_c_units(tcc string, base_args []string, unit_paths []string, prepared FastcPreparedUnits) ![]string {
 	bench_phases := os.getenv('FASTC_BENCH_PHASES') != ''
 	sw := time.new_stopwatch()
 	mut compiles := []FastcUnitCompile{cap: unit_paths.len}
 	mut start_error := ''
-	for unit_path in unit_paths {
-		object := unit_path[..unit_path.len - 2] + '.o'
+	for i, unit_path in unit_paths {
+		entry := prepared.entries[i]
+		if entry.hit {
+			continue
+		}
+		object := entry.object
 		mut args := [tcc]
 		args << base_args
 		args << ['-c', unit_path, '-o', object]
@@ -42,7 +46,6 @@ pub fn fastc_compile_c_units(tcc string, base_args []string, unit_paths []string
 	if bench_phases {
 		eprintln('fastc-phase tcc.units_started ${sw.elapsed().microseconds()}us')
 	}
-	mut objects := []string{cap: unit_paths.len}
 	mut failure := start_error
 	for compile in compiles {
 		// The merged output is drained before the wait, so a compiler that
@@ -56,12 +59,14 @@ pub fn fastc_compile_c_units(tcc string, base_args []string, unit_paths []string
 		if code != 0 && failure == '' {
 			failure = if output.len > 0 { output } else { 'tcc failed on ${compile.object}' }
 		}
-		objects << compile.object
 	}
 	if failure != '' {
 		return error(failure)
 	}
-	return objects
+	for entry in prepared.entries {
+		fastc_publish_unit_cache(entry)
+	}
+	return prepared.objects
 }
 
 // fastc_run_command runs the program with the argument vector and returns

--- a/vlib/v3/gen/fastc/unit_compile_nix.c.v
+++ b/vlib/v3/gen/fastc/unit_compile_nix.c.v
@@ -107,6 +107,9 @@ fn fastc_render_c_unit_stdin(fd int, pieces []string, units &FastcUnitLayout, g 
 // fastc_prestart_c_units starts TinyCC processes that wait for their source on
 // stdin. Starting this on a worker lets source generation hide process launch.
 pub fn fastc_prestart_c_units(tcc string, base_args []string, build_dir string, unit_count int) FastcPrestartedCUnits {
+	if unit_count < 2 {
+		return FastcPrestartedCUnits{}
+	}
 	os.mkdir_all(build_dir) or { return FastcPrestartedCUnits{} }
 	mut units := FastcPrestartedCUnits{
 		build_dir: build_dir

--- a/vlib/v3/gen/fastc/unit_compile_nix.c.v
+++ b/vlib/v3/gen/fastc/unit_compile_nix.c.v
@@ -94,6 +94,79 @@ fn fastc_write_unit_stdin(fd int, source string) {
 	C.close(fd)
 }
 
+fn fastc_render_unit_stdin(fd int, worker thread string) {
+	source := worker.wait()
+	fastc_write_unit_stdin(fd, source)
+}
+
+// fastc_compile_rendering_c_units starts concurrent TinyCC processes while
+// their translation units are still being rendered, then streams each unit
+// as soon as its render worker completes.
+pub fn fastc_compile_rendering_c_units(tcc string, base_args []string, mut rendering FastcRenderingCUnits, prepared FastcPreparedUnits, mut prepared_link FastcPreparedLink, preload_link bool) ![]string {
+	if rendering.paths.len != rendering.workers.len
+		|| prepared.entries.len != rendering.paths.len {
+		return error('invalid rendering FastC unit layout')
+	}
+	bench_phases := os.getenv('FASTC_BENCH_PHASES') != ''
+	sw := time.new_stopwatch()
+	mut compiles := []FastcUnitCompile{len: rendering.paths.len}
+	mut writers := []thread{len: rendering.paths.len}
+	mut handed := []bool{len: rendering.paths.len}
+	mut start_error := ''
+	for i in rendering.order {
+		object := prepared.entries[i].object
+		mut args := [tcc]
+		args << base_args
+		args << ['-c', '-', '-o', object]
+		mut pid := 0
+		mut read_fd := -1
+		mut write_fd := -1
+		if !fastc_start_capture_input(args, &pid, &read_fd, &write_fd) {
+			start_error = 'could not start ${tcc} for ${rendering.paths[i]}'
+			break
+		}
+		compiles[i] = FastcUnitCompile{
+			pid: pid
+			read_fd: read_fd
+			object: object
+		}
+		handed[i] = true
+		writers[i] = spawn fastc_render_unit_stdin(write_fd, rendering.workers[i])
+	}
+	if bench_phases {
+		eprintln('fastc-phase tcc.units_started ${sw.elapsed().microseconds()}us streamed=rendering')
+	}
+	mut failure := start_error
+	for i, compile in compiles {
+		if !handed[i] {
+			continue
+		}
+		output := os.fd_slurp(compile.read_fd).join('')
+		os.fd_close(compile.read_fd)
+		writers[i].wait()
+		code := fastc_wait_exit_code(compile.pid)
+		if bench_phases {
+			eprintln('fastc-phase tcc.unit_done ${sw.elapsed().microseconds()}us ${os.file_name(compile.object)}')
+		}
+		if code != 0 && failure == '' {
+			failure = if output.len > 0 { output } else { 'tcc failed on ${compile.object}' }
+		} else if code == 0 && preload_link && failure == '' {
+			fastc_add_prepared_link_input(mut prepared_link, compile.object) or {
+				failure = err.msg()
+			}
+		}
+	}
+	for i, was_handed in handed {
+		if !was_handed {
+			rendering.workers[i].wait()
+		}
+	}
+	if failure != '' {
+		return error(failure)
+	}
+	return prepared.objects
+}
+
 // fastc_compile_c_unit_texts streams in-memory translation units to concurrent
 // TinyCC processes. This avoids a temporary-file write/read round trip and
 // overlaps feeding earlier processes with starting the remaining ones.

--- a/vlib/v3/gen/fastc/unit_compile_windows.c.v
+++ b/vlib/v3/gen/fastc/unit_compile_windows.c.v
@@ -12,10 +12,14 @@ mut:
 // fastc_compile_c_units compiles the translation units to objects with
 // concurrent TinyCC processes and returns the object paths, or the output of
 // the first compile that failed.
-pub fn fastc_compile_c_units(tcc string, base_args []string, unit_paths []string) ![]string {
+pub fn fastc_compile_c_units(tcc string, base_args []string, unit_paths []string, prepared FastcPreparedUnits) ![]string {
 	mut compiles := []FastcUnitCompile{cap: unit_paths.len}
-	for unit_path in unit_paths {
-		object := unit_path[..unit_path.len - 2] + '.o'
+	for i, unit_path in unit_paths {
+		entry := prepared.entries[i]
+		if entry.hit {
+			continue
+		}
+		object := entry.object
 		mut args := base_args.clone()
 		args << ['-c', unit_path, '-o', object]
 		mut process := os.new_process(tcc)
@@ -27,7 +31,6 @@ pub fn fastc_compile_c_units(tcc string, base_args []string, unit_paths []string
 			object: object
 		}
 	}
-	mut objects := []string{cap: unit_paths.len}
 	mut failure := ''
 	for mut compile in compiles {
 		compile.process.wait()
@@ -37,12 +40,14 @@ pub fn fastc_compile_c_units(tcc string, base_args []string, unit_paths []string
 		if code != 0 && failure == '' {
 			failure = if output.len > 0 { output } else { 'tcc failed on ${compile.object}' }
 		}
-		objects << compile.object
 	}
 	if failure != '' {
 		return error(failure)
 	}
-	return objects
+	for entry in prepared.entries {
+		fastc_publish_unit_cache(entry)
+	}
+	return prepared.objects
 }
 
 // fastc_run_command runs the program with the argument vector and returns

--- a/vlib/v3/gen/fastc/unit_compile_windows.c.v
+++ b/vlib/v3/gen/fastc/unit_compile_windows.c.v
@@ -48,6 +48,18 @@ pub fn fastc_compile_c_units(tcc string, base_args []string, unit_paths []string
 	return prepared.objects
 }
 
+// fastc_compile_c_unit_texts keeps the cross-platform API available; Windows
+// currently uses temporary files because its process wrapper has no stdin pipe.
+pub fn fastc_compile_c_unit_texts(tcc string, base_args []string, unit_paths []string, sources []string, prepared FastcPreparedUnits) ![]string {
+	if unit_paths.len != sources.len {
+		return error('invalid streamed FastC unit layout')
+	}
+	for i, source in sources {
+		os.write_file(unit_paths[i], source)!
+	}
+	return fastc_compile_c_units(tcc, base_args, unit_paths, prepared)
+}
+
 // fastc_run_command runs the program with the argument vector and returns
 // its exit code and merged output.
 pub fn fastc_run_command(program string, args []string) os.Result {

--- a/vlib/v3/gen/fastc/unit_compile_windows.c.v
+++ b/vlib/v3/gen/fastc/unit_compile_windows.c.v
@@ -9,6 +9,35 @@ mut:
 	object  string
 }
 
+// fastc_prestart_c_units is unavailable on Windows, whose process wrapper has
+// no stdin-pipe prestart path.
+pub fn fastc_prestart_c_units(_ string, _ []string, _ string, _ int) FastcPrestartedCUnits {
+	return FastcPrestartedCUnits{}
+}
+
+// fastc_discard_prestarted_c_units is a no-op on Windows.
+pub fn fastc_discard_prestarted_c_units(mut _ FastcPrestartedCUnits) {}
+
+// fastc_begin_feed_prestarted_c_units is unavailable on Windows.
+pub fn fastc_begin_feed_prestarted_c_units(mut _ FastcPrestartedCUnits, mut _ FastcRenderingCUnits) !FastcFeedingCUnits {
+	return error('prestarted FastC units are unavailable on Windows')
+}
+
+// fastc_begin_render_prestarted_c_units is unavailable on Windows.
+pub fn fastc_begin_render_prestarted_c_units(mut _ FastcPrestartedCUnits, _ string, _ []string, _ FastcUnitLayout, _ int) !FastcFeedingCUnits {
+	return error('prestarted FastC units are unavailable on Windows')
+}
+
+// fastc_finish_prestarted_c_units is unavailable on Windows.
+pub fn fastc_finish_prestarted_c_units(mut _ FastcPrestartedCUnits, mut _ FastcFeedingCUnits, _ FastcPreparedUnits, mut _ FastcPreparedLink, _ bool) ![]string {
+	return error('prestarted FastC units are unavailable on Windows')
+}
+
+// fastc_compile_prestarted_rendering_c_units is unavailable on Windows.
+pub fn fastc_compile_prestarted_rendering_c_units(mut _ FastcPrestartedCUnits, mut _ FastcRenderingCUnits, _ FastcPreparedUnits, mut _ FastcPreparedLink, _ bool) ![]string {
+	return error('prestarted FastC units are unavailable on Windows')
+}
+
 // fastc_compile_c_units compiles the translation units to objects with
 // concurrent TinyCC processes and returns the object paths, or the output of
 // the first compile that failed.

--- a/vlib/v3/gen/fastc/unit_compile_windows.c.v
+++ b/vlib/v3/gen/fastc/unit_compile_windows.c.v
@@ -14,11 +14,9 @@ mut:
 // the first compile that failed.
 pub fn fastc_compile_c_units(tcc string, base_args []string, unit_paths []string, prepared FastcPreparedUnits) ![]string {
 	mut compiles := []FastcUnitCompile{cap: unit_paths.len}
-	for i, unit_path in unit_paths {
+	for i in fastc_unit_compile_order(unit_paths, prepared) {
+		unit_path := unit_paths[i]
 		entry := prepared.entries[i]
-		if entry.hit {
-			continue
-		}
 		object := entry.object
 		mut args := base_args.clone()
 		args << ['-c', unit_path, '-o', object]

--- a/vlib/v3/gen/fastc/validate.v
+++ b/vlib/v3/gen/fastc/validate.v
@@ -155,7 +155,7 @@ fn (g &Parser) resolved_nonlocal_expression_name_cached(name string) string {
 // resolved_expression_name memoizes the answer per name.
 fn (g &Parser) resolved_nonlocal_expression_name(name string) string {
 	if imported_module := g.imports[name] {
-		return imported_module.replace('.', '__')
+		return fastc_c_module_name(imported_module)
 	}
 	function_key := g.unqualified_function_key(name)
 	if function_key in g.functions {

--- a/vlib/v3/gen/fastc/validate.v
+++ b/vlib/v3/gen/fastc/validate.v
@@ -837,6 +837,10 @@ fn (g &Parser) struct_direct_member_type(receiver_type string, field_name string
 }
 
 fn (g &Parser) struct_member_type(receiver_type string, field_name string) string {
+	direct_type := g.struct_direct_member_type(receiver_type, field_name)
+	if direct_type != '' {
+		return direct_type
+	}
 	field := g.struct_field_metadata(receiver_type, field_name) or { return '' }
 	return field.typ
 }
@@ -849,6 +853,16 @@ fn (g &Parser) struct_field_metadata(receiver_type string, field_name string) ?F
 		return g.last_field
 	}
 	mut w := unsafe { &Parser(g) }
+	// Most lookups are direct fields already present in the program-wide index.
+	// Return those without copying them into every file parser's recursive
+	// embedded-field memo.
+	if field := g.direct_struct_field_metadata(receiver_type, field_name) {
+		w.last_field_receiver = receiver_type
+		w.last_field_name = field_name
+		w.last_field = field
+		w.last_field_known = true
+		return field
+	}
 	if by_name := g.field_memo[receiver_type] {
 		if cached := by_name[field_name] {
 			w.last_field_receiver = receiver_type
@@ -881,7 +895,7 @@ fn (g &Parser) struct_field_metadata(receiver_type string, field_name string) ?F
 	return none
 }
 
-fn (g &Parser) struct_field_metadata_impl(receiver_type string, field_name string) ?FastcStructField {
+fn (g &Parser) direct_struct_field_metadata(receiver_type string, field_name string) ?FastcStructField {
 	mut layout_type := fastc_trim_pointer_suffix(receiver_type)
 	if layout_type.starts_with('Array_') {
 		layout_type = 'array'
@@ -893,10 +907,15 @@ fn (g &Parser) struct_field_metadata_impl(receiver_type string, field_name strin
 			return field
 		}
 	}
-	for field in g.struct_field_info[layout_type] {
-		if field.name == field_name {
-			return field
-		}
+	return none
+}
+
+fn (g &Parser) struct_field_metadata_impl(receiver_type string, field_name string) ?FastcStructField {
+	mut layout_type := fastc_trim_pointer_suffix(receiver_type)
+	if layout_type.starts_with('Array_') {
+		layout_type = 'array'
+	} else if layout_type.starts_with('Map_') {
+		layout_type = 'map'
 	}
 	direct_type := g.struct_direct_member_type(receiver_type, field_name)
 	if direct_type != '' {


### PR DESCRIPTION
This speeds up uncached V3 FastC self-host builds while preserving the existing compiler and linker semantics.

- compact self-host-only generated C names and avoid redundant type/declaration work
- reuse unchanged resolver memo stamps and tune parallel generation fragments
- prestart bundled TinyCC while FastC is still generating C
- render 12 balanced translation units directly into TinyCC stdin
- overlap completed object loading with compilation and keep ordered linker operands intact
- use native parallel hashing and mapped writes for macOS ad-hoc signing
- keep `-no-parallel` and `V3_FASTC_NO_PARALLEL` behavior intact

An optimized host compiling the unoptimized 79,877-line V3 target with `-nocache` completed FastC generation plus real TCC compilation, linking, and signing in 36.790 ms (2.171 MLOC/s).

Validation:

- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -silent vlib/v3/gen/fastc/macho_sign_test.v`
- uncached FastC self-host build, followed by compiling and running Hello World
- strict `codesign --verify` on the generated V3 and Hello World binaries
- `git diff --check`

Large test suites were skipped as requested. The broad `fastc_test.v` currently stops at the unchanged `test_selfhost_multi_return_interface_component_is_macro_safe` unnamed-receiver case that is also present on the base branch.