### PR TITLE
v3: dedupe monomorph signature type logging

### DIFF
--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -4285,11 +4285,18 @@ fn (mut t Transformer) register_specialized_fn_signature_value(decl GenericFnDec
 		t.tc.cur_file = decl.file
 	}
 	generic_params := t.generic_fn_param_names(decl.node, decl.module)
+	signature_key := t.generic_specialization_progress_key(decl, concrete_args)
+	record_signature_types := signature_key !in t.monomorph_signature_spec_keys
+	if record_signature_types {
+		t.monomorph_signature_spec_keys[signature_key] = true
+	}
 	ret_name := t.specialized_signature_type_text(decl, t.generic_fn_return_type_text(decl), concrete_args, generic_params)
-	t.monomorph_signature_types << MonomorphSignatureType{
-		typ: ret_name
-		module: decl.module
-		file: decl.file
+	if record_signature_types {
+		t.monomorph_signature_types << MonomorphSignatureType{
+			typ: ret_name
+			module: decl.module
+			file: decl.file
+		}
 	}
 	ret := if !isnil(t.tc) {
 		t.tc.parse_resolution_type(ret_name)
@@ -4307,10 +4314,12 @@ fn (mut t Transformer) register_specialized_fn_signature_value(decl GenericFnDec
 			continue
 		}
 		param_type := explicit_mut_pointer_param_type_text(child, t.specialized_signature_type_text(decl, child.typ, concrete_args, generic_params))
-		t.monomorph_signature_types << MonomorphSignatureType{
-			typ: param_type
-			module: decl.module
-			file: decl.file
+		if record_signature_types {
+			t.monomorph_signature_types << MonomorphSignatureType{
+				typ: param_type
+				module: decl.module
+				file: decl.file
+			}
 		}
 		if param_type.starts_with('...') {
 			variadic = true

--- a/vlib/v3/transform/monomorphize_test.v
+++ b/vlib/v3/transform/monomorphize_test.v
@@ -3,6 +3,43 @@ module transform
 import v3.flat
 import v3.types
 
+fn test_specialized_fn_signature_types_are_recorded_once() {
+	mut a := flat.FlatAst.new()
+	param_id := a.add_node(flat.Node{
+		kind:  .param
+		value: 'value'
+		typ:   'T'
+	})
+	children_start := a.children.len
+	a.children << param_id
+	mut fn_node := flat.Node{
+		kind:           .fn_decl
+		value:          'identity'
+		typ:            'T'
+		children_start: children_start
+		children_count: 1
+	}
+	fn_node.set_generic_params(['T'])
+	fn_id := a.add_node(fn_node)
+	mut tc := types.TypeChecker.new(&a)
+	mut t := new_transformer(mut a, &tc, map[string]bool{})
+	decl := GenericFnDecl{
+		id:     fn_id
+		node:   fn_node
+		module: 'main'
+		file:   'main.v'
+		key:    'identity'
+	}
+
+	t.request_generic_fn_specialization(decl, ['int'])
+	assert t.monomorph_signature_types.len == 2
+	t.register_specialized_fn_signature_value(decl, specialized_generic_fn_value(fn_node.value,
+		['int']), ['int'])
+
+	assert t.monomorph_signature_types.len == 2
+	assert t.monomorph_signature_spec_keys.len == 1
+}
+
 fn test_comptime_loop_type_metadata_survives_generic_specialization() {
 	mut a := flat.FlatAst.new()
 	mut tc := types.TypeChecker.new(&a)

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -376,6 +376,7 @@ mut:
 	generic_fn_spec_nodes              map[string]flat.NodeId
 	monomorph_cache_specs              map[string]MonomorphCacheSpec
 	monomorph_signature_types          []MonomorphSignatureType
+	monomorph_signature_spec_keys      map[string]bool
 	generic_clone_children             []flat.NodeId
 	node_context_stack                 []flat.NodeId
 	specialization_decl_nodes_by_name  map[string][]int

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -1235,7 +1235,8 @@ fn (mut t Transformer) run_parallel_monomorphize_specs(specs []PendingGenericFnS
 						t.generic_specialization_args[name.clone()] = spec_args.clone()
 					}
 				}
-				t.monomorph_signature_types << w.monomorph_signature_types
+				// Every emitted worker specialization is registered by the master below.
+				// Importing the worker's private log would duplicate materialization work.
 			}
 			for idx in args[ci].scan_nodes {
 				t.parallel_monomorph_scan_nodes << idx + node_shift


### PR DESCRIPTION
Follow-up to #28349.

## Summary

- record monomorph signature types once per specialization key
- discard private parallel-worker signature logs because the master registers every emitted specialization
- add a regression test for queue-time plus emission-time registration

## Tests

- `./vnew -silent vlib/v3/transform/monomorphize_test.v`
- `./vnew -d v3_no_parallel vlib/v3/transform/monomorphize_test.v`
- V3 transform directory: 8/9 test files pass; `transform_parallel_test.v` has four pre-existing assertion failures reproduced unchanged on an untouched `origin/master` archive with the same toolchain
- rebuilt `./vnew` from the updated compiler sources
- `git diff --check`