### PR TITLE
v3: speed up uncached self-host transforms

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -10034,7 +10034,8 @@ pub fn run(args []string) {
 			prealloc_scope_leave_for_v3(transform_scope)
 			retain_transform_scope := building_v && current_parallel_transform && backend == 'c'
 				&& !cache_state.manager.enabled && retained_transform_regions.len == 0
-				&& os.getenv('V3_RETAIN_TRANSFORM_SCOPE') != ''
+				&& (input_is_v3_compiler_entry(input_file)
+					|| os.getenv('V3_RETAIN_TRANSFORM_SCOPE') != '')
 			if retain_transform_scope {
 				// Cgen is the only remaining semantic consumer in this no-cache self-host
 				// path. Keep the typed transform arena alive through it instead of cloning
@@ -15653,9 +15654,10 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 		}
 	}
 	mut was_parallel := false
-	// Explicit self-hosting is faster through the normal incremental import loop:
+	// Compiler self-hosting is faster through the normal incremental import loop:
 	// eager discovery duplicates import-identity and collision work for this graph.
 	if prefs.building_v && !prefs.selfhost && allow_parallel && !cache_state.manager.enabled
+		&& !initial_files.any(input_is_v3_compiler_entry(it))
 		&& os.getenv('V3_NO_EAGER_SELFHOST_IMPORTS') == '' {
 		modules := discover_eager_selfhost_modules(a, prefs, first_file, project_root, mut parsed_modules, mut module_path_cache)
 		mut eager_files := []string{}

--- a/vlib/v3/tests/selfhost_parallel_expansion_test.v
+++ b/vlib/v3/tests/selfhost_parallel_expansion_test.v
@@ -1,0 +1,60 @@
+// vtest build: !windows
+
+import os
+import strings
+import v3.cmdexec
+
+fn test_selfhost_parallel_workers_grow_for_struct_defaults() {
+	root := os.join_path(os.temp_dir(), 'v3_selfhost_parallel_expansion_${os.getpid()}')
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	v3_dir := os.dir(os.dir(@FILE))
+	compiler := os.join_path(root, 'compiler')
+	build := cmdexec.run(@VEXE, ['-gc', 'none', '-prealloc', '-path',
+		'${os.dir(v3_dir)}|@vlib|@vmodules', '-o', compiler, os.join_path(v3_dir, 'v3.v')])
+	assert build.exit_code == 0, build.output
+	mut source := strings.new_builder(64_000)
+	source.writeln('struct Entry {\nmut:\nvalue int = 7\n}')
+	source.writeln('struct State {\nmut:\nvalue int\nvalues [300]Entry\n}')
+	for i in 0 .. 300 {
+		source.writeln('fn helper_${i}() int {')
+		source.writeln('mut state := State{value: ${i}}')
+		source.writeln('state.values[299].value = state.value + 1')
+		source.writeln('return state.values[299].value + state.values[0].value')
+		source.writeln('}')
+	}
+	source.writeln('fn main() { mut total := 0')
+	for i in 0 .. 300 {
+		source.writeln('total += helper_${i}()')
+	}
+	source.writeln('println(total) }')
+	input := os.join_path(root, 'main.v')
+	os.write_file(input, source.str()) or { panic(err) }
+	old_jobs := os.getenv_opt('VJOBS')
+	os.setenv('VJOBS', '4', true)
+	defer {
+		if jobs := old_jobs {
+			os.setenv('VJOBS', jobs, true)
+		} else {
+			os.unsetenv('VJOBS')
+		}
+	}
+	for parallel in [true, false] {
+		output := os.join_path(root, if parallel { 'parallel' } else { 'serial' })
+		mut args := ['-nocache', '-building-v', '-o', output]
+		if !parallel {
+			args << '-no-parallel'
+		}
+		args << input
+		compile := cmdexec.run(compiler, args)
+		assert compile.exit_code == 0, compile.output
+		if parallel {
+			assert compile.output.contains('transform (parallel)'), compile.output
+		}
+		run := cmdexec.run(output, []string{})
+		assert run.exit_code == 0, run.output
+		assert run.output.trim_space() == '47250', run.output
+	}
+}

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -3421,8 +3421,8 @@ fn (mut t Transformer) transform_serial_then_collect_pure(literal_decls []int) [
 			} else {
 				// Clone-free workers need conservative expansion estimates because they
 				// append into fixed .nogrow regions. Generic transform workers have
-				// private growable ASTs, so avoid rescanning every function solely to
-				// estimate capacity they do not use.
+				// private growable ASTs, as do self-host transforms. Avoid rescanning
+				// those functions to estimate capacity they do not use.
 				if sc_profile {
 					scsw.restart()
 				}
@@ -3437,7 +3437,7 @@ fn (mut t Transformer) transform_serial_then_collect_pure(literal_decls []int) [
 						str_est, str_needs_deferred_lowering = t.fn_span_interp_estimate(range_lo, i)
 					}
 				}
-				map_est := if t.skip_generics {
+				map_est := if t.skip_generics && !t.building_v {
 					t.fn_span_map_expansion_estimate(range_lo, i)
 				} else {
 					0
@@ -3616,10 +3616,25 @@ fn (mut t Transformer) transform_deferred_expansion_items() {
 // rest of the build (worker memory is never freed under -gc none). Transform grows
 // the AST by well under 25% per worker, so a fixed base/4 margin avoids the cliff.
 fn (t &Transformer) clone_ast_base(base_nodes int, base_children int) &flat.FlatAst {
+	mut cloned := t.allocate_ast_base_clone(base_nodes, base_children)
+	// Both arrays own enough storage for these immutable base payloads.
+	unsafe {
+		vmemcpy(cloned.nodes.data, t.a.nodes.data, isize(base_nodes) * isize(t.a.nodes.element_size))
+		vmemcpy(cloned.children.data, t.a.children.data, isize(base_children) * isize(t.a.children.element_size))
+	}
+	return cloned
+}
+
+// allocate_ast_base_clone reserves a private AST whose base payload is filled
+// before use. Parallel transform copies the disjoint allocations concurrently.
+fn (t &Transformer) allocate_ast_base_clone(base_nodes int, base_children int) &flat.FlatAst {
 	mut nodes := []flat.Node{cap: base_nodes + base_nodes / 4}
-	nodes << t.a.nodes[0..base_nodes]
 	mut children := []flat.NodeId{cap: base_children + base_children / 4}
-	children << t.a.children[0..base_children]
+	// The caller fills these uninitialized slots from the immutable source AST.
+	unsafe {
+		nodes.grow_len(base_nodes)
+		children.grow_len(base_children)
+	}
 	return &flat.FlatAst{
 		nodes: nodes
 		children: children

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -15,6 +15,9 @@ import v3.workers
 
 const min_parallel_transform_items = 256
 const max_parallel_transform_jobs = 7
+// Disposable self-host scratch permits more growable workers within the same
+// memory ceiling. Ordinary generic builds keep the smaller clone limit.
+const max_selfhost_transform_jobs = 12
 // Shared-base workers share the AST but retain private checker and transform
 // scratch. Eight lanes keep large user builds below the ordinary memory ceiling.
 const max_shared_transform_jobs = 8
@@ -2106,13 +2109,17 @@ fn (mut t Transformer) run_parallel_transform(items []FnWorkItem, base_nodes int
 		t.transform_pure_items_serial(items)
 		return false
 	} $else {
+
 		// Generic body lowering can discover signatures, so generic builds use the
-		// cloned-worker path below. Each worker owns its signature maps and the
-		// deterministic merge publishes additions after all body work has joined.
+		// cloned-worker path below. Self-host builds also use growable clones:
+		// metadata-driven expansions otherwise send most compiler functions to the
+		// serial fallback and require an expensive whole-program estimate first.
+		// Each worker owns its signature maps, and the deterministic merge publishes
+		// additions after all body work has joined.
 		if isnil(t.a.worker_pool) {
 			t.a.worker_pool = workers.new(runtime.nr_jobs() - 1)
 		}
-		n_jobs := transform_job_count(t.a.worker_pool.size() + 1, items.len)
+		n_jobs := transform_job_count(t.a.worker_pool.size() + 1, items.len, t.building_v && t.scope_parallel_workers)
 		if items.len < min_parallel_transform_items || n_jobs <= 1 {
 			t.transform_pure_items_serial(items)
 			return false
@@ -2126,11 +2133,10 @@ fn (mut t Transformer) run_parallel_transform(items []FnWorkItem, base_nodes int
 		// Clone-free shared-base path: needs the checker's top-level index for
 		// exact per-item subtree ranges, and skip_generics (the generic passes
 		// scan and mutate arbitrary AST regions, which the shared design forbids).
-		if t.skip_generics && !isnil(t.tc) && t.tc.top_level_idx.len > 0 {
+		if t.skip_generics && !t.building_v && !isnil(t.tc) && t.tc.top_level_idx.len > 0 {
 			shared_jobs := shared_transform_job_count(t.a.worker_pool.size() + 1, items.len)
 			if shared_jobs > 1 {
-				return t.run_parallel_transform_shared(items, base_nodes, base_children,
-					shared_jobs)
+				return t.run_parallel_transform_shared(items, base_nodes, base_children, shared_jobs)
 			}
 		}
 		// Freeze the checker's warm type cache (fully populated by the check
@@ -2151,16 +2157,41 @@ fn (mut t Transformer) run_parallel_transform(items []FnWorkItem, base_nodes int
 		mut transform_workers := []voidptr{cap: thread_count}
 		mut args := []TransformChunkArgs{cap: chunk_count}
 		args << TransformChunkArgs{
-			worker:    voidptr(t)
+			worker: voidptr(t)
 			items_ptr: unsafe { voidptr(&chunks[0]) }
 		}
-		for ci in 0 .. thread_count {
-			wast := t.clone_ast_base(base_nodes, base_children)
+		mut worker_asts := []&flat.FlatAst{cap: thread_count}
+		mut copies := []TransformByteCopy{cap: thread_count * 2}
+		for _ in 0 .. thread_count {
+			wast := t.allocate_ast_base_clone(base_nodes, base_children)
+			worker_asts << wast
+			copies << TransformByteCopy{
+				dst: wast.nodes.data
+				src: t.a.nodes.data
+				bytes: u64(base_nodes) * u64(t.a.nodes.element_size)
+			}
+			copies << TransformByteCopy{
+				dst: wast.children.data
+				src: t.a.children.data
+				bytes: u64(base_children) * u64(t.a.children.element_size)
+			}
+		}
+		mut copy_tasks := []workers.Task{cap: copies.len}
+		for ci in 0 .. copies.len {
+			copy_tasks << workers.Task{
+				run: transform_byte_copy_thread
+				arg: unsafe { voidptr(&copies[ci]) }
+				force_sync: ci == 0
+			}
+		}
+		// No body can mutate the source until every base copy has completed.
+		t.a.worker_pool.run(copy_tasks)
+		for ci, wast in worker_asts {
 			wtc := t.tc.fork_for_parallel_transform(wast)
 			ww := t.fork_worker(wast, wtc)
 			transform_workers << voidptr(ww)
 			args << TransformChunkArgs{
-				worker:    voidptr(ww)
+				worker: voidptr(ww)
 				items_ptr: unsafe { voidptr(&chunks[ci + 1]) }
 			}
 		}
@@ -2174,8 +2205,8 @@ fn (mut t Transformer) run_parallel_transform(items []FnWorkItem, base_nodes int
 		for ci in 0 .. chunk_count {
 			helper_idx := ci - 1
 			tasks << workers.Task{
-				run:        transform_chunk_thread
-				arg:        unsafe { voidptr(&args[ci]) }
+				run: transform_chunk_thread
+				arg: unsafe { voidptr(&args[ci]) }
 				force_sync: ci == 0 || fail == 'transform:all' || fail == 'transform:${helper_idx}'
 			}
 		}
@@ -2694,13 +2725,14 @@ fn late_scan_chunk_bounds(a &flat.FlatAst, cands []LateFnCandidate, n int) []int
 
 // transform_job_count caps the worker count by both the runtime job count and a
 // fixed ceiling (each worker clones the base AST, so more workers cost more memory).
-fn transform_job_count(n_runtime_jobs int, n_items int) int {
+fn transform_job_count(n_runtime_jobs int, n_items int, scoped_selfhost bool) int {
 	if n_runtime_jobs <= 0 || n_items <= 0 {
 		return 0
 	}
 	mut n := n_runtime_jobs
-	if n > max_parallel_transform_jobs {
-		n = max_parallel_transform_jobs
+	limit := if scoped_selfhost { max_selfhost_transform_jobs } else { max_parallel_transform_jobs }
+	if n > limit {
+		n = limit
 	}
 	if n > n_items {
 		n = n_items


### PR DESCRIPTION
Self-host transform's expansion estimator routes ordinary compiler functions with struct
initializers into serial lowering. In the measured build, 2,629 functions were deferred.
Use growable worker ASTs for self-host transforms, copy their bases concurrently, and allow
up to 12 workers when disposable scratch arenas are available. This removes the expensive
capacity scan while preserving the ability to grow for metadata-driven expansion.

Uncached builds of the v3 compiler entry also use the normal import resolver and retain the
transform arena for C generation, avoiding duplicate import discovery and metadata promotion.
Adds a regression comparing parallel and serial execution with 300 functions containing
large nested struct defaults.

Measured on an Apple M5 Max with 18 CPU cores, using a `-gc none -prealloc -prod` bootstrap.
From `vlib/v3`, the measured command was:

```sh
./v3 -nocache -building-v -o v4 v3.v
```

| Measurement | Before | Final run 1 | Final run 2 | Final run 3 |
| --- | ---: | ---: | ---: | ---: |
| Transform | 889.61 ms | 226.88 ms | 242.88 ms | 240.73 ms |
| Total minus CC | 1479.04 ms | 739.26 ms | 775.11 ms | 769.47 ms |

All three final runs meet the 400 ms transform and 800 ms non-CC targets. One earlier
workspace run reached 821 ms non-CC; timings vary with system load. Peak RSS was about
3,700 MB, compared with about 3,350 MB before.

Validation:

- Passed `./vnew -old-compiler -gc none vlib/v3/tests/selfhost_parallel_expansion_test.v`.
- Passed `./vnew -old-compiler -gc none vlib/v3/tests/selfhost_transform_regression_test.v`.
- Passed `./vnew -old-compiler -gc none vlib/v3/tests/transformer_parity_test.v`.
- Passed `./vnew -old-compiler -gc none vlib/v3/driver/eager_import_scan_test.v`.
- Built v4 through uncached self-hosting; v4 compiled and ran Hello World successfully.
- Ran `./vnew -old-compiler -gc none -cflags '-Wl,-stack_size,0x4000000' -silent test vlib/v3/transform/`:
  8 test files passed; `transform_parallel_test.v` retains the existing
  `test_pointer_formatted_interp_still_accounts_for_temp_hoisting` assertion failure.
  Reproduced that failure on unmodified base commit `e9bb2f0d85`.
- Ran formatting on the touched V files and `git diff --check`.

No language or public API changes. The full `test-all` suite was not run; validation focused
on the affected transform, import, and self-host paths.
