### PR TITLE
parser: support unnamed method receivers

### DIFF
--- a/vlib/v/ast/str.v
+++ b/vlib/v/ast/str.v
@@ -126,7 +126,11 @@ pub fn (t &Table) stringify_fn_decl(node &FnDecl, cur_mod string, m2a map[string
 			f.write_string(node.receiver.typ.share().str() + ' ')
 			styp = styp[1..] // remove &
 		}
-		f.write_string(node.receiver.name + ' ')
+		is_type_only_receiver := node.receiver.name == '_' && node.receiver.type_pos.len > 0
+			&& node.receiver.pos.pos == node.receiver.type_pos.pos
+		if !is_type_only_receiver {
+			f.write_string(node.receiver.name + ' ')
+		}
 		styp = util.no_cur_mod(styp, cur_mod)
 		if t.new_int_fmt_fix && styp == 'int' {
 			styp = 'i32'

--- a/vlib/v/fmt/tests/unnamed_receiver_keep.vv
+++ b/vlib/v/fmt/tests/unnamed_receiver_keep.vv
@@ -1,0 +1,5 @@
+struct Receiver {}
+
+fn (Receiver) type_only() {}
+
+fn (_ Receiver) explicitly_ignored() {}

--- a/vlib/v/parser/fn.v
+++ b/vlib/v/parser/fn.v
@@ -1279,7 +1279,14 @@ fn (mut p Parser) fn_receiver(mut params []ast.Param, mut rec ReceiverParsingInf
 		p.register_auto_import('sync')
 	}
 	rec_start_pos := p.tok.pos()
-	rec.name = p.check_name()
+	is_type_only_receiver := p.tok.kind == .name && p.peek_tok.kind == .rpar
+	if is_type_only_receiver {
+		// Keep type-only receivers in sync with V3. The ignored binding still needs to be
+		// present in the method signature so dispatch and code generation receive argument 0.
+		rec.name = '_'
+	} else {
+		rec.name = p.check_name()
+	}
 	if !rec.is_mut {
 		rec.is_mut = p.tok.kind == .key_mut
 		if rec.is_mut {

--- a/vlib/v/tests/testdata/unnamed_receiver_c_module/module.c.v
+++ b/vlib/v/tests/testdata/unnamed_receiver_c_module/module.c.v
@@ -1,0 +1,7 @@
+module unnamed_receiver_c_module
+
+#flag -lm
+
+pub fn identity(value int) int {
+	return value
+}

--- a/vlib/v/tests/unnamed_receiver_c_import_test.v
+++ b/vlib/v/tests/unnamed_receiver_c_import_test.v
@@ -2,7 +2,7 @@ import v.tests.testdata.unnamed_receiver_c_module
 
 struct Foo {}
 
-fn (_ Foo) work(value int) int {
+fn (Foo) work(value int) int {
 	return value
 }
 

--- a/vlib/v/tests/unnamed_receiver_c_import_test.v
+++ b/vlib/v/tests/unnamed_receiver_c_import_test.v
@@ -1,0 +1,11 @@
+import v.tests.testdata.unnamed_receiver_c_module
+
+struct Foo {}
+
+fn (_ Foo) work(value int) int {
+	return value
+}
+
+fn test_unnamed_receiver_with_c_backed_import() {
+	assert Foo{}.work(unnamed_receiver_c_module.identity(1)) == 1
+}


### PR DESCRIPTION
Fixes #28339

Bring the stable parser in line with V3 by accepting type-only method receivers such as `fn (Foo) work()`. The receiver is represented by an ignored `_` binding, so method dispatch and code generation still receive argument 0.

Adds a regression with a local C-backed imported module, matching the fallback path from the issue.

Tests:
- `./vnew -silent vlib/v/tests/unnamed_receiver_c_import_test.v`
- exact `crypto.ecdsa` reproduction and unresolved-import diagnostic
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew -silent test vlib/v/parser/`
- `./vnew -silent test vlib/v/` (attempted; stopped after unrelated existing failures in anon-function/fixed-array tests)