### PR TITLE
db.pg: select Windows import libraries by compiler

### DIFF
--- a/vlib/crypto/ecdsa/ecdsa_d_use_openssl.c.v
+++ b/vlib/crypto/ecdsa/ecdsa_d_use_openssl.c.v
@@ -28,7 +28,12 @@ module ecdsa
 #flag windows -IC:/Program Files/OpenSSL/include
 #flag windows -LC:/Program Files/OpenSSL/lib/VC/x64/MD
 
-#flag -lcrypto
+$if msvc {
+	// OpenSSL's MSVC import library is conventionally named libcrypto.lib.
+	#flag -llibcrypto
+} $else {
+	#flag -lcrypto
+}
 
 #include <openssl/ecdsa.h>
 #include <openssl/obj_mac.h>

--- a/vlib/db/pg/README.md
+++ b/vlib/db/pg/README.md
@@ -69,6 +69,9 @@ after following all instructions. Create the `pg` folder yourself if it does not
 │       postgres_ext.h
 │
 └───win64
+    ├───mingw
+    │       libpq.dll.a
+    │
     └───msvc
             libpq.lib
 ```
@@ -96,8 +99,18 @@ Any program that wants to use postgres client functionality require these DLLs f
 - libssl-3-x64.dll
 - libwinpthread-1.dll
 
-If you want to compile with MSVC, you will need to copy `C:/Program Files/PostgreSQL/<version>/bin/libpq.lib`
-into the `@VEXEROOT/thirdparty/pg/win64/msvc` directory.
+If you want to compile with MSVC, copy
+`C:/Program Files/PostgreSQL/<version>/bin/libpq.lib` into the
+`@VEXEROOT/thirdparty/pg/win64/msvc` directory.
+
+GCC and TCC cannot use the MSVC import library. For these compilers, copy a MinGW-compatible
+`libpq.dll.a` into `@VEXEROOT/thirdparty/pg/win64/mingw`. You can install one with the MSYS2
+`mingw-w64-x86_64-postgresql` package, or generate it from `libpq.dll` with `gendef` and `dlltool`:
+
+```powershell
+gendef "C:/Program Files/PostgreSQL/<version>/bin/libpq.dll"
+dlltool -d libpq.def -l libpq.dll.a -D libpq.dll
+```
 
 Navigate to `C:/Program Files/PostgreSQL/<version>/include`. There you will find the files:
 - `libpq-fe.h`

--- a/vlib/db/pg/pg.c.v
+++ b/vlib/db/pg/pg.c.v
@@ -9,6 +9,10 @@ $if $pkgconfig('libpq') {
 } $else {
 	$if msvc {
 		#flag -llibpq
+	} $else $if windows {
+		// GCC and TCC need a GNU-compatible import library, not MSVC's libpq.lib.
+		// Keep the path explicit so a missing dependency names the expected file.
+		#flag @VEXEROOT/thirdparty/pg/win64/mingw/libpq.dll.a
 	} $else {
 		#flag -lpq
 	}


### PR DESCRIPTION
Fixes #28281.

On Windows, GCC and TCC now link `db.pg` through a GNU-compatible `libpq.dll.a`, while MSVC continues to use `libpq.lib`. The optional OpenSSL ECDSA backend also requests the conventional `libcrypto.lib` name under MSVC instead of `crypto.lib`.

The PostgreSQL module documentation now describes the per-toolchain import-library layout and how to obtain or generate the MinGW library.

Tests:
- `./vnew -check` for the reported `db.pg` + `net.http` imports
- Windows cross-checks with `-cc gcc`, `-cc tcc`, and `-cc msvc`
- OpenSSL opt-in cross-checks with GCC and MSVC
- `./vnew check-md vlib/db/pg/README.md`
- vfmt verification for the changed V files