### PR TITLE
js: avoid invoking native prototype accessors

### DIFF
--- a/examples/js_dom_cube/index.html
+++ b/examples/js_dom_cube/index.html
@@ -1,6 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>V WebGL cube</title>
+</head>
 <body>
     <canvas width="570" height="570" id="myCanvas"></canvas>
-    <script src="cube.js">
-
-    </script>
+    <script src="cube.js"></script>
 </body>
+</html>

--- a/examples/js_dom_draw/index.html
+++ b/examples/js_dom_draw/index.html
@@ -1,7 +1,12 @@
-<body class="main">
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
     <title>Drawing with mouse events</title>
+</head>
+<body class="main">
     <input type="button" id="clearButton" value="Clear canvas">
     <canvas style="border: 1px solid black;" width="720" height="480" id="canvas"></canvas>
-    <script type="text/javascript" src="draw.js"></script>
-
+    <script src="draw.js"></script>
 </body>
+</html>

--- a/vlib/v/gen/js/js.v
+++ b/vlib/v/gen/js/js.v
@@ -2195,7 +2195,11 @@ fn (mut g JsGen) gen_struct_decl(node ast.StructDecl) {
 				sym := g.table.sym(ty)
 
 				if sym.name == node.name {
-					g.writeln('...${g.js_name(iface)}.prototype,')
+					js_iface := g.js_name(iface)
+					g.writeln('...Object.fromEntries(Reflect.ownKeys(${js_iface}.prototype)')
+					g.writeln('\t.map((key) => [key, Object.getOwnPropertyDescriptor(${js_iface}.prototype, key)])')
+					g.writeln("\t.filter(([, descriptor]) => descriptor.enumerable && 'value' in descriptor)")
+					g.writeln('\t.map(([key, descriptor]) => [key, descriptor.value])),')
 				}
 			}
 		}

--- a/vlib/v/gen/js/jsgen_test.v
+++ b/vlib/v/gen/js/jsgen_test.v
@@ -53,7 +53,7 @@ fn test_example_compilation() {
 		if should_create_source_map {
 			if there_is_grep_available {
 				grep_code_sourcemap_found :=
-					os.system('grep -q -E "//#\\ssourceMappingURL=data:application/json;base64,[-A-Za-z0-9+/=]+$" ${os.quoted_path(jsfile)}')
+					os.system('grep -q -E "//#\\ssourceMappingURL=data:application/json;base64,[-A-Za-z0-9+/=]+\$" ${os.quoted_path(jsfile)}')
 				assert grep_code_sourcemap_found == 0
 				println('file has a source map embedded')
 			} else {
@@ -88,6 +88,21 @@ fn test_issue_20667_js_can_compile_game_of_life_example() {
 	assert os.exists(output)
 }
 
+fn test_issue_28253_js_dom_examples_do_not_read_native_prototype_accessors() {
+	vexe := os.getenv('VEXE')
+	os.chdir(os.dir(vexe)) or {}
+	os.mkdir_all(output_dir) or { panic(err) }
+	for example in ['js_dom_cube/cube.js.v', 'js_dom_draw/draw.js.v'] {
+		program := os.join_path('examples', example)
+		output := os.join_path(output_dir, '${os.file_name(example)}.js')
+		res := os.execute('${os.quoted_path(vexe)} -b js_browser -o ${os.quoted_path(output)} ${os.quoted_path(program)}')
+		assert res.exit_code == 0, res.output
+		js := os.read_file(output) or { panic(err) }
+		assert !js.contains('...WebGL2RenderingContext.prototype')
+		assert js.contains('Object.getOwnPropertyDescriptor(WebGL2RenderingContext.prototype, key)')
+	}
+}
+
 fn test_issue_23554_js_browser_interpolated_at_exprs_do_not_emit_nested_templates() {
 	vexe := os.getenv('VEXE')
 	os.chdir(os.dir(vexe)) or {}
@@ -107,7 +122,7 @@ fn test_issue_23554_js_browser_interpolated_at_exprs_do_not_emit_nested_template
 		os.execute('${os.quoted_path(vexe)} -b js_browser -o ${os.quoted_path(output)} ${os.quoted_path(program)}')
 	assert res.exit_code == 0, res.output
 	js := os.read_file(output) or { panic(err) }
-	assert !js.contains('new string(`' + '$' + '{"')
+	assert !js.contains('new string(`' + '\$' + '{"')
 	assert os.exists(output)
 }
 


### PR DESCRIPTION
Fixes #28253.

The JavaScript generator no longer spreads browser-native prototypes directly, which invoked enumerable WebIDL getters such as `WebGL2RenderingContext.canvas` with an invalid receiver in Firefox. It now copies only enumerable data properties through descriptors, avoiding getter evaluation.

Both DOM example pages also declare an HTML doctype and complete document structure so browsers use standards mode.

Tests:
- `./vnew -silent vlib/v/compiler_errors_test.v`
- `./vnew -silent vlib/v/gen/js/jsgen_test.v`
- both reported examples compiled with `-b js_browser`
- vfmt verification for changed V files
- `./vnew -silent test vlib/v/` attempted; stopped after the unrelated existing `vlib/v/tests/anon_fn_map_assign_test.v` failure reproduced