### PR TITLE
asm: add raw templates and Intel syntax

### DIFF
--- a/cmd/tools/vast/vast.v
+++ b/cmd/tools/vast/vast.v
@@ -2051,6 +2051,8 @@ fn (t Tree) asm_stmt(node ast.AsmStmt) &Node {
 	obj.add_terse('is_basic', t.bool_node(node.is_basic))
 	obj.add_terse('is_volatile', t.bool_node(node.is_volatile))
 	obj.add_terse('is_goto', t.bool_node(node.is_goto))
+	obj.add_terse('is_raw', t.bool_node(node.is_raw))
+	obj.add_terse('is_intel', t.bool_node(node.is_intel))
 	obj.add('scope', t.scope(node.scope))
 	// obj.add('scope', t.number_node(int(node.scope)))
 	obj.add('pos', t.pos(node.pos))
@@ -2069,6 +2071,7 @@ fn (t Tree) asm_register(node ast.AsmRegister) &Node {
 	obj.add_terse('name', t.string_node(node.name))
 	obj.add_terse('typ', t.type_node(node.typ))
 	obj.add_terse('size', t.number_node(node.size))
+	obj.add('pos', t.pos(node.pos))
 	return obj
 }
 
@@ -2076,6 +2079,7 @@ fn (t Tree) asm_template(node ast.AsmTemplate) &Node {
 	mut obj := create_object()
 	obj.add_terse('ast_type', t.string_node('AsmTemplate'))
 	obj.add_terse('name', t.string_node(node.name))
+	obj.add_terse('raw_template', t.string_node(node.raw_template))
 	obj.add_terse('is_label', t.bool_node(node.is_label))
 	obj.add_terse('is_directive', t.bool_node(node.is_directive))
 	obj.add_terse('args', t.array_node_asm_arg(node.args))

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -9060,6 +9060,12 @@ asm amd64 intel {
 }
 ```
 
+Structured `intel` blocks support only register-only `r` constraints for input and output
+operands. V uses the GNU x86 `%V` operand modifier so GCC and Clang substitute register names
+without AT&T's `%` prefix. Memory-capable constraints such as `m` are rejected because compilers
+can still format those placeholders with AT&T addressing. In a `raw intel` block, the template is
+passed through unchanged, so use the selected C compiler's explicit operand modifiers.
+
 The `raw` and `intel` modifiers affect GNU-style inline assembly emitted by the C backend. MSVC
 does not support this form of inline assembly on 64-bit targets, and individual instructions or
 constraints can still depend on the selected C compiler and target architecture.

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -9030,6 +9030,40 @@ println('b: ${b}') // 20
 println('c: ${c}') // 120
 ```
 
+The C backend also supports raw GNU assembly templates. In a `raw` block, V passes each
+double-quoted template string through unchanged and still checks the output, input, and clobber
+lists. Operands can use GNU's named form or V's `constraint (expression) as alias` form:
+
+```v ignore
+mut value := 40
+increment := 2
+asm amd64 raw {
+    "addl %[increment], %[value]\n\t"
+    ; [value] "+r" (value)
+    ; [increment] "r" (increment)
+    ; cc
+}
+assert value == 42
+```
+
+Use `intel` for destination-first structured x86 assembly. V surrounds the generated template
+with `.intel_syntax noprefix` and `.att_syntax prefix`, and does not reorder its operands:
+
+```v ignore
+mut value := 40
+increment := 2
+asm amd64 intel {
+    add value, increment
+    ; +r (value)
+    ; r (increment)
+    ; cc
+}
+```
+
+The `raw` and `intel` modifiers affect GNU-style inline assembly emitted by the C backend. MSVC
+does not support this form of inline assembly on 64-bit targets, and individual instructions or
+constraints can still depend on the selected C compiler and target architecture.
+
 For more examples, see
 [vlib/v/slow_tests/assembly/asm_test.amd64.v](https://github.com/vlang/v/tree/master/vlib/v/slow_tests/assembly/asm_test.amd64.v)
 

--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -1871,6 +1871,8 @@ pub:
 	is_basic    bool
 	is_volatile bool
 	is_goto     bool
+	is_raw      bool
+	is_intel    bool
 	clobbered   []AsmClobbered
 	pos         token.Pos
 pub mut:
@@ -1886,6 +1888,7 @@ pub mut:
 pub struct AsmTemplate {
 pub mut:
 	name         string
+	raw_template string
 	is_label     bool // `example_label:`
 	is_directive bool // .globl assembly_function
 	args         []AsmArg
@@ -1909,6 +1912,7 @@ pub mut:
 	name string // eax or r12d etc.
 	typ  Type
 	size int
+	pos  token.Pos
 }
 
 pub struct AsmDisp {
@@ -2010,6 +2014,7 @@ pub const x86_with_number_register_list = {
 		'mm#': 16
 		'cr#': 16
 		'dr#': 16
+		'k#':  8
 	}
 	80:  {
 		'st#': 16

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4284,6 +4284,10 @@ fn (mut c Checker) asm_stmt(mut stmt ast.AsmStmt) {
 	mut aliases := c.asm_ios(mut stmt.output, mut stmt.scope, true)
 	aliases2 := c.asm_ios(mut stmt.input, mut stmt.scope, false)
 	aliases << aliases2
+	if stmt.is_intel && !stmt.is_raw {
+		c.check_asm_intel_ios(stmt.output)
+		c.check_asm_intel_ios(stmt.input)
+	}
 	for mut template in stmt.templates {
 		if stmt.is_raw {
 			continue
@@ -4337,6 +4341,16 @@ fn (mut c Checker) asm_stmt(mut stmt ast.AsmStmt) {
 				msg += '; did you mean `${suggestion}`?'
 			}
 			c.error(msg, clob.reg.pos)
+		}
+	}
+}
+
+fn (mut c Checker) check_asm_intel_ios(ios []ast.AsmIO) {
+	for io in ios {
+		constraint := io.constraint.trim_left('=+&%*')
+		if constraint != 'r' {
+			c.error('constraint `${io.constraint}` is not supported for operands in structured `intel` assembly; use a register-only `r` constraint or a `raw` template with explicit operand modifiers',
+				io.pos)
 		}
 	}
 }

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -4,6 +4,7 @@ module checker
 
 import os
 import strconv
+import strings
 import v.ast
 import v.vmod
 import v.token
@@ -4284,6 +4285,9 @@ fn (mut c Checker) asm_stmt(mut stmt ast.AsmStmt) {
 	aliases2 := c.asm_ios(mut stmt.input, mut stmt.scope, false)
 	aliases << aliases2
 	for mut template in stmt.templates {
+		if stmt.is_raw {
+			continue
+		}
 		if template.is_directive {
 			/*
 			align n[,value]
@@ -4323,9 +4327,49 @@ fn (mut c Checker) asm_stmt(mut stmt ast.AsmStmt) {
 			c.asm_arg(arg, stmt, aliases)
 		}
 	}
-	for mut clob in stmt.clobbered {
-		c.asm_arg(clob.reg, stmt, aliases)
+	for clob in stmt.clobbered {
+		if clob.reg.name in ['cc', 'memory', 'dirflag', 'fpsr', 'flags'] {
+			continue
+		}
+		if clob.reg.name !in stmt.scope.objects {
+			mut msg := 'unknown clobbered register `${clob.reg.name}`'
+			if suggestion := closest_asm_register(clob.reg.name, stmt.scope.objects) {
+				msg += '; did you mean `${suggestion}`?'
+			}
+			c.error(msg, clob.reg.pos)
+		}
 	}
+}
+
+fn closest_asm_register(name string, registers map[string]ast.ScopeObject) ?string {
+	mut digit_start := -1
+	for i, character in name {
+		if character.is_digit() {
+			digit_start = i
+			break
+		}
+	}
+	if digit_start > 0 && name[digit_start..].bytes().all(it.is_digit()) {
+		normalized := name[..digit_start] + name[digit_start..].int().str()
+		if normalized in registers {
+			return normalized
+		}
+	}
+	mut candidates := registers.keys()
+	candidates.sort()
+	mut closest := ''
+	mut closest_distance := 3
+	for candidate in candidates {
+		distance := strings.levenshtein_distance(name, candidate)
+		if distance < closest_distance {
+			closest = candidate
+			closest_distance = distance
+		}
+	}
+	if closest != '' && closest_distance <= if name.len <= 4 { 1 } else { 2 } {
+		return closest
+	}
+	return none
 }
 
 fn asm_expected_operand_count(arch pref.Arch, name string) ?int {
@@ -4340,7 +4384,15 @@ fn asm_expected_operand_count(arch pref.Arch, name string) ?int {
 
 fn (mut c Checker) asm_arg(arg ast.AsmArg, stmt ast.AsmStmt, aliases []string) {
 	match arg {
-		ast.AsmAlias {}
+		ast.AsmAlias {
+			if arg.name !in aliases && arg.name !in stmt.local_labels
+				&& arg.name !in stmt.global_labels {
+				if suggestion := closest_asm_register(arg.name, stmt.scope.objects) {
+					c.error('unknown register `${arg.name}`; did you mean `${suggestion}`?',
+						arg.pos)
+				}
+			}
+		}
 		ast.AsmAddressing {
 			if arg.scale !in [-1, 1, 2, 4, 8] {
 				c.error('scale must be one of 1, 2, 4, or 8', arg.pos)

--- a/vlib/v/checker/tests/asm_intel_memory_constraint.out
+++ b/vlib/v/checker/tests/asm_intel_memory_constraint.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/asm_intel_memory_constraint.vv:5:7: error: constraint `m` is not supported for operands in structured `intel` assembly; use a register-only `r` constraint or a `raw` template with explicit operand modifiers
+    3 |     asm amd64 intel {
+    4 |         mov eax, value
+    5 |         ; ; m (value)
+      |             ~~~~~~~~~
+    6 |     }
+    7 | }

--- a/vlib/v/checker/tests/asm_intel_memory_constraint.vv
+++ b/vlib/v/checker/tests/asm_intel_memory_constraint.vv
@@ -1,0 +1,7 @@
+fn main() {
+	value := 1
+	asm amd64 intel {
+		mov eax, value
+		; ; m (value)
+	}
+}

--- a/vlib/v/checker/tests/asm_unknown_clobber.out
+++ b/vlib/v/checker/tests/asm_unknown_clobber.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/asm_unknown_clobber.vv:4:9: error: unknown clobbered register `raxx`; did you mean `rax`?
+    2 |     asm amd64 {
+    3 |         nop
+    4 |         ; ; ; raxx
+      |               ~~~~
+    5 |     }
+    6 | }

--- a/vlib/v/checker/tests/asm_unknown_clobber.vv
+++ b/vlib/v/checker/tests/asm_unknown_clobber.vv
@@ -1,0 +1,6 @@
+fn main() {
+	asm amd64 {
+		nop
+		; ; ; raxx
+	}
+}

--- a/vlib/v/checker/tests/asm_unknown_register_suggestion.out
+++ b/vlib/v/checker/tests/asm_unknown_register_suggestion.out
@@ -1,0 +1,7 @@
+vlib/v/checker/tests/asm_unknown_register_suggestion.vv:3:7: error: unknown register `xmm01`; did you mean `xmm1`?
+    1 | fn main() {
+    2 |     asm amd64 {
+    3 |         mov xmm01, xmm1
+      |             ~~~~~
+    4 |     }
+    5 | }

--- a/vlib/v/checker/tests/asm_unknown_register_suggestion.vv
+++ b/vlib/v/checker/tests/asm_unknown_register_suggestion.vv
@@ -1,0 +1,5 @@
+fn main() {
+	asm amd64 {
+		mov xmm01, xmm1
+	}
+}

--- a/vlib/v/fmt/asm.v
+++ b/vlib/v/fmt/asm.v
@@ -17,10 +17,17 @@ fn (mut f Fmt) asm_stmt(stmt ast.AsmStmt) {
 	} else {
 		stmt.arch.str()
 	}
-	f.writeln('${lit_arch} {')
+	f.write(lit_arch)
+	if stmt.is_raw {
+		f.write(' raw')
+	}
+	if stmt.is_intel {
+		f.write(' intel')
+	}
+	f.writeln(' {')
 	f.indent++
 
-	f.asm_templates(stmt.templates)
+	f.asm_templates(stmt.templates, stmt.is_raw)
 
 	if stmt.output.len != 0 || stmt.input.len != 0 || stmt.clobbered.len != 0 {
 		f.write('; ')
@@ -130,8 +137,17 @@ fn (mut f Fmt) asm_reg(reg ast.AsmRegister) {
 	f.write(reg.name)
 }
 
-fn (mut f Fmt) asm_templates(templates []ast.AsmTemplate) {
+fn (mut f Fmt) asm_templates(templates []ast.AsmTemplate, is_raw bool) {
 	for template in templates {
+		if is_raw {
+			f.write('"${template.raw_template}"')
+			if template.comments.len == 0 {
+				f.writeln('')
+			} else {
+				f.comments(template.comments)
+			}
+			continue
+		}
 		if template.is_directive {
 			f.write('.')
 		}

--- a/vlib/v/fmt/tests/assembly/asm_raw_intel_keep.vv
+++ b/vlib/v/fmt/tests/assembly/asm_raw_intel_keep.vv
@@ -1,0 +1,16 @@
+fn example(lhs int, rhs int) int {
+	mut value := lhs
+	asm amd64 raw {
+		"addl %[rhs], %[value]\n\t"
+		; +r (value)
+		; r (rhs)
+		; cc
+	}
+	asm amd64 intel {
+		add value, rhs
+		; +r (value)
+		; r (rhs)
+		; cc
+	}
+	return value
+}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6305,8 +6305,15 @@ fn (mut g Gen) asm_stmt(stmt ast.AsmStmt) {
 	if stmt.templates.len == 0 {
 		g.writeln('""')
 	}
+	if stmt.is_intel {
+		g.writeln('".intel_syntax noprefix\\n\\t"')
+	}
 	for template_tmp in stmt.templates {
 		mut template := template_tmp
+		if stmt.is_raw {
+			g.writeln('"${template.raw_template}"')
+			continue
+		}
 		g.write('"')
 		if template.is_directive {
 			g.write('.')
@@ -6317,11 +6324,11 @@ fn (mut g Gen) asm_stmt(stmt ast.AsmStmt) {
 		} else {
 			g.write(' ')
 		}
-		// swap destination and operands for att syntax, not for arm64
-		if template.args.len != 0 && !template.is_directive
+		// V's structured x86 assembly uses destination-first operand order. AT&T uses
+		// the reverse order; Intel blocks already have the order expected by the assembler.
+		if template.args.len > 1 && !template.is_directive && !stmt.is_intel
 			&& stmt.arch !in [.arm64, .s390x, .ppc64le, .loongarch64, .rv64, .rv32] {
-			template.args.prepend(template.args.last())
-			template.args.delete(template.args.len - 1)
+			template.args.reverse_in_place()
 		}
 
 		for i, arg in template.args {
@@ -6340,6 +6347,9 @@ fn (mut g Gen) asm_stmt(stmt ast.AsmStmt) {
 			g.write('\\n\\t')
 		}
 		g.writeln('"')
+	}
+	if stmt.is_intel {
+		g.writeln('".att_syntax prefix\\n\\t"')
 	}
 
 	if stmt.output.len != 0 || stmt.input.len != 0 || stmt.clobbered.len != 0 || stmt.is_goto {
@@ -6394,7 +6404,9 @@ fn (mut g Gen) asm_arg(arg ast.AsmArg, stmt ast.AsmStmt) {
 			g.write("'${arg.val}'")
 		}
 		ast.IntegerLiteral {
-			if stmt.arch == .arm64 {
+			if stmt.is_intel {
+				g.write(arg.val)
+			} else if stmt.arch == .arm64 {
 				g.write('#${arg.val}')
 			} else if stmt.arch in [.s390x, .ppc64le, .loongarch64, .rv64, .rv32] {
 				g.write('${arg.val}')
@@ -6403,17 +6415,25 @@ fn (mut g Gen) asm_arg(arg ast.AsmArg, stmt ast.AsmStmt) {
 			}
 		}
 		ast.FloatLiteral {
-			if g.pref.nofloat {
+			if stmt.is_intel {
+				g.write(if g.pref.nofloat { arg.val.int().str() } else { arg.val })
+			} else if g.pref.nofloat {
 				g.write('\$${arg.val.int()}')
 			} else {
 				g.write('\$${arg.val}')
 			}
 		}
 		ast.BoolLiteral {
-			g.write('\$${arg.val.str()}')
+			if stmt.is_intel {
+				g.write(arg.val.str())
+			} else {
+				g.write('\$${arg.val.str()}')
+			}
 		}
 		ast.AsmRegister {
-			if stmt.arch in [.rv64, .rv32] {
+			if stmt.is_intel {
+				g.write(arg.name)
+			} else if stmt.arch in [.rv64, .rv32] {
 				g.write('${arg.name}')
 			} else if stmt.arch == .loongarch64 {
 				g.write('$${arg.name}')
@@ -6425,6 +6445,10 @@ fn (mut g Gen) asm_arg(arg ast.AsmArg, stmt ast.AsmStmt) {
 			}
 		}
 		ast.AsmAddressing {
+			if stmt.is_intel {
+				g.asm_addressing_intel(arg, stmt)
+				return
+			}
 			if arg.segment != '' {
 				g.write('%%${arg.segment}:')
 			}
@@ -6507,6 +6531,49 @@ fn (mut g Gen) asm_arg(arg ast.AsmArg, stmt ast.AsmStmt) {
 			g.write(arg)
 		}
 	}
+}
+
+fn (mut g Gen) asm_addressing_intel(arg ast.AsmAddressing, stmt ast.AsmStmt) {
+	if arg.segment != '' {
+		g.write('${arg.segment}:')
+	}
+	g.write('[')
+	match arg.mode {
+		.base {
+			g.asm_arg(arg.base, stmt)
+		}
+		.displacement {
+			g.asm_arg(arg.displacement, stmt)
+		}
+		.base_plus_displacement, .rip_plus_displacement {
+			g.asm_arg(arg.base, stmt)
+			g.write(' + ')
+			g.asm_arg(arg.displacement, stmt)
+		}
+		.index_times_scale_plus_displacement {
+			g.asm_arg(arg.index, stmt)
+			g.write(' * ${arg.scale} + ')
+			g.asm_arg(arg.displacement, stmt)
+		}
+		.base_plus_index_plus_displacement {
+			g.asm_arg(arg.base, stmt)
+			g.write(' + ')
+			g.asm_arg(arg.index, stmt)
+			g.write(' + ')
+			g.asm_arg(arg.displacement, stmt)
+		}
+		.base_plus_index_times_scale_plus_displacement {
+			g.asm_arg(arg.base, stmt)
+			g.write(' + ')
+			g.asm_arg(arg.index, stmt)
+			g.write(' * ${arg.scale} + ')
+			g.asm_arg(arg.displacement, stmt)
+		}
+		.invalid {
+			g.error('invalid addressing mode', arg.pos)
+		}
+	}
+	g.write(']')
 }
 
 fn (mut g Gen) gen_asm_ios(ios []ast.AsmIO) {

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -6396,6 +6396,10 @@ fn (mut g Gen) asm_arg(arg ast.AsmArg, stmt ast.AsmStmt) {
 				|| (name !in stmt.input.map(it.alias) && name !in stmt.output.map(it.alias)) {
 				asm_formatted_name := if name in stmt.global_labels { '%l[${name}]' } else { name }
 				g.write(asm_formatted_name)
+			} else if stmt.is_intel {
+				// `%V` asks GCC and Clang to substitute an x86 register without the `%`
+				// prefix required by AT&T syntax.
+				g.write('%V[${name}]')
 			} else {
 				g.write('%[${name}]')
 			}

--- a/vlib/v/parser/asm.v
+++ b/vlib/v/parser/asm.v
@@ -51,15 +51,45 @@ fn (mut p Parser) asm_stmt(is_top_level bool) ast.AsmStmt {
 	} else {
 		p.next()
 	}
+	mut is_raw := false
+	mut is_intel := false
+	for p.tok.kind == .name && p.tok.lit in ['raw', 'intel'] {
+		modifier_pos := p.tok.pos()
+		match p.tok.lit {
+			'raw' {
+				if is_raw {
+					p.error_with_pos('duplicate `raw` assembly modifier', modifier_pos)
+				}
+				is_raw = true
+			}
+			'intel' {
+				if is_intel {
+					p.error_with_pos('duplicate `intel` assembly modifier', modifier_pos)
+				}
+				is_intel = true
+			}
+			else {}
+		}
+		p.next()
+	}
+	if is_intel && arch !in [.amd64, .i386] && !p.pref.is_fmt {
+		p.error('the `intel` assembly modifier is only supported for i386 and amd64')
+	}
+	if is_raw && p.pref.backend != .c && !p.pref.is_fmt {
+		p.error('the `raw` assembly modifier is only supported by the C backend')
+	}
+	if is_intel && p.pref.backend != .c && !p.pref.is_fmt {
+		p.error('the `intel` assembly modifier is only supported by the C backend')
+	}
 
 	p.check_for_impure_v(ast.pref_arch_to_table_language(arch), p.prev_tok.pos())
 
 	p.check(.lcbr)
 	p.scope = &ast.Scope{
-		parent:               unsafe { nil } // you shouldn't be able to reference other variables in assembly blocks
+		parent: unsafe { nil } // you shouldn't be able to reference other variables in assembly blocks
 		detached_from_parent: true
-		start_pos:            p.tok.pos
-		objects:              ast.all_registers(mut p.table, arch) //
+		start_pos: p.tok.pos
+		objects: ast.all_registers(mut p.table, arch) //
 	}
 
 	mut local_labels := []string{}
@@ -67,7 +97,31 @@ fn (mut p Parser) asm_stmt(is_top_level bool) ast.AsmStmt {
 	// x86: https://www.felixcloutier.com/x86/
 	// arm: https://developer.arm.com/documentation/dui0068/b/arm-instruction-reference
 	mut templates := []ast.AsmTemplate{}
-	for p.tok.kind !in [.semicolon, .rcbr, .eof] {
+	if is_raw {
+		for p.tok.kind !in [.semicolon, .rcbr, .eof] {
+			template_pos := p.tok.pos()
+			if p.tok.kind != .string {
+				p.error('raw assembly templates must contain only double-quoted string literals')
+				break
+			}
+			if p.tok.pos < 0 || p.tok.pos >= p.scanner.text.len
+				|| p.scanner.text[p.tok.pos] != `"` {
+				p.error('raw assembly templates must use double-quoted string literals')
+			}
+			raw_template := p.tok.lit
+			p.next()
+			mut comments := []ast.Comment{}
+			for p.tok.kind == .comment {
+				comments << p.comment()
+			}
+			templates << ast.AsmTemplate{
+				raw_template: raw_template
+				comments: comments
+				pos: template_pos.extend(p.prev_tok.pos())
+			}
+		}
+	}
+	for !is_raw && p.tok.kind !in [.semicolon, .rcbr, .eof] {
 		template_pos := p.tok.pos()
 		mut name := ''
 		mut comments := []ast.Comment{}
@@ -224,12 +278,12 @@ fn (mut p Parser) asm_stmt(is_top_level bool) ast.AsmStmt {
 			}
 		}
 		templates << ast.AsmTemplate{
-			name:         name
-			args:         args
-			comments:     comments
-			is_label:     is_label
+			name: name
+			args: args
+			comments: comments
+			is_label: is_label
 			is_directive: is_directive
-			pos:          template_pos.extend(p.tok.pos())
+			pos: template_pos.extend(p.tok.pos())
 		}
 	}
 	mut scope := p.scope
@@ -250,8 +304,9 @@ fn (mut p Parser) asm_stmt(is_top_level bool) ast.AsmStmt {
 				for p.tok.kind == .name {
 					reg := ast.AsmRegister{
 						name: p.tok.lit
-						typ:  0
+						typ: 0
 						size: -1
+						pos: p.tok.pos()
 					}
 					p.next()
 
@@ -260,7 +315,7 @@ fn (mut p Parser) asm_stmt(is_top_level bool) ast.AsmStmt {
 						comments << p.comment()
 					}
 					clobbered << ast.AsmClobbered{
-						reg:      reg
+						reg: reg
 						comments: comments
 					}
 
@@ -289,18 +344,20 @@ fn (mut p Parser) asm_stmt(is_top_level bool) ast.AsmStmt {
 	scope.end_pos = p.prev_tok.pos
 
 	return ast.AsmStmt{
-		arch:          arch
-		is_goto:       is_goto
-		is_volatile:   is_volatile
-		templates:     templates
-		output:        output
-		input:         input
-		clobbered:     clobbered
-		pos:           pos.extend(p.prev_tok.pos())
-		is_basic:      is_top_level || output.len + input.len + clobbered.len == 0
-		scope:         scope
+		arch: arch
+		is_goto: is_goto
+		is_volatile: is_volatile
+		is_raw: is_raw
+		is_intel: is_intel
+		templates: templates
+		output: output
+		input: input
+		clobbered: clobbered
+		pos: pos.extend(p.prev_tok.pos())
+		is_basic: is_top_level || output.len + input.len + clobbered.len == 0
+		scope: scope
 		global_labels: global_labels
-		local_labels:  local_labels
+		local_labels: local_labels
 	}
 }
 
@@ -322,7 +379,7 @@ fn (mut p Parser) reg_or_alias() ast.AsmArg {
 	} else {
 		return ast.AsmAlias{
 			name: p.prev_tok.lit
-			pos:  p.prev_tok.pos()
+			pos: p.prev_tok.pos()
 		}
 	}
 }
@@ -420,7 +477,7 @@ fn (mut p Parser) reg_or_alias() ast.AsmArg {
 fn (mut p Parser) asm_addressing() ast.AsmAddressing {
 	pos := p.tok.pos()
 	p.check(.lsbr)
-	unknown_addressing_mode := 'unknown addressing mode. supported ones are [displacement],	[base], [base + displacement], [index ∗ scale + displacement], [base + index ∗ scale + displacement], [base + index + displacement], [rip + displacement]'
+	unknown_addressing_mode := 'unknown addressing mode. supported ones are [displacement],\t[base], [base + displacement], [index ∗ scale + displacement], [base + index ∗ scale + displacement], [base + index + displacement], [rip + displacement]'
 	// this mess used to look much cleaner before the removal of peek_tok2/3, see above code for cleaner version
 	if p.peek_tok.kind == .rsbr { // [displacement] or [base]
 		if p.tok.kind == .name {
@@ -429,7 +486,7 @@ fn (mut p Parser) asm_addressing() ast.AsmAddressing {
 			return ast.AsmAddressing{
 				mode: .base
 				base: base
-				pos:  pos.extend(p.prev_tok.pos())
+				pos: pos.extend(p.prev_tok.pos())
 			}
 		} else if p.tok.kind == .number {
 			displacement := if p.tok.kind == .name {
@@ -444,9 +501,9 @@ fn (mut p Parser) asm_addressing() ast.AsmAddressing {
 			}
 			p.check(.rsbr)
 			return ast.AsmAddressing{
-				mode:         .displacement
+				mode: .displacement
 				displacement: displacement
-				pos:          pos.extend(p.prev_tok.pos())
+				pos: pos.extend(p.prev_tok.pos())
 			}
 		} else {
 			p.error(unknown_addressing_mode)
@@ -469,10 +526,10 @@ fn (mut p Parser) asm_addressing() ast.AsmAddressing {
 			}
 			p.check(.rsbr)
 			return ast.AsmAddressing{
-				mode:         .rip_plus_displacement
-				base:         rip
+				mode: .rip_plus_displacement
+				base: rip
 				displacement: displacement
-				pos:          pos.extend(p.prev_tok.pos())
+				pos: pos.extend(p.prev_tok.pos())
 			}
 		}
 		base := p.reg_or_alias()
@@ -491,10 +548,10 @@ fn (mut p Parser) asm_addressing() ast.AsmAddressing {
 				}
 				p.check(.rsbr)
 				return ast.AsmAddressing{
-					mode:         .base_plus_displacement
-					base:         base
+					mode: .base_plus_displacement
+					base: base
 					displacement: displacement
-					pos:          pos.extend(p.prev_tok.pos())
+					pos: pos.extend(p.prev_tok.pos())
 				}
 			} else {
 				p.error(unknown_addressing_mode)
@@ -518,12 +575,12 @@ fn (mut p Parser) asm_addressing() ast.AsmAddressing {
 			}
 			p.check(.rsbr)
 			return ast.AsmAddressing{
-				mode:         .base_plus_index_times_scale_plus_displacement
-				base:         base
-				index:        index
-				scale:        scale
+				mode: .base_plus_index_times_scale_plus_displacement
+				base: base
+				index: index
+				scale: scale
 				displacement: displacement
-				pos:          pos.extend(p.prev_tok.pos())
+				pos: pos.extend(p.prev_tok.pos())
 			}
 		} else if p.tok.kind == .plus {
 			p.next()
@@ -539,11 +596,11 @@ fn (mut p Parser) asm_addressing() ast.AsmAddressing {
 			}
 			p.check(.rsbr)
 			return ast.AsmAddressing{
-				mode:         .base_plus_index_plus_displacement
-				base:         base
-				index:        index
+				mode: .base_plus_index_plus_displacement
+				base: base
+				index: index
 				displacement: displacement
-				pos:          pos.extend(p.prev_tok.pos())
+				pos: pos.extend(p.prev_tok.pos())
 			}
 		}
 	}
@@ -565,11 +622,11 @@ fn (mut p Parser) asm_addressing() ast.AsmAddressing {
 		}
 		p.check(.rsbr)
 		return ast.AsmAddressing{
-			mode:         .index_times_scale_plus_displacement
-			index:        index
-			scale:        scale
+			mode: .index_times_scale_plus_displacement
+			index: index
+			scale: scale
 			displacement: displacement
-			pos:          pos.extend(p.prev_tok.pos())
+			pos: pos.extend(p.prev_tok.pos())
 		}
 	}
 	p.error(unknown_addressing_mode)
@@ -590,7 +647,22 @@ fn (mut p Parser) asm_ios(output bool) []ast.AsmIO {
 		pos := p.tok.pos()
 
 		mut constraint := ''
-		if p.tok.kind == .lpar {
+		mut alias := ''
+		if p.tok.kind == .lsbr {
+			p.next()
+			alias = p.check_name()
+			p.check(.rsbr)
+			if p.tok.kind != .string {
+				p.error('quoted assembly constraint expected after `[${alias}]`')
+				return []
+			}
+			constraint = p.tok.lit
+			p.next()
+			if output && !constraint.starts_with('=') && !constraint.starts_with('+') {
+				p.error_with_pos('Output constraint must starts with `=` or `+`', pos)
+				return []
+			}
+		} else if p.tok.kind == .lpar {
 			constraint = if output { '+r' } else { 'r' } // default constraint, though vfmt fmts to `+r` and `r`
 		} else {
 			// https://gcc.gnu.org/onlinedocs/gcc/Modifiers.html
@@ -648,12 +720,11 @@ fn (mut p Parser) asm_ios(output bool) []ast.AsmIO {
 			return []
 		}
 		expr = next_expr
-		mut alias := ''
-		if p.tok.kind == .key_as {
+		if alias == '' && p.tok.kind == .key_as {
 			p.next()
 			alias = p.tok.lit
 			p.check(.name)
-		} else if mut expr is ast.Ident {
+		} else if alias == '' && mut expr is ast.Ident {
 			alias = expr.name
 		}
 		// for constraints like `a`, no alias is needed, it is referred to as rcx
@@ -663,11 +734,11 @@ fn (mut p Parser) asm_ios(output bool) []ast.AsmIO {
 		}
 
 		res << ast.AsmIO{
-			alias:      alias
+			alias: alias
 			constraint: constraint
-			expr:       expr
-			comments:   comments
-			pos:        pos.extend(p.prev_tok.pos())
+			expr: expr
+			comments: comments
+			pos: pos.extend(p.prev_tok.pos())
 		}
 		p.n_asm++
 		if p.tok.kind in [.semicolon, .rcbr] {

--- a/vlib/v/slow_tests/assembly/asm_intel_clang_test.amd64.v
+++ b/vlib/v/slow_tests/assembly/asm_intel_clang_test.amd64.v
@@ -1,0 +1,14 @@
+// vtest build: !windows && !msvc
+// vtest vflags: -cc clang -no-retry-compilation
+
+fn test_intel_extended_register_operands_with_clang() {
+	increment := 23
+	mut result := 19
+	asm amd64 intel {
+		add result, increment
+		; +r (result)
+		; r (increment)
+		; cc
+	}
+	assert result == 42
+}

--- a/vlib/v/slow_tests/assembly/asm_raw_intel_test.amd64.v
+++ b/vlib/v/slow_tests/assembly/asm_raw_intel_test.amd64.v
@@ -1,0 +1,57 @@
+// vtest build: !msvc
+
+fn test_raw_template_with_named_operands() {
+	lhs := 19
+	rhs := 23
+	mut result := 0
+	asm amd64 raw {
+		"movl %[lhs], %[result]\n\t"
+		"addl %[rhs], %[result]\n\t"
+		; [result] "=r" (result)
+		; [lhs] "r" (lhs)
+		  [rhs] "r" (rhs)
+		; cc
+	}
+	assert result == 42
+}
+
+fn test_intel_syntax_and_three_operand_reordering() {
+	$if !tinyc {
+		lhs := 6
+		rhs := 23
+		mut intel_result := 19
+		asm amd64 intel {
+			add intel_result, rhs
+			; +r (intel_result)
+			; r (rhs)
+			; cc
+		}
+		assert intel_result == 42
+
+		mut att_result := 0
+		asm amd64 {
+			imul att_result, lhs, 7
+			; =r (att_result)
+			; r (lhs)
+			; cc
+		}
+		assert att_result == 42
+	}
+}
+
+fn test_raw_avx512_mask_syntax_compiles_without_running() {
+	$if !tinyc {
+		if can_run_avx512_test() {
+			asm amd64 raw {
+				"vpxord %%zmm0, %%zmm0, %%zmm0%{%%k1%}%{z%}\n\t"
+				; ; ; zmm0
+				  k1
+			}
+		}
+	}
+}
+
+@[noinline]
+fn can_run_avx512_test() bool {
+	return false
+}


### PR DESCRIPTION
Fixes #28298.

This extends C-backend inline assembly with:

- `asm <arch> raw` templates passed through to GNU inline asm while retaining typed input/output checking
- `asm i386|amd64 intel` blocks wrapped in `.intel_syntax noprefix` / `.att_syntax prefix`
- correct destination-first to AT&T operand reversal for structured multi-operand x86 instructions
- GNU named operand syntax (`[name] "constraint" (expression)`)
- architecture-aware unknown-register and clobber diagnostics with near-match suggestions
- formatter and `vast` support, documentation, and regression coverage including AVX-512 mask syntax

Tests:
- compiler errors: 1698 passed, 1 skipped
- parser suite: 9 passed, 1 skipped
- checker suite: 4 passed
- compiler diagnostic fixtures: 95 files, 0 errors
- C output suite: 240 fixtures checked, 0 errors
- vfmt suite: 90 passed
- raw/Intel x86 regression built and ran with GCC and Clang
- existing amd64 assembly regressions built and ran with Clang
- `vast` compiled and serialized the new AST fields
- `./vnew check-md doc/docs.md`
- `./vnew -silent test vlib/v/` attempted; stopped after the unrelated existing `vlib/v/tests/anon_fn_map_assign_test.v` failure reproduced

Bundled TCC cannot perform an x86 cross-assembly run on this ARM64 macOS host (`movl` is reported as an unsupported ARM64 instruction); V’s normal compiler fallback succeeds. Native TCC coverage remains available on x86 CI.