### PR TITLE
fasthttp: harden framing and connection state

### DIFF
--- a/vlib/fasthttp/README.md
+++ b/vlib/fasthttp/README.md
@@ -164,8 +164,9 @@ fn handle(req fasthttp.HttpRequest, mut out []u8, ws voidptr, mut ctl fasthttp.R
 ## Configuration
 
 `ServerConfig` fields: `family` (`.ip` / `.ip6`), `port`,
-`max_request_buffer_size` (bounds the request head; an oversized head gets `413`),
-`timeout_in_seconds` (read/write deadlines; a stalled request gets `408`),
+`max_request_buffer_size` (bounds the request head; an oversized head gets `431`),
+`max_request_body_size` (defaults to 64 MiB; set to `0` only to allow unlimited buffered
+request bodies), `timeout_in_seconds` (read/write deadlines; a stalled request gets `408`),
 `user_data` (an opaque pointer surfaced as `HttpRequest.user_data`), `handler` /
 `append_handler`, and `make_state`.
 
@@ -185,8 +186,8 @@ handle.shutdown(timeout: 5 * time.second)! // drain in-flight, then stop
 | Platform | Backend | Pooling + pipelining | Append handler | make_state |
 |---|---|---|---|---|
 | Linux   | epoll  | yes | yes | yes |
-| macOS/BSD | kqueue | one request per read | yes | yes |
-| Windows | IOCP   | one request per read | yes | not yet (`run` WIP) |
+| macOS/BSD | kqueue | yes, serial responses | yes | yes |
+| Windows | IOCP   | yes, serial responses | yes | yes |
 
 ## Request-scoped allocation with `-prealloc`
 

--- a/vlib/fasthttp/fasthttp.v
+++ b/vlib/fasthttp/fasthttp.v
@@ -9,10 +9,20 @@ import time
 
 const max_thread_pool_size = runtime.nr_cpus()
 const max_connection_size = 65536 // Max events per epoll_wait
+const default_max_request_body_size = 64 * 1024 * 1024
 
 const tiny_bad_request_response = 'HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\nConnection: close\r\n\r\n'.bytes()
 const status_444_response = 'HTTP/1.1 444 No Response\r\nContent-Length: 0\r\nConnection: close\r\n\r\n'.bytes()
 const status_413_response = 'HTTP/1.1 413 Payload Too Large\r\nContent-Length: 0\r\nConnection: close\r\n\r\n'.bytes()
+const status_431_response = 'HTTP/1.1 431 Request Header Fields Too Large\r\nContent-Length: 0\r\nConnection: close\r\n\r\n'.bytes()
+
+fn response_for_frame_error(frame_result int) []u8 {
+	return match frame_result {
+		frame_err_body { status_413_response }
+		frame_err_header { status_431_response }
+		else { tiny_bad_request_response }
+	}
+}
 
 pub struct Slice {
 pub:
@@ -233,7 +243,11 @@ pub:
 	host                    string
 	port                    int = 3000
 	max_request_buffer_size int = 8192
-	timeout_in_seconds      int = 30
+	// max_request_body_size independently bounds buffered request payload bytes.
+	// Set it to 0 only for trusted deployments that intentionally allow unlimited
+	// in-memory request bodies.
+	max_request_body_size int = default_max_request_body_size
+	timeout_in_seconds    int = 30
 	// handler is the classic contract: it builds and returns a full HttpResponse.
 	// Set exactly ONE of `handler` or `append_handler`.
 	handler   fn (HttpRequest) !HttpResponse = unsafe { nil }
@@ -254,7 +268,7 @@ pub:
 pub struct ShutdownParams {
 pub:
 	timeout         time.Duration = time.infinite
-	retry_period_ms int           = 10
+	retry_period_ms int = 10
 }
 
 // WaitTillRunningParams allows parametrizing the calls to `ServerHandle.wait_till_running()`.

--- a/vlib/fasthttp/fasthttp_bsd.c.v
+++ b/vlib/fasthttp/fasthttp_bsd.c.v
@@ -5,26 +5,47 @@ import sync.stdatomic
 import time
 
 #include <errno.h>
+
 #include <fcntl.h>
+
 #include <sys/event.h>
+
 #include <sys/stat.h>
+
 #include <sys/types.h>
+
 #include <sys/socket.h>
+
 #include <sys/uio.h>
+
 #include <netinet/in.h>
+
 #include <netinet/tcp.h>
+
 #include <signal.h>
 
+#include <string.h>
+
 fn C.socket(domain i32, typ i32, protocol i32) i32
+
 fn C.bind(sockfd i32, addr voidptr, addrlen u32) i32
+
 fn C.send(__fd i32, __buf voidptr, __n usize, __flags i32) i32
+
 fn C.recv(__fd i32, __buf voidptr, __n usize, __flags i32) i32
+
 fn C.setsockopt(__fd i32, __level i32, __optname i32, __optval voidptr, __optlen u32) i32
+
 fn C.listen(__fd i32, __n i32) i32
+
 fn C.perror(s &u8)
+
 fn C.close(fd i32) i32
+
 fn C.htons(__hostshort u16) u16
+
 fn C.fcntl(fd i32, cmd i32, arg ...voidptr) i32
+
 fn C.signal(sig int, handler voidptr) voidptr
 
 const buf_size = max_connection_size
@@ -42,7 +63,9 @@ const bsd_thread_pool_size = if max_thread_pool_size < 2 { 2 } else { max_thread
 const send_flags = $if openbsd { int(C.MSG_NOSIGNAL) } $else { 0 }
 
 fn C.kevent(kq i32, changelist &C.kevent, nchanges i32, eventlist &C.kevent, nevents i32, timeout &C.timespec) i32
+
 fn C.kqueue() i32
+
 fn C.fstat(fd i32, buf &C.stat) i32
 
 // send_file_bytes has three implementations across BSD-family OSes:
@@ -68,6 +91,7 @@ fn send_file_bytes(file_fd i32, sock_fd i32, offset i64, nbytes i64) (int, i64) 
 		ret := C.sendfile(file_fd, sock_fd, offset, &len, unsafe { nil }, 0)
 		return int(ret), len
 	} $else $if openbsd {
+
 		// No sendfile(2) on OpenBSD; pread into a stack buffer, then send.
 		// Cap one call at sendfile_fallback_buf_size so we don't starve
 		// other connections in the kqueue loop.
@@ -99,9 +123,11 @@ $if macos {
 	// int sendfile(int fd, int s, off_t offset, off_t *len, struct sf_hdtr *hdtr, int flags);
 	fn C.sendfile(fd i32, s i32, offset i64, len &i64, hdtr voidptr, flags i32) i32
 } $else $if openbsd {
+
 	// ssize_t pread(int fd, void *buf, size_t nbyte, off_t offset);
 	fn C.pread(fd i32, buf voidptr, nbyte usize, offset i64) isize
 } $else {
+
 	// int sendfile(int fd, int s, off_t offset, size_t nbytes, struct sf_hdtr *hdtr, off_t *sbytes, int flags);
 	fn C.sendfile(fd i32, s i32, offset i64, nbytes usize, hdtr voidptr, sbytes &i64, flags i32) i32
 }
@@ -136,6 +162,8 @@ mut:
 	write_pos      int
 	request_active bool
 	read_start     i64 // monotonic timestamp (in microseconds) when first data was received
+	write_start    i64 // monotonic timestamp while a response is blocked on the socket
+	read_eof       bool
 
 	// Sendfile state
 	file_fd       int = -1
@@ -144,6 +172,33 @@ mut:
 	should_close  bool
 	request_arena voidptr
 	worker_state  voidptr // this worker thread's make_state value (nil if unset)
+	retired       &RetiredConns = unsafe { nil }
+}
+
+// Kqueue can return read and write notifications for the same connection in one
+// batch. Closed connection objects are therefore retired until every event in
+// that batch has been inspected, instead of freeing event.udata immediately.
+@[heap]
+struct RetiredConns {
+mut:
+	items []voidptr
+}
+
+fn (mut retired RetiredConns) free_all() {
+	for c_ptr in retired.items {
+		unsafe { free(c_ptr) }
+	}
+	retired.items.clear()
+}
+
+fn retire_conn(mut c Conn, c_ptr voidptr) {
+	if c.retired == unsafe { nil } {
+		// Unit tests that construct a Conn outside the event loop do not need batch
+		// lifetime protection.
+		unsafe { free(c_ptr) }
+		return
+	}
+	c.retired.items << c_ptr
 }
 
 fn (mut c Conn) free_write_buf() {
@@ -168,24 +223,31 @@ pub mut:
 	host                    string
 	port                    int
 	max_request_buffer_size int = 8192
+	max_request_body_size   int = default_max_request_body_size
 	timeout_in_seconds      int = 30
 	socket_fd               int = -1
 	poll_fd                 int = -1 // kqueue fd
 	user_data               voidptr
 	request_handler         fn (HttpRequest) !HttpResponse = unsafe { nil }
-	append_handler          AppendHandler                  = unsafe { nil }
-	make_state              fn () voidptr                  = unsafe { nil }
-	running                 &stdatomic.AtomicVal[bool]     = stdatomic.new_atomic(false)
-	shutting_down           &stdatomic.AtomicVal[bool]     = stdatomic.new_atomic(false)
-	stopped                 &stdatomic.AtomicVal[bool]     = stdatomic.new_atomic(true)
-	active_requests         &stdatomic.AtomicVal[int]      = stdatomic.new_atomic(0)
+	append_handler          AppendHandler = unsafe { nil }
+	make_state              fn () voidptr = unsafe { nil }
+	running                 &stdatomic.AtomicVal[bool] = stdatomic.new_atomic(false)
+	shutting_down           &stdatomic.AtomicVal[bool] = stdatomic.new_atomic(false)
+	stopped                 &stdatomic.AtomicVal[bool] = stdatomic.new_atomic(true)
+	active_requests         &stdatomic.AtomicVal[int] = stdatomic.new_atomic(0)
 mut:
-	poll_fds []int    = []int{len: bsd_thread_pool_size, cap: bsd_thread_pool_size, init: -1}
+	poll_fds []int = []int{len: bsd_thread_pool_size, cap: bsd_thread_pool_size, init: -1}
 	threads  []thread = []thread{len: bsd_thread_pool_size, cap: bsd_thread_pool_size}
 }
 
 // new_server creates and initializes a new Server instance.
 pub fn new_server(config ServerConfig) !&Server {
+	if config.max_request_buffer_size <= 0 {
+		return error('max_request_buffer_size must be greater than 0')
+	}
+	if config.max_request_body_size < 0 {
+		return error('max_request_body_size must not be negative')
+	}
 	has_handler := config.handler != unsafe { nil }
 	has_append := config.append_handler != unsafe { nil }
 	if !has_handler && !has_append {
@@ -195,19 +257,20 @@ pub fn new_server(config ServerConfig) !&Server {
 		return error('set only one of `handler` or `append_handler`, not both')
 	}
 	mut server := &Server{
-		family:                  config.family
-		host:                    config.host
-		port:                    config.port
+		family: config.family
+		host: config.host
+		port: config.port
 		max_request_buffer_size: config.max_request_buffer_size
-		timeout_in_seconds:      config.timeout_in_seconds
-		user_data:               config.user_data
-		request_handler:         config.handler
-		append_handler:          config.append_handler
-		make_state:              config.make_state
-		running:                 stdatomic.new_atomic(false)
-		shutting_down:           stdatomic.new_atomic(false)
-		stopped:                 stdatomic.new_atomic(true)
-		active_requests:         stdatomic.new_atomic(0)
+		max_request_body_size: config.max_request_body_size
+		timeout_in_seconds: config.timeout_in_seconds
+		user_data: config.user_data
+		request_handler: config.handler
+		append_handler: config.append_handler
+		make_state: config.make_state
+		running: stdatomic.new_atomic(false)
+		shutting_down: stdatomic.new_atomic(false)
+		stopped: stdatomic.new_atomic(true)
+		active_requests: stdatomic.new_atomic(0)
 	}
 	unsafe {
 		server.poll_fds.flags.set(.noslices | .noshrink | .nogrow)
@@ -255,7 +318,7 @@ fn close_conn(server &Server, kq int, c_ptr voidptr, mut clients map[int]voidptr
 		C.close(c.file_fd)
 		c.file_fd = -1
 	}
-	unsafe { free(c_ptr) }
+	retire_conn(mut c, c_ptr)
 }
 
 fn send_pending(c_ptr voidptr) bool {
@@ -338,20 +401,27 @@ fn complete_response(server &Server, kq int, c_ptr voidptr, mut clients map[int]
 	c.free_write_buf()
 	c.free_request_arena()
 	c.write_pos = 0
-	c.read_len = 0
-	if c.read_extra.cap > 0 {
-		unsafe { c.read_extra.free() }
-		c.read_extra = []u8{}
+	c.write_start = 0
+	c.should_close = false
+	if c.total_read_len() > 0 {
+		dispatch_buffered_request(server, kq, c_ptr, mut clients)
+		return
+	}
+	if c.read_eof {
+		close_conn(server, kq, c_ptr, mut clients)
+		return
 	}
 	c.read_start = 0
-	c.should_close = false
 	add_event(kq, u64(c.fd), i16(C.EVFILT_READ), u16(C.EV_ADD | C.EV_ENABLE | C.EV_CLEAR), c)
 }
 
 // process_request handles a complete HTTP request: decodes, calls the handler,
 // sends the response (or handles takeover/sendfile).
-fn process_request(server &Server, kq int, c_ptr voidptr, mut clients map[int]voidptr) {
+fn process_request(server &Server, kq int, c_ptr voidptr, frame_total int, mut clients map[int]voidptr) {
 	mut c := unsafe { &Conn(c_ptr) }
+	// A connection owns at most one response. Disable further reads until this
+	// response has drained; already-buffered pipelined bytes are handled serially.
+	add_event(kq, u64(c.fd), i16(C.EVFILT_READ), u16(C.EV_DISABLE), c)
 	// The append handler manages its own -prealloc scope (it writes into a buffer
 	// it owns); only the legacy return-a-response path uses the reactor arena.
 	using_append := server.append_handler != unsafe { nil }
@@ -362,26 +432,9 @@ fn process_request(server &Server, kq int, c_ptr voidptr, mut clients map[int]vo
 		}
 	}
 
-	mut req_buf := c.get_full_request_data()
-	if c.read_extra.cap > 0 {
-		unsafe { c.read_extra.free() }
-		c.read_extra = []u8{}
-	}
-
-	// Frame the request to its exact declared length (RFC 9112 §6), mirroring the
-	// Linux reactor's `buf_view(read_buf, pos, total)`: the body is trimmed to
-	// Content-Length so `decoded.body` sees exactly the declared bytes, not any
-	// surplus the peer sent (which would otherwise be mis-attributed to this
-	// request — a request-smuggling gap). BSD serves one request per read, so a
-	// trailing pipelined request is dropped; a valid `total` here is <= req_buf.len
-	// because has_complete_body already gated on it. On a framing sentinel (< 0)
-	// the buffer is left intact and decode_http_request handles the error path.
-	frame_total := frame_request_length_lim_idx(req_buf, server.max_request_buffer_size, 0)
-	if frame_total >= 0 && frame_total < req_buf.len {
-		// Reslice in place (no copy): req_buf is a freshly-owned buffer and only its
-		// prefix is handed to decode_http_request, so trimming the length is safe.
-		req_buf = unsafe { req_buf[..frame_total] }
-	}
+	full_data := c.get_full_request_data()
+	req_buf := unsafe { full_data[..frame_total] }
+	c.consume_read_prefix(full_data, frame_total)
 
 	mut decoded := decode_http_request(req_buf) or {
 		send_bad_request(c.fd)
@@ -409,11 +462,11 @@ fn process_request(server &Server, kq int, c_ptr voidptr, mut clients map[int]vo
 		mut ctl := ResponseControl{}
 		step := server.append_handler(decoded, mut out, c.worker_state, mut ctl)
 		HttpResponse{
-			content:       out
+			content: out
 			content_owned: true
 			takeover_mode: ctl.takeover_mode
-			should_close:  ctl.should_close || step != .done
-			file_path:     ctl.file_path
+			should_close: ctl.should_close || step != .done
+			file_path: ctl.file_path
 		}
 	} else {
 		server.request_handler(decoded) or {
@@ -439,14 +492,14 @@ fn process_request(server &Server, kq int, c_ptr voidptr, mut clients map[int]vo
 			}
 			resp.free_owned_content()
 			resp.abandon_request_arena_current_thread()
-			unsafe { free(c_ptr) }
+			if c.read_extra.cap > 0 {
+				unsafe { c.read_extra.free() }
+			}
+			retire_conn(mut c, c_ptr)
 			return
 		}
 		.reusable {
 			set_nonblocking(c.fd)
-			c.read_len = 0
-			c.read_extra.clear()
-			c.read_start = 0
 			if c.request_active {
 				server.end_request()
 				c.request_active = false
@@ -455,13 +508,19 @@ fn process_request(server &Server, kq int, c_ptr voidptr, mut clients map[int]vo
 			resp.end_request_arena_current_thread()
 			if server.is_shutting_down() || resp.should_close {
 				close_conn(server, kq, c_ptr, mut clients)
+			} else if c.total_read_len() > 0 {
+				dispatch_buffered_request(server, kq, c_ptr, mut clients)
+			} else if c.read_eof {
+				close_conn(server, kq, c_ptr, mut clients)
+			} else {
+				add_event(kq, u64(c.fd), i16(C.EVFILT_READ), u16(C.EV_ADD | C.EV_ENABLE | C.EV_CLEAR), c)
 			}
 			return
 		}
 		.none {}
 	}
 
-	c.should_close = resp.should_close
+	c.should_close = resp.should_close || (c.read_eof && c.total_read_len() == 0)
 	c.free_write_buf()
 	c.free_request_arena()
 	c.request_arena = resp.take_request_arena()
@@ -485,11 +544,9 @@ fn process_request(server &Server, kq int, c_ptr voidptr, mut clients map[int]vo
 	}
 
 	c.write_pos = 0
-	c.read_len = 0
-	c.read_extra.clear()
-	c.read_start = 0
 
 	if send_pending(c_ptr) {
+		c.write_start = time.sys_mono_now()
 		add_event(kq, u64(c.fd), i16(C.EVFILT_WRITE), u16(C.EV_ADD | C.EV_ENABLE | C.EV_CLEAR), c)
 		return
 	}
@@ -516,8 +573,89 @@ fn (c &Conn) get_full_request_data() []u8 {
 	return req_buf
 }
 
+// consume_read_prefix preserves any pipelined suffix after one framed request.
+fn (mut c Conn) consume_read_prefix(full_data []u8, consumed int) {
+	leftover := full_data.len - consumed
+	c.read_extra.clear()
+	if leftover <= 0 {
+		c.read_len = 0
+		c.read_start = 0
+		return
+	}
+	fixed_len := if leftover < buf_size { leftover } else { buf_size }
+	unsafe { C.memcpy(&c.read_buf[0], &full_data[consumed], usize(fixed_len)) }
+	c.read_len = fixed_len
+	if leftover > fixed_len {
+		c.read_extra << full_data[consumed + fixed_len..]
+	}
+	c.read_start = time.sys_mono_now()
+}
+
+fn send_terminal_response(server &Server, kq int, c_ptr voidptr, response []u8, mut clients map[int]voidptr) {
+	mut c := unsafe { &Conn(c_ptr) }
+	add_event(kq, u64(c.fd), i16(C.EVFILT_READ), u16(C.EV_DISABLE), c)
+	if !c.request_active {
+		server.begin_request()
+		c.request_active = true
+	}
+	c.free_write_buf()
+	c.free_request_arena()
+	c.write_buf = response.clone()
+	c.write_pos = 0
+	c.read_len = 0
+	c.read_extra.clear()
+	c.read_start = 0
+	c.should_close = true
+	if send_pending(c_ptr) {
+		c.write_start = time.sys_mono_now()
+		add_event(kq, u64(c.fd), i16(C.EVFILT_WRITE), u16(C.EV_ADD | C.EV_ENABLE | C.EV_CLEAR), c)
+		return
+	}
+	complete_response(server, kq, c_ptr, mut clients, false)
+}
+
+fn dispatch_buffered_request(server &Server, kq int, c_ptr voidptr, mut clients map[int]voidptr) {
+	mut c := unsafe { &Conn(c_ptr) }
+	if c.request_active {
+		return
+	}
+	if c.total_read_len() == 0 {
+		if c.read_eof {
+			close_conn(server, kq, c_ptr, mut clients)
+		} else {
+			add_event(kq, u64(c.fd), i16(C.EVFILT_READ), u16(C.EV_ADD | C.EV_ENABLE | C.EV_CLEAR), c)
+		}
+		return
+	}
+	full_data := c.get_full_request_data()
+	frame_total := frame_request_length_lim_idx(full_data, server.max_request_buffer_size, server.max_request_body_size)
+	if frame_total == -1 {
+		if c.read_eof {
+			send_terminal_response(server, kq, c_ptr, tiny_bad_request_response, mut clients)
+			return
+		}
+		if server.timeout_in_seconds > 0 && c.read_start > 0 {
+			timeout_ns := i64(server.timeout_in_seconds) * 1_000_000_000
+			if time.sys_mono_now() - c.read_start >= timeout_ns {
+				send_terminal_response(server, kq, c_ptr, status_408_response, mut clients)
+				return
+			}
+		}
+		add_event(kq, u64(c.fd), i16(C.EVFILT_READ), u16(C.EV_ADD | C.EV_ENABLE | C.EV_CLEAR), c)
+		return
+	}
+	if frame_total < -1 {
+		send_terminal_response(server, kq, c_ptr, response_for_frame_error(frame_total), mut clients)
+		return
+	}
+	process_request(server, kq, c_ptr, frame_total, mut clients)
+}
+
 fn handle_read(server &Server, kq int, c_ptr voidptr, mut clients map[int]voidptr) {
 	mut c := unsafe { &Conn(c_ptr) }
+	if c.request_active {
+		return
+	}
 
 	// Drain the socket for this kqueue notification. EV_CLEAR only rearms once
 	// all readable data has been consumed.
@@ -533,10 +671,7 @@ fn handle_read(server &Server, kq int, c_ptr voidptr, mut clients map[int]voidpt
 				return
 			}
 			if n == 0 {
-				if c.total_read_len() == 0 {
-					close_conn(server, kq, c_ptr, mut clients)
-					return
-				}
+				c.read_eof = true
 				break
 			}
 			c.read_len += int(n)
@@ -553,10 +688,7 @@ fn handle_read(server &Server, kq int, c_ptr voidptr, mut clients map[int]voidpt
 				return
 			}
 			if n == 0 {
-				if c.total_read_len() == 0 {
-					close_conn(server, kq, c_ptr, mut clients)
-					return
-				}
+				c.read_eof = true
 				break
 			}
 			c.read_extra << tmp[..int(n)]
@@ -565,22 +697,9 @@ fn handle_read(server &Server, kq int, c_ptr voidptr, mut clients map[int]voidpt
 
 	total := c.total_read_len()
 	if total == 0 {
-		return
-	}
-
-	// Enforce the configured header limit without capping large request bodies.
-	mut header_end := -1
-	mut full_data := []u8{}
-	if c.read_extra.len > 0 {
-		full_data = c.get_full_request_data()
-		header_end = find_header_end_in_buf(full_data.data, full_data.len)
-	} else {
-		header_end = find_header_end_in_buf(&c.read_buf[0], c.read_len)
-	}
-	if (header_end == -1 && total >= server.max_request_buffer_size)
-		|| header_end > server.max_request_buffer_size {
-		C.send(c.fd, status_413_response.data, status_413_response.len, send_flags)
-		close_conn(server, kq, c_ptr, mut clients)
+		if c.read_eof {
+			close_conn(server, kq, c_ptr, mut clients)
+		}
 		return
 	}
 
@@ -589,33 +708,10 @@ fn handle_read(server &Server, kq int, c_ptr voidptr, mut clients map[int]voidpt
 		c.read_start = time.sys_mono_now()
 	}
 
-	// Check if the full body has been received.
-	if c.read_extra.len > 0 {
-		if !has_complete_body(full_data.data, full_data.len) {
-			elapsed_ns := time.sys_mono_now() - c.read_start
-			timeout_ns := i64(server.timeout_in_seconds) * 1_000_000_000
-			if elapsed_ns >= timeout_ns {
-				send_request_timeout(c.fd)
-				close_conn(server, kq, c_ptr, mut clients)
-			}
-			return
-		}
-	} else if !has_complete_body(&c.read_buf[0], c.read_len) {
-		// Body not complete yet - check for timeout
-		elapsed_ns := time.sys_mono_now() - c.read_start
-		timeout_ns := i64(server.timeout_in_seconds) * 1_000_000_000
-		if elapsed_ns >= timeout_ns {
-			send_request_timeout(c.fd)
-			close_conn(server, kq, c_ptr, mut clients)
-		}
-		// Otherwise wait for more data on the next kqueue event
-		return
-	}
-
-	process_request(server, kq, c_ptr, mut clients)
+	dispatch_buffered_request(server, kq, c_ptr, mut clients)
 }
 
-fn accept_clients(kq int, listen_fd int, worker_state voidptr, mut clients map[int]voidptr) {
+fn accept_clients(kq int, listen_fd int, worker_state voidptr, retired &RetiredConns, mut clients map[int]voidptr) {
 	for _ in 0 .. accept_batch_size {
 		client_fd := C.accept(listen_fd, unsafe { nil }, unsafe { nil })
 		if client_fd < 0 {
@@ -635,13 +731,13 @@ fn accept_clients(kq int, listen_fd int, worker_state voidptr, mut clients map[i
 			C.setsockopt(client_fd, C.SOL_SOCKET, C.SO_NOSIGPIPE, &nosigpipe_opt, sizeof(int))
 		}
 		mut c := &Conn{
-			fd:           client_fd
-			user_data:    unsafe { nil }
-			file_fd:      -1
+			fd: client_fd
+			user_data: unsafe { nil }
+			file_fd: -1
 			worker_state: worker_state
+			retired: retired
 		}
-		if add_event(kq, u64(client_fd), i16(C.EVFILT_READ),
-			u16(C.EV_ADD | C.EV_ENABLE | C.EV_CLEAR), c) < 0 {
+		if add_event(kq, u64(client_fd), i16(C.EVFILT_READ), u16(C.EV_ADD | C.EV_ENABLE | C.EV_CLEAR), c) < 0 {
 			C.close(client_fd)
 			unsafe { free(c) }
 			continue
@@ -715,6 +811,7 @@ fn create_server_socket(server Server) !int {
 fn process_events(server &Server, kq int, listen_fd int) {
 	mut events := [kqueue_max_events]C.kevent{}
 	mut clients := map[int]voidptr{}
+	mut retired := &RetiredConns{}
 	// Build this worker thread's lock-free per-worker state exactly once.
 	mut worker_state := voidptr(unsafe { nil })
 	if server.make_state != unsafe { nil } {
@@ -723,10 +820,11 @@ fn process_events(server &Server, kq int, listen_fd int) {
 	for {
 		if server.is_shutting_down() && server.active_request_count() == 0 {
 			close_all_conns(server, kq, mut clients)
+			retired.free_all()
 			return
 		}
 		timeout := C.timespec{
-			tv_sec:  0
+			tv_sec: 0
 			tv_nsec: kqueue_wait_timeout_ms * 1_000_000
 		}
 		nev := C.kevent(kq, unsafe { nil }, 0, &events[0], kqueue_max_events, &timeout)
@@ -741,49 +839,54 @@ fn process_events(server &Server, kq int, listen_fd int) {
 			}
 			C.perror(c'kevent')
 			close_all_conns(server, kq, mut clients)
+			retired.free_all()
 			return
 		}
 
 		for i := 0; i < nev; i++ {
 			event := events[i]
-			if event.flags & u16(C.EV_ERROR) != 0 {
-				if event.ident == u64(listen_fd) {
+			if event.ident == u64(listen_fd) {
+				if event.flags & u16(C.EV_ERROR) != 0 {
 					C.perror(c'listener error')
 					continue
 				}
-				if event.udata != unsafe { nil } {
-					close_conn(server, kq, event.udata, mut clients)
-				}
-				continue
-			}
-
-			if event.ident == u64(listen_fd) {
 				if server.is_shutting_down() {
 					continue
 				}
-				accept_clients(kq, listen_fd, worker_state, mut clients)
+				accept_clients(kq, listen_fd, worker_state, retired, mut clients)
 				continue
 			}
 
 			if event.udata == unsafe { nil } {
 				continue
 			}
-
-			if event.flags & u16(C.EV_EOF) != 0 {
-				close_conn(server, kq, event.udata, mut clients)
+			// A previous event in this returned batch may have closed this fd. Validate
+			// both fd and pointer generation before dereferencing event.udata.
+			c_ptr := clients[int(event.ident)] or { continue }
+			if c_ptr != event.udata {
+				continue
+			}
+			if event.flags & u16(C.EV_ERROR) != 0 {
+				close_conn(server, kq, c_ptr, mut clients)
 				continue
 			}
 
 			if event.filter == i16(C.EVFILT_READ) {
 				if server.is_shutting_down() {
-					close_conn(server, kq, event.udata, mut clients)
+					close_conn(server, kq, c_ptr, mut clients)
 					continue
 				}
-				handle_read(server, kq, event.udata, mut clients)
+				handle_read(server, kq, c_ptr, mut clients)
 			} else if event.filter == i16(C.EVFILT_WRITE) {
-				handle_write(server, kq, event.udata, mut clients)
+				if event.flags & u16(C.EV_EOF) != 0 {
+					close_conn(server, kq, c_ptr, mut clients)
+					continue
+				}
+				handle_write(server, kq, c_ptr, mut clients)
 			}
 		}
+		// event.udata pointers from this batch are no longer observable by kqueue.
+		retired.free_all()
 		// Sweep for connections waiting for body data that have timed out
 		if server.timeout_in_seconds > 0 {
 			now := time.sys_mono_now()
@@ -791,15 +894,17 @@ fn process_events(server &Server, kq int, listen_fd int) {
 			for client_fd in clients.keys() {
 				c_ptr := clients[client_fd] or { continue }
 				c := unsafe { &Conn(c_ptr) }
-				if c.read_start > 0 && c.read_len > 0 && !c.request_active {
+				if c.read_start > 0 && c.total_read_len() > 0 && !c.request_active {
 					elapsed := now - c.read_start
 					if elapsed >= timeout_ns {
-						send_request_timeout(c.fd)
-						close_conn(server, kq, c_ptr, mut clients)
+						send_terminal_response(server, kq, c_ptr, status_408_response, mut clients)
 					}
+				} else if c.write_start > 0 && now - c.write_start >= timeout_ns {
+					close_conn(server, kq, c_ptr, mut clients)
 				}
 			}
 		}
+		retired.free_all()
 	}
 }
 
@@ -826,8 +931,7 @@ pub fn (mut s Server) run() ! {
 		// level-triggered so accept_clients can cap each batch without losing
 		// readiness for queued connections. Accepted client fds stay local to the
 		// worker that accepted them.
-		if add_event(s.poll_fds[i], u64(s.socket_fd), i16(C.EVFILT_READ),
-			u16(C.EV_ADD | C.EV_ENABLE), unsafe { nil }) < 0 {
+		if add_event(s.poll_fds[i], u64(s.socket_fd), i16(C.EVFILT_READ), u16(C.EV_ADD | C.EV_ENABLE), unsafe { nil }) < 0 {
 			s.stop_accepting()
 			s.close_pollers()
 			return error('failed to register listener with kqueue')

--- a/vlib/fasthttp/fasthttp_bsd_loopback_test.c.v
+++ b/vlib/fasthttp/fasthttp_bsd_loopback_test.c.v
@@ -3,17 +3,20 @@ module fasthttp
 
 import net.http
 import time
+import net
+
+fn C.shutdown(fd i32, how i32) i32
 
 const loopback_request_port = 13020
 const loopback_request_addr = '127.0.0.1:${loopback_request_port}'
 
 fn test_handler_can_make_loopback_request_to_same_server() {
 	mut server := new_server(ServerConfig{
-		family:                  .ip
-		port:                    loopback_request_port
-		timeout_in_seconds:      2
+		family: .ip
+		port: loopback_request_port
+		timeout_in_seconds: 2
 		max_request_buffer_size: 8192
-		handler:                 loopback_request_handler
+		handler: loopback_request_handler
 	}) or {
 		assert false, 'Failed to create server: ${err}'
 		return
@@ -29,10 +32,10 @@ fn test_handler_can_make_loopback_request_to_same_server() {
 	}
 
 	resp := http.fetch(
-		method:                   .get
-		url:                      'http://${loopback_request_addr}/outer'
-		read_timeout:             2 * time.second
-		write_timeout:            2 * time.second
+		method: .get
+		url: 'http://${loopback_request_addr}/outer'
+		read_timeout: 2 * time.second
+		write_timeout: 2 * time.second
 		disable_connection_reuse: true
 	) or {
 		assert false, 'loopback request failed: ${err}'
@@ -40,6 +43,38 @@ fn test_handler_can_make_loopback_request_to_same_server() {
 	}
 	assert resp.status_code == 200
 	assert resp.body == 'outer:inner'
+
+	mut conn := net.dial_tcp(loopback_request_addr) or {
+		assert false, 'pipelining connection failed: ${err}'
+		return
+	}
+	defer {
+		conn.close() or {}
+	}
+	conn.set_read_timeout(2 * time.second)
+	conn.set_write_timeout(2 * time.second)
+	conn.write_string('GET /one HTTP/1.1\r\nHost: ${loopback_request_addr}\r\n\r\n' + 'GET /two HTTP/1.1\r\nHost: ${loopback_request_addr}\r\nConnection: close\r\n\r\n') or {
+		assert false, 'pipelined write failed: ${err}'
+		return
+	}
+	assert C.shutdown(conn.sock.handle, C.SHUT_WR) == 0
+	mut pipelined := []u8{}
+	mut chunk := []u8{len: 1024}
+	for pipelined.bytestr().count('HTTP/1.1 200 OK') < 2 {
+		n := conn.read(mut chunk) or {
+			assert false, 'pipelined read failed: ${err}'
+			return
+		}
+		if n == 0 {
+			break
+		}
+		pipelined << chunk[..n]
+	}
+	pipelined_response := pipelined.bytestr()
+	assert pipelined_response.count('HTTP/1.1 200 OK') == 2, pipelined_response
+	one_pos := pipelined_response.index('one') or { -1 }
+	two_pos := pipelined_response.index('two') or { -1 }
+	assert one_pos >= 0 && two_pos > one_pos
 }
 
 fn loopback_request_handler(req HttpRequest) !HttpResponse {
@@ -51,10 +86,10 @@ fn loopback_request_handler(req HttpRequest) !HttpResponse {
 	}
 	if path == '/outer' {
 		inner := http.fetch(
-			method:                   .get
-			url:                      'http://${loopback_request_addr}/inner'
-			read_timeout:             time.second
-			write_timeout:            time.second
+			method: .get
+			url: 'http://${loopback_request_addr}/inner'
+			read_timeout: time.second
+			write_timeout: time.second
 			disable_connection_reuse: true
 		)!
 		body := 'outer:${inner.body}'
@@ -62,8 +97,15 @@ fn loopback_request_handler(req HttpRequest) !HttpResponse {
 			content: 'HTTP/1.1 200 OK\r\nContent-Length: ${body.len}\r\n\r\n${body}'.bytes()
 		}
 	}
+	if path == '/one' || path == '/two' {
+		body := path[1..]
+		return HttpResponse{
+			content: 'HTTP/1.1 200 OK\r\nContent-Length: ${body.len}\r\n\r\n${body}'.bytes()
+			should_close: path == '/two'
+		}
+	}
 	return HttpResponse{
-		content:      'HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n'.bytes()
+		content: 'HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n'.bytes()
 		should_close: true
 	}
 }

--- a/vlib/fasthttp/fasthttp_bsd_regression_test.c.v
+++ b/vlib/fasthttp/fasthttp_bsd_regression_test.c.v
@@ -11,51 +11,52 @@ fn bsd_reregistration_test_handler(_ HttpRequest) !HttpResponse {
 
 fn test_keep_alive_completion_rearms_kqueue_read_after_consumed_edge() ! {
 	server := new_server(ServerConfig{
-		family:                  .ip
-		port:                    0
+		family: .ip
+		port: 0
 		max_request_buffer_size: 8192
-		handler:                 bsd_reregistration_test_handler
+		handler: bsd_reregistration_test_handler
 	})!
 	kq := C.kqueue()
 	assert kq >= 0
 	defer {
 		C.close(kq)
 	}
-	mut sockets := [2]int{}
+	mut sockets := [2]i32{}
 	assert C.socketpair(C.AF_UNIX, C.SOCK_STREAM, 0, &sockets[0]) == 0
+	server_fd := int(sockets[0])
+	client_fd := int(sockets[1])
 	defer {
-		C.close(sockets[0])
-		C.close(sockets[1])
+		C.close(server_fd)
+		C.close(client_fd)
 	}
-	set_nonblocking(sockets[0])
+	set_nonblocking(server_fd)
 	mut conn := &Conn{
-		fd:             sockets[0]
+		fd: server_fd
 		request_active: true
-		file_fd:        -1
+		file_fd: -1
 	}
-	assert add_event(kq, u64(sockets[0]), i16(C.EVFILT_READ),
-		u16(C.EV_ADD | C.EV_ENABLE | C.EV_CLEAR), conn) == 0
-	assert C.write(sockets[1], c'GET ', 4) == 4
+	assert add_event(kq, u64(server_fd), i16(C.EVFILT_READ), u16(C.EV_ADD | C.EV_ENABLE | C.EV_CLEAR), conn) == 0
+	assert C.write(client_fd, c'GET ', 4) == 4
 
 	mut event := C.kevent{}
 	mut timeout := C.timespec{
 		tv_sec: 1
 	}
 	assert C.kevent(kq, unsafe { nil }, 0, &event, 1, &timeout) == 1
-	assert event.ident == u64(sockets[0])
+	assert event.ident == u64(server_fd)
 
 	server.begin_request()
 	mut clients := {
-		sockets[0]: voidptr(conn)
+		server_fd: voidptr(conn)
 	}
 	complete_response(server, kq, conn, mut clients, false)
 
 	assert server.active_request_count() == 0
-	assert clients[sockets[0]] or { unsafe { nil } } == voidptr(conn)
+	assert clients[server_fd] or { unsafe { nil } } == voidptr(conn)
 	timeout = C.timespec{
 		tv_sec: 1
 	}
 	assert C.kevent(kq, unsafe { nil }, 0, &event, 1, &timeout) == 1
-	assert event.ident == u64(sockets[0])
+	assert event.ident == u64(server_fd)
 	close_conn(server, kq, conn, mut clients)
 }

--- a/vlib/fasthttp/fasthttp_linux.v
+++ b/vlib/fasthttp/fasthttp_linux.v
@@ -20,6 +20,14 @@ const sendfile_chunk = 1024 * 1024
 // Write-side cap: close a peer that pipelines requests but never drains responses
 // (otherwise the per-connection write buffer would grow without bound).
 const max_pending_write = 8 * 1024 * 1024
+const max_pooled_read_cap = 64 * 1024
+const max_pooled_write_cap = 64 * 1024
+
+enum FlushResult {
+	closed
+	blocked
+	drained
+}
 
 @[heap]
 pub struct Server {
@@ -28,25 +36,29 @@ pub:
 	host                    string
 	port                    int = 3000
 	max_request_buffer_size int = 8192
+	max_request_body_size   int = default_max_request_body_size
 	timeout_in_seconds      int = 30
 	user_data               voidptr
 mut:
-	listen_fds      []int                          = []int{len: max_thread_pool_size, cap: max_thread_pool_size, init: -1}
-	epoll_fds       []int                          = []int{len: max_thread_pool_size, cap: max_thread_pool_size, init: -1}
-	threads         []thread                       = []thread{len: max_thread_pool_size, cap: max_thread_pool_size}
+	listen_fds      []int = []int{len: max_thread_pool_size, cap: max_thread_pool_size, init: -1}
+	epoll_fds       []int = []int{len: max_thread_pool_size, cap: max_thread_pool_size, init: -1}
+	threads         []thread = []thread{len: max_thread_pool_size, cap: max_thread_pool_size}
 	request_handler fn (HttpRequest) !HttpResponse = unsafe { nil }
-	append_handler  AppendHandler                  = unsafe { nil }
-	make_state      fn () voidptr                  = unsafe { nil }
-	running         &stdatomic.AtomicVal[bool]     = stdatomic.new_atomic(false)
-	shutting_down   &stdatomic.AtomicVal[bool]     = stdatomic.new_atomic(false)
-	stopped         &stdatomic.AtomicVal[bool]     = stdatomic.new_atomic(true)
-	active_requests &stdatomic.AtomicVal[int]      = stdatomic.new_atomic(0)
+	append_handler  AppendHandler = unsafe { nil }
+	make_state      fn () voidptr = unsafe { nil }
+	running         &stdatomic.AtomicVal[bool] = stdatomic.new_atomic(false)
+	shutting_down   &stdatomic.AtomicVal[bool] = stdatomic.new_atomic(false)
+	stopped         &stdatomic.AtomicVal[bool] = stdatomic.new_atomic(true)
+	active_requests &stdatomic.AtomicVal[int] = stdatomic.new_atomic(0)
 }
 
 // new_server creates and initializes a new Server instance.
 pub fn new_server(config ServerConfig) !&Server {
 	if config.max_request_buffer_size <= 0 {
 		return error('max_request_buffer_size must be greater than 0')
+	}
+	if config.max_request_body_size < 0 {
+		return error('max_request_body_size must not be negative')
 	}
 	has_handler := config.handler != unsafe { nil }
 	has_append := config.append_handler != unsafe { nil }
@@ -57,19 +69,20 @@ pub fn new_server(config ServerConfig) !&Server {
 		return error('set only one of `handler` or `append_handler`, not both')
 	}
 	mut server := &Server{
-		family:                  config.family
-		host:                    config.host
-		port:                    config.port
+		family: config.family
+		host: config.host
+		port: config.port
 		max_request_buffer_size: config.max_request_buffer_size
-		timeout_in_seconds:      config.timeout_in_seconds
-		user_data:               config.user_data
-		request_handler:         config.handler
-		append_handler:          config.append_handler
-		make_state:              config.make_state
-		running:                 stdatomic.new_atomic(false)
-		shutting_down:           stdatomic.new_atomic(false)
-		stopped:                 stdatomic.new_atomic(true)
-		active_requests:         stdatomic.new_atomic(0)
+		max_request_body_size: config.max_request_body_size
+		timeout_in_seconds: config.timeout_in_seconds
+		user_data: config.user_data
+		request_handler: config.handler
+		append_handler: config.append_handler
+		make_state: config.make_state
+		running: stdatomic.new_atomic(false)
+		shutting_down: stdatomic.new_atomic(false)
+		stopped: stdatomic.new_atomic(true)
+		active_requests: stdatomic.new_atomic(0)
 	}
 	unsafe {
 		server.listen_fds.flags.set(.noslices | .noshrink | .nogrow)
@@ -113,9 +126,10 @@ mut:
 	file_off       i64
 	file_remaining i64
 	should_close   bool // close the connection once the current batch is flushed
+	read_eof       bool // peer half-closed its write side; flush queued responses, then close
 	request_active bool // a response is buffered/parked and counts toward active_requests
-	read_start_ns  i64  // monotonic ns; >0 while a partial request is buffered (408)
-	write_start_ns i64  // monotonic ns; >0 while a batch is parked for writing
+	read_start_ns  i64 // monotonic ns; >0 while a partial request is buffered (408)
+	write_start_ns i64 // monotonic ns; >0 while a batch is parked for writing
 	// request_arena is the -prealloc scope that must be freed once a parked write
 	// completes (the response bytes were copied out of it into write_buf, but the
 	// scope is kept and freed as a unit for symmetry with the non-parked path).
@@ -131,17 +145,15 @@ mut:
 	listen_fd    int
 	conns        []&ConnState
 	free_conns   []&ConnState
-	parked       int     // connections with an armed read/write deadline (gates the sweep)
+	parked       int // connections with an armed read/write deadline (gates the sweep)
 	worker_state voidptr // this worker thread's ServerConfig.make_state value (nil if unset)
 }
 
 fn close_socket(fd int) bool {
 	ret := C.close(fd)
 	if ret == -1 {
-		if C.errno == C.EINTR {
-			// Interrupted by signal, retry is safe
-			return close_socket(fd)
-		}
+		// Linux may already have released fd even when close reports EINTR. Retrying
+		// can close an unrelated descriptor that another thread reused.
 		eprintln('ERROR: close(fd=${fd}) failed with errno=${C.errno}')
 		return false
 	}
@@ -250,7 +262,7 @@ fn state_for(mut w Worker, fd int) &ConnState {
 			return w.conns[fd]
 		}
 		w.conns[fd] = &ConnState{
-			read_buf:  []u8{len: 0, cap: read_buf_cap}
+			read_buf: []u8{len: 0, cap: read_buf_cap}
 			write_buf: []u8{len: 0, cap: write_buf_cap}
 		}
 	}
@@ -304,15 +316,24 @@ fn close_conn(mut w Worker, fd int) {
 					unsafe { prealloc_scope_free_after(cs.request_arena) }
 				}
 			}
-			unsafe {
-				cs.read_buf.len = 0
-				cs.write_buf.len = 0
+			if cs.read_buf.cap > max_pooled_read_cap {
+				unsafe { cs.read_buf.free() }
+				cs.read_buf = []u8{len: 0, cap: read_buf_cap}
+			} else {
+				unsafe { cs.read_buf.len = 0 }
+			}
+			if cs.write_buf.cap > max_pooled_write_cap {
+				unsafe { cs.write_buf.free() }
+				cs.write_buf = []u8{len: 0, cap: write_buf_cap}
+			} else {
+				unsafe { cs.write_buf.len = 0 }
 			}
 			cs.write_off = 0
 			cs.file_fd = -1
 			cs.file_off = 0
 			cs.file_remaining = 0
 			cs.should_close = false
+			cs.read_eof = false
 			cs.read_start_ns = 0
 			cs.write_start_ns = 0
 			cs.request_arena = unsafe { nil }
@@ -359,6 +380,9 @@ fn detach_conn(mut w Worker, fd int) {
 	cs.file_off = 0
 	cs.file_remaining = 0
 	cs.should_close = false
+	cs.read_eof = false
+	cs.read_start_ns = 0
+	cs.write_start_ns = 0
 	cs.request_arena = unsafe { nil }
 	w.conns[fd] = unsafe { nil }
 	w.free_conns << cs
@@ -413,12 +437,12 @@ fn drain_file(fd int, mut cs ConnState) int {
 // flush_batch sends all pending response bytes then streams any deferred file
 // body, or parks the remainder for EPOLLOUT. On full completion the write buffer
 // is reset (capacity kept) and the connection is either closed or kept alive.
-// Returns false if the connection was closed (the caller must not touch it).
-fn flush_batch(mut w Worker, fd int, mut cs ConnState) bool {
+// Returns an explicit state so callers cannot mistake a blocked write for a
+// fully drained response and dispatch a later request out of order.
+fn flush_batch(mut w Worker, fd int, mut cs ConnState) FlushResult {
 	// Phase 1: the buffered response bytes (status lines, headers, small bodies).
 	for cs.write_off < cs.write_buf.len {
-		n := C.send(fd, unsafe { &u8(cs.write_buf.data) + cs.write_off },
-			usize(cs.write_buf.len - cs.write_off), C.MSG_NOSIGNAL)
+		n := C.send(fd, unsafe { &u8(cs.write_buf.data) + cs.write_off }, usize(cs.write_buf.len - cs.write_off), C.MSG_NOSIGNAL)
 		if n > 0 {
 			cs.write_off += n
 			continue
@@ -432,7 +456,7 @@ fn flush_batch(mut w Worker, fd int, mut cs ConnState) bool {
 			}
 		}
 		close_conn(mut w, fd)
-		return false
+		return .closed
 	}
 	// Phase 2: stream the deferred file body straight from the page cache. Guard on
 	// file_fd, not file_remaining: a zero-length file leaves an open fd with
@@ -445,7 +469,7 @@ fn flush_batch(mut w Worker, fd int, mut cs ConnState) bool {
 			}
 			-1 {
 				close_conn(mut w, fd)
-				return false
+				return .closed
 			}
 			else {
 				C.close(cs.file_fd)
@@ -471,24 +495,31 @@ fn flush_batch(mut w Worker, fd int, mut cs ConnState) bool {
 	clear_active(mut w, mut cs)
 	if w.server.is_shutting_down() || cs.should_close {
 		close_conn(mut w, fd)
-		return false
+		return .closed
 	}
 	// Keep-alive: make sure the connection is armed only for readability again.
 	mod_fd_in_epoll(w.epoll_fd, fd, u32(C.EPOLLIN | C.EPOLLET))
-	return true
+	return .drained
 }
 
 // park_write arms the write deadline (once), subscribes the fd to EPOLLOUT so the
 // unfinished batch resumes on the next writable edge, and keeps the response
-// counted as in-flight. Always returns true (still alive, just parked).
-fn park_write(mut w Worker, fd int, mut cs ConnState) bool {
+// counted as in-flight.
+fn park_write(mut w Worker, fd int, mut cs ConnState) FlushResult {
 	if w.server.timeout_in_seconds > 0 && cs.write_start_ns == 0 {
 		cs.write_start_ns = time.sys_mono_now()
 		w.parked++
 	}
 	mark_active(mut w, mut cs)
-	mod_fd_in_epoll(w.epoll_fd, fd, u32(C.EPOLLIN | C.EPOLLOUT | C.EPOLLET))
-	return true
+	// Pause reads while this response owns the wire. Re-enabling EPOLLIN after the
+	// write drains produces readiness for bytes that arrived during backpressure.
+	mod_fd_in_epoll(w.epoll_fd, fd, u32(C.EPOLLOUT | C.EPOLLET))
+	return .blocked
+}
+
+@[inline]
+fn has_pending_response(cs &ConnState) bool {
+	return cs.write_off < cs.write_buf.len || cs.file_fd != -1
 }
 
 // compact_read_buf drops the first `pos` consumed bytes, keeping any leftover
@@ -510,6 +541,10 @@ fn compact_read_buf(mut cs ConnState, pos int) {
 // open_deferred_file opens response.file_path for a sendfile(2) body streamed by
 // flush_batch after the buffered bytes, or marks the connection to close on error.
 fn open_deferred_file(mut cs ConnState, file_path string) {
+	if cs.file_fd != -1 {
+		cs.should_close = true
+		return
+	}
 	file_fd := C.open(&char(file_path.str), C.O_RDONLY, 0)
 	if file_fd == -1 {
 		eprintln('ERROR: open file failed: ${file_path}')
@@ -534,27 +569,23 @@ fn open_deferred_file(mut cs ConnState, file_path string) {
 @[direct_array_access]
 fn drain_requests(mut w Worker, fd int, mut cs ConnState) bool {
 	mut pos := 0
-	// max_header bounds the request-head size (→ 413 before the handler runs); the
-	// body is left unbounded here to preserve the legacy no-body-limit behavior.
+	// Header and body limits are independent; the framer rejects either before a
+	// handler sees a partial or ambiguous request.
 	max_header := w.server.max_request_buffer_size
+	max_body := w.server.max_request_body_size
 	for pos < cs.read_buf.len {
-		total := frame_request_length_lim_idx(buf_view(cs.read_buf, pos, cs.read_buf.len - pos),
-			max_header, 0)
+		total := frame_request_length_lim_idx(buf_view(cs.read_buf, pos, cs.read_buf.len - pos), max_header, max_body)
 		if total == -1 {
 			break // incomplete — wait for more bytes
 		}
 		if total < -1 {
 			// Malformed framing (413/431/400 sentinels). Answer once and close.
-			cs.write_buf << if total == frame_err_body || total == frame_err_header {
-				status_413_response
-			} else {
-				tiny_bad_request_response
-			}
+			cs.write_buf << response_for_frame_error(total)
 			pos += cs.read_buf.len - pos // consume the rest; we are closing
 			cs.should_close = true
 			compact_read_buf(mut cs, pos)
 			mark_active(mut w, mut cs)
-			return flush_batch(mut w, fd, mut cs)
+			return flush_batch(mut w, fd, mut cs) != .closed
 		}
 		// A file deferred by an earlier request in this batch must be streamed (in
 		// byte order) before this next response can be appended: flush now. Gate on
@@ -563,8 +594,14 @@ fn drain_requests(mut w Worker, fd int, mut cs ConnState) bool {
 		if cs.file_fd != -1 {
 			compact_read_buf(mut cs, pos)
 			mark_active(mut w, mut cs)
-			if !flush_batch(mut w, fd, mut cs) {
-				return false
+			match flush_batch(mut w, fd, mut cs) {
+				.closed {
+					return false
+				}
+				.blocked {
+					return true
+				}
+				.drained {}
 			}
 			pos = 0
 		}
@@ -584,7 +621,7 @@ fn drain_requests(mut w Worker, fd int, mut cs ConnState) bool {
 				cs.should_close = true
 				compact_read_buf(mut cs, pos)
 				mark_active(mut w, mut cs)
-				return flush_batch(mut w, fd, mut cs)
+				return flush_batch(mut w, fd, mut cs) != .closed
 			}
 			decoded.client_conn_fd = fd
 			decoded.client_conn_handle = usize(fd)
@@ -623,7 +660,7 @@ fn drain_requests(mut w Worker, fd int, mut cs ConnState) bool {
 						cs.should_close = true
 						compact_read_buf(mut cs, pos)
 						mark_active(mut w, mut cs)
-						return flush_batch(mut w, fd, mut cs)
+						return flush_batch(mut w, fd, mut cs) != .closed
 					}
 					continue
 				}
@@ -654,7 +691,7 @@ fn drain_requests(mut w Worker, fd int, mut cs ConnState) bool {
 				cs.should_close = true
 				compact_read_buf(mut cs, pos)
 				mark_active(mut w, mut cs)
-				return flush_batch(mut w, fd, mut cs)
+				return flush_batch(mut w, fd, mut cs) != .closed
 			}
 			decoded.client_conn_fd = fd
 			decoded.client_conn_handle = usize(fd)
@@ -669,7 +706,7 @@ fn drain_requests(mut w Worker, fd int, mut cs ConnState) bool {
 				cs.should_close = true
 				compact_read_buf(mut cs, pos)
 				mark_active(mut w, mut cs)
-				return flush_batch(mut w, fd, mut cs)
+				return flush_batch(mut w, fd, mut cs) != .closed
 			}
 
 			if resp.takeover_mode != .none && cs.write_buf.len > cs.write_off {
@@ -712,7 +749,7 @@ fn drain_requests(mut w Worker, fd int, mut cs ConnState) bool {
 						cs.should_close = true
 						compact_read_buf(mut cs, pos)
 						mark_active(mut w, mut cs)
-						return flush_batch(mut w, fd, mut cs)
+						return flush_batch(mut w, fd, mut cs) != .closed
 					}
 					continue
 				}
@@ -750,13 +787,14 @@ fn drain_requests(mut w Worker, fd int, mut cs ConnState) bool {
 			// new edge fires for bytes already in read_buf) until it spuriously times out.
 			compact_read_buf(mut cs, pos)
 			mark_active(mut w, mut cs)
-			if !flush_batch(mut w, fd, mut cs) {
-				return false // connection closed (should_close, or a write error)
-			}
-			// If the flush parked on EPOLLOUT (still pending), stop; handle_writable
-			// resumes and re-drains. Otherwise it fully drained (keep-alive) — carry on.
-			if cs.write_off < cs.write_buf.len || cs.file_remaining > 0 {
-				return true
+			match flush_batch(mut w, fd, mut cs) {
+				.closed {
+					return false
+				}
+				.blocked {
+					return true
+				}
+				.drained {}
 			}
 			pos = 0
 			continue
@@ -766,7 +804,7 @@ fn drain_requests(mut w Worker, fd int, mut cs ConnState) bool {
 			cs.should_close = true
 			compact_read_buf(mut cs, pos)
 			mark_active(mut w, mut cs)
-			return flush_batch(mut w, fd, mut cs)
+			return flush_batch(mut w, fd, mut cs) != .closed
 		}
 	}
 	compact_read_buf(mut cs, pos)
@@ -801,9 +839,10 @@ fn serve_conn(mut w Worker, fd int, mut cs ConnState) {
 			return
 		}
 		if n == 0 {
-			// Peer closed (FIN). If there is nothing buffered, this is a clean close.
-			close_conn(mut w, fd)
-			return
+			// FIN closes only the read side. Preserve valid requests/responses already
+			// buffered and close after their output has drained.
+			cs.read_eof = true
+			break
 		}
 		unsafe {
 			cs.read_buf.len += n
@@ -811,24 +850,30 @@ fn serve_conn(mut w Worker, fd int, mut cs ConnState) {
 		if !drain_requests(mut w, fd, mut cs) {
 			return
 		}
-		// Reject a request whose head cannot fit the configured buffer.
-		if cs.read_buf.len > 0 {
-			hl := frame_head_len(cs.read_buf)
-			too_large := (hl < 0 && cs.read_buf.len >= w.server.max_request_buffer_size)
-				|| hl > w.server.max_request_buffer_size
-			if too_large {
-				// Append the 413 after any responses already buffered for earlier
-				// pipelined requests, then flush in order and close (should_close).
-				cs.write_buf << status_413_response
-				cs.should_close = true
-				mark_active(mut w, mut cs)
-				flush_batch(mut w, fd, mut cs)
-				return
-			}
+		// A file or buffered response that hit EAGAIN owns the wire until it drains.
+		// Do not read/dispatch another request across that ordering boundary.
+		if cs.write_start_ns != 0 {
+			return
 		}
 	}
+	if cs.read_eof {
+		if cs.read_buf.len > 0 {
+			// EOF in the middle of a request can never become complete.
+			cs.write_buf << tiny_bad_request_response
+			unsafe { cs.read_buf.len = 0 }
+		}
+		cs.should_close = true
+		mark_read_deadline(mut w, mut cs)
+		if has_pending_response(cs) {
+			mark_active(mut w, mut cs)
+			flush_batch(mut w, fd, mut cs)
+		} else {
+			close_conn(mut w, fd)
+		}
+		return
+	}
 	mark_read_deadline(mut w, mut cs)
-	if cs.write_buf.len > cs.write_off || cs.file_remaining > 0 {
+	if has_pending_response(cs) {
 		mark_active(mut w, mut cs)
 		flush_batch(mut w, fd, mut cs)
 	}
@@ -844,25 +889,35 @@ fn handle_writable(mut w Worker, fd int) {
 	if unsafe { cs == nil } {
 		return
 	}
-	if cs.write_off >= cs.write_buf.len && cs.file_remaining <= 0 {
+	if !has_pending_response(cs) {
 		// Spurious wake — nothing parked; stop watching writability.
 		mod_fd_in_epoll(w.epoll_fd, fd, u32(C.EPOLLIN | C.EPOLLET))
 		return
 	}
-	if !flush_batch(mut w, fd, mut cs) {
-		return
+	match flush_batch(mut w, fd, mut cs) {
+		.closed, .blocked {
+			return
+		}
+		.drained {}
 	}
-	// If the parked batch fully drained (keep-alive) and requests were pipelined
-	// behind it, drain them now: their bytes are already in read_buf, so no new
-	// EPOLLIN edge will fire for them.
-	if cs.write_off >= cs.write_buf.len && cs.file_remaining <= 0 && cs.read_buf.len > 0 {
+	// If a parked batch fully drains, keep processing complete requests already in
+	// read_buf until output blocks again. No new EPOLLIN edge will fire for those
+	// bytes, including when several pipelined responses each contain a file.
+	for cs.read_buf.len > 0 {
 		if !drain_requests(mut w, fd, mut cs) {
 			return
 		}
-		if cs.write_buf.len > cs.write_off || cs.file_remaining > 0 {
-			flush_batch(mut w, fd, mut cs)
+		if !has_pending_response(cs) {
+			break
+		}
+		match flush_batch(mut w, fd, mut cs) {
+			.closed, .blocked {
+				return
+			}
+			.drained {}
 		}
 	}
+	mark_read_deadline(mut w, mut cs)
 }
 
 // handle_accept_loop accepts every pending connection (edge-triggered) and
@@ -928,9 +983,9 @@ fn close_worker_clients(mut w Worker) {
 
 fn process_events(server &Server, epoll_fd int, listen_fd int) {
 	mut w := Worker{
-		epoll_fd:  epoll_fd
+		epoll_fd: epoll_fd
 		listen_fd: listen_fd
-		conns:     []&ConnState{len: conn_table_min, init: unsafe { nil }}
+		conns: []&ConnState{len: conn_table_min, init: unsafe { nil }}
 	}
 	unsafe {
 		w.server = server
@@ -969,11 +1024,9 @@ fn process_events(server &Server, epoll_fd int, listen_fd int) {
 			if ev & u32(C.EPOLLHUP | C.EPOLLERR) != 0 {
 				if fd > 0 {
 					has_pending := fd < w.conns.len && unsafe { w.conns[fd] != nil }
-						&& (w.conns[fd].write_off < w.conns[fd].write_buf.len
-						|| w.conns[fd].file_remaining > 0)
+						&& has_pending_response(w.conns[fd])
 					if !has_pending {
-						C.send(fd, status_444_response.data, status_444_response.len,
-							C.MSG_NOSIGNAL)
+						C.send(fd, status_444_response.data, status_444_response.len, C.MSG_NOSIGNAL)
 					}
 					close_conn(mut w, fd)
 				}
@@ -995,7 +1048,7 @@ fn process_events(server &Server, epoll_fd int, listen_fd int) {
 				mut cs := w.conns[fd]
 				// While a response is still draining for this fd, defer new requests:
 				// reading now would clobber the in-flight write buffer.
-				if cs.write_off < cs.write_buf.len || cs.file_remaining > 0 {
+				if has_pending_response(cs) {
 					continue
 				}
 				if server.is_shutting_down() {

--- a/vlib/fasthttp/fasthttp_linux_regression_test.v
+++ b/vlib/fasthttp/fasthttp_linux_regression_test.v
@@ -10,6 +10,8 @@ import os
 
 fn C.socketpair(domain i32, typ i32, protocol i32, sockets &i32) i32
 
+fn C.shutdown(fd i32, how i32) i32
+
 fn regression_handler(_ HttpRequest) !HttpResponse {
 	return HttpResponse{
 		content: 'HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: keep-alive\r\n\r\nok'.bytes()
@@ -18,9 +20,9 @@ fn regression_handler(_ HttpRequest) !HttpResponse {
 
 fn new_regression_worker(server &Server, epoll_fd int) Worker {
 	mut w := Worker{
-		epoll_fd:  epoll_fd
+		epoll_fd: epoll_fd
 		listen_fd: -1
-		conns:     []&ConnState{len: conn_table_min, init: unsafe { nil }}
+		conns: []&ConnState{len: conn_table_min, init: unsafe { nil }}
 	}
 	unsafe {
 		w.server = server
@@ -47,14 +49,14 @@ fn recv_available(fd int) string {
 
 fn test_pipelined_requests_answered_in_one_batch() ! {
 	server := new_server(ServerConfig{
-		family:  .ip
-		port:    0
+		family: .ip
+		port: 0
 		handler: regression_handler
 	})!
 	epoll_fd := C.epoll_create1(0)
 	assert epoll_fd >= 0
 	defer { C.close(epoll_fd) }
-	mut sockets := [2]int{}
+	mut sockets := [2]i32{}
 	assert C.socketpair(C.AF_UNIX, C.SOCK_STREAM, 0, &sockets[0]) == 0
 	server_fd := sockets[0]
 	client_fd := sockets[1]
@@ -83,14 +85,14 @@ fn test_pipelined_requests_answered_in_one_batch() ! {
 
 fn test_fragmented_request_is_reassembled() ! {
 	server := new_server(ServerConfig{
-		family:  .ip
-		port:    0
+		family: .ip
+		port: 0
 		handler: regression_handler
 	})!
 	epoll_fd := C.epoll_create1(0)
 	assert epoll_fd >= 0
 	defer { C.close(epoll_fd) }
-	mut sockets := [2]int{}
+	mut sockets := [2]i32{}
 	assert C.socketpair(C.AF_UNIX, C.SOCK_STREAM, 0, &sockets[0]) == 0
 	server_fd := sockets[0]
 	client_fd := sockets[1]
@@ -121,16 +123,48 @@ fn test_fragmented_request_is_reassembled() ! {
 	C.close(client_fd)
 }
 
-fn test_keep_alive_rearms_after_consumed_edge() ! {
+fn test_half_closed_client_still_receives_buffered_response() ! {
 	server := new_server(ServerConfig{
-		family:  .ip
-		port:    0
+		family: .ip
+		port: 0
 		handler: regression_handler
 	})!
 	epoll_fd := C.epoll_create1(0)
 	assert epoll_fd >= 0
 	defer { C.close(epoll_fd) }
-	mut sockets := [2]int{}
+	mut sockets := [2]i32{}
+	assert C.socketpair(C.AF_UNIX, C.SOCK_STREAM, 0, &sockets[0]) == 0
+	server_fd := sockets[0]
+	client_fd := sockets[1]
+	set_blocking(server_fd, false)
+	set_blocking(client_fd, false)
+
+	mut w := new_regression_worker(server, epoll_fd)
+	assert add_fd_to_epoll(epoll_fd, server_fd, u32(C.EPOLLIN | C.EPOLLET)) == 0
+	mut cs := state_for(mut w, server_fd)
+	req := 'GET /half-close HTTP/1.1\r\nHost: x\r\n\r\n'
+	assert C.send(client_fd, req.str, req.len, C.MSG_NOSIGNAL) == req.len
+	assert C.shutdown(client_fd, C.SHUT_WR) == 0
+
+	serve_conn(mut w, server_fd, mut cs)
+	response := recv_available(client_fd)
+	assert response.contains('HTTP/1.1 200 OK'), response
+	assert response.ends_with('ok'), response
+	assert unsafe { w.conns[server_fd] == nil }
+
+	C.close(client_fd)
+}
+
+fn test_keep_alive_rearms_after_consumed_edge() ! {
+	server := new_server(ServerConfig{
+		family: .ip
+		port: 0
+		handler: regression_handler
+	})!
+	epoll_fd := C.epoll_create1(0)
+	assert epoll_fd >= 0
+	defer { C.close(epoll_fd) }
+	mut sockets := [2]i32{}
 	assert C.socketpair(C.AF_UNIX, C.SOCK_STREAM, 0, &sockets[0]) == 0
 	server_fd := sockets[0]
 	client_fd := sockets[1]
@@ -182,14 +216,14 @@ fn append_close_handler(req HttpRequest, mut out []u8, worker_state voidptr, mut
 
 fn test_append_handler_pipelining_zero_copy() ! {
 	server := new_server(ServerConfig{
-		family:         .ip
-		port:           0
+		family: .ip
+		port: 0
 		append_handler: append_ok_handler
 	})!
 	epoll_fd := C.epoll_create1(0)
 	assert epoll_fd >= 0
 	defer { C.close(epoll_fd) }
-	mut sockets := [2]int{}
+	mut sockets := [2]i32{}
 	assert C.socketpair(C.AF_UNIX, C.SOCK_STREAM, 0, &sockets[0]) == 0
 	server_fd := sockets[0]
 	client_fd := sockets[1]
@@ -214,14 +248,14 @@ fn test_append_handler_pipelining_zero_copy() ! {
 
 fn test_append_handler_should_close() ! {
 	server := new_server(ServerConfig{
-		family:         .ip
-		port:           0
+		family: .ip
+		port: 0
 		append_handler: append_close_handler
 	})!
 	epoll_fd := C.epoll_create1(0)
 	assert epoll_fd >= 0
 	defer { C.close(epoll_fd) }
-	mut sockets := [2]int{}
+	mut sockets := [2]i32{}
 	assert C.socketpair(C.AF_UNIX, C.SOCK_STREAM, 0, &sockets[0]) == 0
 	server_fd := sockets[0]
 	client_fd := sockets[1]
@@ -249,11 +283,10 @@ fn test_new_server_requires_exactly_one_handler() {
 	}
 	// Both set → error.
 	if _ := new_server(ServerConfig{
-		port:           0
-		handler:        regression_handler
+		port: 0
+		handler: regression_handler
 		append_handler: append_ok_handler
-	})
-	{
+	}) {
 		assert false, 'expected an error when both handlers are set'
 	}
 }
@@ -271,15 +304,15 @@ fn test_worker_state_reaches_handler() ! {
 		}
 	}
 	server := new_server(ServerConfig{
-		family:     .ip
-		port:       0
-		handler:    handler
+		family: .ip
+		port: 0
+		handler: handler
 		make_state: make_state
 	})!
 	epoll_fd := C.epoll_create1(0)
 	assert epoll_fd >= 0
 	defer { C.close(epoll_fd) }
-	mut sockets := [2]int{}
+	mut sockets := [2]i32{}
 	assert C.socketpair(C.AF_UNIX, C.SOCK_STREAM, 0, &sockets[0]) == 0
 	server_fd := sockets[0]
 	client_fd := sockets[1]
@@ -313,25 +346,25 @@ fn test_pipelined_request_behind_file_response_is_served() ! {
 		path := req.buffer[req.path.start..req.path.start + req.path.len].bytestr()
 		if path == '/file' {
 			return HttpResponse{
-				content:       'HTTP/1.1 200 OK\r\nContent-Length: 8\r\nConnection: keep-alive\r\n\r\n'.bytes()
+				content: 'HTTP/1.1 200 OK\r\nContent-Length: 8\r\nConnection: keep-alive\r\n\r\n'.bytes()
 				content_owned: true
-				file_path:     tmp
+				file_path: tmp
 			}
 		}
 		return HttpResponse{
-			content:       'HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: keep-alive\r\n\r\nafter'.bytes()
+			content: 'HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: keep-alive\r\n\r\nafter'.bytes()
 			content_owned: true
 		}
 	}
 	server := new_server(ServerConfig{
-		family:  .ip
-		port:    0
+		family: .ip
+		port: 0
 		handler: file_handler
 	})!
 	epoll_fd := C.epoll_create1(0)
 	assert epoll_fd >= 0
 	defer { C.close(epoll_fd) }
-	mut sockets := [2]int{}
+	mut sockets := [2]i32{}
 	assert C.socketpair(C.AF_UNIX, C.SOCK_STREAM, 0, &sockets[0]) == 0
 	server_fd := sockets[0]
 	client_fd := sockets[1]
@@ -355,6 +388,77 @@ fn test_pipelined_request_behind_file_response_is_served() ! {
 	C.close(client_fd)
 }
 
+fn test_blocked_file_response_stays_a_pipeline_boundary() ! {
+	file_size := 2 * 1024 * 1024
+	tmp := os.join_path(os.vtmp_dir(), 'fasthttp_blocked_pipe_file_test.txt')
+	os.write_file(tmp, 'x'.repeat(file_size))!
+	defer {
+		os.rm(tmp) or {}
+	}
+	mut handled := 0
+	file_handler := fn [tmp, file_size, mut handled] (req HttpRequest) !HttpResponse {
+		handled++
+		path := req.buffer[req.path.start..req.path.start + req.path.len].bytestr()
+		if path == '/file' {
+			return HttpResponse{
+				content: 'HTTP/1.1 200 OK\r\nContent-Length: ${file_size}\r\nConnection: keep-alive\r\n\r\n'.bytes()
+				file_path: tmp
+			}
+		}
+		return HttpResponse{
+			content: 'HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: keep-alive\r\n\r\nafter'.bytes()
+		}
+	}
+	server := new_server(ServerConfig{
+		family: .ip
+		port: 0
+		handler: file_handler
+	})!
+	epoll_fd := C.epoll_create1(0)
+	assert epoll_fd >= 0
+	defer { C.close(epoll_fd) }
+	mut sockets := [2]i32{}
+	assert C.socketpair(C.AF_UNIX, C.SOCK_STREAM, 0, &sockets[0]) == 0
+	server_fd := sockets[0]
+	client_fd := sockets[1]
+	send_buffer_size := 4096
+	assert C.setsockopt(server_fd, C.SOL_SOCKET, C.SO_SNDBUF, &send_buffer_size, sizeof(send_buffer_size)) == 0
+	set_blocking(server_fd, false)
+	set_blocking(client_fd, false)
+
+	mut w := new_regression_worker(server, epoll_fd)
+	assert add_fd_to_epoll(epoll_fd, server_fd, u32(C.EPOLLIN | C.EPOLLET)) == 0
+	mut cs := state_for(mut w, server_fd)
+	req := 'GET /file HTTP/1.1\r\nHost: x\r\n\r\nGET /next HTTP/1.1\r\nHost: x\r\n\r\n'
+	assert C.send(client_fd, req.str, req.len, C.MSG_NOSIGNAL) == req.len
+	serve_conn(mut w, server_fd, mut cs)
+	assert handled == 1
+	assert cs.file_fd != -1
+	assert cs.read_buf.len > 0
+
+	mut response := ''
+	for _ in 0 .. 64 {
+		response += recv_available(client_fd)
+		if handled == 2 && !has_pending_response(cs) {
+			break
+		}
+		handle_writable(mut w, server_fd)
+	}
+	response += recv_available(client_fd)
+	assert handled == 2
+	assert response.count('HTTP/1.1 200 OK') == 2, response[..if response.len < 512 {
+		response.len
+	} else {
+		512
+	}]
+	assert response.ends_with('after')
+	assert cs.file_fd == -1
+	assert cs.read_buf.len == 0
+
+	C.close(server_fd)
+	C.close(client_fd)
+}
+
 // A zero-length file response leaves cs.file_fd open with file_remaining == 0.
 // flush_batch must still close it (guarding on file_fd, not file_remaining), or the
 // descriptor leaks; on a keep-alive connection two empty-file responses would then
@@ -368,20 +472,20 @@ fn test_zero_length_file_response_does_not_leak_fd() ! {
 	}
 	empty_file_handler := fn [tmp] (req HttpRequest) !HttpResponse {
 		return HttpResponse{
-			content:       'HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
+			content: 'HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n'.bytes()
 			content_owned: true
-			file_path:     tmp
+			file_path: tmp
 		}
 	}
 	server := new_server(ServerConfig{
-		family:  .ip
-		port:    0
+		family: .ip
+		port: 0
 		handler: empty_file_handler
 	})!
 	epoll_fd := C.epoll_create1(0)
 	assert epoll_fd >= 0
 	defer { C.close(epoll_fd) }
-	mut sockets := [2]int{}
+	mut sockets := [2]i32{}
 	assert C.socketpair(C.AF_UNIX, C.SOCK_STREAM, 0, &sockets[0]) == 0
 	server_fd := sockets[0]
 	client_fd := sockets[1]
@@ -452,7 +556,7 @@ fn test_sendfile_to_disconnected_client_preserves_sigpipe_handler() ! {
 	defer {
 		file.close()
 	}
-	mut sockets := [2]int{}
+	mut sockets := [2]i32{}
 	assert C.socketpair(C.AF_UNIX, C.SOCK_STREAM, 0, &sockets[0]) == 0
 	server_fd := sockets[0]
 	client_fd := sockets[1]
@@ -499,14 +603,14 @@ fn reorder_takeover_handler(req HttpRequest, mut out []u8, worker_state voidptr,
 
 fn test_reusable_takeover_behind_buffered_response_closes() ! {
 	server := new_server(ServerConfig{
-		family:         .ip
-		port:           0
+		family: .ip
+		port: 0
 		append_handler: reorder_takeover_handler
 	})!
 	epoll_fd := C.epoll_create1(0)
 	assert epoll_fd >= 0
 	defer { C.close(epoll_fd) }
-	mut sockets := [2]int{}
+	mut sockets := [2]i32{}
 	assert C.socketpair(C.AF_UNIX, C.SOCK_STREAM, 0, &sockets[0]) == 0
 	server_fd := sockets[0]
 	client_fd := sockets[1]
@@ -530,14 +634,14 @@ fn test_reusable_takeover_behind_buffered_response_closes() ! {
 
 fn test_conn_state_is_pooled_with_buffers_retained() ! {
 	server := new_server(ServerConfig{
-		family:  .ip
-		port:    0
+		family: .ip
+		port: 0
 		handler: regression_handler
 	})!
 	epoll_fd := C.epoll_create1(0)
 	assert epoll_fd >= 0
 	defer { C.close(epoll_fd) }
-	mut sockets := [2]int{}
+	mut sockets := [2]i32{}
 	assert C.socketpair(C.AF_UNIX, C.SOCK_STREAM, 0, &sockets[0]) == 0
 	server_fd := sockets[0]
 	client_fd := sockets[1]

--- a/vlib/fasthttp/fasthttp_test.v
+++ b/vlib/fasthttp/fasthttp_test.v
@@ -20,8 +20,7 @@ fn test_fasthttp_example_compiles() {
 	vroot := os.dir(vexe)
 
 	// Build the fasthttp example
-	build_result := os.system('${os.quoted_path(vexe)} -o ${os.quoted_path(fasthttp_example_exe)} ${os.join_path(vroot,
-		'examples', 'fasthttp')}')
+	build_result := os.system('${os.quoted_path(vexe)} -o ${os.quoted_path(fasthttp_example_exe)} ${os.join_path(vroot, 'examples', 'fasthttp')}')
 	assert build_result == 0, 'fasthttp example failed to compile'
 	assert os.exists(fasthttp_example_exe), 'fasthttp example binary not found after build'
 }
@@ -107,7 +106,7 @@ fn test_new_server() {
 	}
 
 	server := new_server(ServerConfig{
-		port:    8080
+		port: 8080
 		handler: handler
 	}) or {
 		assert false, 'Failed to create server: ${err}'
@@ -115,6 +114,15 @@ fn test_new_server() {
 	}
 
 	assert server.port == 8080
+	assert server.max_request_body_size == default_max_request_body_size
+
+	if _ := new_server(ServerConfig{
+		port: 8080
+		max_request_body_size: -1
+		handler: handler
+	}) {
+		assert false, 'negative max_request_body_size should be rejected'
+	}
 }
 
 fn test_server_ipv4_ipv6_binding() {
@@ -126,8 +134,8 @@ fn test_server_ipv4_ipv6_binding() {
 	}
 
 	server_ipv4 := new_server(ServerConfig{
-		family:  .ip
-		port:    8081
+		family: .ip
+		port: 8081
 		handler: handler
 	}) or {
 		assert false, 'Failed to create IPv4 server: ${err}'
@@ -136,8 +144,8 @@ fn test_server_ipv4_ipv6_binding() {
 
 	// Test IPv6 binding
 	server_ipv6 := new_server(ServerConfig{
-		family:  .ip6
-		port:    8082
+		family: .ip6
+		port: 8082
 		handler: handler
 	}) or {
 		assert false, 'Failed to create IPv6 server: ${err}'
@@ -153,11 +161,11 @@ fn test_server_ipv4_ipv6_binding() {
 fn test_response_takeover_mode_reusable_keeps_connection() {
 	$if linux || bsd || windows {
 		mut server := new_server(ServerConfig{
-			family:                  .ip
-			port:                    reusable_takeover_port
-			timeout_in_seconds:      2
+			family: .ip
+			port: reusable_takeover_port
+			timeout_in_seconds: 2
 			max_request_buffer_size: 8192
-			handler:                 reusable_takeover_handler
+			handler: reusable_takeover_handler
 		}) or {
 			assert false, 'Failed to create server: ${err}'
 			return
@@ -199,8 +207,7 @@ fn reusable_takeover_handler(req HttpRequest) !HttpResponse {
 	path := req.buffer[req.path.start..req.path.start + req.path.len].bytestr()
 	if path == '/reusable' {
 		body := 'manual'
-		send_raw_response(req.client_conn_handle,
-			'HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n${body.len:x}\r\n${body}\r\n0\r\n\r\n')
+		send_raw_response(req.client_conn_handle, 'HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n${body.len:x}\r\n${body}\r\n0\r\n\r\n')
 		return HttpResponse{
 			takeover_mode: .reusable
 		}

--- a/vlib/fasthttp/fasthttp_windows.v
+++ b/vlib/fasthttp/fasthttp_windows.v
@@ -23,10 +23,14 @@ struct IocpConn {
 	server &Server
 	fd     C.SOCKET
 mut:
-	request_buf    []u8
-	read_start     i64
-	write_start    i64
-	request_active bool
+	request_buf []u8
+	request_len int
+	read_eof    bool
+	// Housekeeping runs concurrently with completion workers, so fields it reads
+	// are atomic rather than merely protected by the registry container mutex.
+	read_start     &stdatomic.AtomicVal[u64] = stdatomic.new_atomic(u64(0))
+	write_start    &stdatomic.AtomicVal[u64] = stdatomic.new_atomic(u64(0))
+	request_active &stdatomic.AtomicVal[bool] = stdatomic.new_atomic(false)
 	request_arena  voidptr
 	should_close   bool
 	closing        &stdatomic.AtomicVal[bool] = stdatomic.new_atomic(false)
@@ -62,26 +66,30 @@ pub:
 	host                    string
 	port                    int = 3000
 	max_request_buffer_size int = 8192
+	max_request_body_size   int = default_max_request_body_size
 	timeout_in_seconds      int = 30
 	user_data               voidptr
 mut:
 	listen_fd       C.SOCKET = iocp_invalid_socket
 	iocp            voidptr
-	threads         []thread                       = []thread{len: iocp_thread_count, cap: iocp_thread_count}
-	registry        &IocpConnRegistry              = &IocpConnRegistry{}
+	threads         []thread = []thread{len: iocp_thread_count, cap: iocp_thread_count}
+	registry        &IocpConnRegistry = &IocpConnRegistry{}
 	request_handler fn (HttpRequest) !HttpResponse = unsafe { nil }
-	append_handler  AppendHandler                  = unsafe { nil }
-	make_state      fn () voidptr                  = unsafe { nil }
-	running         &stdatomic.AtomicVal[bool]     = stdatomic.new_atomic(false)
-	shutting_down   &stdatomic.AtomicVal[bool]     = stdatomic.new_atomic(false)
-	stopped         &stdatomic.AtomicVal[bool]     = stdatomic.new_atomic(true)
-	active_requests &stdatomic.AtomicVal[int]      = stdatomic.new_atomic(0)
+	append_handler  AppendHandler = unsafe { nil }
+	make_state      fn () voidptr = unsafe { nil }
+	running         &stdatomic.AtomicVal[bool] = stdatomic.new_atomic(false)
+	shutting_down   &stdatomic.AtomicVal[bool] = stdatomic.new_atomic(false)
+	stopped         &stdatomic.AtomicVal[bool] = stdatomic.new_atomic(true)
+	active_requests &stdatomic.AtomicVal[int] = stdatomic.new_atomic(0)
 }
 
 // new_server creates and initializes a new Server instance.
 pub fn new_server(config ServerConfig) !&Server {
 	if config.max_request_buffer_size <= 0 {
 		return error('max_request_buffer_size must be greater than 0')
+	}
+	if config.max_request_body_size < 0 {
+		return error('max_request_body_size must not be negative')
 	}
 	has_handler := config.handler != unsafe { nil }
 	has_append := config.append_handler != unsafe { nil }
@@ -92,20 +100,21 @@ pub fn new_server(config ServerConfig) !&Server {
 		return error('set only one of `handler` or `append_handler`, not both')
 	}
 	mut server := &Server{
-		family:                  config.family
-		host:                    config.host
-		port:                    config.port
+		family: config.family
+		host: config.host
+		port: config.port
 		max_request_buffer_size: config.max_request_buffer_size
-		timeout_in_seconds:      config.timeout_in_seconds
-		user_data:               config.user_data
-		request_handler:         config.handler
-		append_handler:          config.append_handler
-		make_state:              config.make_state
-		running:                 stdatomic.new_atomic(false)
-		shutting_down:           stdatomic.new_atomic(false)
-		stopped:                 stdatomic.new_atomic(true)
-		active_requests:         stdatomic.new_atomic(0)
-		registry:                &IocpConnRegistry{
+		max_request_body_size: config.max_request_body_size
+		timeout_in_seconds: config.timeout_in_seconds
+		user_data: config.user_data
+		request_handler: config.handler
+		append_handler: config.append_handler
+		make_state: config.make_state
+		running: stdatomic.new_atomic(false)
+		shutting_down: stdatomic.new_atomic(false)
+		stopped: stdatomic.new_atomic(true)
+		active_requests: stdatomic.new_atomic(0)
+		registry: &IocpConnRegistry{
 			mutex: sync.new_mutex()
 		}
 	}
@@ -134,9 +143,7 @@ fn get_transmit_file_fn(fd C.SOCKET) ?IocpTransmitFileFn {
 	}
 	mut transmit_file := voidptr(unsafe { nil })
 	mut bytes_returned := C.DWORD(0)
-	rc := C.WSAIoctl(fd, C.SIO_GET_EXTENSION_FUNCTION_POINTER, voidptr(&transmit_file_guid),
-		C.DWORD(sizeof(C.GUID)), voidptr(&transmit_file), C.DWORD(sizeof(voidptr)),
-		&bytes_returned, unsafe { nil }, unsafe { nil })
+	rc := C.WSAIoctl(fd, C.SIO_GET_EXTENSION_FUNCTION_POINTER, voidptr(&transmit_file_guid), C.DWORD(sizeof(C.GUID)), voidptr(&transmit_file), C.DWORD(sizeof(voidptr)), &bytes_returned, unsafe { nil }, unsafe { nil })
 	if rc == C.SOCKET_ERROR || transmit_file == unsafe { nil } {
 		return none
 	}
@@ -152,8 +159,7 @@ fn create_server_socket(server &Server) !C.SOCKET {
 	// family, and a configured host may resolve to a different family than
 	// server.family (e.g. an IPv4 host with the default family: .ip6).
 	addr := resolve_bind_addr(server.host, server.family, server.port)!
-	server_fd := C.WSASocketW(i32(addr.family()), i32(net.SocketType.tcp), 0, unsafe { nil }, 0,
-		u32(C.WSA_FLAG_OVERLAPPED))
+	server_fd := C.WSASocketW(i32(addr.family()), i32(net.SocketType.tcp), 0, unsafe { nil }, 0, u32(C.WSA_FLAG_OVERLAPPED))
 	if server_fd == iocp_invalid_socket {
 		return error(wsa_error_message('WSASocketW'))
 	}
@@ -165,8 +171,7 @@ fn create_server_socket(server &Server) !C.SOCKET {
 	}
 	if addr.family() == .ip6 {
 		ipv6_only := 0
-		C.v_fasthttp_setsockopt(server_fd, C.IPPROTO_IPV6, C.IPV6_V6ONLY, voidptr(&ipv6_only),
-			sizeof(ipv6_only))
+		C.v_fasthttp_setsockopt(server_fd, C.IPPROTO_IPV6, C.IPV6_V6ONLY, voidptr(&ipv6_only), sizeof(ipv6_only))
 	}
 
 	if C.v_fasthttp_bind(server_fd, voidptr(&addr), int(addr.len())) < 0 {
@@ -262,7 +267,7 @@ fn (mut registry IocpConnRegistry) close_all_async() {
 	registry.mutex.unlock()
 }
 
-fn (mut registry IocpConnRegistry) sweep_timed_out_io(timeout_ns i64) {
+fn (mut registry IocpConnRegistry) sweep_timed_out_io(timeout_ns u64) {
 	now := time.sys_mono_now()
 	registry.mutex.lock()
 	for key in registry.conns.keys() {
@@ -270,12 +275,14 @@ fn (mut registry IocpConnRegistry) sweep_timed_out_io(timeout_ns i64) {
 		if conn.is_closing() {
 			continue
 		}
-		if !conn.request_active && conn.read_start > 0 && now - conn.read_start >= timeout_ns
+		read_start := conn.read_start.load()
+		write_start := conn.write_start.load()
+		if !conn.request_active.load() && read_start > 0 && now - read_start >= timeout_ns
 			&& conn.mark_closing() {
 			C.v_fasthttp_send(conn.fd, status_408_response.data, status_408_response.len, 0)
 			close_conn_socket(conn.fd)
 		}
-		if conn.write_start > 0 && now - conn.write_start >= timeout_ns && conn.mark_closing() {
+		if write_start > 0 && now - write_start >= timeout_ns && conn.mark_closing() {
 			close_conn_socket(conn.fd)
 		}
 	}
@@ -296,8 +303,7 @@ fn (mut conn IocpConn) open_response_file(path string) bool {
 	conn.close_response_file()
 	st := os.stat(path) or { return false }
 	path_wide := path.to_wide()
-	handle := C.CreateFileW(path_wide, C.GENERIC_READ, C.FILE_SHARE_READ, 0, C.OPEN_EXISTING,
-		C.FILE_ATTRIBUTE_NORMAL, 0)
+	handle := C.CreateFileW(path_wide, C.GENERIC_READ, C.FILE_SHARE_READ, 0, C.OPEN_EXISTING, C.FILE_ATTRIBUTE_NORMAL, 0)
 	if handle == C.INVALID_HANDLE_VALUE || handle == unsafe { nil } {
 		return false
 	}
@@ -326,16 +332,16 @@ fn (mut conn IocpConn) free_request_arena() {
 }
 
 fn (mut conn IocpConn) end_active_request() {
-	if conn.request_active {
+	mut request_active := conn.request_active
+	if request_active.compare_and_swap(true, false) {
 		conn.server.end_request()
-		conn.request_active = false
 	}
 }
 
 fn (mut conn IocpConn) begin_active_request() {
-	if !conn.request_active {
+	mut request_active := conn.request_active
+	if request_active.compare_and_swap(false, true) {
 		conn.server.begin_request()
-		conn.request_active = true
 	}
 }
 
@@ -355,6 +361,18 @@ fn free_conn_storage(mut conn IocpConn) {
 		}
 		unsafe { free(conn.pending_op) }
 		conn.pending_op = unsafe { nil }
+	}
+	if conn.read_start != unsafe { nil } {
+		unsafe { free(conn.read_start) }
+		conn.read_start = unsafe { nil }
+	}
+	if conn.write_start != unsafe { nil } {
+		unsafe { free(conn.write_start) }
+		conn.write_start = unsafe { nil }
+	}
+	if conn.request_active != unsafe { nil } {
+		unsafe { free(conn.request_active) }
+		conn.request_active = unsafe { nil }
 	}
 	unsafe { free(conn) }
 }
@@ -381,9 +399,12 @@ fn reset_conn_for_next_request(mut conn IocpConn) {
 	conn.end_active_request()
 	conn.close_response_file()
 	conn.free_request_arena()
-	conn.request_buf.clear()
-	conn.read_start = 0
-	conn.write_start = 0
+	if conn.request_len > 0 {
+		conn.request_buf.delete_many(0, conn.request_len)
+		conn.request_len = 0
+	}
+	conn.read_start.store(if conn.request_buf.len > 0 { time.sys_mono_now() } else { u64(0) })
+	conn.write_start.store(0)
 	conn.should_close = false
 }
 
@@ -391,7 +412,7 @@ fn post_recv(mut conn IocpConn) bool {
 	mut op := &IocpOperation{
 		kind: .read
 		conn: conn
-		buf:  []u8{len: iocp_read_buf_size}
+		buf: []u8{len: iocp_read_buf_size}
 	}
 	op.wsabuf = C.WSABUF{
 		len: u32(op.buf.len)
@@ -423,7 +444,7 @@ fn post_write_op(mut op IocpOperation) bool {
 		buf: unsafe { &char(&op.buf[op.pos]) }
 	}
 	mut bytes_sent := C.DWORD(0)
-	op.conn.write_start = time.sys_mono_now()
+	op.conn.write_start.store(time.sys_mono_now())
 	op.conn.register_op(op)
 	ret := C.WSASend(op.conn.fd, &op.wsabuf, 1, &bytes_sent, 0, &op.overlapped, unsafe { nil })
 	if ret == C.SOCKET_ERROR {
@@ -455,14 +476,13 @@ fn post_transmit_file(mut conn IocpConn) bool {
 	file_pos := u64(conn.file_pos)
 	op.overlapped.Offset = u32(file_pos & 0xffffffff)
 	op.overlapped.OffsetHigh = u32(file_pos >> 32)
-	conn.write_start = time.sys_mono_now()
+	conn.write_start.store(time.sys_mono_now())
 	transmit_file := get_transmit_file_fn(conn.fd) or {
 		op.free()
 		return false
 	}
 	conn.register_op(op)
-	ret := transmit_file(conn.fd, conn.file_handle, C.DWORD(chunk_size), 0, &op.overlapped,
-		unsafe { nil }, 0)
+	ret := transmit_file(conn.fd, conn.file_handle, C.DWORD(chunk_size), 0, &op.overlapped, unsafe { nil }, 0)
 	if ret == 0 {
 		code := C.WSAGetLastError()
 		if code != C.WSA_IO_PENDING {
@@ -474,11 +494,11 @@ fn post_transmit_file(mut conn IocpConn) bool {
 	return true
 }
 
-fn continue_response_after_write(mut conn IocpConn) {
+fn continue_response_after_write(mut conn IocpConn, worker_state voidptr) {
 	if conn.has_file {
 		if conn.file_pos >= conn.file_len {
 			conn.close_response_file()
-			complete_response(mut conn)
+			complete_response(mut conn, worker_state)
 			return
 		}
 		if !post_transmit_file(mut conn) {
@@ -486,13 +506,21 @@ fn continue_response_after_write(mut conn IocpConn) {
 		}
 		return
 	}
-	complete_response(mut conn)
+	complete_response(mut conn, worker_state)
 }
 
-fn complete_response(mut conn IocpConn) {
+fn complete_response(mut conn IocpConn, worker_state voidptr) {
 	should_close := conn.should_close
 	reset_conn_for_next_request(mut conn)
 	if conn.server.is_shutting_down() || should_close {
+		close_conn(mut conn)
+		return
+	}
+	if conn.request_buf.len > 0 {
+		dispatch_iocp_request(mut conn, worker_state)
+		return
+	}
+	if conn.read_eof {
 		close_conn(mut conn)
 		return
 	}
@@ -501,16 +529,16 @@ fn complete_response(mut conn IocpConn) {
 	}
 }
 
-fn send_response(mut conn IocpConn, content []u8, should_close bool) {
+fn send_response(mut conn IocpConn, content []u8, should_close bool, worker_state voidptr) {
 	conn.should_close = should_close
 	if content.len == 0 {
-		continue_response_after_write(mut conn)
+		continue_response_after_write(mut conn, worker_state)
 		return
 	}
 	mut op := &IocpOperation{
 		kind: .write
 		conn: conn
-		buf:  content
+		buf: content
 	}
 	if !post_write_op(mut op) {
 		op.free()
@@ -518,13 +546,16 @@ fn send_response(mut conn IocpConn, content []u8, should_close bool) {
 	}
 }
 
-fn send_terminal_response(mut conn IocpConn, response []u8) {
-	conn.read_start = 0
-	send_response(mut conn, response.clone(), true)
+fn send_terminal_response(mut conn IocpConn, response []u8, worker_state voidptr) {
+	conn.begin_active_request()
+	conn.request_len = conn.request_buf.len
+	conn.read_start.store(0)
+	send_response(mut conn, response.clone(), true, worker_state)
 }
 
-fn process_request(mut conn IocpConn) {
+fn process_request(mut conn IocpConn, frame_total int, worker_state voidptr) {
 	conn.begin_active_request()
+	conn.request_len = frame_total
 	// The append handler manages its own -prealloc scope; only the legacy path
 	// uses the reactor arena.
 	using_append := conn.server.append_handler != unsafe { nil }
@@ -535,30 +566,18 @@ fn process_request(mut conn IocpConn) {
 		}
 	}
 
-	// Frame the request to its exact declared length (RFC 9112 §6), like the Linux
-	// reactor: trim the body to Content-Length so `decoded.body` sees exactly the
-	// declared bytes and any surplus is not mis-attributed to this request. IOCP
-	// serves one request per read; a valid `total` is <= request_buf.len because
-	// has_complete_body already gated on it. Pass a view without mutating the
-	// persistent request_buf (which is cleared/freed on its own lifecycle).
-	frame_total := frame_request_length_lim_idx(conn.request_buf,
-		conn.server.max_request_buffer_size, 0)
-	req_view := if frame_total >= 0 && frame_total < conn.request_buf.len {
-		conn.request_buf[..frame_total]
-	} else {
-		conn.request_buf
-	}
+	// The consumed prefix remains stable until this response completes.
+	req_view := conn.request_buf[..frame_total]
 	mut decoded := decode_http_request(req_view) or {
 		end_request_arena_current_thread(request_arena)
-		send_terminal_response(mut conn, tiny_bad_request_response)
+		send_terminal_response(mut conn, tiny_bad_request_response, worker_state)
 		return
 	}
 	// Keep legacy int fd consumers working; client_conn_handle preserves the full SOCKET.
 	decoded.client_conn_fd = int(conn.fd)
 	decoded.client_conn_handle = usize(conn.fd)
 	decoded.user_data = conn.server.user_data
-	// NOTE: per-worker make_state is not yet wired on the IOCP thread pool (it
-	// would need thread-local storage); worker_state stays nil on Windows.
+	decoded.worker_state = worker_state
 
 	mut response := if using_append {
 		// Zero-copy contract: the handler appends its response into `out`; wrap it
@@ -566,22 +585,21 @@ fn process_request(mut conn IocpConn) {
 		// NOTE: `out` is a fresh per-request buffer. Under the default GC it is
 		// reclaimed after the send; under -prealloc the append path opens no request
 		// scope, so it is not reclaimed per request (known limitation — IOCP does not
-		// yet reuse a persistent per-connection write buffer). Server.run is also not
-		// implemented on Windows yet.
+		// yet reuse a persistent per-connection write buffer).
 		mut out := []u8{}
 		mut ctl := ResponseControl{}
-		step := conn.server.append_handler(decoded, mut out, unsafe { nil }, mut ctl)
+		step := conn.server.append_handler(decoded, mut out, worker_state, mut ctl)
 		HttpResponse{
-			content:       out
+			content: out
 			content_owned: true
 			takeover_mode: ctl.takeover_mode
-			should_close:  ctl.should_close || step != .done
-			file_path:     ctl.file_path
+			should_close: ctl.should_close || step != .done
+			file_path: ctl.file_path
 		}
 	} else {
 		conn.server.request_handler(decoded) or {
 			end_request_arena_current_thread(request_arena)
-			send_terminal_response(mut conn, tiny_bad_request_response)
+			send_terminal_response(mut conn, tiny_bad_request_response, worker_state)
 			return
 		}
 	}
@@ -595,14 +613,20 @@ fn process_request(mut conn IocpConn) {
 			return
 		}
 		.reusable {
+			should_close := response.should_close
+				|| (conn.read_eof && frame_total == conn.request_buf.len)
 			response.free_owned_content()
 			response.end_request_arena_current_thread()
 			reset_conn_for_next_request(mut conn)
-			if conn.server.is_shutting_down() || response.should_close {
+			if conn.server.is_shutting_down() || should_close {
 				close_conn(mut conn)
 				return
 			}
-			if !post_recv(mut conn) {
+			if conn.request_buf.len > 0 {
+				dispatch_iocp_request(mut conn, worker_state)
+			} else if conn.read_eof {
+				close_conn(mut conn)
+			} else if !post_recv(mut conn) {
 				close_conn(mut conn)
 			}
 			return
@@ -614,17 +638,54 @@ fn process_request(mut conn IocpConn) {
 		if !conn.open_response_file(response.file_path) {
 			response.free_owned_content()
 			response.end_request_arena_current_thread()
-			send_terminal_response(mut conn, tiny_bad_request_response)
+			send_terminal_response(mut conn, tiny_bad_request_response, worker_state)
 			return
 		}
 	}
 	mut content := response.take_or_clone_content()
 	conn.request_arena = response.take_request_arena()
 	leave_request_arena_current_thread(conn.request_arena)
-	send_response(mut conn, content, response.should_close)
+	should_close := response.should_close || (conn.read_eof && frame_total == conn.request_buf.len)
+	send_response(mut conn, content, should_close, worker_state)
 }
 
-fn handle_read_completion(mut conn IocpConn, mut op IocpOperation, bytes_read C.DWORD) {
+fn dispatch_iocp_request(mut conn IocpConn, worker_state voidptr) {
+	if conn.request_buf.len == 0 {
+		if conn.read_eof {
+			close_conn(mut conn)
+		} else if !post_recv(mut conn) {
+			close_conn(mut conn)
+		}
+		return
+	}
+	frame_total := frame_request_length_lim_idx(conn.request_buf, conn.server.max_request_buffer_size, conn.server.max_request_body_size)
+	if frame_total == -1 {
+		if conn.read_eof {
+			send_terminal_response(mut conn, tiny_bad_request_response, worker_state)
+			return
+		}
+		read_start := conn.read_start.load()
+		if conn.server.timeout_in_seconds > 0 && read_start > 0 {
+			timeout_ns := u64(conn.server.timeout_in_seconds) * 1_000_000_000
+			if time.sys_mono_now() - read_start >= timeout_ns {
+				send_terminal_response(mut conn, status_408_response, worker_state)
+				return
+			}
+		}
+		if !post_recv(mut conn) {
+			close_conn(mut conn)
+		}
+		return
+	}
+	if frame_total < -1 {
+		send_terminal_response(mut conn, response_for_frame_error(frame_total), worker_state)
+		return
+	}
+	conn.read_start.store(0)
+	process_request(mut conn, frame_total, worker_state)
+}
+
+fn handle_read_completion(mut conn IocpConn, mut op IocpOperation, bytes_read C.DWORD, worker_state voidptr) {
 	defer {
 		op.free()
 	}
@@ -633,43 +694,19 @@ fn handle_read_completion(mut conn IocpConn, mut op IocpOperation, bytes_read C.
 		return
 	}
 	if bytes_read == 0 {
-		close_conn(mut conn)
+		conn.read_eof = true
+		dispatch_iocp_request(mut conn, worker_state)
 		return
 	}
 
-	if conn.read_start == 0 {
-		conn.read_start = time.sys_mono_now()
+	if conn.read_start.load() == 0 {
+		conn.read_start.store(time.sys_mono_now())
 	}
 	conn.request_buf << op.buf[..int(bytes_read)]
-	buffer_len := conn.request_buf.len
-	header_end_pos := find_header_end_in_buf(conn.request_buf.data, buffer_len)
-	if (header_end_pos == -1 && buffer_len >= conn.server.max_request_buffer_size)
-		|| header_end_pos > conn.server.max_request_buffer_size {
-		send_terminal_response(mut conn, status_413_response)
-		return
-	}
-	if header_end_pos >= 0 && has_complete_body(conn.request_buf.data, buffer_len) {
-		conn.read_start = 0
-		conn.begin_active_request()
-		process_request(mut conn)
-		return
-	}
-
-	if conn.server.timeout_in_seconds > 0 {
-		elapsed_ns := time.sys_mono_now() - conn.read_start
-		timeout_ns := i64(conn.server.timeout_in_seconds) * 1_000_000_000
-		if elapsed_ns >= timeout_ns {
-			send_terminal_response(mut conn, status_408_response)
-			return
-		}
-	}
-
-	if !post_recv(mut conn) {
-		close_conn(mut conn)
-	}
+	dispatch_iocp_request(mut conn, worker_state)
 }
 
-fn handle_write_completion(mut conn IocpConn, mut op IocpOperation, bytes_written C.DWORD) {
+fn handle_write_completion(mut conn IocpConn, mut op IocpOperation, bytes_written C.DWORD, worker_state voidptr) {
 	if conn.is_closing() {
 		op.free()
 		close_conn(mut conn)
@@ -684,10 +721,10 @@ fn handle_write_completion(mut conn IocpConn, mut op IocpOperation, bytes_writte
 		return
 	}
 	op.free()
-	continue_response_after_write(mut conn)
+	continue_response_after_write(mut conn, worker_state)
 }
 
-fn handle_transmit_file_completion(mut conn IocpConn, mut op IocpOperation, bytes_transferred C.DWORD) {
+fn handle_transmit_file_completion(mut conn IocpConn, mut op IocpOperation, bytes_transferred C.DWORD, worker_state voidptr) {
 	if conn.is_closing() {
 		op.free()
 		close_conn(mut conn)
@@ -700,13 +737,13 @@ fn handle_transmit_file_completion(mut conn IocpConn, mut op IocpOperation, byte
 	}
 	conn.file_pos += i64(bytes_transferred)
 	op.free()
-	continue_response_after_write(mut conn)
+	continue_response_after_write(mut conn, worker_state)
 }
 
 fn run_iocp_housekeeping(server &Server) bool {
 	mut registry := server.registry
 	if server.timeout_in_seconds > 0 {
-		timeout_ns := i64(server.timeout_in_seconds) * 1_000_000_000
+		timeout_ns := u64(server.timeout_in_seconds) * 1_000_000_000
 		registry.sweep_timed_out_io(timeout_ns)
 	}
 	if server.is_shutting_down() && server.active_request_count() == 0 {
@@ -717,6 +754,10 @@ fn run_iocp_housekeeping(server &Server) bool {
 }
 
 fn process_iocp_events(server &Server) {
+	mut worker_state := voidptr(unsafe { nil })
+	if server.make_state != unsafe { nil } {
+		worker_state = server.make_state()
+	}
 	for {
 		if run_iocp_housekeeping(server) {
 			return
@@ -724,8 +765,7 @@ fn process_iocp_events(server &Server) {
 		mut bytes_transferred := C.DWORD(0)
 		mut completion_key := C.ULONG_PTR(0)
 		mut overlapped := &C.OVERLAPPED(unsafe { nil })
-		ok := C.GetQueuedCompletionStatus(server.iocp, &bytes_transferred, &completion_key,
-			&overlapped, iocp_wait_timeout_ms)
+		ok := C.GetQueuedCompletionStatus(server.iocp, &bytes_transferred, &completion_key, &overlapped, iocp_wait_timeout_ms)
 		if overlapped == unsafe { nil } {
 			if run_iocp_housekeeping(server) {
 				return
@@ -745,13 +785,13 @@ fn process_iocp_events(server &Server) {
 		}
 		match op.kind {
 			.read {
-				handle_read_completion(mut conn, mut op, bytes_transferred)
+				handle_read_completion(mut conn, mut op, bytes_transferred, worker_state)
 			}
 			.write {
-				handle_write_completion(mut conn, mut op, bytes_transferred)
+				handle_write_completion(mut conn, mut op, bytes_transferred, worker_state)
 			}
 			.transmit_file {
-				handle_transmit_file_completion(mut conn, mut op, bytes_transferred)
+				handle_transmit_file_completion(mut conn, mut op, bytes_transferred, worker_state)
 			}
 		}
 
@@ -774,11 +814,11 @@ fn accept_loop(server &Server) {
 		opt := 1
 		C.v_fasthttp_setsockopt(client_fd, C.IPPROTO_TCP, C.TCP_NODELAY, voidptr(&opt), sizeof(opt))
 		mut conn := &IocpConn{
-			server:      server
-			fd:          client_fd
+			server: server
+			fd: client_fd
 			request_buf: []u8{cap: server.max_request_buffer_size}
-			closing:     stdatomic.new_atomic(false)
-			pending_op:  stdatomic.new_atomic(voidptr(unsafe { nil }))
+			closing: stdatomic.new_atomic(false)
+			pending_op: stdatomic.new_atomic(voidptr(unsafe { nil }))
 		}
 		if !associate_socket_with_iocp(server.iocp, client_fd) {
 			close_socket(client_fd)
@@ -809,8 +849,7 @@ fn (mut server Server) stop_accepting() {
 // run starts the server and begins listening for incoming connections.
 pub fn (mut server Server) run() ! {
 	server.listen_fd = create_server_socket(server)!
-	server.iocp = C.CreateIoCompletionPort(C.INVALID_HANDLE_VALUE, unsafe { nil }, 0,
-		C.DWORD(max_thread_pool_size))
+	server.iocp = C.CreateIoCompletionPort(C.INVALID_HANDLE_VALUE, unsafe { nil }, 0, C.DWORD(max_thread_pool_size))
 	if server.iocp == unsafe { nil } {
 		close_socket(server.listen_fd)
 		server.listen_fd = iocp_invalid_socket

--- a/vlib/fasthttp/framing_test.v
+++ b/vlib/fasthttp/framing_test.v
@@ -123,9 +123,9 @@ fn test_frame_public_result_wrappers() {
 }
 
 fn test_frame_content_length_overflow_rejected() {
-	// A Content-Length far beyond i32 must be rejected (400), not wrapped to a
-	// negative int that frames the request as body-less (a smuggling primitive).
-	req := 'POST /a HTTP/1.1\r\nContent-Length: 99999999999\r\n\r\n'.bytes()
+	// A Content-Length beyond the active int width must be rejected (400), not
+	// wrapped to a negative length that frames the request as body-less.
+	req := ('POST /a HTTP/1.1\r\nContent-Length: ' + max_int.str() + '0\r\n\r\n').bytes()
 	assert frame_request_length_lim_idx(req, 0, 0) == frame_err_malformed
 	mut code := 0
 	frame_request_length_lim(req, 0, 0) or { code = err.code() }
@@ -133,10 +133,84 @@ fn test_frame_content_length_overflow_rejected() {
 }
 
 fn test_frame_chunked_size_overflow_rejected() {
-	// A hex chunk size beyond i32 must be rejected, not wrapped negative (which
-	// would make the next offset negative and read out of bounds).
-	req := 'POST /c HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\nffffffffff\r\nx'.bytes()
+	// A hexadecimal size beyond the active int width must be rejected.
+	req := ('POST /c HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n' + i64(max_int).hex() + '0\r\nx').bytes()
 	assert frame_request_length_lim_idx(req, 0, 0) == frame_err_malformed
+}
+
+fn test_frame_content_length_offset_overflow_rejected() {
+	// The numeral itself fits, but adding the nonzero head offset does not.
+	req := ('POST /a HTTP/1.1\r\nContent-Length: ' + max_int.str() + '\r\n\r\n').bytes()
+	assert frame_request_length_lim_idx(req, 0, 0) == frame_err_malformed
+}
+
+fn test_frame_chunk_offset_overflow_rejected() {
+	// No enormous body is required: the declared size plus data_start overflows.
+	req := ('POST /c HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n' + i64(max_int).hex() + '\r\n').bytes()
+	assert frame_request_length_lim_idx(req, 0, 0) == frame_err_malformed
+}
+
+fn test_frame_conflicting_content_lengths_rejected() {
+	conflicting := 'POST / HTTP/1.1\r\nContent-Length: 4\r\nContent-Length: 0\r\n\r\n'.bytes()
+	assert frame_request_length_lim_idx(conflicting, 0, 0) == frame_err_malformed
+	identical := 'POST / HTTP/1.1\r\nContent-Length: 4\r\nContent-Length: 4\r\n\r\ntest'.bytes()
+	assert frame_request_length_lim_idx(identical, 0, 0) == identical.len
+}
+
+fn test_frame_content_length_accepts_tab_ows_and_waits_for_body() {
+	head := 'POST / HTTP/1.1\r\nContent-Length:\t5\r\n\r\n'
+	partial := (head + 'abc').bytes()
+	complete := (head + 'abcde').bytes()
+	assert frame_request_length_lim_idx(partial, 0, 0) == -1
+	assert frame_request_length_lim_idx(complete, 0, 0) == complete.len
+}
+
+fn test_frame_malformed_content_length_rejected() {
+	req := 'POST / HTTP/1.1\r\nContent-Length: nope\r\n\r\n'.bytes()
+	assert frame_request_length_lim_idx(req, 0, 0) == frame_err_malformed
+}
+
+fn test_frame_transfer_encoding_uses_exact_final_token() {
+	for raw in [
+		'POST / HTTP/1.1\r\nTransfer-Encoding: xchunked\r\n\r\n',
+		'POST / HTTP/1.1\r\nTransfer-Encoding: chunked, gzip\r\n\r\n',
+		'POST / HTTP/1.1\r\nTransfer-Encoding: gzip\r\n\r\n',
+	] {
+		assert frame_request_length_lim_idx(raw.bytes(), 0, 0) == frame_err_malformed
+	}
+	valid := 'POST / HTTP/1.1\r\nTransfer-Encoding: gzip, chunked\r\n\r\n0\r\n\r\n'.bytes()
+	assert frame_request_length_lim_idx(valid, 0, 0) == valid.len
+}
+
+fn test_frame_transfer_encoding_with_content_length_rejected() {
+	req := 'POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\nContent-Length: 5\r\n\r\n0\r\n\r\n'.bytes()
+	assert frame_request_length_lim_idx(req, 0, 0) == frame_err_malformed
+	assert frame_expected_total(req) == -1
+}
+
+fn test_frame_empty_chunk_size_rejected() {
+	req := 'POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n\r\n0\r\n\r\n'.bytes()
+	assert frame_request_length_lim_idx(req, 0, 0) == frame_err_malformed
+}
+
+fn test_frame_chunk_data_requires_crlf() {
+	req := 'POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n4\r\nWikiXX0\r\n\r\n'.bytes()
+	assert frame_request_length_lim_idx(req, 0, 0) == frame_err_malformed
+}
+
+fn test_frame_chunk_body_limit_ignores_pipelined_suffix() {
+	first := 'POST / HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n1\r\nx\r\n0\r\n\r\n'
+	second := 'GET /next HTTP/1.1\r\n\r\n'
+	combined := (first + second).bytes()
+	assert frame_request_length_lim_idx(combined, 0, 1) == first.len
+}
+
+fn test_frame_head_limit_covers_request_line_and_final_blank_line() {
+	unterminated := 'GET /a-very-long-target-without-a-line-ending HTTP/1.1'.bytes()
+	assert frame_request_length_lim_idx(unterminated, 16, 0) == frame_err_header
+	req := 'GET / HTTP/1.1\r\nHost: h\r\n\r\n'.bytes()
+	assert frame_request_length_lim_idx(req, req.len - 1, 0) == frame_err_header
+	assert frame_request_length_lim_idx(req, req.len, 0) == req.len
 }
 
 fn test_frame_chunked_with_trailers() {

--- a/vlib/fasthttp/request_parser.v
+++ b/vlib/fasthttp/request_parser.v
@@ -32,72 +32,52 @@ fn find_byte(buf &u8, len int, c u8) int {
 // returns the position after the CRLF on success
 @[direct_array_access]
 pub fn parse_http1_request_line(mut req HttpRequest) !int {
-	unsafe {
-		buf := &req.buffer[0]
-		len := req.buffer.len
-
-		if len < 12 {
-			return error('Too short')
-		}
-
-		// METHOD
-		pos1 := find_byte(buf, len, empty_space)
-		if pos1 <= 0 {
-			return error('Invalid method')
-		}
-		req.method = Slice{0, pos1}
-
-		// PATH - skip any extra spaces
-		mut pos2 := pos1 + 1
-		for pos2 < len && buf[pos2] == empty_space {
-			pos2++
-		}
-		if pos2 >= len {
-			return error('Missing path')
-		}
-
-		path_start := pos2
-		space_pos := find_byte(buf + pos2, len - pos2, empty_space)
-		cr_pos := find_byte(buf + pos2, len - pos2, cr_char)
-
-		if space_pos < 0 && cr_pos < 0 {
-			return error('Invalid request line')
-		}
-
-		// pick earliest delimiter
-		mut path_len := 0
-		mut delim_pos := 0
-		if space_pos >= 0 && (cr_pos < 0 || space_pos < cr_pos) {
-			path_len = space_pos
-			delim_pos = pos2 + space_pos
-		} else {
-			path_len = cr_pos
-			delim_pos = pos2 + cr_pos
-		}
-
-		req.path = Slice{path_start, path_len}
-
-		// VERSION
-		if buf[delim_pos] == cr_char {
-			// No HTTP version specified
-			req.version = Slice{delim_pos, 0}
-		} else {
-			version_start := delim_pos + 1
-			cr := find_byte(buf + version_start, len - version_start, cr_char)
-			if cr < 0 {
-				return error('Invalid HTTP request line: Missing CR')
-			}
-			req.version = Slice{version_start, cr}
-			delim_pos = version_start + cr
-		}
-
-		// Validate CRLF
-		if delim_pos + 1 >= len || buf[delim_pos + 1] != lf_char {
-			return error('Invalid CRLF')
-		}
-
-		return delim_pos + 2 // Return position after CRLF
+	buf := req.buffer
+	if buf.len < 12 {
+		return error('Too short')
 	}
+	line_lf := find_byte(&buf[0], buf.len, lf_char)
+	if line_lf < 0 {
+		return error('Invalid HTTP request line: Missing CR')
+	}
+	line_end := if line_lf > 0 && buf[line_lf - 1] == cr_char {
+		line_lf - 1
+	} else {
+		line_lf
+	}
+	method_end := find_byte(&buf[0], line_end, empty_space)
+	if method_end <= 0 {
+		return error('Invalid method')
+	}
+	req.method = Slice{0, method_end}
+
+	mut path_start := method_end + 1
+	for path_start < line_end && buf[path_start] == empty_space {
+		path_start++
+	}
+	if path_start >= line_end {
+		return error('Missing path')
+	}
+	path_end_rel := find_byte(&buf[path_start], line_end - path_start, empty_space)
+	if path_end_rel < 0 {
+		req.path = Slice{path_start, line_end - path_start}
+		req.version = Slice{line_end, 0}
+		return line_lf + 1
+	}
+	path_end := path_start + path_end_rel
+	if path_end == path_start {
+		return error('Missing path')
+	}
+	req.path = Slice{path_start, path_end - path_start}
+	mut version_start := path_end + 1
+	for version_start < line_end && buf[version_start] == empty_space {
+		version_start++
+	}
+	if version_start >= line_end {
+		return error('Missing HTTP version')
+	}
+	req.version = Slice{version_start, line_end - version_start}
+	return line_lf + 1
 }
 
 // decode_http_request parses a raw HTTP request from the given byte buffer
@@ -109,31 +89,30 @@ pub fn decode_http_request(buffer []u8) !HttpRequest {
 	// header_start is the byte index immediately after the request line's \r\n
 	header_start := parse_http1_request_line(mut req)!
 
-	// Find the end of the header block (\r\n\r\n)
-	mut body_start := -1
-	for i := header_start; i <= buffer.len - 4; i++ {
-		if buffer[i] == cr_char && buffer[i + 1] == lf_char && buffer[i + 2] == cr_char
-			&& buffer[i + 3] == lf_char {
-			body_start = i + 4
-
-			// The header fields slice covers everything from header_start
-			// up to (but not including) the final double CRLF
-			req.header_fields = Slice{
-				start: header_start
-				len:   i - header_start
-			}
-			break
-		}
+	head := scan_request_head(buffer, 0)
+	if head.head_len < -1 {
+		return error_with_code('malformed request framing', 400)
 	}
-
-	if body_start != -1 {
+	if head.head_len >= 0 {
+		req.header_fields = Slice{
+			start: header_start
+			len: head.header_fields_end - header_start
+		}
 		req.body = Slice{
-			start: body_start
-			len:   buffer.len - body_start
+			start: head.head_len
+			len: buffer.len - head.head_len
 		}
 	} else {
-		// If no body delimiter found, assume headers go to end or body is missing
-		req.header_fields = Slice{header_start, buffer.len - header_start - 2}
+		// Keep decode_http_request useful for callers that only pass a request line
+		// or an incomplete header block. Server backends dispatch only complete frames.
+		mut header_fields_end := buffer.len
+		if header_fields_end >= header_start + 2 && buffer[header_fields_end - 2] == cr_char
+			&& buffer[header_fields_end - 1] == lf_char {
+			header_fields_end -= 2
+		} else if header_fields_end > header_start && buffer[header_fields_end - 1] == lf_char {
+			header_fields_end--
+		}
+		req.header_fields = Slice{header_start, header_fields_end - header_start}
 		req.body = Slice{0, 0}
 	}
 
@@ -148,159 +127,23 @@ fn (slice Slice) to_string(buffer []u8) string {
 	return buffer[slice.start..slice.start + slice.len].bytestr()
 }
 
-@[direct_array_access]
-fn find_header_end_in_buf(buf &u8, buf_len int) int {
-	for i := 0; i < buf_len - 1; i++ {
-		unsafe {
-			if buf[i] == `\n` {
-				if i + 1 < buf_len && buf[i + 1] == `\n` {
-					return i + 2
-				}
-				if i + 2 < buf_len && buf[i + 1] == `\r` && buf[i + 2] == `\n` {
-					return i + 3
-				}
-			}
-			if i + 3 < buf_len && buf[i] == `\r` && buf[i + 1] == `\n` && buf[i + 2] == `\r`
-				&& buf[i + 3] == `\n` {
-				return i + 4
-			}
-		}
-	}
-	return -1
-}
-
 // has_complete_body checks if a raw HTTP request buffer contains the full body
-// as indicated by the Content-Length or Transfer-Encoding headers. Returns true if:
-//   - there is no Content-Length header and no chunked encoding (body not expected)
-//   - Content-Length is 0
-//   - enough body bytes have been received
-//   - chunked encoding is complete (the zero-size chunk and trailers were parsed)
-// Returns false only when more body data is expected.
-@[direct_array_access]
+// according to the authoritative request framer. Malformed requests are not
+// complete; server backends inspect the framing sentinel to reject them.
 fn has_complete_body(buf &u8, buf_len int) bool {
-	header_end := find_header_end_in_buf(buf, buf_len)
-	if header_end < 0 {
-		return false // headers not complete yet
+	if buf_len <= 0 {
+		return false
 	}
-	// Check for Transfer-Encoding: chunked header (case-insensitive)
-	if has_chunked_transfer_encoding_in_buf(buf, header_end) {
-		return has_complete_chunked_body(buf, buf_len, header_end)
-	}
-	content_length := parse_content_length_from_buf(buf, header_end)
-	if content_length <= 0 {
-		return true // no content-length or zero: body complete
-	}
-	body_received := buf_len - header_end
-	return body_received >= content_length
+	view := unsafe { buf.vbytes(buf_len) }
+	return frame_request_length_lim_idx(view, 0, 0) >= 0
 }
 
-@[direct_array_access]
-fn has_complete_chunked_body(buf &u8, buf_len int, body_start int) bool {
-	mut pos := body_start
-	for {
-		lf_pos := find_line_lf_in_buf(buf, buf_len, pos)
-		if lf_pos < 0 {
-			return false
-		}
-		mut line_end := lf_pos
-		unsafe {
-			if line_end > pos && buf[line_end - 1] == `\r` {
-				line_end--
-			}
-		}
-		mut size_end := line_end
-		for i := pos; i < line_end; i++ {
-			unsafe {
-				if buf[i] == `;` {
-					size_end = i
-					break
-				}
-			}
-		}
-		mut size_start := pos
-		for size_start < size_end {
-			unsafe {
-				if buf[size_start] != ` ` && buf[size_start] != `\t` {
-					break
-				}
-			}
-			size_start++
-		}
-		for size_end > size_start {
-			unsafe {
-				if buf[size_end - 1] != ` ` && buf[size_end - 1] != `\t` {
-					break
-				}
-			}
-			size_end--
-		}
-		if size_start == size_end {
-			return true
-		}
-		mut chunk_size := 0
-		for i := size_start; i < size_end; i++ {
-			digit := chunked_hex_digit_value(unsafe { buf[i] })
-			if digit < 0 {
-				return true
-			}
-			if chunk_size > (max_int - digit) / 16 {
-				return true
-			}
-			chunk_size = chunk_size * 16 + digit
-		}
-		pos = lf_pos + 1
-		if chunk_size == 0 {
-			return has_complete_chunked_trailers(buf, buf_len, pos)
-		}
-		if chunk_size > buf_len - pos {
-			return false
-		}
-		data_end := pos + chunk_size
-		if data_end + 2 > buf_len {
-			return false
-		}
-		unsafe {
-			if buf[data_end] != `\r` || buf[data_end + 1] != `\n` {
-				return true
-			}
-		}
-		pos = data_end + 2
+fn find_header_end_in_buf(buf &u8, buf_len int) int {
+	if buf_len <= 0 {
+		return -1
 	}
-	return false
-}
-
-@[direct_array_access]
-fn has_complete_chunked_trailers(buf &u8, buf_len int, start int) bool {
-	mut pos := start
-	for {
-		lf_pos := find_line_lf_in_buf(buf, buf_len, pos)
-		if lf_pos < 0 {
-			return false
-		}
-		mut line_end := lf_pos
-		unsafe {
-			if line_end > pos && buf[line_end - 1] == `\r` {
-				line_end--
-			}
-		}
-		if line_end == pos {
-			return true
-		}
-		pos = lf_pos + 1
-	}
-	return false
-}
-
-@[direct_array_access]
-fn find_line_lf_in_buf(buf &u8, buf_len int, start int) int {
-	for i := start; i < buf_len; i++ {
-		unsafe {
-			if buf[i] == `\n` {
-				return i
-			}
-		}
-	}
-	return -1
+	view := unsafe { buf.vbytes(buf_len) }
+	return frame_head_len(view)
 }
 
 fn chunked_hex_digit_value(ch u8) int {
@@ -312,100 +155,6 @@ fn chunked_hex_digit_value(ch u8) int {
 	}
 	if ch >= `A` && ch <= `F` {
 		return int(ch - `A` + 10)
-	}
-	return -1
-}
-
-// has_chunked_transfer_encoding_in_buf scans the header bytes for a
-// "Transfer-Encoding:" header whose value contains "chunked" (case-insensitive).
-@[direct_array_access]
-fn has_chunked_transfer_encoding_in_buf(buf &u8, header_end int) bool {
-	te_lower := 'transfer-encoding:'
-	for i := 0; i < header_end - te_lower.len; i++ {
-		unsafe {
-			if buf[i] != `\n` {
-				continue
-			}
-			pos := i + 1
-			if pos + te_lower.len > header_end {
-				continue
-			}
-			mut matched := true
-			for j := 0; j < te_lower.len; j++ {
-				mut ch := buf[pos + j]
-				if ch >= `A` && ch <= `Z` {
-					ch = ch + 32
-				}
-				if ch != te_lower[j] {
-					matched = false
-					break
-				}
-			}
-			if matched {
-				chunked_str := 'chunked'
-				for val_start := pos + te_lower.len; val_start < header_end - chunked_str.len; val_start++ {
-					if buf[val_start] == `\r` || buf[val_start] == `\n` {
-						break
-					}
-					mut cmatch := true
-					for k := 0; k < chunked_str.len; k++ {
-						mut ch2 := buf[val_start + k]
-						if ch2 >= `A` && ch2 <= `Z` {
-							ch2 = ch2 + 32
-						}
-						if ch2 != chunked_str[k] {
-							cmatch = false
-							break
-						}
-					}
-					if cmatch {
-						return true
-					}
-				}
-			}
-		}
-	}
-	return false
-}
-
-// parse_content_length_from_buf scans the header bytes for a Content-Length header
-// and returns its integer value, or -1 if not found.
-@[direct_array_access]
-fn parse_content_length_from_buf(buf &u8, header_end int) int {
-	cl_lower := 'content-length:'
-	for i := 0; i < header_end - cl_lower.len; i++ {
-		unsafe {
-			if buf[i] != `\n` {
-				continue
-			}
-			pos := i + 1
-			if pos + cl_lower.len > header_end {
-				continue
-			}
-			mut matched := true
-			for j := 0; j < cl_lower.len; j++ {
-				mut ch := buf[pos + j]
-				if ch >= `A` && ch <= `Z` {
-					ch = ch + 32
-				}
-				if ch != cl_lower[j] {
-					matched = false
-					break
-				}
-			}
-			if matched {
-				mut start := pos + cl_lower.len
-				for start < header_end && buf[start] == ` ` {
-					start++
-				}
-				mut val := 0
-				for start < header_end && buf[start] >= `0` && buf[start] <= `9` {
-					val = val * 10 + int(buf[start] - `0`)
-					start++
-				}
-				return val
-			}
-		}
 	}
 	return -1
 }
@@ -426,6 +175,20 @@ fn parse_content_length_from_buf(buf &u8, header_end int) int {
 const frame_err_malformed = -400
 const frame_err_body = -413 // body exceeds the configured max_body
 const frame_err_header = -431 // header block exceeds the configured max_header
+
+struct TransferEncodingState {
+mut:
+	seen          bool
+	final_chunked bool
+	chunked_seen  bool
+}
+
+struct RequestHead {
+	head_len          int = -1
+	header_fields_end int
+	content_length    int = -1
+	chunked           bool
+}
 
 // frame_request_length inspects the bytes received so far and returns:
 //   -1          -> incomplete; read more bytes
@@ -464,74 +227,135 @@ pub fn frame_request_length_lim(buf []u8, max_header int, max_body int) !int {
 // a frame_err_* sentinel that the Result wrapper maps to 400 / 413 / 431.
 @[direct_array_access]
 pub fn frame_request_length_lim_idx(buf []u8, max_header int, max_body int) int {
-	if buf.len < 4 {
-		return -1
+	head := scan_request_head(buf, max_header)
+	if head.head_len < 0 {
+		return head.head_len
 	}
-	// End of the request line (first LF). Headers start right after it.
+	if head.chunked {
+		return frame_chunked_total_idx(buf, head.head_len, max_header, max_body)
+	}
+	if head.content_length >= 0 {
+		if max_body > 0 && head.content_length > max_body {
+			return frame_err_body
+		}
+		if head.content_length > max_int - head.head_len {
+			return frame_err_malformed
+		}
+		total := head.head_len + head.content_length
+		return if buf.len >= total { total } else { -1 }
+	}
+	return head.head_len
+}
+
+// scan_request_head parses request framing fields once and returns canonical
+// offsets for the framer, allocation hint, and decoder.
+@[direct_array_access]
+fn scan_request_head(buf []u8, max_header int) RequestHead {
+	if buf.len == 0 {
+		return RequestHead{}
+	}
 	rl := find_byte(&buf[0], buf.len, lf_char)
 	if rl < 0 {
-		return -1
+		return RequestHead{
+			head_len: if max_header > 0 && buf.len >= max_header {
+				frame_err_header
+			} else {
+				-1
+			}
+		}
+	}
+	if rl == 0 {
+		return RequestHead{
+			head_len: frame_err_malformed
+		}
 	}
 	mut pos := rl + 1
-
-	// ONE pass over the header lines: locate the blank-line terminator AND detect
-	// Content-Length / Transfer-Encoding as we go (a single walk with a cheap
-	// per-line reject beats two separate header scans).
+	mut header_fields_end := pos
 	mut content_length := -1
-	mut chunked := false
+	mut transfer := TransferEncodingState{}
 	for {
-		// Cap the head size so a hostile peer can't grow it without bound.
-		if max_header > 0 && pos > max_header {
-			return frame_err_header
-		}
 		if pos >= buf.len {
-			return -1
-		}
-		// Blank line (CRLF or bare LF) => end of header section.
-		blank := blank_line_end(buf, pos)
-		if blank == frame_need_more {
-			return -1
-		}
-		if blank >= 0 {
-			body_start := blank
-			if chunked {
-				// Cold path: map the chunked framer's Result to a sentinel.
-				return frame_chunked_total(buf, body_start, max_body) or {
-					if err.code() == 413 {
-						frame_err_body
-					} else {
-						frame_err_malformed
-					}
+			return RequestHead{
+				head_len: if max_header > 0 && buf.len >= max_header {
+					frame_err_header
+				} else {
+					-1
 				}
 			}
-			if content_length >= 0 {
-				total := body_start + content_length
-				return if buf.len >= total { total } else { -1 }
+		}
+		blank := blank_line_end(buf, pos)
+		if blank == frame_need_more {
+			return RequestHead{
+				head_len: if max_header > 0 && buf.len >= max_header {
+					frame_err_header
+				} else {
+					-1
+				}
 			}
-			return body_start
+		}
+		if blank >= 0 {
+			if max_header > 0 && blank > max_header {
+				return RequestHead{
+					head_len: frame_err_header
+				}
+			}
+			if transfer.seen && (!transfer.final_chunked || content_length >= 0) {
+				return RequestHead{
+					head_len: frame_err_malformed
+				}
+			}
+			return RequestHead{
+				head_len: blank
+				header_fields_end: header_fields_end
+				content_length: content_length
+				chunked: transfer.final_chunked
+			}
 		}
 		line_lf := find_byte(&buf[pos], buf.len - pos, lf_char)
 		if line_lf < 0 {
-			return -1
+			return RequestHead{
+				head_len: if max_header > 0 && buf.len >= max_header {
+					frame_err_header
+				} else {
+					-1
+				}
+			}
 		}
 		line_start := pos
 		line_len := header_line_content_len(buf, line_start, line_lf)
 		pos = line_start + line_lf + 1
-
-		// Cheap checks: both reject at byte 0 for the vast majority of headers.
-		if v := line_header_value(buf, line_start, line_len, 'Content-Length') {
-			content_length = parse_content_length(buf, v) or { return frame_err_malformed }
-			// Reject an over-large body from the declared length, BEFORE buffering it.
-			if max_body > 0 && content_length > max_body {
-				return frame_err_body
+		if max_header > 0 && pos >= max_header {
+			return RequestHead{
+				head_len: frame_err_header
 			}
+		}
+		if !valid_header_line(buf, line_start, line_len) {
+			return RequestHead{
+				head_len: frame_err_malformed
+			}
+		}
+		header_fields_end = line_start + line_len
+		if v := line_header_value(buf, line_start, line_len, 'Content-Length') {
+			parsed := parse_content_length(buf, v) or {
+				return RequestHead{
+					head_len: frame_err_malformed
+				}
+			}
+			if content_length >= 0 && content_length != parsed {
+				return RequestHead{
+					head_len: frame_err_malformed
+				}
+			}
+			content_length = parsed
 		} else if v := line_header_value(buf, line_start, line_len, 'Transfer-Encoding') {
-			if ci_contains(buf, v, 'chunked') {
-				chunked = true
+			if !parse_transfer_encoding(buf, v, mut transfer) {
+				return RequestHead{
+					head_len: frame_err_malformed
+				}
 			}
 		}
 	}
-	return -1
+	return RequestHead{}
 }
 
 // frame_expected_total returns the full HTTP/1.1 message length (headers + body)
@@ -546,41 +370,12 @@ pub fn frame_request_length_lim_idx(buf []u8, max_header int, max_body int) int 
 // frame_request_length_lim, which the read loop still runs once the bytes arrive.
 @[direct_array_access]
 pub fn frame_expected_total(buf []u8) int {
-	if buf.len < 4 {
+	head := scan_request_head(buf, 0)
+	if head.head_len < 0 || head.chunked || head.content_length < 0
+		|| head.content_length > max_int - head.head_len {
 		return -1
 	}
-	rl := find_byte(&buf[0], buf.len, lf_char)
-	if rl < 0 {
-		return -1
-	}
-	mut pos := rl + 1
-	mut content_length := -1
-	for {
-		if pos >= buf.len {
-			return -1
-		}
-		blank := blank_line_end(buf, pos)
-		if blank == frame_need_more {
-			return -1
-		}
-		if blank >= 0 {
-			if content_length >= 0 {
-				return blank + content_length
-			}
-			return -1 // chunked or bodyless — nothing to pre-size against
-		}
-		line_lf := find_byte(&buf[pos], buf.len - pos, lf_char)
-		if line_lf < 0 {
-			return -1
-		}
-		line_start := pos
-		line_len := header_line_content_len(buf, line_start, line_lf)
-		pos = line_start + line_lf + 1
-		if v := line_header_value(buf, line_start, line_len, 'Content-Length') {
-			content_length = parse_content_length(buf, v) or { return -1 }
-		}
-	}
-	return -1
+	return head.head_len + head.content_length
 }
 
 // frame_head_len returns the byte offset where the body begins — the length of
@@ -588,32 +383,8 @@ pub fn frame_expected_total(buf []u8) int {
 // or -1 if the head is not yet complete in `buf`.
 @[direct_array_access]
 pub fn frame_head_len(buf []u8) int {
-	if buf.len < 4 {
-		return -1
-	}
-	rl := find_byte(&buf[0], buf.len, lf_char)
-	if rl < 0 {
-		return -1
-	}
-	mut pos := rl + 1
-	for {
-		if pos >= buf.len {
-			return -1
-		}
-		blank := blank_line_end(buf, pos)
-		if blank == frame_need_more {
-			return -1
-		}
-		if blank >= 0 {
-			return blank // body start
-		}
-		line_lf := find_byte(&buf[pos], buf.len - pos, lf_char)
-		if line_lf < 0 {
-			return -1
-		}
-		pos = pos + line_lf + 1
-	}
-	return -1
+	head := scan_request_head(buf, 0)
+	return if head.head_len >= 0 { head.head_len } else { -1 }
 }
 
 // blank_line_end classifies the bytes at `pos` as a header-section terminator.
@@ -674,7 +445,7 @@ fn line_header_value(buf []u8, line_start int, line_len int, name string) ?Slice
 	}
 	return Slice{
 		start: v
-		len:   line_end - v
+		len: line_end - v
 	}
 }
 
@@ -696,6 +467,105 @@ fn parse_content_length(buf []u8, s Slice) !int {
 		n = n * 10 + digit
 	}
 	return n
+}
+
+@[inline]
+fn is_http_token_char(ch u8) bool {
+	return (ch >= `0` && ch <= `9`) || (ch >= `A` && ch <= `Z`)
+		|| (ch >= `a` && ch <= `z`) || ch == 33 || ch == 35 || ch == 36 || ch == 37
+		|| ch == 38 || ch == 39 || ch == 42 || ch == 43 || ch == 45 || ch == 46
+		|| ch == 94 || ch == 95 || ch == 96 || ch == 124 || ch == 126
+}
+
+// valid_header_line rejects whitespace before the field name/colon, obsolete
+// folding, and control characters that different HTTP parsers can interpret
+// differently.
+@[direct_array_access]
+fn valid_header_line(buf []u8, start int, len int) bool {
+	if len == 0 {
+		return false
+	}
+	mut colon := -1
+	for i in start .. start + len {
+		ch := buf[i]
+		if colon < 0 {
+			if ch == colon_char {
+				if i == start {
+					return false
+				}
+				colon = i
+			} else if !is_http_token_char(ch) {
+				return false
+			}
+		} else if ch == 0 || ch == cr_char || ch == lf_char || (ch < 32 && ch != tab_char) {
+			return false
+		}
+	}
+	return colon >= 0
+}
+
+// parse_transfer_encoding parses exact comma-separated transfer-coding tokens.
+// Unknown codings are allowed before chunked, but chunked must occur once and be
+// final. The server rejects a transfer-encoded request without final chunked
+// framing because a request cannot be delimited by connection close.
+@[direct_array_access]
+fn parse_transfer_encoding(buf []u8, value Slice, mut state TransferEncodingState) bool {
+	mut pos := value.start
+	end := value.start + value.len
+	for {
+		for pos < end && (buf[pos] == empty_space || buf[pos] == tab_char) {
+			pos++
+		}
+		if pos >= end || state.chunked_seen {
+			return false
+		}
+		token_start := pos
+		for pos < end && is_http_token_char(buf[pos]) {
+			pos++
+		}
+		if pos == token_start {
+			return false
+		}
+		is_chunked := pos - token_start == 7 && ascii_ci_eq(&buf[token_start], c'chunked', 7)
+		state.seen = true
+		state.final_chunked = is_chunked
+		state.chunked_seen = is_chunked
+		for pos < end && (buf[pos] == empty_space || buf[pos] == tab_char) {
+			pos++
+		}
+		if pos < end && buf[pos] == `;` {
+			// RFC 9112 forbids parameters on the chunked coding. Other codings are
+			// not decoded here, but their parameters do not affect message framing.
+			if is_chunked {
+				return false
+			}
+			pos++
+			mut parameter_bytes := 0
+			for pos < end && buf[pos] != `,` {
+				ch := buf[pos]
+				if ch == 0 || ch == cr_char || ch == lf_char || (ch < 32 && ch != tab_char) {
+					return false
+				}
+				parameter_bytes++
+				pos++
+			}
+			if parameter_bytes == 0 {
+				return false
+			}
+		} else {
+			for pos < end && (buf[pos] == empty_space || buf[pos] == tab_char) {
+				pos++
+			}
+		}
+		if pos == end {
+			return true
+		}
+		if buf[pos] != `,` || is_chunked {
+			return false
+		}
+		pos++
+	}
+	return false
 }
 
 // ascii_ci_eq compares `len` bytes case-insensitively (ASCII only — HTTP header
@@ -722,84 +592,115 @@ fn ascii_ci_eq(a &u8, b &u8, len int) bool {
 	return true
 }
 
-// ci_contains reports whether the value slice contains `needle` (ASCII, CI).
-fn ci_contains(buf []u8, val Slice, needle string) bool {
-	if needle.len > val.len {
-		return false
-	}
-	last := val.start + val.len - needle.len
-	for i := val.start; i <= last; i++ {
-		if ascii_ci_eq(&buf[i], needle.str, needle.len) {
-			return true
-		}
-	}
-	return false
-}
-
 // frame_chunked_total walks chunk-size lines from body_start and returns the
 // total message length once the terminating zero-length chunk + CRLF is present,
-// -1 if more bytes are needed, or an error on malformed chunk framing.
+// -1 if more bytes are needed, or a framing sentinel on failure.
 @[direct_array_access]
-fn frame_chunked_total(buf []u8, body_start int, max_body int) !int {
-	// Bound the buffered chunked payload (the total length isn't known up front).
-	if max_body > 0 && buf.len - body_start > max_body {
-		return error_with_code('body exceeds ${max_body} bytes', 413)
-	}
+fn frame_chunked_total_idx(buf []u8, body_start int, max_header int, max_body int) int {
 	mut pos := body_start
+	mut body_bytes := 0
 	for {
 		if pos >= buf.len {
 			return -1
 		}
 		line_lf := find_byte(&buf[pos], buf.len - pos, lf_char)
 		if line_lf < 0 {
-			return -1
+			return if max_header > 0 && buf.len - pos >= max_header {
+				frame_err_header
+			} else {
+				-1
+			}
 		}
-		size_end := pos + line_lf // index of LF
+		if line_lf == 0 || buf[pos + line_lf - 1] != cr_char {
+			return frame_err_malformed
+		}
+		if max_header > 0 && line_lf + 1 > max_header {
+			return frame_err_header
+		}
+		size_end := pos + line_lf - 1 // index of CR
 		mut size := 0
 		mut j := pos
-		for j < size_end && buf[j] != cr_char {
+		mut digits := 0
+		for j < size_end {
 			c := buf[j]
 			if c == `;` {
 				break // chunk extensions: ignore the rest of the size line
 			}
 			d := chunked_hex_digit_value(c)
 			if d < 0 {
-				return error_with_code('invalid chunk size', 400)
+				return frame_err_malformed
 			}
 			if size > (max_int - d) / 16 {
-				return error_with_code('chunk size overflow', 400)
+				return frame_err_malformed
 			}
 			size = size * 16 + d
+			digits++
 			j++
 		}
-		data_start := size_end + 1
+		if digits == 0 {
+			return frame_err_malformed
+		}
+		if j < size_end {
+			for k in j + 1 .. size_end {
+				ch := buf[k]
+				if ch == 0 || (ch < 32 && ch != tab_char) {
+					return frame_err_malformed
+				}
+			}
+		}
+		if size > max_int - body_bytes {
+			return frame_err_malformed
+		}
+		body_bytes += size
+		if max_body > 0 && body_bytes > max_body {
+			return frame_err_body
+		}
+		data_start := pos + line_lf + 1
 		if size == 0 {
-			// Terminating chunk: consume optional trailer field lines up to the
-			// blank line (CRLF or bare LF) that ends the message.
+			// Terminating chunk: validate trailer fields and their CRLF boundaries.
 			mut tpos := data_start
 			for {
 				if tpos >= buf.len {
 					return -1
 				}
-				tblank := blank_line_end(buf, tpos)
-				if tblank == frame_need_more {
-					return -1
-				}
-				if tblank >= 0 {
-					return tblank
-				}
 				tlf := find_byte(&buf[tpos], buf.len - tpos, lf_char)
 				if tlf < 0 {
-					return -1
+					return if max_header > 0 && buf.len - data_start >= max_header {
+						frame_err_header
+					} else {
+						-1
+					}
+				}
+				if tlf == 0 || buf[tpos + tlf - 1] != cr_char {
+					return frame_err_malformed
+				}
+				if max_header > 0 && tpos + tlf + 1 - data_start > max_header {
+					return frame_err_header
+				}
+				trailer_len := tlf - 1
+				if trailer_len == 0 {
+					return tpos + tlf + 1
+				}
+				if !valid_header_line(buf, tpos, trailer_len) {
+					return frame_err_malformed
 				}
 				tpos = tpos + tlf + 1
 			}
 		}
-		next := data_start + size + 2 // data + trailing CRLF
-		if next > buf.len {
+		// Check representability before any offset addition, then compare against
+		// remaining bytes by subtraction so a declared size cannot wrap `pos`.
+		if data_start > max_int - 2 || size > max_int - data_start - 2 {
+			return frame_err_malformed
+		}
+		remaining := buf.len - data_start
+		if size > remaining || remaining - size < 2 {
 			return -1
 		}
-		pos = next
+		data_end := data_start + size
+		if buf[data_end] != cr_char || buf[data_end + 1] != lf_char {
+			return frame_err_malformed
+		}
+		pos = data_end + 2
 	}
 	return -1
 }

--- a/vlib/fasthttp/request_parser_test.v
+++ b/vlib/fasthttp/request_parser_test.v
@@ -48,9 +48,7 @@ fn test_decode_http_request_invalid_request() {
 }
 
 fn test_decode_http_request_with_headers_and_body() {
-	raw := 'POST /submit HTTP/1.1\r\n' + 'Host: localhost\r\n' +
-		'Content-Type: application/json\r\n' + 'Content-Length: 18\r\n' + '\r\n' +
-		'{"status": "ok"}'
+	raw := 'POST /submit HTTP/1.1\r\n' + 'Host: localhost\r\n' + 'Content-Type: application/json\r\n' + 'Content-Length: 18\r\n' + '\r\n' + '{"status": "ok"}'
 
 	buffer := raw.bytes()
 	req := decode_http_request(buffer) or { panic(err) }
@@ -74,6 +72,14 @@ fn test_decode_http_request_no_body() {
 
 	assert req.header_fields.to_string(req.buffer) == 'User-Agent: V'
 	assert req.body.len == 0
+}
+
+fn test_decode_http_request_uses_framer_offsets_for_bare_lf_headers() {
+	buffer := 'POST /mixed HTTP/1.1\r\nHost: example.com\nContent-Length: 4\n\ntest'.bytes()
+	req := decode_http_request(buffer) or { panic(err) }
+
+	assert req.header_fields.to_string(req.buffer) == 'Host: example.com\nContent-Length: 4'
+	assert req.body.to_string(req.buffer) == 'test'
 }
 
 fn test_decode_http_request_malformed_no_double_crlf() {

--- a/vlib/veb/tests/large_payload_test.v
+++ b/vlib/veb/tests/large_payload_test.v
@@ -45,10 +45,10 @@ fn testsuite_begin() {
 		assert true == false, 'timeout reached!'
 		exit(1)
 	}()
-
 	mut app := &App{}
-	spawn veb.run_at[App, Context](mut app, port: port, timeout_in_seconds: 2, family: .ip)
+
 	// app startup time
+	spawn veb.run_at[App, Context](mut app, port: port, timeout_in_seconds: 2, family: .ip)
 	_ := <-app.started
 }
 
@@ -73,24 +73,24 @@ fn test_large_request_header() {
 	str := buf.bytestr()
 	// make 1 header longer than vebs max read limit
 	mut x := http.fetch(http.FetchConfig{
-		url:    localserver
+		url: localserver
 		header: http.new_custom_header_from_map({
 			'X-Overflow-Header': str
 		})!
 	})!
 
-	assert x.status() == .request_entity_too_large
+	assert x.status() == .request_header_fields_too_large
 }
 
 fn test_bigger_content_length() {
 	data := '123456789'
 	mut x := http.fetch(http.FetchConfig{
 		method: .post
-		url:    '${localserver}/post_request'
+		url: '${localserver}/post_request'
 		header: http.new_header_from_map({
 			.content_length: '10'
 		})
-		data:   data
+		data: data
 	})!
 
 	// Content-length is larger than the data sent, so the request should timeout
@@ -101,11 +101,11 @@ fn test_smaller_content_length() {
 	data := '123456789'
 	mut x := http.fetch(http.FetchConfig{
 		method: .post
-		url:    '${localserver}/post_request'
+		url: '${localserver}/post_request'
 		header: http.new_header_from_map({
 			.content_length: '5'
 		})
-		data:   data
+		data: data
 	})!
 
 	// The fasthttp backend frames requests by their exact declared length


### PR DESCRIPTION
## Summary

- make the pure HTTP/1.1 framer authoritative for decoding and all three server backends
- reject conflicting Content-Length values, Transfer-Encoding plus Content-Length, non-final/unsupported transfer codings, empty chunk sizes, invalid chunk CRLF, and offset arithmetic overflow
- preserve and serially dispatch pipelined request suffixes on kqueue and IOCP
- distinguish blocked, drained, and closed Linux writes so a later response cannot cross a pending file response
- preserve complete requests and queued responses across read-side EOF
- pause reads while responses are blocked, add BSD write deadlines, and defer kqueue connection frees until the current event batch is consumed
- wire per-worker state through IOCP and make fields shared with housekeeping atomic
- add an independent 64 MiB default body limit, return 431 for header-limit failures, and cap retained Linux pool buffers
- cover overflow/framing cases, Linux file backpressure and half-close behavior, and BSD pipelining plus half-close behavior

## Validation

- `./vnew -silent test vlib/fasthttp/` (7 passed, 2 platform-specific tests skipped on macOS)
- `./vnew -cc clang -cflags '-fsanitize=undefined' -ldflags '-fsanitize=undefined' -silent vlib/fasthttp/framing_test.v`
- `./vnew -silent vlib/veb/tests/large_payload_test.v`
- `./vnew -silent vlib/veb/tests/persistent_connection_test.v`
- `./vnew check-md vlib/fasthttp/README.md`
- generated C successfully for the Linux and Windows fasthttp regression tests

Linux and Windows runtime tests were not available on the macOS host; their platform-specific regression programs were cross-compiled through C generation.