### PR TITLE
db.pg: bind `u8`/`i8` as smallint instead of `"char"` (fix #27986)

### DIFF
--- a/vlib/db/pg/orm.v
+++ b/vlib/db/pg/orm.v
@@ -311,9 +311,14 @@ fn pg_stmt_match(mut types []u32, mut vals []&char, mut lens []i32, mut formats 
 			formats << 1
 		}
 		u8 {
-			types << u32(Oid.t_char)
-			vals << &char(&data)
-			lens << i32(sizeof(u8))
+			// `u8` columns are declared as SMALLINT (int2) by pg_type_from_v(), so
+			// they have to be bound as int2 too. Binding them as the internal
+			// `"char"` type (Oid.t_char) makes PostgreSQL reject the statement with
+			// `column ... is of type smallint but expression is of type "char"`.
+			types << u32(Oid.t_int2)
+			num := conv.hton16(u16(data))
+			vals << &char(&num)
+			lens << i32(sizeof(u16))
 			formats << 1
 		}
 		u16 {
@@ -338,9 +343,11 @@ fn pg_stmt_match(mut types []u32, mut vals []&char, mut lens []i32, mut formats 
 			formats << 1
 		}
 		i8 {
-			types << u32(Oid.t_char)
-			vals << &char(&data)
-			lens << i32(sizeof(i8))
+			// See the `u8` branch above: `i8` columns are SMALLINT (int2) as well.
+			types << u32(Oid.t_int2)
+			num := conv.hton16(u16(i16(data)))
+			vals << &char(&num)
+			lens << i32(sizeof(i16))
 			formats << 1
 		}
 		i16 {
@@ -687,8 +694,10 @@ fn val_to_primitive(val ?string, typ int) !orm.Primitive {
 			}
 			// u8
 			orm.type_idx['u8'] {
-				data := str.i8()
-				return orm.Primitive(*unsafe { &u8(&data) })
+				// `u8` columns are SMALLINT, and are bound as a non negative int2,
+				// so the text PostgreSQL returns spans the full 0..255 range;
+				// parsing it as an i8 would saturate everything above 127.
+				return orm.Primitive(str.u8())
 			}
 			// u16
 			orm.type_idx['u16'] {

--- a/vlib/db/pg/pg_orm_test.v
+++ b/vlib/db/pg/pg_orm_test.v
@@ -48,6 +48,79 @@ struct TestCommentAttribute {
 	created_at string @[default: 'CURRENT_TIMESTAMP'; sql_type: 'TIMESTAMP']
 }
 
+@[table: 'test_small_int_types']
+struct TestSmallIntTypes {
+mut:
+	id     int @[primary; sql: serial]
+	status u8
+	delta  i8
+}
+
+// Regression test for https://github.com/vlang/v/issues/27986:
+// `u8`/`i8` fields are declared as SMALLINT by pg_type_from_v(), so they have to
+// be bound as int2 as well. Binding them as PostgreSQL's internal `"char"` type
+// made every insert fail with `column "status" is of type smallint but
+// expression is of type "char"`.
+fn test_pg_orm_u8_i8_are_bound_as_smallint() {
+	$if !network ? {
+		eprintln('> Skipping test ${@FN}, since `-d network` is not passed.')
+		eprintln('> This test requires a working postgres server running on localhost.')
+		return
+	}
+	mut db := pg.connect(
+		host:     'localhost'
+		user:     'postgres'
+		password: '12345678'
+		dbname:   'postgres'
+	) or { panic(err) }
+	defer {
+		db.close() or {}
+	}
+	sql db {
+		drop table TestSmallIntTypes
+	} or {}
+	sql db {
+		create table TestSmallIntTypes
+	}!
+
+	samples := [
+		TestSmallIntTypes{
+			status: 0
+			delta:  0
+		},
+		TestSmallIntTypes{
+			status: 255
+			delta:  -1
+		},
+		TestSmallIntTypes{
+			status: 200
+			delta:  -128
+		},
+		TestSmallIntTypes{
+			status: 1
+			delta:  127
+		},
+	]
+	for sample in samples {
+		sql db {
+			insert sample into TestSmallIntTypes
+		}!
+	}
+
+	rows := sql db {
+		select from TestSmallIntTypes order by id
+	}!
+	assert rows.len == samples.len
+	for i, row in rows {
+		assert row.status == samples[i].status
+		assert row.delta == samples[i].delta
+	}
+
+	sql db {
+		drop table TestSmallIntTypes
+	}!
+}
+
 fn test_pg_orm() {
 	$if !network ? {
 		eprintln('> Skipping test ${@FN}, since `-d network` is not passed.')


### PR DESCRIPTION
Fixes #27986.

### Problem

`pg_type_from_v()` declares `u8`/`i8` columns as `SMALLINT` (int2), but `pg_stmt_match()` bound their values as `Oid.t_char` — PostgreSQL's internal one-byte `"char"` type (OID 18). Every insert/update of such a field failed:

```
ERROR:  column "status" is of type smallint but expression is of type "char"
LINE 1: ...NTO "v_u8_i8_roundtrip" ("status", "delta") VALUES ($1, $2);
                                                               ^
HINT:  You will need to rewrite or cast the expression.
```

### Fix

Bind `u8` and `i8` as `Oid.t_int2` with `conv.hton16()`, the same way `u16`/`i16` already are. `i8` is sign-extended through `i16` first, so negative values keep their value in the int2 column.

Fixing the bind path exposed a second defect on the read side: the column now carries the full `0..255` range, and `val_to_primitive()` parsed it with `str.i8()`, which saturates — `255` came back as `127`, `200` as `127`. It now parses the text as an unsigned 8-bit value.

| value | before | after |
|---|---|---|
| `u8(0)` / `i8(0)` | insert rejected | `0` / `0` |
| `u8(255)` / `i8(-1)` | insert rejected | `255` / `-1` |
| `u8(200)` / `i8(-128)` | insert rejected | `200` / `-128` |
| `u8(1)` / `i8(127)` | insert rejected | `1` / `127` |

### Tests

`vlib/db/pg/pg_orm_test.v` gains `test_pg_orm_u8_i8_are_bound_as_smallint()`, a `create` / `insert` / `select` round-trip over the boundary values above, guarded by the same `$if !network ?` check as the rest of the file.

Verified against a local PostgreSQL 18 server: the new test fails on `master` with the exact error from the issue, and passes with this change. The rest of `vlib/db/pg/pg_orm_test.v` keeps passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)