### PR TITLE
cgen, v3: fix fixed array sumtype variants on both backends (fix #28127)

### DIFF
--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -1388,7 +1388,13 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 		right_sym := g.table.sym(unwrapped_val_type)
 		unaliased_right_sym := g.table.final_sym(unwrapped_val_type)
 		unaliased_left_sym := g.table.final_sym(g.unwrap_generic(var_type))
-		is_fixed_array_var := unaliased_right_sym.kind == .array_fixed && val !is ast.ArrayInit && (val in [
+		// A fixed array assigned to a sumtype/interface has to be boxed into the variant
+		// (`Array_fixed_f64_3_to_sumtype_Val(...)`), not memcpy()-ed over the receiving
+		// sumtype/interface struct.
+		is_boxed_fixed_array_val := unaliased_right_sym.kind == .array_fixed
+			&& unaliased_left_sym.kind in [.sum_type, .interface] && !var_type.has_flag(.option)
+		is_fixed_array_var := unaliased_right_sym.kind == .array_fixed && !is_boxed_fixed_array_val
+			&& val !is ast.ArrayInit && (val in [
 			ast.Ident,
 			ast.IndexExpr,
 			ast.CallExpr,
@@ -1493,7 +1499,8 @@ fn (mut g Gen) assign_stmt(node_ ast.AssignStmt) {
 				}
 				g.writeln(';}')
 			}
-		} else if node.op == .assign && (is_fixed_array_init || is_fixed_array_var || (unaliased_right_sym.kind == .array_fixed && val is ast.CastExpr)) {
+		} else if node.op == .assign && !is_boxed_fixed_array_val
+			&& (is_fixed_array_init || is_fixed_array_var || (unaliased_right_sym.kind == .array_fixed && val is ast.CastExpr)) {
 			// Fixed arrays
 			if unaliased_left_sym.kind != .array_fixed && unaliased_right_sym.kind == .array_fixed && (g.pref.translated || g.file.is_translated) {
 				// translated:

--- a/vlib/v/tests/sumtypes/sumtype_fixed_array_variant_assign_test.v
+++ b/vlib/v/tests/sumtypes/sumtype_fixed_array_variant_assign_test.v
@@ -1,0 +1,71 @@
+type Val = f64 | [3]f64 | []Val
+
+type Num = int | [2]int
+
+fn test_fixed_array_variant_assigned_to_map_value() {
+	mut m := map[string]Val{}
+	m['p'] = [1.0, 2.0, 3.0]!
+	v := m['p'] or { panic('missing key') }
+	if v is [3]f64 {
+		assert v == [1.0, 2.0, 3.0]!
+	} else {
+		assert false
+	}
+}
+
+fn test_fixed_array_variant_assigned_to_var() {
+	mut v := Val(0.0)
+	v = [4.0, 5.0, 6.0]!
+	match v {
+		[3]f64 { assert v == [4.0, 5.0, 6.0]! }
+		else { assert false }
+	}
+}
+
+fn test_fixed_array_var_assigned_to_sumtype() {
+	arr := [7.0, 8.0, 9.0]!
+	mut v := Val(0.0)
+	v = arr
+	if v is [3]f64 {
+		assert v == [7.0, 8.0, 9.0]!
+	} else {
+		assert false
+	}
+}
+
+fn test_fixed_array_variant_assigned_to_array_element() {
+	mut a := [Val(0.0)]
+	a[0] = [1.0, 1.5, 2.0]!
+	if a[0] is [3]f64 {
+		assert a[0] == [1.0, 1.5, 2.0]!
+	} else {
+		assert false
+	}
+}
+
+struct Holder {
+mut:
+	val Num
+}
+
+fn test_fixed_array_variant_assigned_to_struct_field() {
+	mut h := Holder{}
+	h.val = [3, 4]!
+	if h.val is [2]int {
+		assert h.val == [3, 4]!
+	} else {
+		assert false
+	}
+}
+
+fn test_plain_fixed_array_assignment_still_works() {
+	mut a := [3]f64{}
+	a = [1.0, 2.0, 3.0]!
+	assert a == [1.0, 2.0, 3.0]!
+	b := [4.0, 5.0, 6.0]!
+	a = b
+	assert a == [4.0, 5.0, 6.0]!
+	mut m := map[string][3]f64{}
+	m['k'] = [1.0, 2.0, 3.0]!
+	assert m['k'] == [1.0, 2.0, 3.0]!
+}

--- a/vlib/v/tests/sumtypes/sumtype_fixed_array_variant_assign_test.v
+++ b/vlib/v/tests/sumtypes/sumtype_fixed_array_variant_assign_test.v
@@ -69,3 +69,35 @@ fn test_plain_fixed_array_assignment_still_works() {
 	m['k'] = [1.0, 2.0, 3.0]!
 	assert m['k'] == [1.0, 2.0, 3.0]!
 }
+
+fn test_match_branch_on_fixed_array_variant() {
+	v := Val([1.0, 2.0, 3.0]!)
+	mut got := ''
+	match v {
+		[3]f64 { got = 'vec ${v}' }
+		[]Val { got = 'list' }
+		else { got = 'other' }
+	}
+	assert got == 'vec [1.0, 2.0, 3.0]'
+
+	n := Num([3, 4]!)
+	match n {
+		[2]int { assert n == [3, 4]! }
+		int { assert false }
+	}
+}
+
+// A `[N]T` match branch is a type pattern, but `[a, b]!` is still a fixed array
+// literal *value* to match against.
+fn test_match_branch_on_fixed_array_literal_value() {
+	pick := fn (a [2]int) string {
+		return match a {
+			[1, 2]! { 'onetwo' }
+			[3, 4]! { 'threefour' }
+			else { 'other' }
+		}
+	}
+	assert pick([1, 2]!) == 'onetwo'
+	assert pick([3, 4]!) == 'threefour'
+	assert pick([9, 9]!) == 'other'
+}

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -7275,6 +7275,13 @@ fn (mut p Parser) match_branch_cond() flat.NodeId {
 			typ: typ
 		})
 	}
+	if p.tok == .lsbr && p.current_lbr_starts_fixed_array_type() {
+		// A fixed array variant pattern, e.g. `match v { [3]f64 { ... } }`.
+		// Without this the `[3]f64` is parsed as an array literal, and the whole
+		// match degrades into a value match against it.
+		typ := p.parse_type_name()
+		return p.match_type_pattern_node(typ)
+	}
 	if p.tok == .name && p.lit == 'map' && p.peek() == .lsbr {
 		typ := p.parse_type_name()
 		return p.add_val(.ident, typ)
@@ -12178,6 +12185,42 @@ fn (mut p Parser) current_lbr_starts_array_type() bool {
 		return false
 	}
 	return p.lbr_starts_array_type_from_offset(p.s.offset)
+}
+
+// current_lbr_starts_fixed_array_type reports whether the current `[` starts a
+// fixed array type like `[3]f64`, rather than an array literal. It scans from the
+// `[` token itself instead of the scanner offset, so that it stays correct after
+// the caller has already peeked past the `[`. A `!` right after the closing `]`
+// marks a fixed array *literal* (`[1, 2]!`), never a type.
+fn (mut p Parser) current_lbr_starts_fixed_array_type() bool {
+	if p.tok != .lsbr || p.char_after_matching_rsbr(p.tok_pos + 1) == `!` {
+		return false
+	}
+	return p.lbr_starts_array_type_from_offset(p.tok_pos + 1)
+}
+
+// char_after_matching_rsbr returns the first non blank character after the `]`
+// that closes the `[` whose contents start at `offset`, or 0 when there is none.
+fn (p &Parser) char_after_matching_rsbr(offset int) u8 {
+	mut idx := offset
+	mut depth := 1
+	for idx < p.s.src.len {
+		c := p.s.src[idx]
+		if c == `[` {
+			depth++
+		} else if c == `]` {
+			depth--
+			if depth == 0 {
+				idx++
+				for idx < p.s.src.len && (p.s.src[idx] == ` ` || p.s.src[idx] == `\t`) {
+					idx++
+				}
+				return if idx < p.s.src.len { p.s.src[idx] } else { u8(0) }
+			}
+		}
+		idx++
+	}
+	return 0
 }
 
 fn (mut p Parser) current_generic_struct_init_suffix_followed_by_lcbr() bool {

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -242,6 +242,23 @@ fn (mut t Transformer) transform_infix_array_ops(_id flat.NodeId, node flat.Node
 			effective_rhs_raw_type = map_value_type
 		}
 	}
+	// An `is` smartcast narrows the operand, but an index/selector node keeps its
+	// declared sum type. Prefer the narrowed type, so that
+	// `if a[0] is [3]f64 { a[0] == [1.0, 1.5, 2.0]! }` lowers as a fixed array
+	// comparison, instead of falling through to the sum type's equality helper -
+	// which would then be handed a raw fixed array and emit uncompilable C.
+	if !t.is_fixed_array_type(t.membership_container_type(effective_lhs_raw_type)) {
+		smartcast_lhs_type := t.smartcast_node_type(lhs_id)
+		if t.is_fixed_array_type(t.membership_container_type(smartcast_lhs_type)) {
+			effective_lhs_raw_type = smartcast_lhs_type
+		}
+	}
+	if !t.is_fixed_array_type(t.membership_container_type(effective_rhs_raw_type)) {
+		smartcast_rhs_type := t.smartcast_node_type(rhs_id)
+		if t.is_fixed_array_type(t.membership_container_type(smartcast_rhs_type)) {
+			effective_rhs_raw_type = smartcast_rhs_type
+		}
+	}
 	lhs_is_array_ptr := t.equality_type_is_array_pointer(effective_lhs_raw_type)
 	rhs_is_array_ptr := t.equality_type_is_array_pointer(effective_rhs_raw_type)
 	if lhs_is_array_ptr && rhs_is_array_ptr {
@@ -1206,6 +1223,19 @@ fn (t &Transformer) checker_node_type(id flat.NodeId) string {
 		return ''
 	}
 	return t.normalize_type_alias(name)
+}
+
+// smartcast_node_type is the type `id` was narrowed to by an enclosing `is` check,
+// or '' when it is not smartcast.
+fn (t &Transformer) smartcast_node_type(id flat.NodeId) string {
+	if isnil(t.tc) || int(id) < 0 {
+		return ''
+	}
+	name := t.tc.smartcast_type_name(id)
+	if name.len == 0 || name == 'void' {
+		return ''
+	}
+	return name
 }
 
 fn (t &Transformer) raw_checker_node_type(id flat.NodeId) string {

--- a/vlib/v3/types/checker_smartcast.v
+++ b/vlib/v3/types/checker_smartcast.v
@@ -1,0 +1,14 @@
+module types
+
+import v3.flat
+
+// smartcast_type_name is the name of the type `id` was narrowed to by an enclosing
+// `is` (or `!= none`) check, or '' when the expression is not smartcast.
+// The transform lowers comparisons after checking, and has to see the same narrowed
+// type the checker validated the expression with: an index or selector node keeps
+// its declared type, so without this a smartcast sum type operand would still be
+// compared with the sum type's equality helper.
+pub fn (tc &TypeChecker) smartcast_type_name(id flat.NodeId) string {
+	typ := tc.smartcast_type(id) or { return '' }
+	return tc.type_name(typ)
+}


### PR DESCRIPTION
Fixes #28127, on both backends.

### V1 (`vlib/v/gen/c`)

```v
type Val = f64 | [3]f64 | []Val

fn main() {
	mut m := map[string]Val{}
	m['p'] = [0.0, 0.0, 0.0]!
}
```

```
error: initializing 'f64 *' (aka 'double *') with an expression of incompatible type 'double'
```

`assign_stmt()` routed this through the fixed-array assignment path, which `memcpy()`s the raw fixed-array bytes over the destination using the *destination's* C type. With a sumtype on the left that produced a temporary declared as the sumtype, and a `memcpy()` spliced into a half-written `map_set()` call:

```c
main__Val _t1 = {0.0, 0.0, 0.0};
memcpy(builtin__map_set(&m, &(string[]){_S("p")}, &(main__Val[]) {, _t1, sizeof(main__Val));
```

That path is only correct when the left side is a fixed array too. When it is a sumtype or an interface, the value has to be boxed into the variant (`Array_fixed_f64_3_to_sumtype_main__Val(...)`) by the regular assignment path — which is what `v := Val([1.0, 2.0, 3.0]!)` already did correctly. The new `is_boxed_fixed_array_val` flag disables both the fixed-array assignment branch and `is_fixed_array_var` for exactly that case.

### V3 (`vlib/v3`)

The same issue family reproduces on V3 — the issue's own reproducer fails there too, under a strict run (`V_MACOS_V3_NO_FALLBACK=1`, which disables the silent `-old-compiler` retry that normally hides it). Two defects:

**Parser.** `match_branch_cond()` only recognised `[]T` as an array type pattern, so a fixed array variant was parsed as an array *literal*:

```v
match v {
	[3]f64 { println('vec ${v}') }   // parsed as the value `[3]f64`
	f64 { println('num') }           // then: `f64` evaluated but not used
}
```

That turned the whole match into a value match, and lowered the branch into a sum type equality call handed a raw `double[3]`. A `!` right after the closing `]` still marks a fixed array *literal* (`[1, 2]!`), so those value patterns keep parsing as values — covered by its own test.

**Transform.** A comparison whose operand is smartcast through an index or selector kept the operand's *declared* sum type, so

```v
if a[0] is [3]f64 {
	assert a[0] == [1.0, 1.5, 2.0]!
}
```

fell past the fixed-array comparison in `transform_infix_array_ops()` and reached the sum type's equality helper, which C could not compile. It now prefers the checker's narrowed type, via a new `TypeChecker.smartcast_type_name()`.

### Covered shapes

`vlib/v/tests/sumtypes/sumtype_fixed_array_variant_assign_test.v` covers a fixed array literal *and* a fixed array variable assigned to:

- a map value of sumtype type (the reported case)
- a plain sumtype variable
- an array element of sumtype type
- a struct field of sumtype type

plus `match` branches on a fixed array variant, `match` branches on fixed array literal *values*, and a guard that ordinary fixed-array assignment (including into a `map[string][3]f64`) still uses the `memcpy()` path. It fails on `master` under `-old-compiler` and under a strict V3 run, and passes here on both.

### Tests

`vlib/v/tests/` — 2212 passed, 4 failed, 7 skipped. The 4 failures are all in `vlib/v/tests/vls/` and reproduce identically on `master` without this change.

For V3, the repro programs and the regression test were checked against a compiler built from clean `origin/master` (all fail there) and against this branch (all pass), plus a targeted `vlib/v3/tests` subset — its only failure, `fixed_array_const_materialization_codegen_test.v`, fails identically on `master`. The full `vlib/v3/test_all.vsh` runs here via the V3 CI workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)