### PR TITLE
cgen: always terminate `#line` directives with a newline (fix #28163)

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -115,6 +115,7 @@ mut:
 	is_sql                               bool // Inside `sql db{}` statement, generating sql instead of C (e.g. `and` instead of `&&` etc)
 	is_shared                            bool // for initialization of hidden mutex in `[rw]shared` literals
 	is_vlines_enabled                    bool // is it safe to generate #line directives when -g is passed
+	vlines_pending_nl                    bool // the output ends with an unterminated `#line` directive
 	is_autofree                          bool // false, inside the bodies of fns marked with [manualfree], otherwise === g.pref.autofree
 	is_autofree_tmp                      bool // when generating autofree temporary variables
 	is_builtin_mod                       bool

--- a/vlib/v/gen/c/text_manipulation.v
+++ b/vlib/v/gen/c/text_manipulation.v
@@ -7,6 +7,9 @@ import v.util
 
 const trace_gen_wanted_value = $d('trace_gen_wanted_value', '')
 
+// line_directive is the start of a `#line N "file"` C preprocessor directive.
+const line_directive = '#line '
+
 @[if trace_gen_wanted ?]
 fn (mut g Gen) trace_gen_wanted_context(last_character_len int, s string) {
 	last_n := g.out.last_n(last_character_len)
@@ -38,18 +41,69 @@ fn (mut g Gen) trace_gen(reason string, s string) {
 	}
 }
 
+// ends_with_open_line_directive reports whether the last line of `s` is a `#line`
+// directive that was not terminated by a newline.
+// With `-g`, cgen routinely cuts an unfinished statement out of the output with
+// go_before_last_stmt()/go_before_ternary(), trims it, and writes it back later.
+// When that chunk ends with a `#line N "file"` directive, whatever is written
+// next lands on the same line, and the C preprocessor swallows it as trailing
+// tokens of the directive - `warning: extra tokens at end of #line directive`,
+// followed by `error: expected expression` for the statement that just lost its
+// value. Tracking it here terminates such a directive before the next write,
+// instead of patching every one of the ~100 write back sites.
+@[direct_array_access]
+fn (g &Gen) ends_with_open_line_directive(s string) bool {
+	if !g.pref.is_vlines || s.len == 0 || s[s.len - 1] == `\n` {
+		return false
+	}
+	mut i := s.len - 1
+	for i > 0 && s[i - 1] != `\n` {
+		i--
+	}
+	for i < s.len && s[i] in [` `, `\t`, `\r`] {
+		i++
+	}
+	if s.len - i < line_directive.len {
+		return false
+	}
+	for j in 0 .. line_directive.len {
+		if s[i + j] != line_directive[j] {
+			return false
+		}
+	}
+	return true
+}
+
+// terminate_open_line_directive closes a pending `#line` directive, so that the
+// next generated code starts on its own line.
+@[inline]
+fn (mut g Gen) terminate_open_line_directive() {
+	if g.vlines_pending_nl {
+		g.vlines_pending_nl = false
+		g.out.writeln('')
+		g.empty_line = true
+	}
+}
+
 @[expand_simple_interpolation]
 fn (mut g Gen) write(s string) {
 	g.trace_gen_wanted(s)
 	g.trace_gen('write', s)
+	g.terminate_open_line_directive()
 	if g.indent > 0 && g.empty_line {
 		g.out.write_string(util.tabs(g.indent))
 	}
 	g.out.write_string(s)
 	g.empty_line = false
+	g.vlines_pending_nl = g.ends_with_open_line_directive(s)
 }
 
 fn (mut g Gen) write2(s1 string, s2 string) {
+	if g.pref.is_vlines {
+		g.write(s1)
+		g.write(s2)
+		return
+	}
 	g.trace_gen_wanted2(s1, s2)
 	g.trace_gen('write2 s1', s1)
 	if g.indent > 0 && g.empty_line {
@@ -68,6 +122,7 @@ fn (mut g Gen) write2(s1 string, s2 string) {
 
 fn (mut g Gen) write_decimal(x i64) {
 	g.trace_gen('write_decimal', x.str())
+	g.terminate_open_line_directive()
 	if g.indent > 0 && g.empty_line {
 		g.out.write_string(util.tabs(g.indent))
 	}
@@ -78,6 +133,7 @@ fn (mut g Gen) write_decimal(x i64) {
 fn (mut g Gen) writeln(s string) {
 	g.trace_gen_wanted(s)
 	g.trace_gen('writeln', s)
+	g.terminate_open_line_directive()
 	if g.indent > 0 && g.empty_line {
 		g.out.write_string(util.tabs(g.indent))
 		// g.out_parallel[g.out_idx].write_string(util.tabs(g.indent))
@@ -90,6 +146,11 @@ fn (mut g Gen) writeln(s string) {
 }
 
 fn (mut g Gen) writeln2(s1 string, s2 string) {
+	if g.pref.is_vlines {
+		g.writeln(s1)
+		g.writeln(s2)
+		return
+	}
 	g.trace_gen_wanted2(s1, s2)
 	g.trace_gen('writeln2 s1', s1)
 	// expansion for s1
@@ -111,11 +172,13 @@ fn (mut g Gen) writeln2(s1 string, s2 string) {
 // Below are hacks that should be removed at some point.
 
 fn (mut g Gen) go_back(n int) {
+	g.vlines_pending_nl = false
 	g.out.go_back(n)
 	// g.out_parallel[g.out_idx].go_back(n)
 }
 
 fn (mut g Gen) go_back_to(n int) {
+	g.vlines_pending_nl = false
 	g.out.go_back_to(n)
 	// g.out_parallel[g.out_idx].go_back_to(n)
 }
@@ -132,21 +195,25 @@ fn (mut g Gen) set_current_pos_as_last_stmt_pos() {
 
 @[inline]
 fn (mut g Gen) go_before_last_stmt() string {
+	g.vlines_pending_nl = false
 	return g.out.cut_to(g.nth_stmt_pos(0))
 }
 
 @[inline]
 fn (mut g Gen) go_before_ternary() string {
+	g.vlines_pending_nl = false
 	return g.out.cut_to(g.nth_stmt_pos(g.inside_ternary))
 }
 
 fn (mut g Gen) insert_before_stmt(s string) {
+	g.vlines_pending_nl = false
 	cur_line := g.out.cut_to(g.nth_stmt_pos(g.inside_ternary))
 	g.writeln(s)
 	g.write(cur_line)
 }
 
 fn (mut g Gen) insert_at(pos int, s string) {
+	g.vlines_pending_nl = false
 	cur_line := g.out.cut_to(pos)
 	// g.out_parallel[g.out_idx].cut_to(pos)
 	g.writeln(s)

--- a/vlib/v/tests/or_block_in_if_expr_branch_with_g_test.v
+++ b/vlib/v/tests/or_block_in_if_expr_branch_with_g_test.v
@@ -1,0 +1,68 @@
+import os
+
+const vexe = @VEXE
+
+// `#line` directives must always be terminated by a newline. When a branch of an
+// if/match *expression* is valued by an `or {}` block, cgen cuts the unfinished
+// assignment (which can end with a `#line` directive) out of the output and
+// writes it back after the `or {}` block. Without a terminating newline the C
+// preprocessor swallows the unwrapped value as trailing tokens of the directive.
+// See https://github.com/vlang/v/issues/28163 and issue #27495 for the earlier,
+// array-literal flavoured instance of the same family.
+fn test_or_block_in_if_expr_branch_compiles_with_g() {
+	test_dir := os.join_path(os.vtmp_dir(), 'or_block_if_expr_g_test_${os.getpid()}')
+	os.mkdir_all(test_dir)!
+	defer {
+		os.rmdir_all(test_dir) or {}
+	}
+	source := os.join_path(test_dir, 'test.v')
+	out_c := os.join_path(test_dir, 'test.c')
+	os.write_file(source, "struct Params {
+	initial_max_stream_data_bidi_remote ?u64
+	initial_max_stream_data_bidi_local  ?u64
+}
+
+fn initial_send_limit_for_stream(locally_initiated bool, peer_params Params) u64 {
+	return if locally_initiated {
+		peer_params.initial_max_stream_data_bidi_remote or { 0 }
+	} else {
+		peer_params.initial_max_stream_data_bidi_local or { 0 }
+	}
+}
+
+struct Conn {
+	initial_keys_server   int
+	handshake_keys_server ?int
+}
+
+fn (c &Conn) process(initial bool) ?int {
+	keys := if initial {
+		c.initial_keys_server
+	} else {
+		c.handshake_keys_server or { return none }
+	}
+	return keys
+}
+
+fn main() {
+	println(initial_send_limit_for_stream(true, Params{ initial_max_stream_data_bidi_remote: u64(7) }))
+	println(initial_send_limit_for_stream(false, Params{}))
+	c := Conn{ initial_keys_server: 3, handshake_keys_server: 5 }
+	println(c.process(true) or { -1 })
+	println(c.process(false) or { -1 })
+}
+")!
+	res :=
+		os.execute('${os.quoted_path(vexe)} -g -o ${os.quoted_path(out_c)} -b c ${os.quoted_path(source)}')
+	assert res.exit_code == 0, res.output
+	generated := os.read_file(out_c)!
+	for line in generated.split_into_lines() {
+		trimmed := line.trim_left(' \t')
+		if !trimmed.starts_with('#line ') {
+			continue
+		}
+		// `#line NN "path"` and nothing else may follow on that line
+		rest := trimmed.all_after_last('"').trim_space()
+		assert rest == '', 'found #line directive glued to an expression: ${line}'
+	}
+}


### PR DESCRIPTION
Fixes #28163.

### Problem

With `-g`, cgen routinely cuts an unfinished statement out of the output with `go_before_last_stmt()` / `go_before_ternary()`, trims it, and writes it back after generating the nested code. When that chunk ends with a `#line N "file"` directive, whatever is written next lands on the same line, and the C preprocessor swallows it as trailing tokens of the directive:

```c
_t2 =
#line 10 "vlib/net/quic/flow_control.v" (*(u64*)_t4->data);
```

```
warning: extra tokens at end of #line directive [-Wextra-tokens]
error: expected expression before '}' token
error: expected expression before 'goto'
```

The shape reported in #28163 is an `or {}` block used as the value of an `if`/`match` **expression** branch, which broke `vlib/net/quic` in every downstream-app-building CI job.

### Fix

#27495 patched two individual write-back sites (array-literal branches). Rather than adding a third — cgen has ~100 `go_before_last_stmt()` write-back sites, any of which can end with a directive — this closes the invariant centrally: an unterminated `#line` directive is tracked as it is written, and terminated before the next write.

Concretely, `write()` / `write_decimal()` / `writeln()` first flush a pending directive, and `write()` records whether the chunk it just wrote ends with an open one. `go_back()`, `go_back_to()`, `go_before_last_stmt()`, `go_before_ternary()`, `insert_before_stmt()` and `insert_at()` clear the flag, since they rewind the output.

### No effect when `-g` is off

`vlines_pending_nl` can only ever be set while `pref.is_vlines` is true, and `terminate_open_line_directive()` is a single already-false bool check otherwise. `write2()` / `writeln2()` keep their fused fast path and only delegate to `write()` / `writeln()` in vlines mode.

Verified empirically: `v -o out.c cmd/tools/vdoc` produces byte-identical C before and after (7.7 MB, only the embedded compiler path differs). With `-g`, the only difference is the newline being added — `master` emits 690 glued `#line` directives for that same program, this branch emits 0.

### Tests

`vlib/v/tests/or_block_in_if_expr_branch_with_g_test.v` compiles both reduced forms from the issue with `-g` and asserts that no `#line` directive in the generated C has anything following the file name. It fails on `master` (`found #line directive glued to an expression: #line 8 "…" (*(u64*)_t4->data);`) and passes here. The existing `match_expr_array_literal_with_g_test.v` from #27495 keeps passing.

`vlib/v/tests/` — 2212 passed, 4 failed, 7 skipped; the 4 failures are all in `vlib/v/tests/vls/` and reproduce identically on `master`. `v -g -o v cmd/v` also builds and runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)