### PR TITLE
v3: reduce uncached self-host frontend work

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -2422,6 +2422,18 @@ fn prealloc_scope_free_for_v3(scope voidptr) {
 	}
 }
 
+// free_retained_scopes releases the stage arenas the self-host path keeps alive
+// through code generation. Unmapping multi-gigabyte arenas is slow enough to be
+// worth overlapping with the C compiler, which reads only the generated file.
+fn free_retained_scopes(transform_scope voidptr, prepare_scope voidptr) {
+	if transform_scope != unsafe { nil } {
+		prealloc_scope_free_for_v3(transform_scope)
+	}
+	if prepare_scope != unsafe { nil } {
+		prealloc_scope_free_for_v3(prepare_scope)
+	}
+}
+
 // release_unused_diagnostic_scope discards notice storage before its arena is released.
 fn release_unused_diagnostic_scope(mut notices []types.TypeError, scope voidptr) {
 	prealloc_scope_leave_for_v3(scope)
@@ -10913,6 +10925,16 @@ pub fn run(args []string) {
 			clear_macos_v3_compiler_error_fallback(macos_v3_fallback_file)
 			return
 		}
+		// Nothing below reads the transformed AST or its checker payloads: the C
+		// compiler consumes the generated file. Release those arenas alongside it
+		// so their unmapping is not serial work after the compile.
+		mut scope_free_threads := []thread{}
+		if retained_transform_scope != unsafe { nil }
+			|| retained_transform_prepare_scope != unsafe { nil } {
+			scope_free_threads << spawn free_retained_scopes(retained_transform_scope, retained_transform_prepare_scope)
+			retained_transform_scope = unsafe { nil }
+			retained_transform_prepare_scope = unsafe { nil }
+		}
 		mut tcc_link_has_incompatible_objects := false
 		if prefs.normalized_target_os() == 'macos' {
 			for flag in resolved_c_flags {
@@ -11505,6 +11527,9 @@ Please install the corresponding development package/libraries and make sure the
 		os.rm(retained_full_c_source) or {}
 		os.rm(cc_src) or {}
 		os.rmdir(cc_dir) or {}
+		for scope_free_thread in scope_free_threads {
+			scope_free_thread.wait()
+		}
 		b.step(if tcc_cache_hit {
 			'tcc (cached)'
 		} else if used_tcc {
@@ -15114,31 +15139,28 @@ fn insert_synthetic_imports(mut a flat.FlatAst, insertions []SyntheticInsertion)
 	}
 	old_len := a.nodes.len
 	mut new_nodes := []flat.Node{cap: old_len + insertions.len}
-	mut ins_idx := 0
-	for i in 0 .. old_len {
-		for ins_idx < insertions.len && insertions[ins_idx].pos == i {
-			new_nodes << canonical_node_texts(mut a, insertions[ins_idx].node)
-			ins_idx++
-		}
-		mut node := a.nodes[i]
+	mut start := 0
+	for insertion in insertions {
+		// Copy each unchanged region once instead of appending every AST node.
+		new_nodes << a.nodes[start..insertion.pos]
+		new_nodes << canonical_node_texts(mut a, insertion.node)
+		start = insertion.pos
+	}
+	new_nodes << a.nodes[start..]
+	for i in 0 .. new_nodes.len {
+		mut node := new_nodes[i]
 		if node.kind == .directive && node.value.starts_with('@attributes:') {
 			target_idx := node.value['@attributes:'.len..].int()
 			if target_idx >= 0 && target_idx < old_len {
 				node.value = '@attributes:${target_idx + synthetic_index_shift(insertions, target_idx)}'
-				node = canonical_node_texts(mut a, node)
+				new_nodes[i] = canonical_node_texts(mut a, node)
 			}
 		}
-		new_nodes << node
-	}
-	// Insertions at pos == old_len append at the very end (the last wave module's
-	// region ends at the array tail).
-	for ins_idx < insertions.len {
-		new_nodes << canonical_node_texts(mut a, insertions[ins_idx].node)
-		ins_idx++
 	}
 	a.nodes = new_nodes
-	a.file_node_ids = []int{}
-	a.file_index_incomplete = true
+	for i, idx in a.file_node_ids {
+		a.file_node_ids[i] = idx + synthetic_index_shift(insertions, idx)
+	}
 	for k in 0 .. a.children.len {
 		cid := int(a.children[k])
 		if cid >= 0 {
@@ -15185,6 +15207,13 @@ fn collect_import_scan_ids(a &flat.FlatAst, region_start int, pair_cursor int) (
 			continue
 		}
 		trailing := a.file_node_ids[cursor + 1]
+		// Implicit imports can be inserted between parsed files. They retain the
+		// preceding file's context and must be visited before the next marker.
+		for i in last_trailing + 1 .. marker {
+			if a.nodes[i].kind in [.file, .module_decl, .import_decl] {
+				ids << i
+			}
+		}
 		ids << marker
 		tnode := a.nodes[trailing]
 		collect_import_scan_children(a, &tnode, mut ids)

--- a/vlib/v3/driver/implicit_import_test.v
+++ b/vlib/v3/driver/implicit_import_test.v
@@ -4,6 +4,7 @@ import os
 import v3.flat
 import v3.parser
 import v3.pref
+import v3.types
 
 fn test_default_bin_file_strips_backend_source_extension() {
 	assert default_bin_file_for_input('foo.c.v') == 'foo'
@@ -26,8 +27,7 @@ fn test_default_bin_file_for_directory_is_source_adjacent() {
 }
 
 fn test_profile_optional_arg_recognizes_vv_source() {
-	value, consumed := v3_profile_optional_arg_value(['-profile', 'fixture.vv', '-o', 'out'], 0,
-		false)
+	value, consumed := v3_profile_optional_arg_value(['-profile', 'fixture.vv', '-o', 'out'], 0, false)
 	assert value == '-'
 	assert !consumed
 }
@@ -36,8 +36,7 @@ fn test_default_bin_file_uses_safe_hidden_source_name() {
 	assert default_bin_file_for_input('.v') == '.v.out'
 	assert default_bin_file_for_input('.vv') == '.vv.out'
 	assert default_bin_file_for_input('.vsh') == '.vsh.out'
-	assert default_bin_file_for_input(os.join_path('source', '.v')) == os.join_path('source',
-		'.v.out')
+	assert default_bin_file_for_input(os.join_path('source', '.v')) == os.join_path('source', '.v.out')
 	assert default_bin_file_for_input('unsafe\t.v') == 'unsafe_.v.out'
 }
 
@@ -186,26 +185,104 @@ fn inspect(mut builder Builder, info Info) int {
 fn test_synthetic_import_insertion_remaps_declaration_attribute_targets() {
 	mut ast := flat.FlatAst.new()
 	ast.add_node(flat.Node{
-		kind:  .field_decl
+		kind: .field_decl
 		value: 'value'
 	})
 	struct_id := ast.add_node(flat.Node{
-		kind:  .struct_decl
+		kind: .struct_decl
 		value: 'Packed'
 	})
 	ast.add_node(flat.Node{
-		kind:  .directive
+		kind: .directive
 		value: '@attributes:${int(struct_id)}'
 	})
 	insert_synthetic_imports(mut ast, [
 		SyntheticInsertion{
-			pos:  0
+			pos: 0
 			node: flat.Node{
-				kind:  .import_decl
+				kind: .import_decl
 				value: 'builtin'
 			}
 		},
 	])
 	assert ast.nodes[3].kind == .directive
 	assert ast.nodes[3].value == '@attributes:2'
+}
+
+fn test_synthetic_import_insertion_preserves_file_index_and_import_order() {
+	root := os.join_path(os.vtmp_dir(), 'v3_synthetic_file_index_${os.getpid()}')
+	os.mkdir_all(root)!
+	defer { os.rmdir_all(root) or {} }
+	first := os.join_path(root, 'first.v')
+	second := os.join_path(root, 'second.v')
+	os.write_file(first, 'module first\nimport math\nfn first() {}\n')!
+	os.write_file(second, 'module second\nimport strings\nfn second() {}\n')!
+	mut p := parser.Parser.new(pref.new_preferences())
+	p.parse_file(first)
+	mut ast := p.parse_file(second)
+	assert p.diagnostics.len == 0
+	boundary := ast.file_node_ids[2]
+	insert_synthetic_imports(mut ast, [
+		SyntheticInsertion{ pos: boundary, node: sync_import_node() },
+		SyntheticInsertion{ pos: boundary, node: embed_file_import_node() },
+		SyntheticInsertion{ pos: ast.nodes.len, node: closure_import_node() },
+	])
+	assert ast.file_node_ids.len == 4
+	assert !ast.file_index_incomplete
+	assert ast.file_node_ids[2] == boundary + 2
+	for pair in 0 .. 2 {
+		marker := ast.nodes[ast.file_node_ids[pair * 2]]
+		trailing := ast.nodes[ast.file_node_ids[pair * 2 + 1]]
+		assert marker.kind == .file && trailing.kind == .file
+		assert marker.value == trailing.value
+	}
+	for region in [0, boundary] {
+		mut expected := []int{}
+		for i in region .. ast.nodes.len {
+			if ast.nodes[i].kind in [.file, .module_decl, .import_decl] {
+				expected << i
+			}
+		}
+		actual, _ := collect_import_scan_ids(ast, region, if region == 0 { 0 } else { 2 })
+		assert actual == expected
+	}
+	mut indexed := types.TypeChecker.new(ast)
+	indexed.collect(ast)
+	ast.file_index_incomplete = true
+	mut scanned := types.TypeChecker.new(ast)
+	scanned.collect(ast)
+	assert indexed.top_level_idx == scanned.top_level_idx
+	assert indexed.file_imports == scanned.file_imports
+	assert indexed.file_imports['${first}\nsync'] == 'sync'
+	assert indexed.file_imports['${first}\nembed_file'] == 'v.embed_file'
+	assert indexed.file_imports['${second}\n${closure_runtime_import_alias}'] == 'builtin.closure'
+}
+
+fn test_file_index_gap_preserves_bundle_file_context() {
+	root := os.join_path(os.vtmp_dir(), 'v3_file_index_gap_${os.getpid()}')
+	os.mkdir_all(root)!
+	defer { os.rmdir_all(root) or {} }
+	mut p := parser.Parser.new(pref.new_preferences())
+	for name in ['first', 'bundle', 'last'] {
+		path := os.join_path(root, '${name}.v')
+		os.write_file(path, 'module ${name}\nimport math as m\nfn ${name}() {}\n')!
+		p.parse_file(path)
+	}
+	mut ast := p.a
+	assert p.diagnostics.len == 0
+	// A synthesized bundle may have complete file nodes but no indexed pair.
+	ast.file_node_ids = [ast.file_node_ids[0], ast.file_node_ids[1], ast.file_node_ids[4],
+		ast.file_node_ids[5]]
+	mut indexed := types.TypeChecker.new(ast)
+	indexed.collect(ast)
+	ast.file_index_incomplete = true
+	mut scanned := types.TypeChecker.new(ast)
+	scanned.collect(ast)
+	assert indexed.top_level_idx == scanned.top_level_idx
+	assert indexed.file_imports == scanned.file_imports
+	for name in ['first', 'bundle', 'last'] {
+		path := os.join_path(root, '${name}.v')
+		assert indexed.file_imports['${path}\nm'] == 'math'
+		assert '${name}.${name}' in indexed.fn_ret_types
+	}
 }

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -465,6 +465,7 @@ mut:
 	c_extern_global_names         map[string]string
 	shared_type_names             map[string]SharedTypeInfo // __shared__ wrapper name -> wrapped type metadata
 	shared_alias_pointer_shorts   map[string]string // alias short name -> shared inner type; '' means ambiguous
+	shared_alias_index_ready      bool
 	needs_shared_runtime          bool
 	const_runtime_inits           []string
 	const_runtime_init_modules    []string
@@ -10183,12 +10184,23 @@ fn (mut g FlatGen) register_struct_decl_info(name string, full_name string, modu
 }
 
 fn (mut g FlatGen) register_struct_decl_info_at(node_id int, name string, full_name string, module_name string, source_file string, node flat.Node) {
+	// These declarations are immutable during codegen. Most structs have no
+	// shared fields, so avoid rescanning their ordinary fields at every selector.
+	mut shared_fields := []flat.NodeId{}
+	for i in 0 .. node.children_count {
+		field_id := g.a.child(&node, i)
+		field := g.a.node(field_id)
+		if field.kind == .field_decl && shared_inner_type_text(field.typ) != none {
+			shared_fields << field_id
+		}
+	}
 	info := StructDeclInfo{
 		node: node
 		node_id: node_id
 		module: module_name
 		file: source_file
 		full_name: full_name
+		shared_fields: shared_fields
 	}
 	g.struct_decl_infos[full_name] = info
 	if name !in g.struct_decl_short_infos {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -1238,7 +1238,7 @@ const c_main_runtime_shadow_fn_names = {
 }
 
 fn (g &FlatGen) main_runtime_shadow_fn_c_name(module_name string, name string) ?string {
-	if name.starts_with('C.') {
+	if module_name !in ['', 'main'] || name.starts_with('C.') {
 		return none
 	}
 	c_type_name := !isnil(g.tc)
@@ -1249,10 +1249,7 @@ fn (g &FlatGen) main_runtime_shadow_fn_c_name(module_name string, name string) ?
 		&& !needs_export_wrapper && !export_name_owned {
 		return none
 	}
-	if module_name.len == 0 || module_name == 'main' {
-		return g.cname('main.${name}')
-	}
-	return none
+	return g.cname('main.${name}')
 }
 
 fn (g &FlatGen) main_export_name_owned_by_other_fn(module_name string, name string) bool {

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -17,7 +17,7 @@ const min_flat_cgen_parallel_items = 128
 // expression. Keep self-host body batches narrow so those values are released
 // throughout cgen instead of accumulating across hundreds of functions.
 const scoped_cgen_worker_batches = 256
-const flat_cgen_chunks_per_job = 12
+const flat_cgen_chunks_per_job = 6
 
 // FlatCgenChunkArgs represents flat cgen chunk args data used by c.
 struct FlatCgenChunkArgs {
@@ -921,7 +921,8 @@ fn (mut g FlatGen) prepare_pre_dispatch_master() {
 	if g.scope_parallel_workers {
 		mut pmsw := time.new_stopwatch()
 		selection_scope := cgen_worker_scope_begin(true)
-		retain_selection := os.getenv('V3_RETAIN_CGEN_PREP_SCOPE') != ''
+		retain_selection := g.tc.building_v_fast
+			|| os.getenv('V3_RETAIN_CGEN_PREP_SCOPE') != ''
 		master_tc := g.tc
 		g.tc = g.clone_parallel_type_checker()
 		g.tc.verbose = master_tc.verbose
@@ -1463,6 +1464,9 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 			// Snapshot body-worker state before the declaration task starts mutating
 			// the master generator. Constructing workers lazily from that task's
 			// concurrent state can copy a moved map or a partially updated cache.
+			// All workers can share the prepared literal table until an insertion.
+			// The declaration task must detach too before adding its own literals.
+			g.str_lits_shared = true
 			worker_setup_scope := cgen_worker_scope_begin(true)
 			for ci := 0; ci < worker_count; ci++ {
 				cgen_workers[ci] = voidptr(g.new_parallel_dispatch_worker(ci))
@@ -1577,6 +1581,9 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 		// Keep helper output in ordered result segments until the join so generated
 		// string IDs can be reconciled with literals emitted by the master chunk.
 		mut cgen_workers := []voidptr{cap: thread_count}
+		if g.scope_parallel_workers {
+			g.str_lits_shared = true
+		}
 		worker_setup_scope := cgen_worker_scope_begin(g.scope_parallel_workers)
 		for ci := 0; ci < thread_count; ci++ {
 			mut w := g.new_parallel_dispatch_worker(ci + 1)
@@ -2357,9 +2364,9 @@ fn (g &FlatGen) new_parallel_dispatch_worker(worker_id int) &FlatGen {
 
 // new_parallel_result_worker creates a non-emitting helper accumulator. Caches
 // that it only passes to fresh batch generators stay shared with the frozen
-// master snapshot; result tables remain private. Its string tables are copied
-// eagerly because the master can extend its own table after tasks start, before
-// a helper's first copy-on-write intern.
+// master snapshot; result tables remain private. String tables can also stay
+// shared when the master detaches its own table on insertion. Other callers
+// still receive an independent snapshot before the master can extend its table.
 fn (g &FlatGen) new_parallel_result_worker(worker_id int) &FlatGen {
 	return g.new_parallel_worker_config(worker_id, true)
 }
@@ -2382,21 +2389,21 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		cache_program_files: g.cache_program_files
 		incremental_fn_names: g.incremental_fn_names
 		cached_support_identifiers: g.cached_support_identifiers
-		str_lits: if result_only {
+		str_lits: if result_only && !g.str_lits_shared {
 			clone_cgen_string_list(g.str_lits)
 		} else if g.scope_parallel_workers {
 			g.str_lits
 		} else {
 			g.str_lits.clone()
 		}
-		str_lit_ids: if result_only {
+		str_lit_ids: if result_only && !g.str_lits_shared {
 			clone_cgen_string_int_map(g.str_lit_ids)
 		} else if g.scope_parallel_workers {
 			g.str_lit_ids
 		} else {
 			g.str_lit_ids.clone()
 		}
-		str_lits_shared: g.scope_parallel_workers && !result_only
+		str_lits_shared: g.scope_parallel_workers && (!result_only || g.str_lits_shared)
 		global_types: g.global_types
 		global_raw_type_texts: g.global_raw_type_texts
 		enum_vals: g.enum_vals
@@ -2475,6 +2482,7 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		decl_attrs_by_source_position: g.decl_attrs_by_source_position
 		shared_type_names: g.shared_type_names
 		shared_alias_pointer_shorts: g.shared_alias_pointer_shorts
+		shared_alias_index_ready: g.shared_alias_index_ready
 		const_runtime_inits: if result_only {
 			g.const_runtime_inits
 		} else {

--- a/vlib/v3/gen/c/naming/naming.v
+++ b/vlib/v3/gen/c/naming/naming.v
@@ -175,21 +175,24 @@ pub fn sanitize(name string) string {
 		return name
 	}
 	out_len := name.len + dot_count
-	mut out := []u8{len: out_len + 1}
+	// The returned string owns a standalone allocation, not managed array storage.
+	mut out := unsafe { malloc_noscan(out_len + 1) }
 	mut dst := 0
 	for i in 0 .. name.len {
 		c := name[i]
 		if c == `.` {
-			out[dst] = `_`
-			out[dst + 1] = `_`
+			unsafe {
+				out[dst] = `_`
+				out[dst + 1] = `_`
+			}
 			dst += 2
 		} else {
-			out[dst] = c
+			unsafe { out[dst] = c }
 			dst++
 		}
 	}
-	// Transfer the private, NUL-terminated buffer; no mutable alias escapes.
-	return unsafe { tos(out.data, out_len) }
+	unsafe { out[out_len] = 0 }
+	return unsafe { tos(out, out_len) }
 }
 
 fn sanitize_complex(name string) string {

--- a/vlib/v3/gen/c/naming/naming.v
+++ b/vlib/v3/gen/c/naming/naming.v
@@ -158,6 +158,7 @@ fn is_string_literal_symbol(name string) bool {
 
 // sanitize converts a V symbol or type spelling into a C identifier spelling
 // without applying reserved-word or libc collision prefixes.
+@[direct_array_access]
 pub fn sanitize(name string) string {
 	mut dot_count := 0
 	for i in 0 .. name.len {
@@ -173,7 +174,8 @@ pub fn sanitize(name string) string {
 	if dot_count == 0 {
 		return name
 	}
-	mut out := []u8{len: name.len + dot_count}
+	out_len := name.len + dot_count
+	mut out := []u8{len: out_len + 1}
 	mut dst := 0
 	for i in 0 .. name.len {
 		c := name[i]
@@ -186,7 +188,8 @@ pub fn sanitize(name string) string {
 			dst++
 		}
 	}
-	return out.bytestr()
+	// Transfer the private, NUL-terminated buffer; no mutable alias escapes.
+	return unsafe { tos(out.data, out_len) }
 }
 
 fn sanitize_complex(name string) string {

--- a/vlib/v3/gen/c/naming/naming_test.v
+++ b/vlib/v3/gen/c/naming/naming_test.v
@@ -1,0 +1,18 @@
+module naming
+
+@[manualfree]
+fn test_sanitize_dotted_name_owns_string_storage() {
+	name := '.alpha..beta.'.clone()
+	result := sanitize(name)
+	unsafe { name.free() }
+	assert result == '__alpha____beta__'
+	// Check the C terminator as well as the V string contents.
+	assert unsafe { result.str[result.len] } == 0
+	// A normal string must own a freeable buffer, not an array's interior pointer.
+	unsafe { result.free() }
+}
+
+fn test_sanitize_dotted_name_autofree() {
+	result := sanitize('alpha.beta')
+	assert result == 'alpha__beta'
+}

--- a/vlib/v3/gen/c/parallel_worker_test.v
+++ b/vlib/v3/gen/c/parallel_worker_test.v
@@ -38,6 +38,24 @@ fn test_scoped_parallel_dispatch_worker_owns_string_snapshot() {
 	assert g.str_lits == ['source', 'master generated']
 }
 
+fn test_scoped_parallel_dispatch_workers_detach_shared_string_snapshot() {
+	mut g, _ := parallel_worker_test_gen(true)
+	assert g.intern_string('source') == 0
+	g.str_lits_shared = true
+	mut first := g.new_parallel_dispatch_worker(1)
+	mut second := g.new_parallel_dispatch_worker(2)
+	assert first.str_lits_shared
+	assert second.str_lits_shared
+	assert g.intern_string('master generated') == 1
+	assert first.str_lits == ['source']
+	assert first.intern_string('first generated') == 1
+	assert second.str_lits == ['source']
+	assert second.intern_string('second generated') == 1
+	assert g.str_lits == ['source', 'master generated']
+	assert first.str_lits == ['source', 'first generated']
+	assert second.str_lits == ['source', 'second generated']
+}
+
 fn test_scoped_parallel_worker_reuses_preselected_functions_and_c_extern_refs() {
 	mut g, _ := parallel_worker_test_gen(true)
 	g.fn_gen_items = [FlatFnGenItem{

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -2234,11 +2234,12 @@ fn (g &FlatGen) scalar_zero_init(c_type string) string {
 
 // StructDeclInfo stores struct decl info metadata used by c.
 struct StructDeclInfo {
-	node      flat.Node
-	node_id   int
-	module    string
-	file      string
-	full_name string
+	node          flat.Node
+	node_id       int
+	module        string
+	file          string
+	full_name     string
+	shared_fields []flat.NodeId
 }
 
 struct SoaFieldInfo {
@@ -2305,6 +2306,9 @@ fn (g &FlatGen) shared_alias_pointer_type_from_text(raw string) ?types.Type {
 			base_type: g.tc.parse_type(inner)
 		})
 	}
+	if g.shared_alias_index_ready && g.shared_alias_pointer_shorts.len == 0 {
+		return none
+	}
 	for candidate in [clean, g.tc.qualify_name(clean)] {
 		if target := g.tc.type_aliases[candidate] {
 			if inner := shared_inner_type_text(target) {
@@ -2328,6 +2332,7 @@ fn (g &FlatGen) shared_alias_pointer_type_from_text(raw string) ?types.Type {
 }
 
 fn (mut g FlatGen) precompute_shared_alias_pointer_shorts() {
+	g.shared_alias_index_ready = true
 	for name, target in g.tc.type_aliases {
 		inner := shared_inner_type_text(target) or { continue }
 		short := name.all_after_last('.')
@@ -3071,9 +3076,9 @@ fn (mut g FlatGen) generic_shared_field_info(type_name string, field_name string
 	defer {
 		g.tc.cur_module = old_module
 	}
-	for i in 0 .. info.node.children_count {
-		field := g.a.child_node(&info.node, i)
-		if field.kind != .field_decl || field.value != field_name {
+	for field_id in info.shared_fields {
+		field := g.a.node(field_id)
+		if field.value != field_name {
 			continue
 		}
 		inner := shared_inner_type_text(field.typ) or { return none }
@@ -3101,9 +3106,9 @@ fn (mut g FlatGen) shared_field_info(type_name string, field_name string) ?Share
 	defer {
 		g.tc.cur_module = old_module
 	}
-	for i in 0 .. info.node.children_count {
-		field := g.a.child_node(&info.node, i)
-		if field.kind != .field_decl || field.value != field_name {
+	for field_id in info.shared_fields {
+		field := g.a.node(field_id)
+		if field.value != field_name {
 			continue
 		}
 		inner := shared_inner_type_text(field.typ) or { return none }

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -708,6 +708,7 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 	// skipping a repeat performs no fewer markings.
 	mut safe_alias_done := map[string]bool{}
 	mut iface_tail_done := map[string]bool{}
+	mut processed_module_calls := map[string]map[string]bool{}
 	safe_alias_done.reserve(u32(fn_decls.len))
 	iface_tail_done.reserve(u32(fn_decls.len))
 	if tc.verbose {
@@ -827,12 +828,24 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 				}
 			}
 			for initializer_ref in initializer_refs {
-				enqueue_initializer_ref_calls(a, collector, fn_decls, initializer_ref, mut
-					processed_initializer_refs, mut initializer_calls, mut used, mut queue)
+				enqueue_initializer_ref_calls(a, collector, fn_decls, initializer_ref, mut processed_initializer_refs, mut initializer_calls, mut used, mut queue)
 			}
 			total_callees += unique_call_count
+			// With no generic discovery, callee processing depends only on the
+			// name and caller module. Resolve repeated edges once across the BFS.
+			mut module_calls := if !detect_reachable_generics {
+				processed_module_calls[fn_info.module] or { map[string]bool{} }
+			} else {
+				map[string]bool{}
+			}
 			for call_idx in 0 .. unique_call_count {
 				callee := calls[call_idx]
+				if !detect_reachable_generics {
+					if module_calls[callee] {
+						continue
+					}
+					module_calls[callee] = true
+				}
 				if !valid_symbol_name(callee) {
 					continue
 				}
@@ -940,6 +953,9 @@ fn mark_used_with_test_files(a &flat.FlatAst, tc &types.TypeChecker, test_files 
 						}
 					}
 				}
+			}
+			if !detect_reachable_generics {
+				processed_module_calls[fn_info.module] = module_calls.move()
 			}
 		}
 		new_added := queue.len - prev_len

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -4601,13 +4601,13 @@ fn (c &CallCollector) collect_calls_with_locals_and_generics(node &flat.Node, cu
 					&& child.children_count > 0 {
 					base := c.a.child_node(child, 0)
 					if base.kind == .ident && base.value.len > 0 && child.value.len > 0 {
-						c.add_initializer_ref_candidates('${base.value}.${child.value}',
-							cur_module, imports, mut initializer_refs)
+						c.add_initializer_ref_candidates('${base.value}.${child.value}', cur_module, imports, mut initializer_refs)
 					}
 				}
-				if c.selector_is_enum_value(child, cur_module, imports, local_values) {
-					// Enum fields are values even when a method has the same name.
-				} else if !source_edges_authoritative {
+				// Authoritative checker edges already cover source function values.
+				// Enum classification is only needed by the fallback collector.
+				if !source_edges_authoritative
+					&& !c.selector_is_enum_value(child, cur_module, imports, local_values) {
 					c.collect_fn_value_selector(child_id, child, cur_module, imports, mut calls)
 				}
 			}
@@ -6639,6 +6639,11 @@ fn markused_index_overload_compound_type_is_string(typ types.Type) bool {
 
 // collect_struct_operator_call updates collect struct operator call state for markused.
 fn (c &CallCollector) collect_struct_operator_call(lhs_id flat.NodeId, op flat.Op, cur_module string, local_types map[string]string, mut calls []string) {
+	// Logical/bitwise operators cannot dispatch to a struct overload. Avoid
+	// resolving their operand types merely to discover that after the lookup.
+	if markused_struct_operator_symbol(op) == none {
+		return
+	}
 	lhs_type := c.operator_lhs_type(lhs_id, local_types)
 	c.collect_struct_operator_call_for_type(lhs_type, op, cur_module, mut calls)
 }

--- a/vlib/v3/parser/comptime_prepass_skip_test.v
+++ b/vlib/v3/parser/comptime_prepass_skip_test.v
@@ -1,0 +1,49 @@
+module parser
+
+import v3.pref
+import v3.scanner
+import v3.token
+
+fn test_comptime_prepass_resolver_preserves_line_and_column() {
+	source := 'module main\n\n  const value = 42\n'
+	prefs := pref.new_preferences()
+	mut p := Parser.new(prefs)
+	pos := source.index('const') or { panic('missing declaration') }
+	assert p.resolve_parallel_comptime_prepass_at_token('@LINE', pos, source, 'prepass.v', 'main') == "'3'"
+	assert p.resolve_parallel_comptime_prepass_at_token('@COLUMN', pos, source, 'prepass.v', 'main') == "'3'"
+}
+
+fn test_comptime_prepass_block_skip_matches_scanner_boundaries() {
+	for body in [
+		'{ if true { value := 123 + 456 } }',
+		'{ text := "} {"; raw := r"\${ untouched }"; ch := `}` }',
+		'{ text := "value: \${if true { "nested \${42}" } else { "}" }}" }',
+		'{ /* } /* { */ } */ value := 1 // }\n }',
+		'{\n#flag -DIGNORED={\nvalue := 1\n}',
+	] {
+		source := body + '\nconst after_body = 42\n'
+		prefs := pref.new_preferences()
+		mut fs := token.FileSet.new()
+		file := fs.add_file('prepass.v', source.len)
+		mut expected := scanner.new_scanner(prefs, .normal)
+		expected.init(file, source)
+		assert expected.scan() == .lcbr
+		mut actual := expected
+		mut depth := 1
+		for depth > 0 {
+			tok := expected.scan()
+			assert tok != .eof
+			if tok == .lcbr {
+				depth++
+			} else if tok == .rcbr {
+				depth--
+			}
+		}
+		skip_parallel_comptime_block(mut actual)
+		assert actual.offset == expected.offset, body
+		for _ in 0 .. 5 {
+			assert actual.scan() == expected.scan(), body
+			assert actual.lit == expected.lit, body
+		}
+	}
+}

--- a/vlib/v3/parser/local_type_index_test.v
+++ b/vlib/v3/parser/local_type_index_test.v
@@ -1,0 +1,49 @@
+module parser
+
+import os
+import v3.pref
+import v3.token
+
+fn test_local_type_index_keeps_nested_block_names_separate() {
+	source := 'struct Top {}
+fn run() {
+	_ := "struct Quoted {}"
+	/* union Comment {} */
+	_ := Outer{}
+	struct Outer {}
+	if true {
+		_ := Inner{}
+		union Inner { value int }
+	}
+	callback := fn () {
+		struct Captured {}
+	}
+}
+'
+	mut p := Parser.new(pref.new_preferences())
+	mut fs := token.FileSet.new()
+	file := fs.add_file('local_types.v', source.len)
+	p.s.init(file, source)
+	p.index_local_type_declarations()
+	outer := (source.index('fn run() ') or { panic(err) }) + 'fn run() '.len
+	inner := (source.index('if true ') or { panic(err) }) + 'if true '.len
+	callback := (source.index('fn () ') or { panic(err) }) + 'fn () '.len
+	assert p.local_type_decls_by_block.len == 3
+	assert p.local_type_decls_by_block[outer] == ['Outer']
+	assert p.local_type_decls_by_block[inner] == ['Inner']
+	assert p.local_type_decls_by_block[callback] == ['Captured']
+}
+
+fn test_local_type_index_is_reset_between_files() {
+	root := os.join_path(os.vtmp_dir(), 'v3_local_type_index_${os.getpid()}')
+	os.mkdir_all(root)!
+	defer { os.rmdir_all(root) or {} }
+	mut p := Parser.new(pref.new_preferences())
+	for name in ['First', 'Other'] {
+		path := os.join_path(root, '${name}.v')
+		os.write_file(path, 'fn run() {\n _ := ${name}{}\n struct ${name} {}\n}\n')!
+		p.parse_file(path)
+		assert p.diagnostics.len == 0, p.diagnostics.str()
+		assert p.local_type_decls_by_block[9] == [name]
+	}
+}

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -115,6 +115,8 @@ mut:
 	parsing_inferred_fixed_array_type bool
 	diagnostic_limit_reached          bool
 	local_type_names                  map[string]string
+	local_type_decls_by_block         map[int][]string
+	local_type_decls_indexed          bool
 	local_type_scopes                 []string
 	anonymous_struct_types            map[string][]string
 	anonymous_struct_count            int
@@ -223,6 +225,8 @@ pub fn (mut p Parser) release_source_storage() {
 	p.cur_struct = ''
 	p.pending_export = ''
 	p.local_type_names = map[string]string{}
+	p.local_type_decls_by_block = map[int][]string{}
+	p.local_type_decls_indexed = false
 	p.export_records = []ExportRecord{}
 	p.s.src = ''
 	p.s.lit = ''
@@ -290,6 +294,8 @@ pub fn (mut p Parser) parse_into(path string) {
 	p.in_for_container = false
 	p.parsing_inferred_fixed_array_type = false
 	p.local_type_scopes = []string{}
+	p.local_type_decls_by_block = map[int][]string{}
+	p.local_type_decls_indexed = false
 	p.anonymous_struct_types = map[string][]string{}
 	p.anonymous_struct_count = 0
 	p.sql_query_data_aliases.clear()
@@ -13452,52 +13458,87 @@ fn (mut p Parser) predeclare_local_type_names_in_block(open_brace_pos int) {
 	if scope.len == 0 || open_brace_pos < 0 || open_brace_pos >= p.s.src.len {
 		return
 	}
+	if !p.local_type_decls_indexed {
+		p.index_local_type_declarations()
+	}
+	for name in p.local_type_decls_by_block[open_brace_pos] {
+		p.declare_local_type_name(name, scope)
+	}
+}
+
+// Index raw lexical blocks once. Forward declarations in a block must not see
+// names from its nested blocks, and the scanner owns string/comment boundaries.
+@[direct_array_access]
+fn (mut p Parser) index_local_type_declarations() {
+	p.local_type_decls_indexed = true
 	mut s := scanner.new_scanner(p.prefs, .normal)
 	s.init(p.s.current_file(), p.s.src)
-	s.offset = open_brace_pos + 1
-	s.pos = s.offset
-	mut depth := 0
+	mut blocks := []int{}
+	mut expecting_name := false
+	mut name := ''
+	mut block := -1
 	for {
+		if !expecting_name && name.len == 0 && !s.in_str_incomplete && !s.in_str_inter {
+			// Only braces and declaration keywords matter here. Skip ordinary
+			// expressions without asking the scanner to classify every token.
+			src := s.src
+			src_len := src.len
+			mut off := s.offset
+			for off < src_len {
+				c := src[off]
+				if c == `{` || c == `}` || c == `/` || c == `'` || c == `"` || c == `\``
+					|| c == `#` {
+					break
+				}
+				if c == `r` || c == `c` {
+					if off + 1 < src_len && (src[off + 1] == `'` || src[off + 1] == `"`) {
+						break
+					}
+				} else if (c == `s` && off + 6 <= src_len && src[off + 1] == `t`
+					&& src[off + 2] == `r` && src[off + 3] == `u` && src[off + 4] == `c`
+					&& src[off + 5] == `t`) || (c == `u` && off + 5 <= src_len
+					&& src[off + 1] == `n` && src[off + 2] == `i` && src[off + 3] == `o`
+					&& src[off + 4] == `n`) {
+					prev := if off > 0 { src[off - 1] } else { u8(0) }
+					if !prev.is_alnum() && prev != `_` && prev < 128 {
+						break
+					}
+				}
+				off++
+			}
+			s.offset = off
+		}
 		tok := s.scan()
+		if name.len > 0 {
+			if tok != .dot {
+				p.local_type_decls_by_block[block] << name
+			}
+			name = ''
+		}
+		if expecting_name {
+			if tok == .name {
+				name = s.lit
+			}
+			expecting_name = false
+		}
 		if tok == .eof {
 			return
 		}
 		if tok == .lcbr {
-			depth++
-			continue
-		}
-		if tok == .rcbr {
-			if depth == 0 {
-				return
+			blocks << s.pos
+		} else if tok == .rcbr {
+			if blocks.len > 0 {
+				blocks.delete_last()
 			}
-			depth--
-			continue
-		}
-		if depth != 0 || (tok != .key_struct && tok != .key_union) {
-			continue
-		}
-		name_tok := s.scan()
-		if name_tok == .lcbr {
-			depth++
-			continue
-		}
-		if name_tok != .name {
-			continue
-		}
-		name := s.lit
-		after_name_tok := s.scan()
-		if after_name_tok != .dot {
-			p.declare_local_type_name(name, scope)
-		}
-		if after_name_tok == .lcbr {
-			depth++
-			continue
+		} else if tok in [.key_struct, .key_union] && blocks.len > 0 {
+			block = blocks.last()
+			expecting_name = true
 		}
 	}
 }
 
 fn (p &Parser) resolve_local_type_name(name string) string {
-	if p.local_type_scopes.len == 0 || name.len == 0 {
+	if p.local_type_names.len == 0 || p.local_type_scopes.len == 0 || name.len == 0 {
 		return name
 	}
 	mut suffix := ''

--- a/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
@@ -400,7 +400,6 @@ fn (mut p Parser) precollect_parallel_comptime_consts(paths []string, start int,
 // the ordered worker-prefix snapshots.
 fn (mut p Parser) precollect_parallel_comptime_scope(mut s scanner.Scanner, src string, path string, module_name string, stop_at_rcbr bool, mut values map[string]string, mut decls []ComptimeConstPrepassDecl) string {
 	mut current_module := module_name
-	mut brace_depth := 0
 	mut has_pending_attrs := false
 	mut pending_decl_disabled := false
 	for {
@@ -409,20 +408,13 @@ fn (mut p Parser) precollect_parallel_comptime_scope(mut s scanner.Scanner, src 
 			return current_module
 		}
 		if tok == .lcbr {
-			brace_depth++
+			skip_parallel_comptime_block(mut s)
 			continue
 		}
 		if tok == .rcbr {
-			if brace_depth > 0 {
-				brace_depth--
-				continue
-			}
 			if stop_at_rcbr {
 				return current_module
 			}
-			continue
-		}
-		if brace_depth != 0 {
 			continue
 		}
 		if tok == .dollar {
@@ -716,7 +708,13 @@ fn (p &Parser) new_parallel_comptime_prepass_resolver(src string, path string, m
 	resolver.cur_module = module_name
 	mut file_set := token.FileSet.new()
 	mut file := file_set.add_file(path, src.len)
-	file.index_lines(src)
+	// This temporary file is only used for pseudo-variable positions. The full
+	// parser hashes the source once when it creates the file retained by the AST.
+	for i, c in src {
+		if c == `\n` {
+			file.add_line(i + 1)
+		}
+	}
 	resolver.s.init(file, src)
 	return resolver
 }
@@ -731,9 +729,24 @@ fn parallel_comptime_prepass_token_text(tok token.Token, s &scanner.Scanner, src
 	return s.lit
 }
 
+@[direct_array_access]
 fn skip_parallel_comptime_block(mut s scanner.Scanner) {
 	mut depth := 1
 	for depth > 0 {
+		// Only block boundaries matter in a skipped declaration body. Let the
+		// scanner handle comments, directives and quoted/interpolated text, but
+		// avoid classifying every identifier and operator in the body twice.
+		if !s.in_str_incomplete && !s.in_str_inter {
+			for s.offset < s.src.len {
+				c := s.src[s.offset]
+				if c in [`{`, `}`, `/`, `'`, `"`, `\``, `#`]
+					|| (c in [`r`, `c`] && s.offset + 1 < s.src.len
+						&& s.src[s.offset + 1] in [`'`, `"`]) {
+					break
+				}
+				s.offset++
+			}
+		}
 		tok := s.scan()
 		if tok == .eof {
 			return

--- a/vlib/v3/tests/loop_smartcast_mut_call_write_test.v
+++ b/vlib/v3/tests/loop_smartcast_mut_call_write_test.v
@@ -572,3 +572,44 @@ fn main() {
 ')
 	assert unrelated_out == '4'
 }
+
+fn test_nearest_mixed_branch_smartcasts() {
+	v3_bin := loop_smartcast_build_v3()
+	output := loop_smartcast_run_good(v3_bin, 'nearest_mixed_branch_smartcasts', 'struct A { value int }
+struct B {}
+struct C {}
+type Inner = A | B
+type Outer = C | Inner
+fn from_if(v Outer) int {
+ if v is Inner {
+  match v {
+   A { return v.value }
+   else {}
+  }
+ }
+ return 0
+}
+fn from_match(v Outer) int {
+ match v {
+  Inner {
+   if v is A { return v.value }
+  }
+  else {}
+ }
+ return 0
+}
+fn from_loop(v Outer) int {
+ if v is Inner {
+  for v is A { return v.value }
+ }
+ return 0
+}
+fn main() {
+ a := Outer(Inner(A{value: 42}))
+ println(from_if(a))
+ println(from_match(a))
+ println(from_loop(a))
+}
+')
+	assert output == '42\n42\n42'
+}

--- a/vlib/v3/tests/markused_test.v
+++ b/vlib/v3/tests/markused_test.v
@@ -468,6 +468,21 @@ fn main() {
 	assert used['default_target']
 }
 
+fn test_non_generic_repeated_calls_keep_each_modules_dependencies() {
+	a, tc := parse_checked_project('repeated_module_edges_${os.getpid()}', {
+		'main.v':    'module main\nimport one\nimport two\nfn main() { one.first() one.second() two.first() two.second() }'
+		'one/one.v': 'module one\npub fn first() { leaf() }\npub fn second() { leaf() }\nfn leaf() { tail() }\nfn tail() {}\nfn unused() {}'
+		'two/two.v': 'module two\npub fn first() { leaf() }\npub fn second() { leaf() }\nfn leaf() { tail() }\nfn tail() {}\nfn unused() {}'
+	}, 'main.v')
+	used := markused.mark_used_without_generic_detection(a, tc)
+	for mod in ['one', 'two'] {
+		for name in ['first', 'second', 'leaf', 'tail'] {
+			assert used['${mod}.${name}']
+		}
+		assert !used['${mod}.unused']
+	}
+}
+
 fn test_self_typed_default_collects_explicit_initializer_calls() {
 	used := mark_used_source('self_typed_default_explicit_call', '
 interface Value {}

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -669,12 +669,9 @@ fn (t &Transformer) resolve_alias_receiver_method(base_type string, method strin
 		}
 		return none
 	}
-	for name, params in t.tc.fn_param_types {
-		if !name.ends_with('.${method}') || params.len == 0 {
-			continue
-		}
-		receiver_name := name.all_before_last('.')
-		if receiver_name.len == 0 || receiver_name !in t.tc.type_aliases {
+	for name in t.alias_receiver_method_candidates(method) {
+		params := t.tc.fn_param_types[name]
+		if params.len == 0 {
 			continue
 		}
 		param_name := t.semantic_type_name(params[0])
@@ -691,6 +688,26 @@ fn (t &Transformer) resolve_alias_receiver_method(base_type string, method strin
 		cache.misses[cache_key] = true
 	}
 	return none
+}
+
+fn (t &Transformer) alias_receiver_method_candidates(method string) []string {
+	// Generic-free lowering cannot add source alias receiver methods. Preserve
+	// declaration order while avoiding a whole signature-table scan per miss.
+	if t.skip_generics && t.alias_method_candidates_ready {
+		return t.alias_method_candidates[method]
+	}
+	mut candidates := []string{}
+	method_suffix := '.${method}'
+	for name, params in t.tc.fn_param_types {
+		if params.len == 0 || !name.ends_with(method_suffix) {
+			continue
+		}
+		receiver_name := name.all_before_last('.')
+		if receiver_name.len > 0 && receiver_name in t.tc.type_aliases {
+			candidates << name
+		}
+	}
+	return candidates
 }
 
 // alias_target_type_preserving_main_lock returns the underlying type while retaining

--- a/vlib/v3/transform/fn_test.v
+++ b/vlib/v3/transform/fn_test.v
@@ -3,6 +3,122 @@ module transform
 import v3.flat
 import v3.types
 
+fn test_cloned_worker_merge_replays_relocated_children_and_body_roots() {
+	// 'plain' copies and relocates inside the serial merge, 'relocated' relocates
+	// the worker region in parallel first, and 'absorbed' also writes it straight
+	// into the master's pre-grown arrays. All three must merge identically.
+	for mode in ['plain', 'relocated', 'absorbed'] {
+		mut a := flat.FlatAst.new()
+		leaf := a.add_node(flat.Node{ kind: .int_literal, value: '1' })
+		base_slot := a.children.len
+		a.add_child(leaf)
+		fn_id := a.add_node(flat.Node{
+			kind: .fn_decl
+			value: 'helper'
+			children_start: base_slot
+			children_count: 1
+		})
+		mut tc := types.TypeChecker.new(&a)
+		mut master := new_transformer(mut a, &tc, map[string]bool{})
+		base_nodes := a.nodes.len
+		base_children := a.children.len
+		mut worker_ast := master.clone_ast_base(base_nodes, base_children)
+		worker_tc := tc.fork_for_parallel_transform(worker_ast)
+		mut worker := master.fork_worker(worker_ast, worker_tc)
+		new_leaf := worker_ast.add_node(flat.Node{ kind: .int_literal, value: '2' })
+		worker_ast.add_child(leaf)
+		worker_ast.add_child(new_leaf)
+		body := worker_ast.add_node(flat.Node{
+			kind: .block
+			children_start: base_children
+			children_count: 2
+		})
+		worker_ast.add_child(body)
+		worker_ast.nodes[int(fn_id)] = flat.Node{
+			kind: .fn_decl
+			value: 'helper'
+			children_start: base_children + 2
+			children_count: 1
+		}
+		worker_ast.children[base_slot] = new_leaf
+		worker.inplace_child_log << InplaceChildRewrite{ slot: base_slot, child: new_leaf }
+		a.add_node(flat.Node{ kind: .int_literal, value: '3' })
+		a.add_child(leaf)
+		merged_leaf := flat.NodeId(a.nodes.len)
+		merged_body := flat.NodeId(a.nodes.len + 1)
+		node_shift := i32(a.nodes.len - base_nodes)
+		child_shift := i32(a.children.len - base_children)
+		if mode == 'relocated' {
+			worker.relocate_region_in_place(base_nodes, worker_ast.nodes.len, base_children, worker_ast.children.len, node_shift, child_shift)
+			master.merge_regions_relocated = true
+		} else if mode == 'absorbed' {
+			nodes_dst := a.nodes.len
+			children_dst := a.children.len
+			unsafe {
+				a.nodes.grow_len(worker_ast.nodes.len - base_nodes)
+				a.children.grow_len(worker_ast.children.len - base_children)
+			}
+			worker.absorb_region_into(base_nodes, worker_ast.nodes.len, base_children, worker_ast.children.len, node_shift, child_shift, unsafe { voidptr(&a.nodes[nodes_dst]) }, unsafe { voidptr(&a.children[children_dst]) })
+			master.merge_regions_relocated = true
+			master.merge_regions_absorbed = true
+			master.merge_absorbed_node_shift = node_shift
+			master.merge_absorbed_child_shift = child_shift
+		}
+		master.merge_worker(worker, [FnWorkItem{ fn_idx: int(fn_id) }], base_nodes, base_children, false)
+		master.merge_regions_absorbed = false
+		assert a.children[base_slot] == merged_leaf
+		assert a.child(a.node(fn_id), 0) == merged_body
+		assert a.child(a.node(merged_body), 0) == leaf
+		assert a.child(a.node(merged_body), 1) == merged_leaf
+	}
+}
+
+fn test_parallel_split_balances_equal_cost_functions() {
+	mut items := []FnWorkItem{}
+	for i in 0 .. 40 {
+		items << FnWorkItem{
+			fn_idx: i
+			cost: 100
+			rank: 100
+		}
+	}
+	chunks := split_work_items(items, 4)
+	mut seen := map[int]bool{}
+	for chunk in chunks {
+		assert chunk.len == 10
+		mut previous := -1
+		for item in chunk {
+			assert item.fn_idx > previous
+			assert item.fn_idx !in seen
+			seen[item.fn_idx] = true
+			previous = item.fn_idx
+		}
+	}
+	assert seen.len == items.len
+}
+
+fn test_alias_receiver_index_preserves_integer_fallback_order() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	tc.type_aliases['Count'] = 'i64'
+	tc.type_aliases['OtherCount'] = 'i32'
+	tc.fn_param_types['Plain.show'] = [types.Type(types.i64_)]
+	tc.fn_param_types['Count.show'] = [types.Type(types.i64_)]
+	tc.fn_param_types['OtherCount.show'] = [types.Type(types.i32_)]
+	tc.fn_param_types['Count.other'] = [types.Type(types.i64_)]
+	mut t := new_transformer(mut a, &tc, map[string]bool{})
+	assert t.resolve_alias_receiver_method('u8', 'show') or { '' } == 'Count.show'
+	t.collect_alias_methods()
+	t.skip_generics = true
+	assert t.resolve_alias_receiver_method('u16', 'show') or { '' } == 'Count.show'
+	assert t.resolve_alias_receiver_method('u16', 'missing') == none
+	// Generic lowering can add signatures after preparation and uses the live table.
+	t.skip_generics = false
+	tc.type_aliases['LateCount'] = 'u64'
+	tc.fn_param_types['LateCount.late'] = [types.Type(types.u64_)]
+	assert t.resolve_alias_receiver_method('u8', 'late') or { '' } == 'LateCount.late'
+}
+
 fn test_generic_app_parts_distinguishes_postfix_fixed_arrays() {
 	_, _, numeric_fixed := generic_app_parts('C.sg_color_attachment_action[4]')
 	assert !numeric_fixed
@@ -674,4 +790,16 @@ fn test_immediate_closure_thread_result_may_alias_capture() {
 
 	without_checker := Transformer{}
 	assert without_checker.immediate_closure_result_may_alias_capture('thread int')
+}
+
+fn test_transform_lane_budget_bounds_base_ast_clones() {
+	// A self-host sized base AST (~95 MiB per clone) keeps every runtime lane.
+	assert transform_clone_budget_jobs(18, 100_000_000) == 18
+	// Ten times that program size only affords two helper clones.
+	assert transform_clone_budget_jobs(18, 1_000_000_000) == 3
+	// Oversized inputs fall back to the master without a helper clone.
+	assert transform_clone_budget_jobs(2, 9_000_000_000) == 1
+	assert transform_clone_budget_jobs(8, 9_000_000_000) == 1
+	assert transform_clone_budget_jobs(18, 1) == 18
+	assert transform_clone_budget_jobs(1, 9_000_000_000) == 1
 }

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -143,6 +143,8 @@ mut:
 	non_main_type_index_ready     bool
 	unique_fields                 map[string]string
 	alias_methods                 map[string]string
+	alias_method_candidates       map[string][]string
+	alias_method_candidates_ready bool
 	globals                       map[string]string
 	sum_types                     map[string][]string
 	sum_variant_parents           map[string][]string
@@ -170,6 +172,12 @@ mut:
 	// merge_regions_relocated marks worker regions as already id-relocated in
 	// place (parallel pass), so merge_worker compacts with plain memmoves.
 	merge_regions_relocated bool
+	// merge_regions_absorbed marks worker regions as already relocated *into*
+	// their final master slots by that same parallel pass, so merge_worker skips
+	// the bulk copies entirely and shifts ids with the offsets recorded below.
+	merge_regions_absorbed     bool
+	merge_absorbed_node_shift  i32
+	merge_absorbed_child_shift i32
 	// const_array_fixed_storage_cache avoids rescanning the complete AST for
 	// repeated uses of the same array constant in one transform worker.
 	const_array_fixed_storage_cache map[string]i8
@@ -1584,18 +1592,19 @@ fn (mut t Transformer) mark_fn_used_name(name string) {
 	if name.len == 0 {
 		return
 	}
-	if !t.used_fn_contains_name(name) && !t.used_fn_contains_name(c_name(name))
+	lowered := if isnil(t.tc) { c_name(name) } else { t.tc.cached_c_name(name) }
+	if !t.used_fn_contains_name(name) && !t.used_fn_contains_name(lowered)
 		&& t.enum_method_name_shadows_field(name) {
 		return
 	}
 	t.mark_used_fn_key(name)
-	t.mark_used_fn_key(c_name(name))
+	t.mark_used_fn_key(lowered)
 	if t.cur_module.len > 0 && t.cur_module != 'main' && t.cur_module != 'builtin' {
 		needs_module_prefix := !name.contains('.') || local_method_fn_name_needs_module_prefix(name)
 		if needs_module_prefix && !name.starts_with('${t.cur_module}.') {
 			qname := '${t.cur_module}.${name}'
 			t.mark_used_fn_key(qname)
-			t.mark_used_fn_key(c_name(qname))
+			t.mark_used_fn_key(if isnil(t.tc) { c_name(qname) } else { t.tc.cached_c_name(qname) })
 		}
 	}
 }
@@ -2951,6 +2960,7 @@ fn (mut t Transformer) collect_alias_methods() {
 			continue
 		}
 		method := name.all_after_last('.')
+		t.alias_method_candidates[method] << name
 		param_name := params[0].name()
 		clean_alias := if param_name.starts_with('&') { param_name[1..] } else { param_name }
 		alias_target := t.normalize_type_alias(clean_alias)
@@ -2962,6 +2972,7 @@ fn (mut t Transformer) collect_alias_methods() {
 			t.alias_methods[key] = name
 		}
 	}
+	t.alias_method_candidates_ready = true
 }
 
 // normalize_sum_variant_type transforms normalize sum variant type data for transform.
@@ -3923,6 +3934,8 @@ fn (t &Transformer) fork_program_view(ast &flat.FlatAst, wtc &types.TypeChecker,
 		non_main_type_index_ready: t.non_main_type_index_ready
 		unique_fields: t.unique_fields
 		alias_methods: t.alias_methods
+		alias_method_candidates: t.alias_method_candidates
+		alias_method_candidates_ready: t.alias_method_candidates_ready
 		globals: t.globals
 		sum_types: t.sum_types
 		sum_variant_parents: t.sum_variant_parents
@@ -4346,6 +4359,43 @@ fn (mut t Transformer) relocate_region_in_place(node_start int, node_end int, ch
 	}
 }
 
+// absorb_region_into is relocate_region_in_place with the relocated values
+// written straight into the master's pre-grown arrays, so the serial merge no
+// longer has to copy the region afterwards. Each worker owns a disjoint
+// destination slice, and the master's arrays cannot move while this runs.
+@[direct_array_access]
+fn (mut t Transformer) absorb_region_into(node_start int, node_end int, child_start int, child_end int, node_shift i32, child_shift i32, dst_nodes voidptr, dst_children voidptr) {
+	unsafe {
+		mut nodes_out := &flat.Node(dst_nodes)
+		for k in node_start .. node_end {
+			node := t.a.nodes[k]
+			nodes_out[k - node_start] = if node.children_start >= child_start {
+				node.with_shifted_children(child_shift)
+			} else {
+				node
+			}
+		}
+		mut children_out := &flat.NodeId(dst_children)
+		for j in child_start .. child_end {
+			cid := t.a.children[j]
+			children_out[j - child_start] = if int(cid) >= node_start {
+				flat.NodeId(int(cid) + int(node_shift))
+			} else {
+				cid
+			}
+		}
+	}
+	// The worker's rewrites of base-region child slots stay in its own array;
+	// merge_worker publishes them from there under the same shift.
+	for rewrite in t.inplace_child_log {
+		t.a.children[rewrite.slot] = if int(rewrite.child) >= node_start {
+			flat.NodeId(int(rewrite.child) + int(node_shift))
+		} else {
+			rewrite.child
+		}
+	}
+}
+
 // merge_worker folds a finished worker's transformed output back into the master
 // AST. The worker created its new nodes/children at indices base_nodes/base_children
 // (matching the master at fork time); here they are appended to the master and every
@@ -4353,22 +4403,33 @@ fn (mut t Transformer) relocate_region_in_place(node_start int, node_end int, ch
 // distance the block moved. `items` lists the function indices this worker owned, so
 // their rewritten top-level nodes can be copied into place.
 fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nodes int, base_children int, clear_node_caches bool) {
-	node_shift := i32(t.a.nodes.len - base_nodes)
-	child_shift := i32(t.a.children.len - base_children)
-	if !t.merge_regions_relocated {
-		for rewrite in w.inplace_child_log {
-			t.a.children[rewrite.slot] = if int(rewrite.child) >= base_nodes {
-				flat.NodeId(int(rewrite.child) + int(node_shift))
-			} else {
-				rewrite.child
-			}
+	// Absorbed regions were written straight into the master arrays, which are
+	// already grown to their final length, so the shifts come from the absorb
+	// pass instead of the current master length.
+	node_shift := if t.merge_regions_absorbed {
+		t.merge_absorbed_node_shift
+	} else {
+		i32(t.a.nodes.len - base_nodes)
+	}
+	child_shift := if t.merge_regions_absorbed {
+		t.merge_absorbed_child_shift
+	} else {
+		i32(t.a.children.len - base_children)
+	}
+	for rewrite in w.inplace_child_log {
+		t.a.children[rewrite.slot] = if t.merge_regions_relocated {
+			w.a.children[rewrite.slot]
+		} else if int(rewrite.child) >= base_nodes {
+			flat.NodeId(int(rewrite.child) + int(node_shift))
+		} else {
+			rewrite.child
 		}
 	}
 	// New children: bulk-copy the worker block, then relocate references to
 	// worker-local new nodes in place (a per-element push paid a capacity check
 	// and branch per child id).
 	new_children := w.a.children.len - base_children
-	if new_children > 0 {
+	if new_children > 0 && !t.merge_regions_absorbed {
 		old_len := t.a.children.len
 		unsafe {
 			t.a.children.grow_len(new_children)
@@ -4397,7 +4458,7 @@ fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nod
 	// points into the new children block in place (a per-element push paid a
 	// capacity check, a branch and a struct copy per node).
 	new_nodes := w.a.nodes.len - base_nodes
-	if new_nodes > 0 {
+	if new_nodes > 0 && !t.merge_regions_absorbed {
 		nodes_old_len := t.a.nodes.len
 		unsafe {
 			t.a.nodes.grow_len(new_nodes)
@@ -4737,48 +4798,12 @@ fn (mut t Transformer) clear_typechecker_node_cache(idx int) {
 	}
 }
 
-// split_work_items distributes items across `n` buckets using greedy
-// least-loaded-by-cost assignment, so heavy functions are spread evenly. The
-// assignment is deterministic for a given input (required for reproducible builds).
-// Buckets are seeded with a virtual load matching their thread's start delay in
-// the spawn chain (see run_parallel_transform): bucket 0 (the master) starts
-// after one AST clone, worker k starts after k+1 clones plus its own
-// clone-for-successor, and the last worker clones nothing. One `unit`
-// approximates one clone-time in cost terms, so all threads finish together.
+// split_work_items distributes functions evenly by estimated cost. All pool
+// workers start after the base copies finish, so no startup bias is needed.
+// Sorting each bucket by source position preserves module cache locality.
 fn split_work_items(items []FnWorkItem, n int) [][]FnWorkItem {
-	return split_work_items_ex(items, n, true)
-}
-
-// split_work_items_ex is split_work_items with the spawn-chain stagger bias
-// made optional: the shared-base path spawns every worker up front, so only
-// the master keeps a lighter share (it pays for the merges afterwards).
-fn split_work_items_ex(items []FnWorkItem, n int, chain_stagger bool) [][]FnWorkItem {
 	mut buckets := [][]FnWorkItem{len: n, init: []FnWorkItem{}}
 	mut loads := []i64{len: n}
-	if n > 1 {
-		mut total := i64(0)
-		for it in items {
-			total += i64(it.cost) + 1
-		}
-		unit := total / i64(n * 16)
-		if chain_stagger {
-			// The master (bucket 0) also pays for the serial pre-phase warmup, the
-			// first worker clone, and the interleaved merges, and measures slower
-			// per cost unit than the helpers; give it a markedly lighter share.
-			loads[0] = unit * 5
-			for b in 1 .. n {
-				if b == n - 1 {
-					loads[b] = unit * i64(b)
-				} else {
-					loads[b] = unit * i64(b + 1)
-				}
-			}
-		} else {
-			// The persistent pool waits for every submitted callback before the
-			// master can merge. Keep shared-base chunks evenly loaded; staggering
-			// their finish times only lengthens the wait for the heaviest bucket.
-		}
-	}
 	mut sorted := items.clone()
 	sorted.sort(a.rank > b.rank)
 	for it in sorted {
@@ -14825,11 +14850,12 @@ fn (t &Transformer) find_multi_return_call_types(node flat.Node, expected_count 
 		return none
 	}
 	for candidate in candidates {
+		suffix := if candidate.starts_with('.') { candidate } else { '.${candidate}' }
 		for key, ret in t.multi_return_fn_ret_types {
 			matches := if candidate.starts_with('.') {
-				key.ends_with(candidate)
+				key.ends_with(suffix)
 			} else {
-				key == candidate || key.ends_with('.${candidate}')
+				key == candidate || key.ends_with(suffix)
 			}
 			if matches {
 				if items := multi_return_types_from_type(ret, expected_count) {

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -17,7 +17,11 @@ const min_parallel_transform_items = 256
 const max_parallel_transform_jobs = 7
 // Disposable self-host scratch permits more growable workers within the same
 // memory ceiling. Ordinary generic builds keep the smaller clone limit.
-const max_selfhost_transform_jobs = 12
+const max_selfhost_transform_jobs = 18
+// Every growable lane clones the base AST, so the lane count is also a memory
+// decision. Bound the combined clone size instead of trusting the lane cap
+// alone: a bigger program on the same machine then keeps its memory ceiling.
+const selfhost_transform_clone_budget_bytes = u64(2_600_000_000)
 // Shared-base workers share the AST but retain private checker and transform
 // scratch. Eight lanes keep large user builds below the ordinary memory ceiling.
 const max_shared_transform_jobs = 8
@@ -28,7 +32,7 @@ const shared_transform_chunks_per_job = 1
 const shared_expansion_pool_divisor = 2
 const max_parallel_monomorph_jobs = 18
 // Recycle scratch arenas throughout large self-hosting transforms.
-const scoped_transform_batches = 16
+const scoped_transform_batches = 8
 const scoped_transform_max_batch_items = 2048
 const scoped_monomorph_batch_specs = 512
 const scoped_monomorph_node_threshold = 1_000_000
@@ -50,9 +54,132 @@ $if !windows {
 	fn region_relocate_thread(arg voidptr) voidptr {
 		a := unsafe { &RegionRelocateArgs(arg) }
 		mut w := unsafe { &Transformer(a.worker) }
-		w.relocate_region_in_place(a.node_start, a.node_end, a.child_start, a.child_end,
-			a.node_shift, a.child_shift)
+		w.relocate_region_in_place(a.node_start, a.node_end, a.child_start, a.child_end, a.node_shift, a.child_shift)
 		return unsafe { nil }
+	}
+
+	// relocate_worker_regions computes final offsets in merge order, then lets
+	// each helper relocate its private appended region before the serial copy.
+	fn (mut t Transformer) relocate_worker_regions(worker_ptrs []voidptr, node_starts []int, child_starts []int) {
+		mut running_nodes := t.a.nodes.len
+		mut running_children := t.a.children.len
+		mut reloc_args := []RegionRelocateArgs{cap: worker_ptrs.len}
+		for ci, ptr in worker_ptrs {
+			w := unsafe { &Transformer(ptr) }
+			ns := node_starts[ci]
+			cs := child_starts[ci]
+			reloc_args << RegionRelocateArgs{
+				worker: ptr
+				node_start: ns
+				node_end: w.a.nodes.len
+				child_start: cs
+				child_end: w.a.children.len
+				node_shift: i32(running_nodes - ns)
+				child_shift: i32(running_children - cs)
+			}
+			running_nodes += w.a.nodes.len - ns
+			running_children += w.a.children.len - cs
+		}
+		mut tasks := []workers.Task{cap: reloc_args.len}
+		for i in 0 .. reloc_args.len {
+			tasks << workers.Task{
+				run: region_relocate_thread
+				arg: unsafe { voidptr(&reloc_args[i]) }
+				force_sync: i == 0
+			}
+		}
+		t.a.worker_pool.run(tasks)
+		t.merge_regions_relocated = true
+	}
+
+	// RegionAbsorbArgs is one worker region's relocate-and-append job. The master
+	// grows its arrays to the final length first, so every worker can write its
+	// own disjoint destination slice at the same time and the merge that follows
+	// only has to publish annotations.
+	struct RegionAbsorbArgs {
+		worker      voidptr // &Transformer (region view)
+		node_start  int
+		node_end    int
+		child_start int
+		child_end   int
+		node_shift  i32
+		child_shift i32
+	mut:
+		dst_nodes    voidptr
+		dst_children voidptr
+	}
+
+	fn region_absorb_thread(arg voidptr) voidptr {
+		a := unsafe { &RegionAbsorbArgs(arg) }
+		mut w := unsafe { &Transformer(a.worker) }
+		w.absorb_region_into(a.node_start, a.node_end, a.child_start, a.child_end, a.node_shift, a.child_shift, a.dst_nodes, a.dst_children)
+		return unsafe { nil }
+	}
+
+	// absorb_worker_regions relocates every helper's appended region straight
+	// into its final master slot, in parallel. It records the per-worker shifts
+	// for the serial merge that follows and reports how many it prepared.
+	fn (mut t Transformer) absorb_worker_regions(worker_ptrs []voidptr, base_nodes int, base_children int) []RegionAbsorbArgs {
+		if worker_ptrs.len == 0 {
+			return []RegionAbsorbArgs{}
+		}
+		mut absorb_args := []RegionAbsorbArgs{cap: worker_ptrs.len}
+		mut running_nodes := t.a.nodes.len
+		mut running_children := t.a.children.len
+		nodes_old_len := t.a.nodes.len
+		children_old_len := t.a.children.len
+		for ptr in worker_ptrs {
+			w := unsafe { &Transformer(ptr) }
+			absorb_args << RegionAbsorbArgs{
+				worker: ptr
+				node_start: base_nodes
+				node_end: w.a.nodes.len
+				child_start: base_children
+				child_end: w.a.children.len
+				node_shift: i32(running_nodes - base_nodes)
+				child_shift: i32(running_children - base_children)
+			}
+			running_nodes += w.a.nodes.len - base_nodes
+			running_children += w.a.children.len - base_children
+		}
+		// One growth each: the destination pointers below must stay valid for the
+		// whole parallel pass, so no worker may trigger a reallocation.
+		if running_nodes > nodes_old_len {
+			unsafe {
+				t.a.nodes.grow_len(running_nodes - nodes_old_len)
+			}
+		}
+		if running_children > children_old_len {
+			unsafe {
+				t.a.children.grow_len(running_children - children_old_len)
+			}
+		}
+		// Address the destinations off the array bases: a worker that appended
+		// nothing lands exactly on the end of the array.
+		nodes_base := unsafe { &u8(t.a.nodes.data) }
+		children_base := unsafe { &u8(t.a.children.data) }
+		node_size := usize(t.a.nodes.element_size)
+		child_size := usize(t.a.children.element_size)
+		for i in 0 .. absorb_args.len {
+			node_off := usize(absorb_args[i].node_start + int(absorb_args[i].node_shift))
+			child_off := usize(absorb_args[i].child_start + int(absorb_args[i].child_shift))
+			absorb_args[i].dst_nodes = unsafe { voidptr(nodes_base + node_off * node_size) }
+			absorb_args[i].dst_children = unsafe {
+				voidptr(children_base + child_off * child_size)
+			}
+		}
+		mut tasks := []workers.Task{cap: absorb_args.len}
+		for i in 0 .. absorb_args.len {
+			tasks << workers.Task{
+				run: region_absorb_thread
+				arg: unsafe { voidptr(&absorb_args[i]) }
+				force_sync: i == 0
+			}
+		}
+		t.a.worker_pool.run(tasks)
+		t.merge_regions_relocated = true
+		t.merge_regions_absorbed = true
+		return absorb_args
 	}
 
 	// transform_pre_scan_index_thread builds the AST/tc-only prepare() indexes
@@ -2119,7 +2246,8 @@ fn (mut t Transformer) run_parallel_transform(items []FnWorkItem, base_nodes int
 		if isnil(t.a.worker_pool) {
 			t.a.worker_pool = workers.new(runtime.nr_jobs() - 1)
 		}
-		n_jobs := transform_job_count(t.a.worker_pool.size() + 1, items.len, t.building_v && t.scope_parallel_workers)
+		mut n_jobs := transform_job_count(t.a.worker_pool.size() + 1, items.len, t.building_v && t.scope_parallel_workers)
+		n_jobs = clamp_transform_jobs_to_clone_budget(n_jobs, base_nodes, base_children, t.a)
 		if items.len < min_parallel_transform_items || n_jobs <= 1 {
 			t.transform_pure_items_serial(items)
 			return false
@@ -2144,6 +2272,8 @@ fn (mut t Transformer) run_parallel_transform(items []FnWorkItem, base_nodes int
 		// do not re-parse every type text from a cold cache; the master itself
 		// writes through a private overlay for the duration of the region.
 		t.tc.freeze_type_cache_for_forks()
+		// Every clone is ready before dispatch. Equal loads avoid the old spawn
+		// chain's startup bias leaving early workers with much more body work.
 		mut chunks := split_work_items(items, n_jobs)
 		chunk_count := chunks.len
 
@@ -2211,12 +2341,25 @@ fn (mut t Transformer) run_parallel_transform(items []FnWorkItem, base_nodes int
 			}
 		}
 		any_started := t.a.worker_pool.run(tasks)
+		mut absorbed := []RegionAbsorbArgs{}
+		if t.building_v && t.scope_parallel_workers && t.retain_worker_results
+			&& os.getenv('V3_NO_MERGE_RELOC').len == 0 {
+			absorbed = t.absorb_worker_regions(transform_workers, base_nodes, base_children)
+		}
 		// Merge each helper in fixed chunk order for deterministic node ids.
 		for ci in 0 .. thread_count {
 			ww := unsafe { &Transformer(transform_workers[ci]) }
 			t.merge_worker_used_fns(ww)
-			t.merge_worker(ww, chunks[ci + 1], base_nodes, base_children, true)
+			if t.merge_regions_absorbed {
+				t.merge_absorbed_node_shift = absorbed[ci].node_shift
+				t.merge_absorbed_child_shift = absorbed[ci].child_shift
+			}
+			// Helpers append into fresh master IDs; their private caches cannot have
+			// populated this range. Publish only the relocated worker annotations.
+			t.merge_worker(ww, chunks[ci + 1], base_nodes, base_children, false)
 		}
+		t.merge_regions_absorbed = false
+		t.merge_regions_relocated = false
 		t.tc.unfreeze_type_cache_after_forks()
 		return any_started
 	}
@@ -2344,7 +2487,7 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 		if chunk_target > bounded_items.len {
 			chunk_target = bounded_items.len
 		}
-		mut chunks := split_work_items_ex(bounded_items, chunk_target, false)
+		mut chunks := split_work_items(bounded_items, chunk_target)
 		chunk_count := chunks.len
 		thread_count := chunk_count - 1
 		// Pool.run queues asynchronous work before running synchronous tasks. Give
@@ -2479,35 +2622,7 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 		// in merge_worker re-reads children_start values).
 		if thread_count > 0 && (t.retain_worker_results || t.stage_scope != unsafe { nil })
 			&& os.getenv('V3_NO_MERGE_RELOC').len == 0 {
-			mut running_nodes := t.a.nodes.len
-			mut running_children := t.a.children.len
-			mut reloc_args := []RegionRelocateArgs{cap: thread_count}
-			for ci in 0 .. thread_count {
-				ww := unsafe { &Transformer(args[ci + 1].worker) }
-				ns := node_starts[ci + 1]
-				cs := child_starts[ci + 1]
-				reloc_args << RegionRelocateArgs{
-					worker:      args[ci + 1].worker
-					node_start:  ns
-					node_end:    ww.a.nodes.len
-					child_start: cs
-					child_end:   ww.a.children.len
-					node_shift:  i32(running_nodes - ns)
-					child_shift: i32(running_children - cs)
-				}
-				running_nodes += ww.a.nodes.len - ns
-				running_children += ww.a.children.len - cs
-			}
-			mut reloc_tasks := []workers.Task{cap: thread_count}
-			for i in 0 .. reloc_args.len {
-				reloc_tasks << workers.Task{
-					run:        region_relocate_thread
-					arg:        unsafe { voidptr(&reloc_args[i]) }
-					force_sync: i == 0
-				}
-			}
-			t.a.worker_pool.run(reloc_tasks)
-			t.merge_regions_relocated = true
+			t.relocate_worker_regions(args[1..].map(it.worker), node_starts[1..chunk_count], child_starts[1..chunk_count])
 		}
 		// Compact each worker region in fixed order (deterministic
 		// node numbering). merge_worker treats the region start exactly like a
@@ -2723,14 +2838,40 @@ fn late_scan_chunk_bounds(a &flat.FlatAst, cands []LateFnCandidate, n int) []int
 	return bounds
 }
 
-// transform_job_count caps the worker count by both the runtime job count and a
-// fixed ceiling (each worker clones the base AST, so more workers cost more memory).
+// clamp_transform_jobs_to_clone_budget lowers the lane count until the private
+// base-AST clones fit selfhost_transform_clone_budget_bytes. The master works on
+// the shared base, so only the n-1 helper lanes clone.
+fn clamp_transform_jobs_to_clone_budget(n_jobs int, base_nodes int, base_children int, a &flat.FlatAst) int {
+	clone_bytes := u64(base_nodes) * u64(a.nodes.element_size) + u64(base_children) * u64(a.children.element_size)
+	return transform_clone_budget_jobs(n_jobs, clone_bytes)
+}
+
+// transform_clone_budget_jobs is the lane arithmetic behind
+// clamp_transform_jobs_to_clone_budget, split out so it can be checked without
+// building an AST.
+fn transform_clone_budget_jobs(n_jobs int, clone_bytes u64) int {
+	if n_jobs <= 1 || clone_bytes == 0 {
+		return n_jobs
+	}
+	affordable := selfhost_transform_clone_budget_bytes / clone_bytes
+	if affordable >= u64(n_jobs - 1) {
+		return n_jobs
+	}
+	// Only convert after bounding by the requested number of helper lanes.
+	return int(affordable) + 1
+}
+
+// transform_job_count caps workers by the runtime job count and clone limit.
 fn transform_job_count(n_runtime_jobs int, n_items int, scoped_selfhost bool) int {
 	if n_runtime_jobs <= 0 || n_items <= 0 {
 		return 0
 	}
 	mut n := n_runtime_jobs
-	limit := if scoped_selfhost { max_selfhost_transform_jobs } else { max_parallel_transform_jobs }
+	limit := if scoped_selfhost {
+		max_selfhost_transform_jobs
+	} else {
+		max_parallel_transform_jobs
+	}
 	if n > limit {
 		n = limit
 	}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -2581,9 +2581,15 @@ fn (mut tc TypeChecker) collect_top_level_idx_fast(a &flat.FlatAst, inactive []b
 		}
 	}
 	mut synthetic_pos := 0
+	mut previous_trailing := -1
+	mut previous_file := ''
+	mut previous_module := ''
 	for k := 0; k + 1 < a.file_node_ids.len; k += 2 {
 		marker := a.file_node_ids[k]
 		trailing := a.file_node_ids[k + 1]
+		// Implicit imports live between file pairs. Preserve the context that a
+		// full node scan would carry from the preceding file through this gap.
+		previous_file, previous_module = tc.collect_index_gap(a, previous_trailing + 1, marker, previous_file, previous_module, inactive)
 		for synthetic_pos < tc.synthetic_top_level_type_ids.len
 			&& tc.synthetic_top_level_type_ids[synthetic_pos] <= marker {
 			synthetic_pos++
@@ -2626,7 +2632,32 @@ fn (mut tc TypeChecker) collect_top_level_idx_fast(a &flat.FlatAst, inactive []b
 			synthetic_pos++
 		}
 		tc.top_level_idx << trailing
+		previous_trailing = trailing
+		previous_file = idx_file
+		previous_module = idx_module
 	}
+	// Anything past the last indexed pair belongs to no later file pair.
+	_, _ = tc.collect_index_gap(a, previous_trailing + 1, a.nodes.len, previous_file, previous_module, inactive)
+}
+
+// collect_index_gap indexes the raw node range between two indexed file pairs,
+// where synthetic import insertion can leave whole bundle files. It mirrors the
+// full scan's `.file` handling, which switches the active file and clears the
+// active module, so a bundle's `module` declaration cannot leak into the file
+// that follows it.
+fn (mut tc TypeChecker) collect_index_gap(a &flat.FlatAst, start int, end int, file string, module_name string, inactive []bool) (string, string) {
+	mut gap_file := file
+	mut gap_module := module_name
+	for idx in start .. end {
+		if a.nodes[idx].kind == .file {
+			gap_file = a.nodes[idx].value
+			gap_module = ''
+			tc.top_level_idx << idx
+			continue
+		}
+		gap_module = tc.collect_index_child(a, idx, gap_file, gap_module, inactive)
+	}
+	return gap_file, gap_module
 }
 
 fn (mut tc TypeChecker) collect_module_attributes(node flat.Node, file string) {

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -12681,45 +12681,50 @@ fn (tc &TypeChecker) smartcast_type(id flat.NodeId) ?Type {
 	return result
 }
 
-struct LexicalSmartcastCandidate {
-	typ   Type
-	depth int
-}
-
 fn (tc &TypeChecker) lexical_smartcast_type(id flat.NodeId, key string) ?Type {
-	mut best := LexicalSmartcastCandidate{
-		depth: max_int
-	}
-	mut found := false
-	if candidate := tc.lexical_if_smartcast_candidate(id, key) {
-		best = candidate
-		found = true
-	}
-	if candidate := tc.lexical_for_smartcast_candidate(id, key) {
-		if !found || candidate.depth < best.depth {
-			best = candidate
-			found = true
-		}
-	}
-	if candidate := tc.lexical_match_smartcast_candidate(id, key) {
-		if !found || candidate.depth < best.depth {
-			best = candidate
-			found = true
-		}
-	}
-	if found {
-		return best.typ
-	}
-	return none
+	return tc.lexical_smartcast_type_in_parents(id, key, false)
 }
 
-fn (tc &TypeChecker) lexical_for_smartcast_candidate(id flat.NodeId, key string) ?LexicalSmartcastCandidate {
+// Walk the parent chain once, returning the nearest valid narrowing. Separate
+// if/for/match walks repeated the same parent lookups and evaluated outer
+// conditions even when a closer branch already determined the type.
+fn (tc &TypeChecker) lexical_smartcast_type_in_parents(id flat.NodeId, key string, match_only bool) ?Type {
+	idx := int(id)
+	if idx < 0 || idx >= tc.direct_parent_ids.len || key.len == 0 || !valid_string_data(key) {
+		return none
+	}
 	mut current := id
 	mut parent_id := tc.direct_parent_id(current)
+	mut match_branch := flat.NodeId(-1)
 	mut depth := 1
 	for tc.valid_node_id(parent_id) {
+		if match_only && depth > 64 {
+			return none
+		}
 		parent := tc.a.node(parent_id)
-		if parent.kind == .for_stmt && parent.children_count > 3 {
+		if !match_only && parent.kind == .if_expr && parent.children_count >= 2 {
+			mut branch_index := -1
+			for i in 1 .. parent.children_count {
+				if tc.a.child(parent, i) == current {
+					branch_index = i
+					break
+				}
+			}
+			if branch_index >= 1 {
+				cond_id := tc.a.child(parent, 0)
+				bindings := if branch_index == 1 {
+					tc.extract_smartcasts(cond_id)
+				} else {
+					tc.extract_else_branch_smartcasts(cond_id)
+				}
+				for binding in bindings {
+					branch_id := tc.a.child(parent, branch_index)
+					if binding.name == key && !tc.branch_writes_key_before(branch_id, id, key) {
+						return binding.typ
+					}
+				}
+			}
+		} else if !match_only && parent.kind == .for_stmt && parent.children_count > 3 {
 			mut body_index := -1
 			for i in 3 .. parent.children_count {
 				if tc.a.child(parent, i) == current {
@@ -12732,19 +12737,26 @@ fn (tc &TypeChecker) lexical_for_smartcast_candidate(id flat.NodeId, key string)
 			// rest of the body (the dynamic pass deletes the smartcast on assignment).
 			// Only reconstruct the condition smartcast when no preceding body statement,
 			// nor the statement holding `id`, writes `key`.
-			if body_index >= 3 && !tc.for_body_writes_key_before(parent, body_index, current, key) {
+			if body_index >= 3 {
 				for binding in tc.extract_smartcasts(tc.a.child(parent, 1)) {
-					if binding.name == key {
-						return LexicalSmartcastCandidate{
-							typ:   binding.typ
-							depth: depth
-						}
+					if binding.name == key
+						&& !tc.for_body_writes_key_before(parent, body_index, current, key) {
+						return binding.typ
 					}
 				}
 			}
+		} else if depth <= 64 && parent.kind == .match_branch {
+			match_branch = parent_id
+		} else if depth <= 64 && parent.kind == .match_stmt && tc.valid_node_id(match_branch) {
+			branch := tc.a.node(match_branch)
+			if typ := tc.lexical_match_branch_smartcast_type(parent, branch, key) {
+				return typ
+			}
+			// An unrelated inner match leaves an enclosing narrowing available.
+			match_branch = flat.empty_node
 		}
 		if parent.kind in [.fn_decl, .fn_literal, .lambda_expr] {
-			break
+			return none
 		}
 		current = parent_id
 		parent_id = tc.direct_parent_id(current)
@@ -12950,96 +12962,8 @@ fn (tc &TypeChecker) subtree_assigns_key(root flat.NodeId, key string) bool {
 	return false
 }
 
-fn (tc &TypeChecker) lexical_if_smartcast_candidate(id flat.NodeId, key string) ?LexicalSmartcastCandidate {
-	idx := int(id)
-	if idx < 0 || idx >= tc.direct_parent_ids.len {
-		return none
-	}
-	mut current := id
-	mut parent_id := tc.direct_parent_id(current)
-	mut depth := 1
-	for tc.valid_node_id(parent_id) {
-		parent := tc.a.node(parent_id)
-		if parent.kind == .if_expr && parent.children_count >= 2 {
-			mut branch_index := -1
-			for i in 1 .. parent.children_count {
-				if tc.a.child(parent, i) == current {
-					branch_index = i
-					break
-				}
-			}
-			if branch_index >= 1 {
-				cond_id := tc.a.child(parent, 0)
-				bindings := if branch_index == 1 {
-					tc.extract_smartcasts(cond_id)
-				} else {
-					tc.extract_else_branch_smartcasts(cond_id)
-				}
-				for binding in bindings {
-					branch_id := tc.a.child(parent, branch_index)
-					if binding.name == key && !tc.branch_writes_key_before(branch_id, id, key) {
-						return LexicalSmartcastCandidate{
-							typ:   binding.typ
-							depth: depth
-						}
-					}
-				}
-			}
-		}
-		if parent.kind in [.fn_decl, .fn_literal, .lambda_expr] {
-			break
-		}
-		current = parent_id
-		parent_id = tc.direct_parent_id(current)
-		depth++
-	}
-	return none
-}
-
 fn (tc &TypeChecker) lexical_match_smartcast_type(id flat.NodeId) ?Type {
-	if candidate := tc.lexical_match_smartcast_candidate(id, tc.expr_key(id)) {
-		return candidate.typ
-	}
-	return none
-}
-
-fn (tc &TypeChecker) lexical_match_smartcast_candidate(id flat.NodeId, key string) ?LexicalSmartcastCandidate {
-	idx := int(id)
-	if idx < 0 || idx >= tc.direct_parent_ids.len {
-		return none
-	}
-	if key.len == 0 || !valid_string_data(key) {
-		return none
-	}
-	mut current := id
-	mut branch_id := flat.NodeId(-1)
-	mut depth := 0
-	for _ in 0 .. 64 {
-		depth++
-		parent_id := tc.direct_parent_id(current)
-		if !tc.valid_node_id(parent_id) {
-			return none
-		}
-		parent := tc.a.node(parent_id)
-		if parent.kind == .match_branch {
-			branch_id = parent_id
-		} else if parent.kind == .match_stmt && tc.valid_node_id(branch_id) {
-			branch := tc.a.node(branch_id)
-			if typ := tc.lexical_match_branch_smartcast_type(parent, branch, key) {
-				return LexicalSmartcastCandidate{
-					typ:   typ
-					depth: depth
-				}
-			}
-			// An unrelated nested match does not cancel a narrowing established by
-			// an enclosing match on the same expression.
-			branch_id = flat.empty_node
-		} else if parent.kind in [.fn_decl, .fn_literal, .lambda_expr] {
-			return none
-		}
-		current = parent_id
-	}
-	return none
+	return tc.lexical_smartcast_type_in_parents(id, tc.expr_key(id), true)
 }
 
 fn (tc &TypeChecker) lexical_match_branch_smartcast_type(parent &flat.Node, branch &flat.Node, key string) ?Type {
@@ -13119,15 +13043,15 @@ pub fn (tc &TypeChecker) cached_c_name(name string) string {
 		return naming.c_name(name)
 	}
 	mut cache := unsafe { tc.type_cache }
+	if cached := cache.c_name_entries[name] {
+		return cached
+	}
 	mut fallback := cache.base
 	for !isnil(fallback) {
 		if cached := fallback.c_name_entries[name] {
 			return cached
 		}
 		fallback = fallback.base
-	}
-	if cached := cache.c_name_entries[name] {
-		return cached
 	}
 	result := naming.c_name(name)
 	cache.c_name_entries[name] = result


### PR DESCRIPTION
Uncached v3 self-hosting repeats lexical scans and symbol lookups, copies prepared Cgen state for each worker, and serially copies transformed AST regions. This change indexes repeated queries, balances self-host transform work across up to 18 lanes with a 2.6 GB base-clone budget, and copies each worker region directly into its final AST range in parallel.

Cgen shares frozen literal tables with copy-on-write insertion, caches shared-field metadata, and retains its preparation arena for self-hosting. Markused deduplicates repeated per-module callees and avoids enum classification when checker edges already cover function values, plus operand-type resolution for operators that cannot be overloaded. Finished transform arenas are released alongside the C compiler and joined before the build returns. Dotted-name sanitization fills a standalone `malloc_noscan` buffer and explicitly NUL-terminates it, so the returned string can be freed safely. Generated behavior and public flags are unchanged.

Performance validation on an 18-core Apple M5 Max. Five sequential full uncached self-host builds under lower load, using the production binary at commit `64bbb11794` (before the naming ownership fix):

```sh
./v3 -nocache -building-v -o v4 v3.v
```

| Run | Total minus CC | Transform |
| --- | ---: | ---: |
| 1 | 606.10 ms | 165.22 ms |
| 2 | 572.92 ms | 152.72 ms |
| 3 | 560.59 ms | 150.23 ms |
| 4 | 565.02 ms | 150.95 ms |
| 5 | 583.38 ms | 154.62 ms |
| Median | **572.92 ms** | **152.72 ms** |

All five executable self-host builds passed. The median meets the requested 600 ms target, with four of five runs below 600 ms; the first run exceeded it by 6.10 ms. Other sessions were left running. These timings supersede the earlier loaded full-build measurement of 1308.84 ms outside CC.

An earlier interleaved comparison under higher load used six C-emission runs per binary:

| Median (`-o out.c`) | Merged baseline | This change |
| --- | ---: | ---: |
| Total | 1375.26 ms | 1183.82 ms |
| Transform | 431.55 ms | 338.40 ms |
| Cgen | 372.96 ms | 335.78 ms |

That comparison measured 13.9% lower total time and 21.6% lower transform time. The two samples had different system loads and should not be compared directly.

Validation:

- Naming ownership regression reproduced an AddressSanitizer invalid free on the pre-fix code; it passes with `-gc none`, `-autofree`, and AddressSanitizer plus `-d debug_malloc`. Existing C naming tests also pass.
- After the ownership fix, a fresh non-production bootstrap completed a full uncached self-host build; the generated compiler built and ran Hello World.

- Production bootstrap with `../../vnew -gc none -prealloc -prod -o v3 v3.v` flags.
- Full uncached self-host: `./v3 -nocache -building-v -o v4 v3.v`; generated v4 compiled and ran Hello World.
- Parser module: 7/7 passed. Cgen module: 18/18 passed. Markused module passed.
- Targeted driver import/index, transform merge/budget/alias, literal-table sharing, name conversion, markused module dependency, nested smartcast, and serial/parallel expansion regressions passed.
- Additional self-host transform and transformer parity regressions passed.
- The final markused changes were checked with `vlib/v3/tests/markused_test.v`, `loop_smartcast_mut_call_write_test.v`, `selfhost_parallel_expansion_test.v`, and `selfhost_transform_regression_test.v`, plus the full self-host and v4 smoke test.
- Broader checks found existing failures reproduced on the merged baseline: one transform interpolation assertion, two types test files, three lock-codegen assertions, and six checker-error cases (C declaration types, globals, integer size, two method-value crashes, and aligned free output). The complete v3 tests suite was not completed.

All touched V files were formatted; `git diff --check` passes. No public behavior or documentation changes.
