### PR TITLE
db.mysql: add a `local_infile` Config option (fix #27525)

### DIFF
--- a/vlib/db/mysql/README.md
+++ b/vlib/db/mysql/README.md
@@ -75,6 +75,29 @@ Sharing one `mysql.DB` across threads now serializes connection-level queries sa
 For concurrent servers, prefer `mysql.new_connection_pool(...)` so requests do not share the same
 session and transaction state on one connection.
 
+## Bulk loading with `LOAD DATA LOCAL INFILE`
+
+libmysqlclient 8.x disables client side `LOAD DATA LOCAL INFILE` by default. Set
+`local_infile` so `connect()` enables it before the handshake - it also turns on the
+`.client_local_files` capability, which the statement needs:
+
+```v oksyntax
+import db.mysql
+
+config := mysql.Config{
+	host:         '127.0.0.1'
+	username:     'root'
+	password:     '12345678'
+	dbname:       'mysql'
+	local_infile: true
+}
+
+mut db := mysql.connect(config)!
+db.exec_none("load data local infile '/tmp/users.csv' into table users fields terminated by ','")
+```
+
+The server has to allow it as well (`local_infile=ON`).
+
 ## Transaction
 
 ```v oksyntax

--- a/vlib/db/mysql/local_infile_options_test.c.v
+++ b/vlib/db/mysql/local_infile_options_test.c.v
@@ -1,3 +1,4 @@
+// vtest build: started_mysqld?
 module mysql
 
 fn test_local_infile_connect_options() {

--- a/vlib/db/mysql/local_infile_options_test.c.v
+++ b/vlib/db/mysql/local_infile_options_test.c.v
@@ -1,0 +1,22 @@
+module mysql
+
+fn test_local_infile_connect_options() {
+	mut db := DB{
+		conn: C.mysql_init(0)
+	}
+	assert !isnil(db.conn)
+	defer {
+		C.mysql_close(db.conn)
+	}
+
+	flags := db.apply_local_infile(Config{
+		flag: .client_found_rows
+		local_infile: true
+	})
+	assert flags.has(.client_found_rows)
+	assert flags.has(.client_local_files)
+
+	mut enabled := u32(0)
+	assert C.mysql_get_option(db.conn, C.MYSQL_OPT_LOCAL_INFILE, &enabled) == 0
+	assert enabled == 1
+}

--- a/vlib/db/mysql/mysql.c.v
+++ b/vlib/db/mysql/mysql.c.v
@@ -96,6 +96,12 @@ pub mut:
 	// `MYSQL_OPT_SSL_MODE` call is made and the libmysqlclient default applies.
 	ssl_mode SslMode
 
+	// local_infile enables `LOAD DATA LOCAL INFILE`, which libmysqlclient 8.x
+	// disables by default. It sets `MYSQL_OPT_LOCAL_INFILE` before connecting and
+	// adds the `.client_local_files` capability flag, since the statement needs
+	// both. The server must also allow it (`local_infile=ON`).
+	local_infile bool
+
 	// SSL params, only valid when set .client_ssl
 	ssl_key    string
 	ssl_cert   string
@@ -137,6 +143,13 @@ pub fn connect(config Config) !DB {
 		db.set_option(C.MYSQL_OPT_SSL_MODE, &ssl_mode)
 	}
 
+	mut connection_flag := config.flag
+	if config.local_infile {
+		enabled := u32(1)
+		db.set_option(C.MYSQL_OPT_LOCAL_INFILE, &enabled)
+		connection_flag.set(.client_local_files)
+	}
+
 	if config.flag.has(.client_ssl) {
 		if config.ssl_key.len > 0 {
 			db.set_option(C.MYSQL_OPT_SSL_KEY, config.ssl_key.str)
@@ -156,7 +169,7 @@ pub fn connect(config Config) !DB {
 	}
 
 	connection := C.mysql_real_connect(db.conn, config.host.str, username.str, config.password.str,
-		config.dbname.str, config.port, 0, config.flag)
+		config.dbname.str, config.port, 0, connection_flag)
 
 	if isnil(connection) {
 		db.throw_mysql_error()!

--- a/vlib/db/mysql/mysql.c.v
+++ b/vlib/db/mysql/mysql.c.v
@@ -143,12 +143,7 @@ pub fn connect(config Config) !DB {
 		db.set_option(C.MYSQL_OPT_SSL_MODE, &ssl_mode)
 	}
 
-	mut connection_flag := config.flag
-	if config.local_infile {
-		enabled := u32(1)
-		db.set_option(C.MYSQL_OPT_LOCAL_INFILE, &enabled)
-		connection_flag.set(.client_local_files)
-	}
+	connection_flag := db.apply_local_infile(config)
 
 	if config.flag.has(.client_ssl) {
 		if config.ssl_key.len > 0 {
@@ -184,6 +179,16 @@ pub fn connect(config Config) !DB {
 	}
 
 	return db
+}
+
+fn (mut db DB) apply_local_infile(config Config) ConnectionFlag {
+	mut connection_flag := config.flag
+	if config.local_infile {
+		enabled := u32(1)
+		db.set_option(C.MYSQL_OPT_LOCAL_INFILE, &enabled)
+		connection_flag.set(.client_local_files)
+	}
+	return connection_flag
 }
 
 // query executes the SQL statement pointed to by the string `q`.

--- a/vlib/db/mysql/mysql_test.v
+++ b/vlib/db/mysql/mysql_test.v
@@ -245,3 +245,18 @@ fn test_query_is_serialized_for_shared_connections() {
 		assert count > 0
 	}
 }
+
+// Regression test for https://github.com/vlang/v/issues/27525. It does not need a
+// server: `local_infile` has to be applied before `mysql_real_connect()`, so the only
+// thing that can be checked from V is that the option is exposed and that enabling it
+// also turns on the `.client_local_files` capability, which the statement needs.
+fn test_local_infile_config_defaults_to_off_and_can_be_enabled() {
+	off := mysql.Config{}
+	assert !off.local_infile
+	assert !off.flag.has(.client_local_files)
+
+	on := mysql.Config{
+		local_infile: true
+	}
+	assert on.local_infile
+}

--- a/vlib/db/mysql/mysql_test.v
+++ b/vlib/db/mysql/mysql_test.v
@@ -246,10 +246,8 @@ fn test_query_is_serialized_for_shared_connections() {
 	}
 }
 
-// Regression test for https://github.com/vlang/v/issues/27525. It does not need a
-// server: `local_infile` has to be applied before `mysql_real_connect()`, so the only
-// thing that can be checked from V is that the option is exposed and that enabling it
-// also turns on the `.client_local_files` capability, which the statement needs.
+// Public configuration regression for https://github.com/vlang/v/issues/27525.
+// The internal option-and-capability wiring is covered by local_infile_options_test.c.v.
 fn test_local_infile_config_defaults_to_off_and_can_be_enabled() {
 	off := mysql.Config{}
 	assert !off.local_infile


### PR DESCRIPTION
Fixes #27525.

### Problem

`LOAD DATA LOCAL INFILE` is the fastest way to bulk-load a table, but libmysqlclient 8.x disables it client-side unless `MYSQL_OPT_LOCAL_INFILE` is set **before** `mysql_real_connect()`. `DB.conn` is private, so this could not be done from outside the module — the statement was simply unavailable to `db.mysql` users.

### Change

`Config.local_infile`, following the existing `ssl_mode` pattern:

```v ignore
config := mysql.Config{
	host:         '127.0.0.1'
	username:     'root'
	dbname:       'mysql'
	local_infile: true
}
```

When set, `connect()` sets `MYSQL_OPT_LOCAL_INFILE` *and* adds the `.client_local_files` capability flag. The issue only asked for the option, but the statement needs both, and `client_local_files` was already in `ConnectionFlag` — requiring users to remember to set it separately would make the boolean a trap. It defaults to `false`, so existing code is unaffected. The server must still allow it (`local_infile=ON`), which the README now documents.

### Verification

I installed `mariadb-connector-c` locally to actually compile this rather than eyeball it. A program using `local_infile: true` builds, links and runs, and the emitted C contains the call in the right place:

```c
db__mysql__DB_set_option(&db, MYSQL_OPT_LOCAL_INFILE, &enabled);
```

`vlib/db/mysql/mysql_test.v` gains a server-free test asserting the option defaults to off, that `.client_local_files` is not set by default, and that it can be enabled. The file is `// vtest build: started_mysqld?`-guarded so it is skipped without a server; I verified it passes by running a copy with that guard removed.

Note: `v build-module vlib/db/mysql` fails on current master for an unrelated reason — the `_v_type_idx_orm__[]orm__Primitive___...` invalid C identifier that open PR #27891 fixes — so I verified via a normal build instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)