### PR TITLE
vself: speed up Linux production builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,8 @@ hello world
 ```
 
 `v self` defaults to `-gc none`. Pass `-gc <mode>` if you need a different GC mode.
-On macOS, `v -prod self` uses a single production build instead of the three-pass PGO cycle.
+On macOS and Linux, `v -prod self` uses a single production build instead of the three-pass
+PGO cycle.
 
 ```bash
 cd examples

--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -62,18 +62,18 @@ fn main() {
 		args << ['-gc', 'none']
 	}
 	effective_args = effective_self_build_args(args)
-	if !fastc_self_build && os.user_os() == 'macos' && '-prod' in effective_args
+	if !fastc_self_build && os.user_os() in ['linux', 'macos'] && '-prod' in effective_args
 		&& '-parallel-cc' !in effective_args {
-		// A V3-only cmd/v is large enough that monolithic clang + LTO dominates
+		// A V3-only cmd/v is large enough that a monolithic C compiler + LTO dominates
 		// the self-build. Parallel C compilation also keeps the generated unit out
 		// of the full-LTO path when the self-build is already running under V3.
 		args << '-parallel-cc'
 	}
 	effective_args = effective_self_build_args(args)
-	if !fastc_self_build && os.user_os() == 'macos' && '-prod' in effective_args
+	if !fastc_self_build && os.user_os() in ['linux', 'macos'] && '-prod' in effective_args
 		&& '-no-memory-limit' !in effective_args && '--no-memory-limit' !in effective_args {
 		// Production C generation for the embedded V3 compiler can legitimately
-		// exceed V3's default 10 GB process limit before clang starts.
+		// exceed V3's default 10 GB process limit before the native compiler starts.
 		args << '-no-memory-limit'
 	}
 	effective_args = effective_self_build_args(args)
@@ -101,7 +101,7 @@ fn main() {
 		compile_args << '-selfhost'
 	}
 	final_binary := if obinary != '' { obinary } else { 'v2' }
-	pgo_cc_kind := if fastc_self_build { '' } else { pgo_compiler_kind(args) }
+	pgo_cc_kind := if fastc_self_build { '' } else { pgo_compiler_kind(effective_args) }
 	// Only explicit FastC builds are standalone. Regular replacements must retain
 	// cmd/v so commands such as self, up, fmt, and version remain available.
 	compilation_source := if fastc_self_build { standalone_v3_source } else { full_v_cli_source }

--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -101,7 +101,11 @@ fn main() {
 		compile_args << '-selfhost'
 	}
 	final_binary := if obinary != '' { obinary } else { 'v2' }
-	pgo_cc_kind := if fastc_self_build { '' } else { pgo_compiler_kind(effective_args) }
+	pgo_cc_kind := if fastc_self_build || '-parallel-cc' in effective_args {
+		''
+	} else {
+		pgo_compiler_kind(args)
+	}
 	// Only explicit FastC builds are standalone. Regular replacements must retain
 	// cmd/v so commands such as self, up, fmt, and version remain available.
 	compilation_source := if fastc_self_build { standalone_v3_source } else { full_v_cli_source }

--- a/cmd/tools/vself_test.v
+++ b/cmd/tools/vself_test.v
@@ -9,6 +9,14 @@ fn assert_vself_preserves_full_cli(output string) {
 	assert output.contains('cmd/v'), output
 }
 
+fn assert_vself_uses_single_prod_build(output string) {
+	assert output.contains('-no-memory-limit'), output
+	assert output.contains('-prealloc'), output
+	assert !output.contains('-fprofile'), output
+	assert output.count('cmd/v') == 1, output
+	assert_vself_preserves_full_cli(output)
+}
+
 fn test_linux_tinyc_self_build_does_not_enable_prealloc() {
 	$if !linux {
 		return
@@ -78,6 +86,15 @@ fn test_linux_default_self_build_preserves_full_cli() {
 	assert !result.output.contains('-b fastc'), result.output
 	assert result.output.contains('-prealloc'), result.output
 	assert_vself_preserves_full_cli(result.output)
+	prod_result :=
+		os.execute('env -u CC VFLAGS="" VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -prod -o /tmp/vself_linux_prod_test')
+	assert prod_result.exit_code == 0, prod_result.output
+	assert prod_result.output.contains('-parallel-cc'), prod_result.output
+	assert_vself_uses_single_prod_build(prod_result.output)
+	vflags_parallel_result :=
+		os.execute('env -u CC VFLAGS="-parallel-cc" VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -prod -o /tmp/vself_linux_prod_vflags_test')
+	assert vflags_parallel_result.exit_code == 0, vflags_parallel_result.output
+	assert_vself_uses_single_prod_build(vflags_parallel_result.output)
 }
 
 fn test_macos_default_self_build_compiler_selection() {
@@ -111,11 +128,7 @@ fn test_macos_default_self_build_compiler_selection() {
 		os.execute('CC=clang VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -prod -o /tmp/vself_macos_prod_test')
 	assert prod_result.exit_code == 0, prod_result.output
 	assert prod_result.output.contains('-parallel-cc'), prod_result.output
-	assert prod_result.output.contains('-no-memory-limit'), prod_result.output
-	assert prod_result.output.contains('-prealloc'), prod_result.output
-	assert !prod_result.output.contains('-fprofile'), prod_result.output
-	assert prod_result.output.count('cmd/v') == 1, prod_result.output
-	assert_vself_preserves_full_cli(prod_result.output)
+	assert_vself_uses_single_prod_build(prod_result.output)
 	old_result :=
 		os.execute('CC=cc VFLAGS="" VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -old-compiler -o /tmp/vself_macos_old_test')
 	assert old_result.exit_code == 0, old_result.output

--- a/vlib/v/help/installation/self.txt
+++ b/vlib/v/help/installation/self.txt
@@ -9,7 +9,8 @@ Options:
   All other options are passed to the build command. (e.g. -prod)
   Plain self-builds compile the full `cmd/v` CLI, which embeds and defaults to V3 on macOS/Linux.
   On Apple Silicon, regular self-builds use bundled TCC by default; `CC` or `-cc` overrides it.
-  With -prod and clang/gcc, `v self` may use PGO automatically when tools are available.
+  On macOS and Linux, -prod uses a single parallel C build without LTO instead of PGO.
+  On other systems, -prod with clang/gcc may use PGO when tools are available.
   On macOS and Linux, `-b fastc` builds the standalone experimental V3 FastC compiler.
   `-prod` cannot be combined with `-b fastc`.
   FastC replacement builds (`xN` without `-o`) reject options that the standalone compiler


### PR DESCRIPTION
## Summary

- make Linux production self-builds use the bounded single-build path already used on macOS
- add parallel C compilation and remove the monolithic LTO plus three-pass PGO cost
- disable the self-host memory guard for production generation, which can exceed 10 GiB
- honor parallel-cc supplied through VFLAGS when deciding whether to enable PGO
- document and test the Linux behavior

This follows PR #28378 and addresses the Linux production timing reported in #26961.

## Validation

- macOS: ./vnew -no-memory-limit cmd/tools/vself_test.v
- Debian x86_64: ./vtesthost -old-compiler -gc none cmd/tools/vself_test.v
- Debian x86_64: ./vtesthost -old-compiler fmt -verify cmd/tools/vself.v cmd/tools/vself_test.v
- git diff --check

README check-md reaches a pre-existing formatting error at README.md:388, outside this change.