### PR TITLE
macos: add typed Objective-C message senders

### DIFF
--- a/vlib/macos/README.md
+++ b/vlib/macos/README.md
@@ -1,0 +1,24 @@
+# macos
+
+The `macos` module provides typed access to the Objective-C runtime on macOS. It includes
+Objective-C object, selector, rectangle, point, and range types together with typed message
+senders.
+
+Choose the message sender whose return and argument types exactly match the Objective-C method.
+For example:
+
+```v
+import macos
+
+value := macos.msg_id_range(
+	macos.get_class('NSValue'),
+	'valueWithRange:',
+	macos.range(2, 5),
+)
+result := macos.msg_range(value, 'rangeValue')
+println('${result.location}, ${result.length}')
+```
+
+The typed senders hide the platform-specific `objc_msgSend` casts. Framework-specific methods
+still require the corresponding `#flag darwin -framework ...` declaration in the importing
+program.

--- a/vlib/macos/macos_darwin.c.v
+++ b/vlib/macos/macos_darwin.c.v
@@ -1,14 +1,38 @@
 module macos
 
 #flag darwin -framework Foundation
+
 #flag darwin -lobjc
+
 #insert "@VEXEROOT/vlib/macos/objc_bridge.h"
 
 pub type Id = voidptr
+
 pub type Sel = voidptr
+
 pub type Class = voidptr
+
 pub type Protocol = voidptr
+
+// Point is a Cocoa-compatible point or size containing two f64 values.
+pub type Point = C.macos_point
+
+// Range is a Cocoa-compatible range containing a location and length.
+pub type Range = C.macos_range
+
 pub type Rect = C.macos_rect
+
+pub struct C.macos_point {
+pub mut:
+	x f64
+	y f64
+}
+
+pub struct C.macos_range {
+pub mut:
+	location u64
+	length   u64
+}
 
 pub struct C.macos_rect {
 pub mut:
@@ -26,46 +50,130 @@ pub const assoc_copy = usize(0o1403)
 pub const run_loop_default_mode = 'kCFRunLoopDefaultMode'
 
 fn C.macos_objc_msg_id0(obj Id, selector Sel) Id
+
 fn C.macos_objc_msg_id1(obj Id, selector Sel, a0 voidptr) Id
+
 fn C.macos_objc_msg_id2(obj Id, selector Sel, a0 voidptr, a1 voidptr) Id
+
 fn C.macos_objc_msg_id3(obj Id, selector Sel, a0 voidptr, a1 voidptr, a2 voidptr) Id
+
 fn C.macos_objc_msg_id4(obj Id, selector Sel, a0 voidptr, a1 voidptr, a2 voidptr, a3 voidptr) Id
+
 fn C.macos_objc_msg_id_rect(obj Id, selector Sel, rect Rect) Id
+
 fn C.macos_objc_msg_id_rect_bool(obj Id, selector Sel, rect Rect, a1 bool) Id
+
 fn C.macos_objc_msg_id_rect_obj(obj Id, selector Sel, rect Rect, a1 voidptr) Id
+
 fn C.macos_objc_msg_id_rect_u64_u64_bool(obj Id, selector Sel, rect Rect, a1 u64, a2 u64, a3 bool) Id
+
 fn C.macos_objc_msg_id_obj_u64_bool(obj Id, selector Sel, a0 voidptr, a1 u64, a2 bool) Id
+
 fn C.macos_objc_msg_id_obj_sel_obj(obj Id, selector Sel, a0 voidptr, a1 voidptr, a2 voidptr) Id
+
 fn C.macos_objc_msg_id_f64(obj Id, selector Sel, a0 f64) Id
+
 fn C.macos_objc_msg_id_u64(obj Id, selector Sel, a0 u64) Id
+
+fn C.macos_objc_msg_id_four_f64(obj Id, selector Sel, a0 f64, a1 f64, a2 f64, a3 f64) Id
+
+fn C.macos_objc_msg_id_id_f64(obj Id, selector Sel, a0 Id, a1 f64) Id
+
+fn C.macos_objc_msg_id_id_u64(obj Id, selector Sel, a0 Id, a1 u64) Id
+
+fn C.macos_objc_msg_id_id_u64_i64_f64(obj Id, selector Sel, a0 Id, a1 u64, a2 i64, a3 f64) Id
+
+fn C.macos_objc_msg_id_u64_id(obj Id, selector Sel, a0 u64, a1 Id) Id
+
+fn C.macos_objc_msg_id_u64_range_ptr(obj Id, selector Sel, a0 u64, range &Range) Id
+
+fn C.macos_objc_msg_id_id_u64_range_ptr(obj Id, selector Sel, a0 Id, a1 u64, range &Range) Id
+
+fn C.macos_objc_msg_id_range(obj Id, selector Sel, range Range) Id
+
+fn C.macos_objc_msg_u64_id(obj Id, selector Sel, a0 Id) u64
+
+fn C.macos_objc_msg_bool_id_bool(obj Id, selector Sel, a0 Id, a1 bool) bool
+
+fn C.macos_objc_msg_bool_sel_id_id(obj Id, selector Sel, a0 Sel, a1 Id, a2 Id) bool
+
+fn C.macos_objc_msg_range(obj Id, selector Sel) Range
+
+fn C.macos_objc_msg_point(obj Id, selector Sel) Point
+
+fn C.macos_objc_msg_point_point_id(obj Id, selector Sel, point Point, a1 Id) Point
+
 fn C.macos_objc_msg_void0(obj Id, selector Sel)
+
 fn C.macos_objc_msg_void1(obj Id, selector Sel, a0 voidptr)
+
 fn C.macos_objc_msg_void2(obj Id, selector Sel, a0 voidptr, a1 voidptr)
+
 fn C.macos_objc_msg_void3(obj Id, selector Sel, a0 voidptr, a1 voidptr, a2 voidptr)
+
 fn C.macos_objc_msg_void_bool(obj Id, selector Sel, a0 bool)
+
 fn C.macos_objc_msg_void_i64(obj Id, selector Sel, a0 i64)
+
 fn C.macos_objc_msg_void_u64(obj Id, selector Sel, a0 u64)
+
 fn C.macos_objc_msg_void_f64(obj Id, selector Sel, a0 f64)
+
 fn C.macos_objc_msg_void_rect(obj Id, selector Sel, rect Rect)
+
 fn C.macos_objc_msg_void_rect_bool_bool(obj Id, selector Sel, rect Rect, a1 bool, a2 bool)
+
+fn C.macos_objc_msg_void_id_i64_id(obj Id, selector Sel, a0 Id, a1 i64, a2 Id)
+
+fn C.macos_objc_msg_void_id_range(obj Id, selector Sel, a0 Id, range Range)
+
+fn C.macos_objc_msg_void_id_id_range(obj Id, selector Sel, a0 Id, a1 Id, range Range)
+
+fn C.macos_objc_msg_void_range(obj Id, selector Sel, range Range)
+
+fn C.macos_objc_msg_void_rect_id(obj Id, selector Sel, rect Rect, a1 Id)
+
+fn C.macos_objc_msg_void_point(obj Id, selector Sel, point Point)
+
+fn C.macos_objc_msg_void_id_sel_id_id(obj Id, selector Sel, a0 Id, a1 Sel, a2 Id, a3 Id)
+
+fn C.macos_objc_msg_void_sel_id_bool(obj Id, selector Sel, a0 Sel, a1 Id, a2 bool)
+
 fn C.macos_objc_msg_bool0(obj Id, selector Sel) bool
+
 fn C.macos_objc_msg_bool1(obj Id, selector Sel, a0 voidptr) bool
+
 fn C.macos_objc_msg_i64(obj Id, selector Sel) i64
+
 fn C.macos_objc_msg_u64(obj Id, selector Sel) u64
+
 fn C.macos_objc_msg_f64(obj Id, selector Sel) f64
+
 fn C.macos_objc_msg_rect(obj Id, selector Sel) Rect
-fn C.macos_objc_get_class(name &char) Class
-fn C.macos_sel_register_name(name &char) Sel
-fn C.macos_objc_allocate_class_pair(superclass Class, name &char, extra_bytes usize) Class
+
+fn C.macos_objc_get_class(const_name &char) Class
+
+fn C.macos_sel_register_name(const_name &char) Sel
+
+fn C.macos_objc_allocate_class_pair(superclass Class, const_name &char, extra_bytes usize) Class
+
 fn C.macos_objc_register_class_pair(cls Class)
-fn C.macos_class_add_method(cls Class, name Sel, imp voidptr, types &char) bool
-fn C.macos_class_add_ivar(cls Class, name &char, size usize, alignment u8, types &char) bool
-fn C.macos_objc_get_protocol(name &char) Protocol
+
+fn C.macos_class_add_method(cls Class, name Sel, imp voidptr, const_types &char) bool
+
+fn C.macos_class_add_ivar(cls Class, const_name &char, size usize, alignment u8, const_types &char) bool
+
+fn C.macos_objc_get_protocol(const_name &char) Protocol
+
 fn C.macos_class_add_protocol(cls Class, protocol Protocol) bool
-fn C.macos_objc_set_ptr_ivar(obj Id, name &char, value voidptr)
-fn C.macos_objc_get_ptr_ivar(obj Id, name &char) voidptr
-fn C.macos_set_associated_object(obj Id, key voidptr, value Id, policy usize)
-fn C.macos_get_associated_object(obj Id, key voidptr) Id
+
+fn C.macos_objc_set_ptr_ivar(obj Id, const_name &char, value voidptr)
+
+fn C.macos_objc_get_ptr_ivar(obj Id, const_name &char) voidptr
+
+fn C.macos_set_associated_object(obj Id, const_key voidptr, value Id, policy usize)
+
+fn C.macos_get_associated_object(obj Id, const_key voidptr) Id
 
 @[inline]
 pub fn get_class(name string) Id {
@@ -85,10 +193,28 @@ pub fn sel(name string) Sel {
 @[inline]
 pub fn rect(x f64, y f64, width f64, height f64) Rect {
 	return C.macos_rect{
-		x:      x
-		y:      y
-		width:  width
+		x: x
+		y: y
+		width: width
 		height: height
+	}
+}
+
+// point returns a Cocoa-compatible point with the supplied coordinates.
+@[inline]
+pub fn point(x f64, y f64) Point {
+	return C.macos_point{
+		x: x
+		y: y
+	}
+}
+
+// range returns a Cocoa-compatible range with the supplied location and length.
+@[inline]
+pub fn range(location u64, length u64) Range {
+	return C.macos_range{
+		location: location
+		length: length
 	}
 }
 
@@ -164,6 +290,109 @@ pub fn msg_id_u64(obj Id, selector string, a0 u64) Id {
 	return C.macos_objc_msg_id_u64(obj, sel(selector), a0)
 }
 
+// msg_id_rect_u64_u64_bool sends a message that returns an object and accepts a rectangle,
+// two unsigned integers, and a boolean.
+@[inline]
+pub fn msg_id_rect_u64_u64_bool(obj Id, selector string, rect Rect, a1 u64, a2 u64, a3 bool) Id {
+	return C.macos_objc_msg_id_rect_u64_u64_bool(obj, sel(selector), rect, a1, a2, a3)
+}
+
+// msg_id_four_f64 sends a message that returns an object and accepts four f64 values.
+@[inline]
+pub fn msg_id_four_f64(obj Id, selector string, a0 f64, a1 f64, a2 f64, a3 f64) Id {
+	return C.macos_objc_msg_id_four_f64(obj, sel(selector), a0, a1, a2, a3)
+}
+
+// msg_id_id_f64 sends a message that returns an object and accepts an object and an f64.
+@[inline]
+pub fn msg_id_id_f64(obj Id, selector string, a0 Id, a1 f64) Id {
+	return C.macos_objc_msg_id_id_f64(obj, sel(selector), a0, a1)
+}
+
+// msg_id_id_u64 sends a message that returns an object and accepts an object and a u64.
+@[inline]
+pub fn msg_id_id_u64(obj Id, selector string, a0 Id, a1 u64) Id {
+	return C.macos_objc_msg_id_id_u64(obj, sel(selector), a0, a1)
+}
+
+// msg_id_id_u64_i64_f64 sends a message that returns an object and accepts mixed numeric arguments.
+@[inline]
+pub fn msg_id_id_u64_i64_f64(obj Id, selector string, a0 Id, a1 u64, a2 i64, a3 f64) Id {
+	return C.macos_objc_msg_id_id_u64_i64_f64(obj, sel(selector), a0, a1, a2, a3)
+}
+
+// msg_id_u64_id sends a message that returns an object and accepts a u64 and an object.
+@[inline]
+pub fn msg_id_u64_id(obj Id, selector string, a0 u64, a1 Id) Id {
+	return C.macos_objc_msg_id_u64_id(obj, sel(selector), a0, a1)
+}
+
+// msg_id_u64_range_ptr sends a message with a u64 and a writable range pointer.
+@[inline]
+pub fn msg_id_u64_range_ptr(obj Id, selector string, a0 u64, range_ptr &Range) Id {
+	return C.macos_objc_msg_id_u64_range_ptr(obj, sel(selector), a0, range_ptr)
+}
+
+// msg_id_id_u64_range_ptr sends a message with an object, a u64, and a writable range pointer.
+@[inline]
+pub fn msg_id_id_u64_range_ptr(obj Id, selector string, a0 Id, a1 u64, range_ptr &Range) Id {
+	return C.macos_objc_msg_id_id_u64_range_ptr(obj, sel(selector), a0, a1, range_ptr)
+}
+
+// msg_id_range sends a message that returns an object and accepts a range.
+@[inline]
+pub fn msg_id_range(obj Id, selector string, value Range) Id {
+	return C.macos_objc_msg_id_range(obj, sel(selector), value)
+}
+
+// msg_u64_id sends a message that returns a u64 and accepts an object.
+@[inline]
+pub fn msg_u64_id(obj Id, selector string, a0 Id) u64 {
+	return C.macos_objc_msg_u64_id(obj, sel(selector), a0)
+}
+
+// msg_bool_id sends a message that returns a boolean and accepts an object.
+@[inline]
+pub fn msg_bool_id(obj Id, selector string, a0 Id) bool {
+	return C.macos_objc_msg_bool1(obj, sel(selector), a0)
+}
+
+// msg_bool_id_bool sends a message that returns a boolean and accepts an object and a boolean.
+@[inline]
+pub fn msg_bool_id_bool(obj Id, selector string, a0 Id, a1 bool) bool {
+	return C.macos_objc_msg_bool_id_bool(obj, sel(selector), a0, a1)
+}
+
+// responds_to reports whether obj responds to selector.
+@[inline]
+pub fn responds_to(obj Id, selector string) bool {
+	return C.macos_objc_msg_bool1(obj, sel('respondsToSelector:'), sel(selector))
+}
+
+// msg_bool_sel_id_id sends a message that returns a boolean and accepts a selector and two objects.
+@[inline]
+pub fn msg_bool_sel_id_id(obj Id, selector string, a0 Sel, a1 Id, a2 Id) bool {
+	return C.macos_objc_msg_bool_sel_id_id(obj, sel(selector), a0, a1, a2)
+}
+
+// msg_range sends a message that returns a range.
+@[inline]
+pub fn msg_range(obj Id, selector string) Range {
+	return C.macos_objc_msg_range(obj, sel(selector))
+}
+
+// msg_point sends a message that returns a point.
+@[inline]
+pub fn msg_point(obj Id, selector string) Point {
+	return C.macos_objc_msg_point(obj, sel(selector))
+}
+
+// msg_point_point_id sends a message that returns a point and accepts a point and an object.
+@[inline]
+pub fn msg_point_point_id(obj Id, selector string, value Point, a1 Id) Point {
+	return C.macos_objc_msg_point_point_id(obj, sel(selector), value, a1)
+}
+
 @[inline]
 pub fn msg_void1(obj Id, selector string, a0 Id) {
 	C.macos_objc_msg_void1(obj, sel(selector), a0)
@@ -202,6 +431,54 @@ pub fn msg_void_f64(obj Id, selector string, a0 f64) {
 @[inline]
 pub fn msg_void_rect(obj Id, selector string, r Rect) {
 	C.macos_objc_msg_void_rect(obj, sel(selector), r)
+}
+
+// msg_void_id_i64_id sends a void message with an object, an i64, and an object.
+@[inline]
+pub fn msg_void_id_i64_id(obj Id, selector string, a0 Id, a1 i64, a2 Id) {
+	C.macos_objc_msg_void_id_i64_id(obj, sel(selector), a0, a1, a2)
+}
+
+// msg_void_id_range sends a void message with an object and a range.
+@[inline]
+pub fn msg_void_id_range(obj Id, selector string, a0 Id, value Range) {
+	C.macos_objc_msg_void_id_range(obj, sel(selector), a0, value)
+}
+
+// msg_void_id_id_range sends a void message with two objects and a range.
+@[inline]
+pub fn msg_void_id_id_range(obj Id, selector string, a0 Id, a1 Id, value Range) {
+	C.macos_objc_msg_void_id_id_range(obj, sel(selector), a0, a1, value)
+}
+
+// msg_void_range sends a void message with a range.
+@[inline]
+pub fn msg_void_range(obj Id, selector string, value Range) {
+	C.macos_objc_msg_void_range(obj, sel(selector), value)
+}
+
+// msg_void_rect_id sends a void message with a rectangle and an object.
+@[inline]
+pub fn msg_void_rect_id(obj Id, selector string, rect Rect, a1 Id) {
+	C.macos_objc_msg_void_rect_id(obj, sel(selector), rect, a1)
+}
+
+// msg_void_point sends a void message with a point.
+@[inline]
+pub fn msg_void_point(obj Id, selector string, value Point) {
+	C.macos_objc_msg_void_point(obj, sel(selector), value)
+}
+
+// msg_void_id_sel_id_id sends a void message with an object, a selector, and two objects.
+@[inline]
+pub fn msg_void_id_sel_id_id(obj Id, selector string, a0 Id, a1 Sel, a2 Id, a3 Id) {
+	C.macos_objc_msg_void_id_sel_id_id(obj, sel(selector), a0, a1, a2, a3)
+}
+
+// msg_void_sel_id_bool sends a void message with a selector, an object, and a boolean.
+@[inline]
+pub fn msg_void_sel_id_bool(obj Id, selector string, a0 Sel, a1 Id, a2 bool) {
+	C.macos_objc_msg_void_sel_id_bool(obj, sel(selector), a0, a1, a2)
 }
 
 // ── Runtime class helpers ──────────────────────────────────────────

--- a/vlib/macos/macos_darwin.c.v
+++ b/vlib/macos/macos_darwin.c.v
@@ -1,25 +1,18 @@
 module macos
 
+// vfmt off
 #flag darwin -framework Foundation
-
 #flag darwin -lobjc
-
 #insert "@VEXEROOT/vlib/macos/objc_bridge.h"
 
 pub type Id = voidptr
-
 pub type Sel = voidptr
-
 pub type Class = voidptr
-
 pub type Protocol = voidptr
-
 // Point is a Cocoa-compatible point or size containing two f64 values.
 pub type Point = C.macos_point
-
 // Range is a Cocoa-compatible range containing a location and length.
 pub type Range = C.macos_range
-
 pub type Rect = C.macos_rect
 
 pub struct C.macos_point {
@@ -50,129 +43,67 @@ pub const assoc_copy = usize(0o1403)
 pub const run_loop_default_mode = 'kCFRunLoopDefaultMode'
 
 fn C.macos_objc_msg_id0(obj Id, selector Sel) Id
-
 fn C.macos_objc_msg_id1(obj Id, selector Sel, a0 voidptr) Id
-
 fn C.macos_objc_msg_id2(obj Id, selector Sel, a0 voidptr, a1 voidptr) Id
-
 fn C.macos_objc_msg_id3(obj Id, selector Sel, a0 voidptr, a1 voidptr, a2 voidptr) Id
-
 fn C.macos_objc_msg_id4(obj Id, selector Sel, a0 voidptr, a1 voidptr, a2 voidptr, a3 voidptr) Id
-
 fn C.macos_objc_msg_id_rect(obj Id, selector Sel, rect Rect) Id
-
 fn C.macos_objc_msg_id_rect_bool(obj Id, selector Sel, rect Rect, a1 bool) Id
-
 fn C.macos_objc_msg_id_rect_obj(obj Id, selector Sel, rect Rect, a1 voidptr) Id
-
 fn C.macos_objc_msg_id_rect_u64_u64_bool(obj Id, selector Sel, rect Rect, a1 u64, a2 u64, a3 bool) Id
-
 fn C.macos_objc_msg_id_obj_u64_bool(obj Id, selector Sel, a0 voidptr, a1 u64, a2 bool) Id
-
 fn C.macos_objc_msg_id_obj_sel_obj(obj Id, selector Sel, a0 voidptr, a1 voidptr, a2 voidptr) Id
-
 fn C.macos_objc_msg_id_f64(obj Id, selector Sel, a0 f64) Id
-
 fn C.macos_objc_msg_id_u64(obj Id, selector Sel, a0 u64) Id
-
 fn C.macos_objc_msg_id_four_f64(obj Id, selector Sel, a0 f64, a1 f64, a2 f64, a3 f64) Id
-
 fn C.macos_objc_msg_id_id_f64(obj Id, selector Sel, a0 Id, a1 f64) Id
-
 fn C.macos_objc_msg_id_id_u64(obj Id, selector Sel, a0 Id, a1 u64) Id
-
 fn C.macos_objc_msg_id_id_u64_i64_f64(obj Id, selector Sel, a0 Id, a1 u64, a2 i64, a3 f64) Id
-
 fn C.macos_objc_msg_id_u64_id(obj Id, selector Sel, a0 u64, a1 Id) Id
-
 fn C.macos_objc_msg_id_u64_range_ptr(obj Id, selector Sel, a0 u64, range &Range) Id
-
 fn C.macos_objc_msg_id_id_u64_range_ptr(obj Id, selector Sel, a0 Id, a1 u64, range &Range) Id
-
 fn C.macos_objc_msg_id_range(obj Id, selector Sel, range Range) Id
-
 fn C.macos_objc_msg_u64_id(obj Id, selector Sel, a0 Id) u64
-
 fn C.macos_objc_msg_bool_id_bool(obj Id, selector Sel, a0 Id, a1 bool) bool
-
 fn C.macos_objc_msg_bool_sel_id_id(obj Id, selector Sel, a0 Sel, a1 Id, a2 Id) bool
-
 fn C.macos_objc_msg_range(obj Id, selector Sel) Range
-
 fn C.macos_objc_msg_point(obj Id, selector Sel) Point
-
 fn C.macos_objc_msg_point_point_id(obj Id, selector Sel, point Point, a1 Id) Point
-
 fn C.macos_objc_msg_void0(obj Id, selector Sel)
-
 fn C.macos_objc_msg_void1(obj Id, selector Sel, a0 voidptr)
-
 fn C.macos_objc_msg_void2(obj Id, selector Sel, a0 voidptr, a1 voidptr)
-
 fn C.macos_objc_msg_void3(obj Id, selector Sel, a0 voidptr, a1 voidptr, a2 voidptr)
-
 fn C.macos_objc_msg_void_bool(obj Id, selector Sel, a0 bool)
-
 fn C.macos_objc_msg_void_i64(obj Id, selector Sel, a0 i64)
-
 fn C.macos_objc_msg_void_u64(obj Id, selector Sel, a0 u64)
-
 fn C.macos_objc_msg_void_f64(obj Id, selector Sel, a0 f64)
-
 fn C.macos_objc_msg_void_rect(obj Id, selector Sel, rect Rect)
-
 fn C.macos_objc_msg_void_rect_bool_bool(obj Id, selector Sel, rect Rect, a1 bool, a2 bool)
-
 fn C.macos_objc_msg_void_id_i64_id(obj Id, selector Sel, a0 Id, a1 i64, a2 Id)
-
 fn C.macos_objc_msg_void_id_range(obj Id, selector Sel, a0 Id, range Range)
-
 fn C.macos_objc_msg_void_id_id_range(obj Id, selector Sel, a0 Id, a1 Id, range Range)
-
 fn C.macos_objc_msg_void_range(obj Id, selector Sel, range Range)
-
 fn C.macos_objc_msg_void_rect_id(obj Id, selector Sel, rect Rect, a1 Id)
-
 fn C.macos_objc_msg_void_point(obj Id, selector Sel, point Point)
-
 fn C.macos_objc_msg_void_id_sel_id_id(obj Id, selector Sel, a0 Id, a1 Sel, a2 Id, a3 Id)
-
 fn C.macos_objc_msg_void_sel_id_bool(obj Id, selector Sel, a0 Sel, a1 Id, a2 bool)
-
 fn C.macos_objc_msg_bool0(obj Id, selector Sel) bool
-
 fn C.macos_objc_msg_bool1(obj Id, selector Sel, a0 voidptr) bool
-
 fn C.macos_objc_msg_i64(obj Id, selector Sel) i64
-
 fn C.macos_objc_msg_u64(obj Id, selector Sel) u64
-
 fn C.macos_objc_msg_f64(obj Id, selector Sel) f64
-
 fn C.macos_objc_msg_rect(obj Id, selector Sel) Rect
-
 fn C.macos_objc_get_class(const_name &char) Class
-
 fn C.macos_sel_register_name(const_name &char) Sel
-
 fn C.macos_objc_allocate_class_pair(superclass Class, const_name &char, extra_bytes usize) Class
-
 fn C.macos_objc_register_class_pair(cls Class)
-
 fn C.macos_class_add_method(cls Class, name Sel, imp voidptr, const_types &char) bool
-
 fn C.macos_class_add_ivar(cls Class, const_name &char, size usize, alignment u8, const_types &char) bool
-
 fn C.macos_objc_get_protocol(const_name &char) Protocol
-
 fn C.macos_class_add_protocol(cls Class, protocol Protocol) bool
-
 fn C.macos_objc_set_ptr_ivar(obj Id, const_name &char, value voidptr)
-
 fn C.macos_objc_get_ptr_ivar(obj Id, const_name &char) voidptr
-
 fn C.macos_set_associated_object(obj Id, const_key voidptr, value Id, policy usize)
-
 fn C.macos_get_associated_object(obj Id, const_key voidptr) Id
 
 @[inline]
@@ -193,12 +124,13 @@ pub fn sel(name string) Sel {
 @[inline]
 pub fn rect(x f64, y f64, width f64, height f64) Rect {
 	return C.macos_rect{
-		x: x
-		y: y
-		width: width
+		x:      x
+		y:      y
+		width:  width
 		height: height
 	}
 }
+// vfmt on
 
 // point returns a Cocoa-compatible point with the supplied coordinates.
 @[inline]

--- a/vlib/macos/macos_test.v
+++ b/vlib/macos/macos_test.v
@@ -1,0 +1,45 @@
+module macos
+
+$if macos {
+	#flag darwin -framework AppKit
+
+	fn test_point_and_range_constructors() {
+		p := point(12.5, -3.25)
+		assert p.x == 12.5
+		assert p.y == -3.25
+		r := range(4, 7)
+		assert r.location == 4
+		assert r.length == 7
+	}
+
+	fn test_typed_range_message_senders() {
+		pool := autorelease_pool_new()
+		defer {
+			release(pool)
+		}
+		value := msg_id_range(get_class('NSValue'), 'valueWithRange:', range(2, 5))
+		result := msg_range(value, 'rangeValue')
+		assert result.location == 2
+		assert result.length == 5
+
+		text := msg_id_range(nsstring('hello'), 'substringWithRange:', range(1, 3))
+		assert utf8_string(text) == 'ell'
+		assert responds_to(text, 'substringWithRange:')
+		assert msg_bool_id(text, 'isEqualToString:', nsstring('ell'))
+	}
+
+	fn test_typed_point_message_senders() {
+		pool := autorelease_pool_new()
+		defer {
+			release(pool)
+		}
+		shadow := new('NSShadow')
+		defer {
+			release(shadow)
+		}
+		msg_void_point(shadow, 'setShadowOffset:', point(1.5, -2.5))
+		result := msg_point(shadow, 'shadowOffset')
+		assert result.x == 1.5
+		assert result.y == -2.5
+	}
+}

--- a/vlib/macos/objc_bridge.h
+++ b/vlib/macos/objc_bridge.h
@@ -38,6 +38,16 @@ typedef struct macos_rect {
 	double height;
 } macos_rect;
 
+typedef struct macos_point {
+	double x;
+	double y;
+} macos_point;
+
+typedef struct macos_range {
+	uint64_t location;
+	uint64_t length;
+} macos_range;
+
 static inline void* macos_objc_get_class(const char* name) {
 	return (__bridge void*)objc_getClass(name);
 }
@@ -154,6 +164,62 @@ static inline void* macos_objc_msg_id_u64(void* obj, void* sel, unsigned long lo
 	return ((void* (*)(void*, void*, unsigned long long))objc_msgSend)(obj, sel, a0);
 }
 
+static inline void* macos_objc_msg_id_four_f64(void* obj, void* sel, double a0, double a1, double a2, double a3) {
+	return ((void* (*)(void*, void*, double, double, double, double))objc_msgSend)(obj, sel, a0, a1, a2, a3);
+}
+
+static inline void* macos_objc_msg_id_id_f64(void* obj, void* sel, void* a0, double a1) {
+	return ((void* (*)(void*, void*, void*, double))objc_msgSend)(obj, sel, a0, a1);
+}
+
+static inline void* macos_objc_msg_id_id_u64(void* obj, void* sel, void* a0, unsigned long long a1) {
+	return ((void* (*)(void*, void*, void*, unsigned long long))objc_msgSend)(obj, sel, a0, a1);
+}
+
+static inline void* macos_objc_msg_id_id_u64_i64_f64(void* obj, void* sel, void* a0, unsigned long long a1, long long a2, double a3) {
+	return ((void* (*)(void*, void*, void*, unsigned long long, long long, double))objc_msgSend)(obj, sel, a0, a1, a2, a3);
+}
+
+static inline void* macos_objc_msg_id_u64_id(void* obj, void* sel, unsigned long long a0, void* a1) {
+	return ((void* (*)(void*, void*, unsigned long long, void*))objc_msgSend)(obj, sel, a0, a1);
+}
+
+static inline void* macos_objc_msg_id_u64_range_ptr(void* obj, void* sel, unsigned long long a0, macos_range* range) {
+	return ((void* (*)(void*, void*, unsigned long long, macos_range*))objc_msgSend)(obj, sel, a0, range);
+}
+
+static inline void* macos_objc_msg_id_id_u64_range_ptr(void* obj, void* sel, void* a0, unsigned long long a1, macos_range* range) {
+	return ((void* (*)(void*, void*, void*, unsigned long long, macos_range*))objc_msgSend)(obj, sel, a0, a1, range);
+}
+
+static inline void* macos_objc_msg_id_range(void* obj, void* sel, macos_range range) {
+	return ((void* (*)(void*, void*, macos_range))objc_msgSend)(obj, sel, range);
+}
+
+static inline unsigned long long macos_objc_msg_u64_id(void* obj, void* sel, void* a0) {
+	return ((unsigned long long (*)(void*, void*, void*))objc_msgSend)(obj, sel, a0);
+}
+
+static inline bool macos_objc_msg_bool_id_bool(void* obj, void* sel, void* a0, bool a1) {
+	return ((bool (*)(void*, void*, void*, bool))objc_msgSend)(obj, sel, a0, a1);
+}
+
+static inline bool macos_objc_msg_bool_sel_id_id(void* obj, void* sel, void* a0, void* a1, void* a2) {
+	return ((bool (*)(void*, void*, void*, void*, void*))objc_msgSend)(obj, sel, a0, a1, a2);
+}
+
+static inline macos_range macos_objc_msg_range(void* obj, void* sel) {
+	return ((macos_range (*)(void*, void*))objc_msgSend)(obj, sel);
+}
+
+static inline macos_point macos_objc_msg_point(void* obj, void* sel) {
+	return ((macos_point (*)(void*, void*))objc_msgSend)(obj, sel);
+}
+
+static inline macos_point macos_objc_msg_point_point_id(void* obj, void* sel, macos_point point, void* a1) {
+	return ((macos_point (*)(void*, void*, macos_point, void*))objc_msgSend)(obj, sel, point, a1);
+}
+
 static inline void macos_objc_msg_void0(void* obj, void* sel) {
 	((void (*)(void*, void*))objc_msgSend)(obj, sel);
 }
@@ -192,6 +258,38 @@ static inline void macos_objc_msg_void_rect(void* obj, void* sel, macos_rect rec
 
 static inline void macos_objc_msg_void_rect_bool_bool(void* obj, void* sel, macos_rect rect, bool a1, bool a2) {
 	((void (*)(void*, void*, macos_rect, bool, bool))objc_msgSend)(obj, sel, rect, a1, a2);
+}
+
+static inline void macos_objc_msg_void_id_i64_id(void* obj, void* sel, void* a0, long long a1, void* a2) {
+	((void (*)(void*, void*, void*, long long, void*))objc_msgSend)(obj, sel, a0, a1, a2);
+}
+
+static inline void macos_objc_msg_void_id_range(void* obj, void* sel, void* a0, macos_range range) {
+	((void (*)(void*, void*, void*, macos_range))objc_msgSend)(obj, sel, a0, range);
+}
+
+static inline void macos_objc_msg_void_id_id_range(void* obj, void* sel, void* a0, void* a1, macos_range range) {
+	((void (*)(void*, void*, void*, void*, macos_range))objc_msgSend)(obj, sel, a0, a1, range);
+}
+
+static inline void macos_objc_msg_void_range(void* obj, void* sel, macos_range range) {
+	((void (*)(void*, void*, macos_range))objc_msgSend)(obj, sel, range);
+}
+
+static inline void macos_objc_msg_void_rect_id(void* obj, void* sel, macos_rect rect, void* a1) {
+	((void (*)(void*, void*, macos_rect, void*))objc_msgSend)(obj, sel, rect, a1);
+}
+
+static inline void macos_objc_msg_void_point(void* obj, void* sel, macos_point point) {
+	((void (*)(void*, void*, macos_point))objc_msgSend)(obj, sel, point);
+}
+
+static inline void macos_objc_msg_void_id_sel_id_id(void* obj, void* sel, void* a0, void* a1, void* a2, void* a3) {
+	((void (*)(void*, void*, void*, void*, void*, void*))objc_msgSend)(obj, sel, a0, a1, a2, a3);
+}
+
+static inline void macos_objc_msg_void_sel_id_bool(void* obj, void* sel, void* a0, void* a1, bool a2) {
+	((void (*)(void*, void*, void*, void*, bool))objc_msgSend)(obj, sel, a0, a1, a2);
 }
 
 static inline bool macos_objc_msg_bool0(void* obj, void* sel) {


### PR DESCRIPTION
## Summary

- add Cocoa-compatible `Point` and `Range` types and constructors
- add typed Objective-C message senders for mixed object, scalar, point, range, and rectangle signatures
- keep the ABI-sensitive `objc_msgSend` casts inside the macOS C bridge
- document the API and add Foundation/AppKit round-trip tests
- mark existing const C parameters correctly for current V3 C declarations

## Testing

- `./vnew -cstrict -cc clang -silent test vlib/macos/`
- `/Users/alex/code/v/vnew check-md vlib/macos/README.md`
- ui2 macOS Objective-C bridge tests against the new API