### PR TITLE
v3: support FastC builds of the V1 compiler

### DIFF
--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -1297,6 +1297,9 @@ mut:
 	function_defer_declarations []string
 	loop_defer_block_starts     []int
 	loop_has_breaks             []bool
+	loop_labels                 []string
+	parsing_loop_labels         []string
+	pending_loop_label          string
 	statement_reachable         bool
 	last_expression_type        string
 	last_expression             []FastcExpressionToken
@@ -1652,6 +1655,8 @@ fn fastc_generate_single_file(ctx &FastcFileGenContext, source_file FastcSourceF
 		deferred_block_starts: []int{}
 		loop_defer_block_starts: []int{}
 		loop_has_breaks: []bool{}
+		loop_labels: []string{}
+		parsing_loop_labels: []string{}
 		statement_reachable: true
 	}
 	// The per-file lookup memos fill up quickly; size them once instead of

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -1104,6 +1104,31 @@ fn test_selfhost_spawn_nested_wait_statement_and_helper_names() {
 	assert c_source.contains('${void_waiter}(done);'), c_source
 }
 
+fn test_selfhost_spawn_wait_uses_explicit_parameter_type() {
+	$if windows {
+		return
+	}
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn produce() string {
+	return "done"
+}
+
+fn consume(worker thread string) {
+	result := worker.wait()
+	println(result)
+}
+
+fn main() {
+	consume(spawn produce())
+}
+', 'spawn_explicit_parameter.v', prefs) or { panic(err) }
+	assert c_source.contains('string result = (__vf_thread_wait_kstring(worker));'), c_source
+	assert !c_source.contains('void result ='), c_source
+}
+
 fn test_selfhost_spawn_rejects_disabled_callee_before_arguments() {
 	$if windows {
 		return
@@ -6512,6 +6537,28 @@ fn main() {
 	assert empty_initializer_source.contains('for (; i<2; i++) {'), empty_initializer_source
 }
 
+fn test_labeled_break_and_continue_target_the_outer_loop() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn main() {
+	outer: for i := 0; i < 2; i++ {
+		for {
+			if i == 0 {
+				continue outer
+			}
+			break outer
+		}
+	}
+}
+', 'labeled_loop.v', prefs) or { panic(err) }
+	assert c_source.contains('goto __vf_loop_outer_continue;'), c_source
+	assert c_source.contains('__vf_loop_outer_continue:;'), c_source
+	assert c_source.contains('goto __vf_loop_outer_break;'), c_source
+	assert c_source.contains('__vf_loop_outer_break:;'), c_source
+}
+
 fn test_negative_integer_literals_are_lowered_for_unsigned_targets() {
 	prefs := pref.new_preferences()
 	for source in [
@@ -9266,6 +9313,37 @@ fn main() {
 	// The appended value is a method call and must be routed through the argument
 	// renderer, not streamed raw as `c.value()` (an unresolved struct field call).
 	assert c_source.contains('Counter_value(c)'), c_source
+}
+
+fn test_selfhost_append_copies_pointer_return_into_value_array() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Node {
+	value int
+}
+
+fn child() &Node {
+	return &Node{
+		value: 1
+	}
+}
+
+fn append_ref(node &Node) {
+	mut refs := []&Node{}
+	refs << node
+}
+
+fn main() {
+	mut pending := []Node{}
+	pending << child()
+	append_ref(child())
+}
+', 'selfhost_append_pointer_return.v', prefs) or { panic(err) }
+	assert c_source.contains('Node __v0 = (*(child()));'), c_source
+	assert c_source.contains('Node* __v0 = (node);'), c_source
+	assert !c_source.contains('Node* __v0 = (*(node));'), c_source
 }
 
 fn test_orm_where_operator_mapping() {

--- a/vlib/v3/gen/fastc/render_method_calls.v
+++ b/vlib/v3/gen/fastc/render_method_calls.v
@@ -325,7 +325,7 @@ fn (g &Parser) render_method_call_expression(tokens []FastcExpressionToken, rend
 				// `[]thread T`.wait() joins every handle and gathers their `[]T` results.
 				wait_end := fastc_matching_rpar(tokens, i + 1) or { continue }
 				receiver := g.render_method_receiver_expression(receiver_tokens) or { continue }
-				value_type := g.thread_value_types[element] or { continue }
+				value_type := g.fastc_thread_value_type(element) or { continue }
 				result_type := fastc_array_c_type(value_type)
 				mut w := unsafe { &Parser(g) }
 				fastc_register_composite_type(result_type, mut w.composite_types)
@@ -364,7 +364,7 @@ fn (g &Parser) render_method_call_expression(tokens []FastcExpressionToken, rend
 			// the collected function signatures.
 			wait_end := fastc_matching_rpar(tokens, i + 1) or { continue }
 			receiver := g.render_method_receiver_expression(receiver_tokens) or { continue }
-			value_type := g.thread_value_types[receiver_type] or { '' }
+			value_type := g.fastc_thread_value_type(receiver_type) or { '' }
 			wait_call := '${g.fastc_unclaimed_generated_name(fastc_thread_wait_name(receiver_type))}(${receiver.source})'
 			if receiver_start == 0 && wait_end == tokens.len - 1 {
 				return FastcRenderedExpression{

--- a/vlib/v3/gen/fastc/spawn.v
+++ b/vlib/v3/gen/fastc/spawn.v
@@ -33,11 +33,61 @@ fn fastc_name_key(text string) string {
 	return fastc_take_string(mut encoded)
 }
 
+fn fastc_name_key_hex_value(value u8) ?u8 {
+	if value >= `0` && value <= `9` {
+		return u8(value - `0`)
+	}
+	if value >= `a` && value <= `f` {
+		return u8(value - `a` + 10)
+	}
+	return none
+}
+
+fn fastc_decode_name_key(encoded string) ?string {
+	mut decoded := strings.new_builder(encoded.len)
+	mut i := 0
+	for i < encoded.len {
+		if encoded[i] != `_` {
+			decoded.write_u8(encoded[i])
+			i++
+			continue
+		}
+		if i + 2 >= encoded.len {
+			return none
+		}
+		high := fastc_name_key_hex_value(encoded[i + 1])?
+		low := fastc_name_key_hex_value(encoded[i + 2])?
+		decoded.write_u8((high << 4) | low)
+		i += 3
+	}
+	return fastc_take_string(mut decoded)
+}
+
 fn fastc_thread_type_name(value_type string) string {
 	if value_type in ['', 'void'] {
 		return '${fastc_thread_type_prefix}void'
 	}
 	return '${fastc_thread_type_prefix}k${fastc_name_key(value_type)}'
+}
+
+fn fastc_thread_value_type_from_name(thread_type string) ?string {
+	name := thread_type.trim_right('*')
+	if name == '${fastc_thread_type_prefix}void' {
+		return ''
+	}
+	value_prefix := '${fastc_thread_type_prefix}k'
+	if !name.starts_with(value_prefix) {
+		return none
+	}
+	return fastc_decode_name_key(name[value_prefix.len..])
+}
+
+fn (g &Parser) fastc_thread_value_type(thread_type string) ?string {
+	name := thread_type.trim_right('*')
+	if value_type := g.thread_value_types[name] {
+		return value_type
+	}
+	return fastc_thread_value_type_from_name(name)
 }
 
 fn fastc_thread_wait_name(thread_type string) string {

--- a/vlib/v3/gen/fastc/stmt.v
+++ b/vlib/v3/gen/fastc/stmt.v
@@ -118,7 +118,15 @@ fn (mut g Parser) parse_statement() !bool {
 			g.parse_if()!
 		}
 		.key_for {
-			g.parse_for()!
+			loop_label := g.pending_loop_label
+			g.pending_loop_label = ''
+			g.parsing_loop_labels << loop_label
+			terminates := g.parse_for()!
+			g.parsing_loop_labels.delete_last()
+			if loop_label != '' {
+				g.write_line('${fastc_loop_break_label(loop_label)}:;')
+			}
+			terminates
 		}
 		.key_match {
 			g.parse_match_statement()!
@@ -131,25 +139,49 @@ fn (mut g Parser) parse_statement() !bool {
 		}
 		.key_break {
 			g.next()
+			mut target_label := ''
+			if g.tok == .name {
+				target_label = g.lit
+				g.next()
+			}
 			g.consume_statement_end()
 			if g.loop_defer_block_starts.len == 0 {
 				return g.unsupported('`break` outside a loop')
 			}
-			if g.statement_reachable && g.loop_has_breaks.len > 0 {
-				g.loop_has_breaks[g.loop_has_breaks.len - 1] = true
+			loop_index := g.loop_index_for_label(target_label) or {
+				return g.unsupported('unknown loop label `${target_label}`')
 			}
-			g.write_deferred_blocks_from(g.loop_defer_block_starts.last())
-			g.write_line('break;')
+			if g.statement_reachable {
+				g.loop_has_breaks[loop_index] = true
+			}
+			g.write_deferred_blocks_from(g.loop_defer_block_starts[loop_index])
+			g.write_line(if target_label == '' {
+				'break;'
+			} else {
+				'goto ${fastc_loop_break_label(target_label)};'
+			})
 			true
 		}
 		.key_continue {
 			g.next()
+			mut target_label := ''
+			if g.tok == .name {
+				target_label = g.lit
+				g.next()
+			}
 			g.consume_statement_end()
 			if g.loop_defer_block_starts.len == 0 {
 				return g.unsupported('`continue` outside a loop')
 			}
-			g.write_deferred_blocks_from(g.loop_defer_block_starts.last())
-			g.write_line('continue;')
+			loop_index := g.loop_index_for_label(target_label) or {
+				return g.unsupported('unknown loop label `${target_label}`')
+			}
+			g.write_deferred_blocks_from(g.loop_defer_block_starts[loop_index])
+			g.write_line(if target_label == '' {
+				'continue;'
+			} else {
+				'goto ${fastc_loop_continue_label(target_label)};'
+			})
 			true
 		}
 		.key_goto {
@@ -532,16 +564,42 @@ fn (g &Parser) deferred_scopes_source() string {
 }
 
 fn (mut g Parser) parse_loop_block_body() !FastcLoopBlockResult {
+	loop_label := if g.parsing_loop_labels.len > 0 { g.parsing_loop_labels.last() } else { '' }
+	g.loop_labels << loop_label
 	g.loop_defer_block_starts << g.deferred_block_starts.len
 	g.loop_has_breaks << false
 	terminates := g.parse_block_body()!
 	has_reachable_break := g.loop_has_breaks.last()
+	if g.loop_labels.len > 0 && g.loop_labels.last() != '' {
+		g.write_line('${fastc_loop_continue_label(g.loop_labels.last())}:;')
+	}
 	g.loop_has_breaks.delete_last()
 	g.loop_defer_block_starts.delete_last()
+	g.loop_labels.delete_last()
 	return FastcLoopBlockResult{
 		terminates: terminates
 		has_reachable_break: has_reachable_break
 	}
+}
+
+fn fastc_loop_break_label(label string) string {
+	return '__vf_loop_${fastc_c_identifier(label)}_break'
+}
+
+fn fastc_loop_continue_label(label string) string {
+	return '__vf_loop_${fastc_c_identifier(label)}_continue'
+}
+
+fn (g &Parser) loop_index_for_label(label string) ?int {
+	if label == '' {
+		return g.loop_labels.len - 1
+	}
+	for i := g.loop_labels.len - 1; i >= 0; i-- {
+		if g.loop_labels[i] == label {
+			return i
+		}
+	}
+	return none
 }
 
 fn (mut g Parser) parse_match_statement() !bool {
@@ -1150,10 +1208,14 @@ fn (mut g Parser) parse_simple_statement() ! {
 			// the connection method call.
 			return g.parse_orm_sql_statement()
 		}
-		if g.selfhost && g.tok == .colon {
+		if g.tok == .colon {
 			g.next()
 			g.skip_semicolons()
-			g.write_line('${fastc_c_identifier(name)}:')
+			if g.tok == .key_for {
+				g.pending_loop_label = name
+			} else {
+				g.write_line('${fastc_c_identifier(name)}:')
+			}
 			return
 		}
 		if g.selfhost && g.tok == .comma {
@@ -1216,13 +1278,17 @@ fn (mut g Parser) parse_simple_statement() ! {
 				g.write_line('${value_decl_type} ${value_name} = (${value});')
 				g.write_line('builtin__array_push_many(${array_target}, ${value_name}.data, ${value_name}.len);')
 			} else {
-				// A `.member` enum-shorthand element needs its target enum type to lower; re-render it
-				// through the argument path. Other values keep their raw streamed form so contextual
-				// re-rendering never disturbs a spawn/thread or already-correct value.
+				// Enum shorthand and pointer/value conversions need the target element type to lower;
+				// re-render them through the argument path. Other values keep their raw streamed form
+				// so contextual re-rendering never disturbs a spawn/thread or already-correct value.
 				is_complex_or := value.contains('({') && (value.contains('return ')
 					|| value.contains('for (') || value.contains('switch ('))
 				boxes_variant := g.should_box_variant(element_type, value_type)
-				push_value := if boxes_variant || (g.last_expression.len == 2 && g.last_expression[0].tok == .dot && g.last_expression[1].tok == .name) || is_complex_or {
+				copies_pointed_value := value_type.ends_with('*')
+					&& element_type == value_type.trim_right('*')
+				converts_pointer_element := element_type.ends_with('*')
+					&& value_type in [element_type, element_type.trim_right('*')]
+				push_value := if boxes_variant || copies_pointed_value || converts_pointer_element || (g.last_expression.len == 2 && g.last_expression[0].tok == .dot && g.last_expression[1].tok == .name) || is_complex_or {
 					// A `.member` enum-shorthand element, or a complex `or { return … }`-unwrap: the
 					// streamed form can carry a paren imbalance and/or unresolved shorthand. A
 					// smart-cast variant appended to a sum-type array also needs to be boxed back into

--- a/vlib/v3/gen/fastc/types.v
+++ b/vlib/v3/gen/fastc/types.v
@@ -727,7 +727,7 @@ fn (g &Parser) infer_expression_type_range_impl(tokens []FastcExpressionToken, e
 			}
 		}
 		if tokens[i].lit == 'wait' && receiver_type.starts_with(fastc_thread_type_prefix) {
-			value_type := g.thread_value_types[receiver_type] or { '' }
+			value_type := g.fastc_thread_value_type(receiver_type) or { '' }
 			if value_type == '' {
 				return 'void'
 			}
@@ -737,7 +737,7 @@ fn (g &Parser) infer_expression_type_range_impl(tokens []FastcExpressionToken, e
 			// `[]thread T`.wait() joins every thread and returns their `[]T` results.
 			element := g.array_element_type(receiver_type) or { '' }
 			if element.starts_with(fastc_thread_type_prefix) {
-				value_type := g.thread_value_types[element] or { '' }
+				value_type := g.fastc_thread_value_type(element) or { '' }
 				if value_type != '' {
 					return fastc_array_c_type(value_type)
 				}


### PR DESCRIPTION
## Summary

- preserve pointer/value conversions when appending compiler data structures
- recover explicit thread result types across per-function FastC parsers
- lower labeled break and continue with dedicated C targets
- add regressions for all three self-host failures

## Validation

- rebuilt vnew from the bootstrap compiler
- built cmd/v/v.v with uncached FastC in single-unit and parallel modes
- built vlib/v3/v3.v with uncached FastC
- used both generated compilers to compile and run examples/hello_world.v

The focused fastc_test.v runner is currently blocked on master by the existing conflicting v_os_exec_capture_input_start declarations. No large test suites were run.