### PR TITLE
scanner, cgen: fix backslash-escape corruption after \x/\u/\U hex decode

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -254,16 +254,18 @@ pub:
 @[minify]
 pub struct StringLiteral {
 pub:
-	val      string
-	is_raw   bool
-	language Language
-	pos      token.Pos
+	val        string
+	is_raw     bool
+	language   Language
+	pos        token.Pos
+	opaque_pos []int // byte offsets in `val` already resolved from a \xXX/\uXXXX/\UXXXXXXXX escape - see Scanner.string_opaque_pos
 }
 
 // 'name: ${name}'
 pub struct StringInterLiteral {
 pub:
 	vals       []string
+	opaque_pos [][]int // opaque_pos[i] are the resolved-escape byte offsets in vals[i] - see StringLiteral.opaque_pos
 	fwidths    []int
 	precisions []int
 	pluss      []bool

--- a/vlib/v/ast/attr.v
+++ b/vlib/v/ast/attr.v
@@ -25,6 +25,11 @@ pub:
 	ct_opt  bool // true for [if user_defined_name?]
 	pos     token.Pos
 	has_at  bool // new syntax `@[attr]`
+	// byte offsets in `name`/`arg` already resolved from a \xXX/\uXXXX/\UXXXXXXXX escape -
+	// see ast.StringLiteral.opaque_pos. name_opaque_pos only applies when kind == .string
+	// (i.e. `name` itself is a quoted string, e.g. `@['A\x5cnB']`).
+	name_opaque_pos []int
+	arg_opaque_pos  []int
 	// original call-style metadata for `@[foo(...)]`, used by vfmt
 	call_name     string
 	call_arg_name string

--- a/vlib/v/checker/comptime.v
+++ b/vlib/v/checker/comptime.v
@@ -1152,7 +1152,7 @@ fn (mut c Checker) eval_comptime_const_expr_with_locals(expr ast.Expr, nlevel in
 			return expr.val.i64()
 		}
 		ast.StringLiteral {
-			return util.smart_quote(expr.val, expr.is_raw)
+			return util.smart_quote(expr.val, expr.is_raw, expr.opaque_pos)
 		}
 		ast.StringInterLiteral {
 			if nlevel < 0 {

--- a/vlib/v/gen/c/comptime.v
+++ b/vlib/v/gen/c/comptime.v
@@ -603,15 +603,25 @@ fn cgen_attrs(attrs []ast.Attr) []string {
 	mut res := []string{cap: attrs.len}
 	for attr in attrs {
 		mut s := attr.name
+		mut s_opaque_pos := attr.name_opaque_pos.clone()
 		if attr.has_arg {
 			mut arg := attr.arg
+			mut arg_opaque_pos := attr.arg_opaque_pos.clone()
 			if attr.kind == .string {
 				quote := if attr.quote == `"` { '"' } else { "'" }
 				arg = '${quote}${arg}${quote}'
+				// shift for the opening quote char just prepended above
+				for i in 0 .. arg_opaque_pos.len {
+					arg_opaque_pos[i] += quote.len
+				}
+			}
+			prefix_len := s.len + ': '.len
+			for pos in arg_opaque_pos {
+				s_opaque_pos << prefix_len + pos
 			}
 			s += ': ${arg}'
 		}
-		res << '_S("${cescape_nonascii(util.smart_quote(s, false))}")'
+		res << '_S("${cescape_nonascii(util.smart_quote(s, false, s_opaque_pos))}")'
 	}
 	return res
 }
@@ -619,8 +629,8 @@ fn cgen_attrs(attrs []ast.Attr) []string {
 fn cgen_vattrs(attrs []ast.Attr) []string {
 	mut res := []string{cap: attrs.len}
 	for attr in attrs {
-		name := cescape_nonascii(util.smart_quote(attr.name, false))
-		arg := cescape_nonascii(util.smart_quote(attr.arg, false))
+		name := cescape_nonascii(util.smart_quote(attr.name, false, attr.name_opaque_pos))
+		arg := cescape_nonascii(util.smart_quote(attr.arg, false, attr.arg_opaque_pos))
 		res << '((VAttribute){.name=_S("${name}"),.has_arg=${attr.has_arg},.arg=_S("${arg}"),.kind=AttributeKind__${attr.kind}})'
 	}
 	return res
@@ -628,7 +638,7 @@ fn cgen_vattrs(attrs []ast.Attr) []string {
 
 fn (mut g Gen) comptime_at(node ast.AtExpr) {
 	if node.kind == .vmod_file {
-		val := cescape_nonascii(util.smart_quote(node.val, false))
+		val := cescape_nonascii(util.smart_quote(node.val, false, []int{}))
 		g.write('_S("${val}")')
 	} else {
 		val := node.val.replace('\\', '\\\\')
@@ -1503,9 +1513,9 @@ fn (mut g Gen) comptime_for(node ast.ComptimeFor) {
 				g.comptime.comptime_for_attr_var = node.val_var
 				g.comptime.comptime_for_attr_value = attr
 				g.writeln('/* attribute ${i} : ${attr.name} */ {')
-				g.writeln('\t${node.val_var}.name = _S("${attr.name}");')
+				g.writeln('\t${node.val_var}.name = _S("${util.smart_quote(attr.name, false, attr.name_opaque_pos)}");')
 				g.writeln('\t${node.val_var}.has_arg = ${attr.has_arg};')
-				g.writeln('\t${node.val_var}.arg = _S("${util.smart_quote(attr.arg, false)}");')
+				g.writeln('\t${node.val_var}.arg = _S("${util.smart_quote(attr.arg, false, attr.arg_opaque_pos)}");')
 				g.writeln('\t${node.val_var}.kind = AttributeKind__${attr.kind};')
 				g.stmts(node.stmts)
 				g.write_defer_stmts(node.scope, false, node.pos)

--- a/vlib/v/gen/c/consts_and_globals.v
+++ b/vlib/v/gen/c/consts_and_globals.v
@@ -227,7 +227,7 @@ fn (mut g Gen) const_decl_precomputed(mod string, name string, cname string, fie
 					write_octal_escape(mut sb, u8(rune_code))
 					sb.str()
 				} else {
-					util.smart_quote(u8(rune_code).ascii_str(), false)
+					util.smart_quote(u8(rune_code).ascii_str(), false, []int{})
 				}
 
 				g.global_const_defs[util.no_dots(field_name)] = GlobalConstDef{
@@ -240,7 +240,7 @@ fn (mut g Gen) const_decl_precomputed(mod string, name string, cname string, fie
 			}
 		}
 		string {
-			escaped_val := util.smart_quote(ct_value, false)
+			escaped_val := util.smart_quote(ct_value, false, []int{})
 			// g.const_decl_write_precomputed(line_nr, styp, cname, '_S("${escaped_val}")')
 			// TODO: ^ the above for strings, cause:
 			// `error C2099: initializer is not a constant` errors in MSVC,

--- a/vlib/v/gen/c/consts_and_globals.v
+++ b/vlib/v/gen/c/consts_and_globals.v
@@ -537,7 +537,8 @@ fn (mut g Gen) global_decl(node ast.GlobalDecl) {
 		attributes += 'VV_EXP '
 	}
 	if attr := node.attrs.find_first('_linker_section') {
-		attributes += '__attribute__ ((section ("${attr.arg}"))) '
+		escaped_section := util.smart_quote(attr.arg, false, attr.arg_opaque_pos)
+		attributes += '__attribute__ ((section ("${escaped_section}"))) '
 	}
 	for field in node.fields {
 		name := c_name(field.name)

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -1448,7 +1448,8 @@ fn (mut g Gen) gen_fn_decl(node &ast.FnDecl, skip bool) {
 		g.definitions.write_string('void')
 	}
 	if attr := node.attrs.find_first('_linker_section') {
-		g.definitions.writeln(') __attribute__ ((section ("${attr.arg}")));')
+		escaped_section := util.smart_quote(attr.arg, false, attr.arg_opaque_pos)
+		g.definitions.writeln(') __attribute__ ((section ("${escaped_section}")));')
 	} else {
 		g.definitions.writeln(');')
 	}

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -270,7 +270,8 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 			g.write('${arrow}len ${node.op} 0')
 		} else if node.left is ast.Ident {
 			// vmemcmp(left, "str", sizeof("str")) optimization
-			slit := cescape_nonascii(util.smart_quote(node.right.val, node.right.is_raw))
+			slit := cescape_nonascii(util.smart_quote(node.right.val, node.right.is_raw,
+				node.right.opaque_pos))
 			var := g.expr_string(ast.Expr(node.left))
 			arrow := if left.typ.is_ptr() { '->' } else { '.' }
 			if node.op == .eq {
@@ -1126,8 +1127,8 @@ fn (mut g Gen) infix_expr_in_optimization(left ast.Expr, left_type ast.Type, rig
 					if left is ast.Ident && left.or_expr.kind == .absent
 						&& array_expr is ast.StringLiteral {
 						var := g.expr_string(left)
-						slit :=
-							cescape_nonascii(util.smart_quote(array_expr.val, array_expr.is_raw))
+						slit := cescape_nonascii(util.smart_quote(array_expr.val, array_expr.is_raw,
+							array_expr.opaque_pos))
 						mut needs_deref := false
 						if left.info is ast.IdentVar && left.obj is ast.Var {
 							if g.table.sym(left.obj.typ).kind in [.interface, .sum_type] {

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -294,7 +294,8 @@ fn (mut g Gen) gen_enum_to_str(utyp ast.Type, sym ast.TypeSymbol, enum_var strin
 			ast.Attr{}
 		}
 		if attr.has_arg {
-			enc.writeln('${result_var} = json__encode_string(_S("${attr.arg}")); break;')
+			escaped_arg := cescape_nonascii(util.smart_quote(attr.arg, false, attr.arg_opaque_pos))
+			enc.writeln('${result_var} = json__encode_string(_S("${escaped_arg}")); break;')
 		} else {
 			enc.writeln('${result_var} = json__encode_string(_S("${val}")); break;')
 		}
@@ -318,7 +319,8 @@ fn (mut g Gen) gen_str_to_enum(utyp ast.Type, sym ast.TypeSymbol, val_var string
 			dec.write_string('${ident}else if (builtin__string__eq(_S("${val}"), ${val_var})')
 		}
 		if attr.has_arg {
-			dec.write_string(' || builtin__string__eq(_S("${attr.arg}"), ${val_var})')
+			escaped_arg := cescape_nonascii(util.smart_quote(attr.arg, false, attr.arg_opaque_pos))
+			dec.write_string(' || builtin__string__eq(_S("${escaped_arg}"), ${val_var})')
 		}
 		dec.write_string(')\t')
 		if is_option {

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -806,6 +806,7 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 	info := type_info as ast.Struct
 	for field in info.fields {
 		mut name := field.name
+		mut name_opaque_pos := []int{}
 		mut is_raw := false
 		mut is_skip := false
 		mut is_required := false
@@ -821,6 +822,7 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 						is_skip = true
 					} else {
 						name = attr.arg
+						name_opaque_pos = attr.arg_opaque_pos.clone()
 					}
 				}
 				'skip' {
@@ -844,6 +846,7 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 		if is_skip {
 			continue
 		}
+		escaped_name := cescape_nonascii(util.smart_quote(name, false, name_opaque_pos))
 		field_type := vint2int(g.styp(field.typ))
 		field_sym := g.table.sym(field.typ)
 		op := if utyp.is_ptr() { '->' } else { '.' }
@@ -858,7 +861,7 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 			if field.typ.has_flag(.option) {
 				g.gen_json_for_type(field.typ)
 				base_typ := g.base_type(field.typ)
-				dec.writeln('\tif (js_get(root, "${name}") == NULL)')
+				dec.writeln('\tif (js_get(root, "${escaped_name}") == NULL)')
 				default_init := if field.typ.is_int() || field.typ.is_float() || field.typ.is_bool() {
 					'0'
 				} else {
@@ -866,9 +869,9 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 				}
 				dec.writeln('\t\tbuiltin___option_none(&(${base_typ}[]) { ${default_init} }, (${option_name}*)&${prefix}${op}${c_name(field.name)}, sizeof(${base_typ}));')
 				dec.writeln('\telse')
-				dec.writeln('\t\tbuiltin___option_ok(&(${base_typ}[]) {  json__json_print(js_get(root, "${name}")) }, (${option_name}*)&${prefix}${op}${c_name(field.name)}, sizeof(${base_typ}));')
+				dec.writeln('\t\tbuiltin___option_ok(&(${base_typ}[]) {  json__json_print(js_get(root, "${escaped_name}")) }, (${option_name}*)&${prefix}${op}${c_name(field.name)}, sizeof(${base_typ}));')
 			} else {
-				dec.writeln('\t${prefix}${op}${c_name(field.name)} = json__json_print(js_get(root, "${name}"));')
+				dec.writeln('\t${prefix}${op}${c_name(field.name)} = json__json_print(js_get(root, "${escaped_name}"));')
 			}
 		} else {
 			// Now generate decoders for all field types in this struct
@@ -877,7 +880,7 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 			dec_name := js_dec_name(field_type)
 			if is_js_prim(field_type) {
 				tmp := g.new_tmp_var()
-				gen_js_get(styp, tmp, name, mut dec, is_required)
+				gen_js_get(styp, tmp, escaped_name, mut dec, is_required)
 				dec.writeln('\tif (jsonroot_${tmp}) {')
 				if utyp.has_flag(.option) {
 					dec.writeln('\t\tres.state = 0;')
@@ -895,11 +898,11 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 				tmp := g.new_tmp_var()
 				is_option_field := field.typ.has_flag(.option)
 				if field.typ.has_flag(.option) {
-					gen_js_get_opt(js_dec_name(field_type), field_type, styp, tmp, name, mut dec,
+					gen_js_get_opt(js_dec_name(field_type), field_type, styp, tmp, escaped_name, mut dec,
 						is_required)
 					dec.writeln('\tif (jsonroot_${tmp} && !cJSON_IsNull(jsonroot_${tmp})) {')
 				} else {
-					gen_js_get(styp, tmp, name, mut dec, is_required)
+					gen_js_get(styp, tmp, escaped_name, mut dec, is_required)
 					dec.writeln('\tif (jsonroot_${tmp}) {')
 				}
 				if g.is_enum_as_int(field_sym) {
@@ -930,7 +933,7 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 				// time struct requires special treatment
 				// it can be decoded from either a JSON string or number
 				tmp := g.new_tmp_var()
-				gen_js_get(styp, tmp, name, mut dec, is_required)
+				gen_js_get(styp, tmp, escaped_name, mut dec, is_required)
 				dec.writeln('\tif (jsonroot_${tmp}) {')
 				tmp_time_res := g.new_tmp_var()
 				dec.writeln('\t\t${result_name}_time__Time ${tmp_time_res} = json__decode_time(jsonroot_${tmp});')
@@ -964,7 +967,7 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 				parent_dec_name := js_dec_name(sparent_type)
 				if is_js_prim(sparent_type) {
 					tmp := g.new_tmp_var()
-					gen_js_get(styp, tmp, name, mut dec, is_required)
+					gen_js_get(styp, tmp, escaped_name, mut dec, is_required)
 					dec.writeln('\tif (jsonroot_${tmp}) {')
 					g.gen_prim_type_validation(field.name, parent_type, tmp, is_required,
 						'${result_name}_${styp}', mut dec)
@@ -978,7 +981,7 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 				} else {
 					g.gen_json_for_type(parent_type)
 					tmp := g.new_tmp_var()
-					gen_js_get_opt(dec_name, field_type, styp, tmp, name, mut dec, is_required)
+					gen_js_get_opt(dec_name, field_type, styp, tmp, escaped_name, mut dec, is_required)
 					dec.writeln('\tif (jsonroot_${tmp}) {')
 					dec.writeln('\t\t${prefix}${op}${c_name(field.name)} = *(${field_type}*) ${tmp}.data;')
 					if field.has_default_expr {
@@ -1006,7 +1009,7 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 					}
 				}
 				tmp := g.new_tmp_var()
-				gen_js_get_opt(dec_name, field_type, styp, tmp, name, mut dec, is_required)
+				gen_js_get_opt(dec_name, field_type, styp, tmp, escaped_name, mut dec, is_required)
 				dec.writeln('\tif (jsonroot_${tmp}) {')
 				if is_js_prim(g.styp(field.typ.clear_option_and_result())) {
 					g.gen_prim_type_validation(field.name, field.typ, tmp, is_required,
@@ -1087,9 +1090,9 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 		if field_sym.kind == .enum {
 			if g.is_enum_as_int(field_sym) {
 				if field.typ.has_flag(.option) {
-					enc.writeln('${indent}\tcJSON_AddItemToObject(o, "${name}", json__encode_u64(*${prefix_enc}${op}${c_name(field.name)}.data));\n')
+					enc.writeln('${indent}\tcJSON_AddItemToObject(o, "${escaped_name}", json__encode_u64(*${prefix_enc}${op}${c_name(field.name)}.data));\n')
 				} else {
-					enc.writeln('${indent}\tcJSON_AddItemToObject(o, "${name}", json__encode_u64(${prefix_enc}${op}${c_name(field.name)}));\n')
+					enc.writeln('${indent}\tcJSON_AddItemToObject(o, "${escaped_name}", json__encode_u64(${prefix_enc}${op}${c_name(field.name)}));\n')
 				}
 			} else {
 				if field.typ.has_flag(.option) {
@@ -1098,7 +1101,7 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 					g.gen_enum_to_str(field.typ, field_sym,
 						'*(${g.base_type(field.typ)}*)${prefix_enc}${op}${c_name(field.name)}.data',
 						'enum_val', '${indent}\t\t', mut enc)
-					enc.writeln('${indent}\t\tcJSON_AddItemToObject(o, "${name}", enum_val);')
+					enc.writeln('${indent}\t\tcJSON_AddItemToObject(o, "${escaped_name}", enum_val);')
 					enc.writeln('${indent}\t}')
 				} else {
 					enc.writeln('${indent}\t{')
@@ -1106,7 +1109,7 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 					g.gen_enum_to_str(field.typ, field_sym,
 						'${prefix_enc}${op}${c_name(field.name)}', 'enum_val', '${indent}\t\t', mut
 						enc)
-					enc.writeln('${indent}\t\tcJSON_AddItemToObject(o, "${name}", enum_val);')
+					enc.writeln('${indent}\t\tcJSON_AddItemToObject(o, "${escaped_name}", enum_val);')
 					enc.writeln('${indent}\t}')
 				}
 			}
@@ -1115,27 +1118,27 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 				// time struct requires special treatment
 				// it has to be encoded as a unix timestamp number
 				if is_option {
-					enc.writeln('${indent}cJSON_AddItemToObject(o, "${name}", json__encode_u64(time__Time_unix(*(${g.base_type(field.typ)}*)(${prefix_enc}${op}${c_name(field.name)}.data))));')
+					enc.writeln('${indent}cJSON_AddItemToObject(o, "${escaped_name}", json__encode_u64(time__Time_unix(*(${g.base_type(field.typ)}*)(${prefix_enc}${op}${c_name(field.name)}.data))));')
 				} else {
-					enc.writeln('${indent}cJSON_AddItemToObject(o, "${name}", json__encode_u64(time__Time_unix(${prefix_enc}${op}${c_name(field.name)})));')
+					enc.writeln('${indent}cJSON_AddItemToObject(o, "${escaped_name}", json__encode_u64(time__Time_unix(${prefix_enc}${op}${c_name(field.name)})));')
 				}
 			} else {
 				if !field.typ.is_any_kind_of_pointer() {
 					if field_sym.kind == .alias && field.typ.has_flag(.option) {
 						parent_type := g.table.unaliased_type(field.typ).set_flag(.option)
-						enc.writeln('${indent}\tcJSON_AddItemToObject(o, "${name}", ${enc_name}(*(${g.styp(parent_type)}*)&${prefix_enc}${op}${c_name(field.name)}));')
+						enc.writeln('${indent}\tcJSON_AddItemToObject(o, "${escaped_name}", ${enc_name}(*(${g.styp(parent_type)}*)&${prefix_enc}${op}${c_name(field.name)}));')
 					} else {
-						enc.writeln('${indent}\tcJSON_AddItemToObject(o, "${name}", ${enc_name}(${prefix_enc}${op}${c_name(field.name)}));')
+						enc.writeln('${indent}\tcJSON_AddItemToObject(o, "${escaped_name}", ${enc_name}(${prefix_enc}${op}${c_name(field.name)}));')
 					}
 				} else {
 					arg_prefix := if field.typ.is_ptr() { '' } else { '*' }
 					sptr_value := '${prefix_enc}${op}${c_name(field.name)}'
 					if !field.typ.has_flag(.option) {
 						enc.writeln('${indent}if (${sptr_value} != 0) {')
-						enc.writeln('${indent}\tcJSON_AddItemToObject(o, "${name}", ${enc_name}(${arg_prefix}${sptr_value}));')
+						enc.writeln('${indent}\tcJSON_AddItemToObject(o, "${escaped_name}", ${enc_name}(${arg_prefix}${sptr_value}));')
 						enc.writeln('${indent}}\n')
 					} else {
-						enc.writeln('${indent}cJSON_AddItemToObject(o, "${name}", ${enc_name}(${arg_prefix}${sptr_value}));')
+						enc.writeln('${indent}cJSON_AddItemToObject(o, "${escaped_name}", ${enc_name}(${arg_prefix}${sptr_value}));')
 					}
 				}
 			}
@@ -1144,7 +1147,7 @@ fn (mut g Gen) gen_struct_enc_dec(utyp ast.Type, type_info ast.TypeInfo, styp st
 		if is_option {
 			if is_json_null {
 				enc.writeln('\t} else {')
-				enc.writeln('\t\tcJSON_AddItemToObject(o, "${name}", cJSON_CreateNull());')
+				enc.writeln('\t\tcJSON_AddItemToObject(o, "${escaped_name}", cJSON_CreateNull());')
 			}
 			enc.writeln('\t}')
 		}

--- a/vlib/v/gen/c/match.v
+++ b/vlib/v/gen/c/match.v
@@ -604,7 +604,8 @@ fn (mut g Gen) match_expr_classic(node ast.MatchExpr, is_expr bool, cond_var str
 					}
 					.string {
 						if expr is ast.StringLiteral {
-							slit := cescape_nonascii(util.smart_quote(expr.val, expr.is_raw))
+							slit := cescape_nonascii(util.smart_quote(expr.val, expr.is_raw,
+								expr.opaque_pos))
 							if node.cond_type.is_ptr() {
 								g.write('_SLIT_EQ(${cond_var}->str, ${cond_var}->len, "${slit}")')
 							} else {

--- a/vlib/v/gen/c/orm.v
+++ b/vlib/v/gen/c/orm.v
@@ -801,11 +801,11 @@ fn (mut g Gen) write_orm_table_struct(typ ast.Type) {
 		for attr in table_attrs {
 			g.write('(VAttribute){')
 			g.indent++
-			name1 := util.smart_quote(attr.name, false)
+			name1 := util.smart_quote(attr.name, false, attr.name_opaque_pos)
 			name := cescape_nonascii(name1)
 			g.write(' .name = _S("${name}"),')
 			g.write(' .has_arg = ${attr.has_arg},')
-			arg1 := util.smart_quote(attr.arg, false)
+			arg1 := util.smart_quote(attr.arg, false, attr.arg_opaque_pos)
 			arg := cescape_nonascii(arg1)
 			g.write(' .arg = _S("${arg}"),')
 			g.write(' .kind = ${int(attr.kind)},')
@@ -869,11 +869,11 @@ fn (mut g Gen) write_orm_create_table(node ast.SqlStmtLine, table_name string, c
 				for attr in field.attrs {
 					g.write('(VAttribute){')
 					g.indent++
-					name1 := util.smart_quote(attr.name, false)
+					name1 := util.smart_quote(attr.name, false, attr.name_opaque_pos)
 					name := cescape_nonascii(name1)
 					g.write(' .name = _S("${name}"),')
 					g.write(' .has_arg = ${attr.has_arg},')
-					arg1 := util.smart_quote(attr.arg, false)
+					arg1 := util.smart_quote(attr.arg, false, attr.arg_opaque_pos)
 					arg := cescape_nonascii(arg1)
 					g.write(' .arg = _S("${arg}"),')
 					g.write(' .kind = ${int(attr.kind)},')
@@ -2234,7 +2234,7 @@ fn (mut g Gen) write_orm_select(node ast.SqlExpr, connection_var_name string, re
 		g.writeln('_MOV((string[${select_exprs.len}]){')
 		g.indent++
 		for select_expr in select_exprs {
-			expr1 := util.smart_quote(select_expr, false)
+			expr1 := util.smart_quote(select_expr, false, []int{})
 			expr := cescape_nonascii(expr1)
 			g.writeln('_S("${expr}"),')
 		}
@@ -2670,14 +2670,16 @@ fn (g &Gen) get_table_name_by_struct_type(typ ast.Type) string {
 		sym.name.all_before('[')
 	}
 	mut table_name := util.strip_mod_name(base_name)
+	mut table_name_opaque_pos := []int{}
 
 	if attr := info.attrs.find_first('table') {
 		table_name = attr.arg
+		table_name_opaque_pos = attr.arg_opaque_pos.clone()
 	} else {
 		// Keep default ORM table names aligned with unquoted SQL identifiers across DB drivers.
 		table_name = table_name.to_lower()
 	}
-	escaped_table_name := cescape_nonascii(util.smart_quote(table_name, false))
+	escaped_table_name := cescape_nonascii(util.smart_quote(table_name, false, table_name_opaque_pos))
 	return escaped_table_name
 }
 

--- a/vlib/v/gen/c/orm.v
+++ b/vlib/v/gen/c/orm.v
@@ -579,7 +579,7 @@ fn (mut g Gen) emit_sql_query_data_leaf(query_var string, expr ast.InfixExpr, re
 		field := g.get_orm_current_table_field(field_name) or {
 			verror('field "${field_name}" does not exist on "${g.sql_table_name}"')
 		}
-		field_name = g.get_orm_column_name_from_struct_field(field)
+		field_name = g.get_orm_escaped_column_name_from_struct_field(field)
 	}
 	is_nil_comparison := expr.right is ast.Nil && expr.op in [.eq, .ne]
 	ignore_rhs := expr.op in [.key_is, .not_is] || is_nil_comparison
@@ -1008,7 +1008,7 @@ fn (mut g Gen) write_orm_bulk_insert(node &ast.SqlStmtLine, table_name string, c
 		g.writeln('_MOV((string[${fields.len}]){')
 		g.indent++
 		for f in fields {
-			g.writeln('_S("${g.get_orm_column_name_from_struct_field(f)}"),')
+			g.writeln('_S("${g.get_orm_escaped_column_name_from_struct_field(f)}"),')
 		}
 		g.indent--
 		g.writeln('})')
@@ -1073,7 +1073,7 @@ fn (mut g Gen) write_orm_upsert(node &ast.SqlStmtLine, table_name string, connec
 		g.writeln('_MOV((string[${fields.len}]){')
 		g.indent++
 		for field in fields {
-			g.writeln('_S("${g.get_orm_column_name_from_struct_field(field)}"),')
+			g.writeln('_S("${g.get_orm_escaped_column_name_from_struct_field(field)}"),')
 		}
 		g.indent--
 		g.writeln('})')
@@ -1581,7 +1581,7 @@ fn (mut g Gen) write_orm_insert_with_last_ids(node ast.SqlStmtLine, connection_v
 		g.writeln('_MOV((string[${fields.len}]){ ')
 		g.indent++
 		for f in fields {
-			g.writeln('_S("${g.get_orm_column_name_from_struct_field(f)}"),')
+			g.writeln('_S("${g.get_orm_escaped_column_name_from_struct_field(f)}"),')
 		}
 		g.indent--
 		g.writeln('})')
@@ -2078,7 +2078,7 @@ fn (mut g Gen) write_orm_where_expr(expr ast.Expr, mut fields []string, mut pare
 				field := g.get_orm_current_table_field(expr.name) or {
 					verror('field "${expr.name}" does not exist on "${g.sql_table_name}"')
 				}
-				fields << g.get_orm_column_name_from_struct_field(field)
+				fields << g.get_orm_escaped_column_name_from_struct_field(field)
 			} else {
 				data << expr
 			}
@@ -2165,7 +2165,7 @@ fn (mut g Gen) write_orm_select(node ast.SqlExpr, connection_var_name string, re
 			field := g.get_orm_current_table_field(node.order_expr.name) or {
 				verror('field "${node.order_expr.name}" does not exist on "${g.sql_table_name}"')
 			}
-			g.write(g.get_orm_column_name_from_struct_field(field))
+			g.write(g.get_orm_escaped_column_name_from_struct_field(field))
 		} else {
 			g.expr(node.order_expr)
 		}
@@ -2197,9 +2197,9 @@ fn (mut g Gen) write_orm_select(node ast.SqlExpr, connection_var_name string, re
 		g.writeln('_MOV((string[${select_fields.len}]){')
 		g.indent++
 		for field in select_fields {
-			column_name := g.get_orm_column_name_from_struct_field(field)
+			column_name := g.get_orm_escaped_column_name_from_struct_field(field)
 			g.writeln('_S("${column_name}"),')
-			select_exprs << g.get_orm_select_expr_from_struct_field(field)
+			select_exprs << g.get_orm_escaped_select_expr_from_struct_field(field)
 			mut final_field_typ := g.table.final_type(field.typ.clear_flag(.option))
 			if node.aggregate_kind == .avg {
 				final_field_typ = ast.f64_type
@@ -2643,7 +2643,7 @@ fn (g &Gen) orm_table_column_names(typ ast.Type) []string {
 			if field.attrs.contains('skip') || field.attrs.contains_arg('sql', '-') {
 				continue
 			}
-			names << g.get_orm_column_name_from_struct_field(field)
+			names << g.get_orm_escaped_column_name_from_struct_field(field)
 		}
 	}
 	return names
@@ -2705,12 +2705,24 @@ fn (g &Gen) get_orm_current_table_field(name string) ?ast.StructField {
 
 // get_orm_column_name_from_struct_field converts the struct field to a table column name.
 fn (g &Gen) get_orm_column_name_from_struct_field(field ast.StructField) string {
+	name, _ := g.get_orm_column_name_and_opaque_pos(field)
+	return name
+}
+
+fn (g &Gen) get_orm_escaped_column_name_from_struct_field(field ast.StructField) string {
+	name, opaque_pos := g.get_orm_column_name_and_opaque_pos(field)
+	return cescape_nonascii(util.smart_quote(name, false, opaque_pos))
+}
+
+fn (g &Gen) get_orm_column_name_and_opaque_pos(field ast.StructField) (string, []int) {
 	mut name := field.name
+	mut opaque_pos := []int{}
 
 	if attr := field.attrs.find_first('sql') {
 		if attr.arg !in ['serial', 'i8', 'i16', 'i32', 'int', 'i64', 'u8', 'u16', 'u32', 'u64',
 			'f32', 'f64', 'bool', 'string'] {
 			name = attr.arg
+			opaque_pos = attr.arg_opaque_pos.clone()
 		}
 	}
 
@@ -2720,7 +2732,7 @@ fn (g &Gen) get_orm_column_name_from_struct_field(field ast.StructField) string 
 		name = '${name}_id'
 	}
 
-	return name
+	return name, opaque_pos
 }
 
 fn (g &Gen) get_orm_field_by_column_name(fields []ast.StructField, column string) ?ast.StructField {
@@ -2732,17 +2744,41 @@ fn (g &Gen) get_orm_field_by_column_name(fields []ast.StructField, column string
 	return none
 }
 
-// get_orm_select_expr_from_struct_field returns the SQL expression used in a SELECT list.
-fn (g &Gen) get_orm_select_expr_from_struct_field(field ast.StructField) string {
+// get_orm_escaped_select_expr_from_struct_field returns the C-escaped SQL expression used in a SELECT list.
+fn (g &Gen) get_orm_escaped_select_expr_from_struct_field(field ast.StructField) string {
 	if attr := field.attrs.find_first('sql_select') {
-		arg := attr.arg.trim_space()
+		mut arg, mut opaque_pos := trim_orm_attr_arg(attr.arg, attr.arg_opaque_pos)
 		if arg.len >= 2 && ((arg.starts_with("'") && arg.ends_with("'"))
 			|| (arg.starts_with('"') && arg.ends_with('"'))) {
-			return arg[1..arg.len - 1].trim_space()
+			mut inner_opaque_pos := []int{}
+			for pos in opaque_pos {
+				if pos > 0 && pos < arg.len - 1 {
+					inner_opaque_pos << pos - 1
+				}
+			}
+			arg, opaque_pos = trim_orm_attr_arg(arg[1..arg.len - 1], inner_opaque_pos)
 		}
-		return arg
+		return cescape_nonascii(util.smart_quote(arg, false, opaque_pos))
 	}
-	return g.get_orm_column_name_from_struct_field(field)
+	return g.get_orm_escaped_column_name_from_struct_field(field)
+}
+
+fn trim_orm_attr_arg(arg string, opaque_pos []int) (string, []int) {
+	mut start := 0
+	mut end := arg.len
+	for start < end && arg[start].is_space() {
+		start++
+	}
+	for end > start && arg[end - 1].is_space() {
+		end--
+	}
+	mut trimmed_opaque_pos := []int{}
+	for pos in opaque_pos {
+		if pos >= start && pos < end {
+			trimmed_opaque_pos << pos - start
+		}
+	}
+	return arg[start..end], trimmed_opaque_pos
 }
 
 // get_orm_struct_primary_field returns the table's primary column field.
@@ -2761,7 +2797,7 @@ fn (g &Gen) get_orm_upsert_conflict_groups(fields []ast.StructField, table_attrs
 	mut named_unique_group_order := []string{}
 	mut seen := map[string]bool{}
 	for field in fields {
-		column_name := g.get_orm_column_name_from_struct_field(field)
+		column_name := g.get_orm_escaped_column_name_from_struct_field(field)
 		for attr in field.attrs {
 			match attr.name {
 				'primary' {

--- a/vlib/v/gen/c/reflection.v
+++ b/vlib/v/gen/c/reflection.v
@@ -98,8 +98,9 @@ fn (g &Gen) gen_attrs_array(attrs []ast.Attr) string {
 	}
 	mut items := []string{cap: attrs.len}
 	for attr in attrs {
-		items << '((${type_name}){.name=_S("${cescape_nonascii(util.smart_quote(attr.name, false))}"),.has_arg=${attr.has_arg},.arg=_S("${cescape_nonascii(util.smart_quote(attr.arg,
-			false))}"),.kind=${int(attr.kind)}})'
+		items << '((${type_name}){.name=_S("${cescape_nonascii(util.smart_quote(attr.name, false,
+			attr.name_opaque_pos))}"),.has_arg=${attr.has_arg},.arg=_S("${cescape_nonascii(util.smart_quote(attr.arg,
+			false, attr.arg_opaque_pos))}"),.kind=${int(attr.kind)}})'
 	}
 	mut out := 'builtin__new_array_from_c_array(${attrs.len},${attrs.len},sizeof(${type_name}),'
 	out += '_MOV((${type_name}[${attrs.len}]){'

--- a/vlib/v/gen/c/str.v
+++ b/vlib/v/gen/c/str.v
@@ -6,7 +6,7 @@ import v.ast
 import v.util
 
 fn (mut g Gen) string_literal(node ast.StringLiteral) {
-	escaped_val := cescape_nonascii(util.smart_quote(node.val, node.is_raw))
+	escaped_val := cescape_nonascii(util.smart_quote(node.val, node.is_raw, node.opaque_pos))
 	if node.language == .c {
 		g.write(cescaped_string_literal(escaped_val))
 	} else {
@@ -89,7 +89,8 @@ fn (mut g Gen) string_inter_literal_sb_optimized(call_expr ast.CallExpr) {
 	g.writeln('// sb inter opt')
 	is_nl := call_expr.name == 'writeln'
 	for i, val in node.vals {
-		escaped_val := cescape_nonascii(util.smart_quote(val, false))
+		val_opaque_pos := if i < node.opaque_pos.len { node.opaque_pos[i] } else { []int{} }
+		escaped_val := cescape_nonascii(util.smart_quote(val, false, val_opaque_pos))
 		g.write('strings__Builder_write_string(&')
 		g.expr(call_expr.left)
 		g.write2(', _S("', escaped_val)

--- a/vlib/v/gen/c/str_intp.v
+++ b/vlib/v/gen/c/str_intp.v
@@ -775,7 +775,8 @@ fn (mut g Gen) string_inter_literal(node ast.StringInterLiteral) {
 	g.write2('builtin__str_intp(', node_.vals.len.str())
 	g.write(', _MOV((StrIntpData[]){')
 	for i, val in node_.vals {
-		mut escaped_val := cescape_nonascii(util.smart_quote(val, false))
+		val_opaque_pos := if i < node_.opaque_pos.len { node_.opaque_pos[i] } else { []int{} }
+		mut escaped_val := cescape_nonascii(util.smart_quote(val, false, val_opaque_pos))
 		escaped_val = escaped_val.replace('\0', '\\0')
 
 		if escaped_val.len > 0 {
@@ -948,7 +949,8 @@ fn (mut g Gen) gen_simple_string_inter_literal(node ast.StringInterLiteral, fmts
 			if written_parts > 0 {
 				g.write(', ')
 			}
-			mut escaped_val := cescape_nonascii(util.smart_quote(val, false))
+			val_opaque_pos := if i < node.opaque_pos.len { node.opaque_pos[i] } else { []int{} }
+			mut escaped_val := cescape_nonascii(util.smart_quote(val, false, val_opaque_pos))
 			escaped_val = escaped_val.replace('\0', '\\0')
 			g.write2('_S("', escaped_val)
 			g.write('")')

--- a/vlib/v/gen/c/testdata/linker_section_nix.c.must_have
+++ b/vlib/v/gen/c/testdata/linker_section_nix.c.must_have
@@ -1,1 +1,3 @@
 VV_LOC void main__test(void) __attribute__ ((section ("foo")));
+VV_LOC void main__test_opaque_section(void) __attribute__ ((section ("A\\nB")));
+__attribute__ ((section ("C\\nD"))) opaque_section_global

--- a/vlib/v/gen/c/testdata/linker_section_nix.vv
+++ b/vlib/v/gen/c/testdata/linker_section_nix.vv
@@ -1,7 +1,18 @@
+// vtest vflags: -enable-globals
+
 @[_linker_section: foo]
 fn test() {
 }
 
+@[_linker_section: 'A\x5cnB']
+fn test_opaque_section() {
+}
+
+@[_linker_section: 'C\x5cnD']
+__global opaque_section_global = 1
+
 fn main() {
 	test()
+	test_opaque_section()
+	println(opaque_section_global)
 }

--- a/vlib/v/parser/attribute.v
+++ b/vlib/v/parser/attribute.v
@@ -14,33 +14,35 @@ fn (p &Parser) current_attr_string_quote() u8 {
 	return `'`
 }
 
-fn (mut p Parser) parse_attr_arg(err_context string) (ast.AttrKind, string, u8) {
+fn (mut p Parser) parse_attr_arg(err_context string) (ast.AttrKind, string, u8, []int) {
 	if p.tok.kind == .name { // `name: arg`
-		return ast.AttrKind.plain, p.check_name(), `'`
+		return ast.AttrKind.plain, p.check_name(), `'`, []int{}
 	} else if p.tok.kind == .number { // `name: 123`
 		arg := p.tok.lit
 		p.next()
-		return ast.AttrKind.number, arg, `'`
+		return ast.AttrKind.number, arg, `'`, []int{}
 	} else if p.tok.kind == .string { // `name: 'arg'`
 		arg := p.tok.lit
+		arg_opaque_pos := p.scanner.string_opaque_pos[p.tok.tidx]
 		quote := p.current_attr_string_quote()
 		p.next()
-		return ast.AttrKind.string, arg, quote
+		return ast.AttrKind.string, arg, quote, arg_opaque_pos
 	} else if p.tok.kind == .key_true || p.tok.kind == .key_false { // `name: true`
 		arg := p.tok.kind.str()
 		p.next()
-		return ast.AttrKind.bool, arg, `'`
+		return ast.AttrKind.bool, arg, `'`, []int{}
 	} else if token.is_key(p.tok.lit) { // `name: keyword`
-		return ast.AttrKind.plain, p.check_name(), `'`
+		return ast.AttrKind.plain, p.check_name(), `'`, []int{}
 	}
 	p.unexpected(additional_msg: 'an argument is expected${err_context}')
-	return ast.AttrKind.plain, '', `'`
+	return ast.AttrKind.plain, '', `'`, []int{}
 }
 
 fn (mut p Parser) parse_attr_call(name string, is_at bool, apos token.Pos) []ast.Attr {
 	p.check(.lpar)
 	mut base_kind := ast.AttrKind.plain
 	mut base_arg := ''
+	mut base_arg_opaque_pos := []int{}
 	mut base_quote := u8(`'`)
 	mut base_arg_name := ''
 	mut base_call_arg_idx := -1
@@ -58,7 +60,7 @@ fn (mut p Parser) parse_attr_call(name string, is_at bool, apos token.Pos) []ast
 			p.next()
 			p.check(.colon)
 		}
-		kind, arg, quote := p.parse_attr_arg(' in `(...)`')
+		kind, arg, quote, arg_opaque_pos := p.parse_attr_arg(' in `(...)`')
 		if is_named {
 			if name == 'deprecated' && arg_name == 'msg' {
 				if has_base_arg {
@@ -67,6 +69,7 @@ fn (mut p Parser) parse_attr_call(name string, is_at bool, apos token.Pos) []ast
 				}
 				base_has_arg = true
 				base_arg = arg
+				base_arg_opaque_pos = arg_opaque_pos.clone()
 				base_kind = kind
 				base_quote = quote
 				base_arg_name = arg_name
@@ -74,21 +77,23 @@ fn (mut p Parser) parse_attr_call(name string, is_at bool, apos token.Pos) []ast
 				has_base_arg = true
 			} else {
 				attrs << ast.Attr{
-					name:          '${name}_${arg_name}'
-					has_arg:       true
-					arg:           arg
-					kind:          kind
-					quote:         quote
-					pos:           apos.extend(p.prev_tok.pos())
-					has_at:        is_at
-					call_name:     name
-					call_arg_name: arg_name
-					call_arg_idx:  call_arg_idx
+					name:           '${name}_${arg_name}'
+					has_arg:        true
+					arg:            arg
+					arg_opaque_pos: arg_opaque_pos
+					kind:           kind
+					quote:          quote
+					pos:            apos.extend(p.prev_tok.pos())
+					has_at:         is_at
+					call_name:      name
+					call_arg_name:  arg_name
+					call_arg_idx:   call_arg_idx
 				}
 			}
 		} else if !has_base_arg {
 			base_has_arg = true
 			base_arg = arg
+			base_arg_opaque_pos = arg_opaque_pos.clone()
 			base_kind = kind
 			base_quote = quote
 			base_arg_name = arg_name
@@ -96,15 +101,16 @@ fn (mut p Parser) parse_attr_call(name string, is_at bool, apos token.Pos) []ast
 			has_base_arg = true
 		} else {
 			attrs << ast.Attr{
-				name:         '${name}_${positional_arg_idx}'
-				has_arg:      true
-				arg:          arg
-				kind:         kind
-				quote:        quote
-				pos:          apos.extend(p.prev_tok.pos())
-				has_at:       is_at
-				call_name:    name
-				call_arg_idx: call_arg_idx
+				name:           '${name}_${positional_arg_idx}'
+				has_arg:        true
+				arg:            arg
+				arg_opaque_pos: arg_opaque_pos
+				kind:           kind
+				quote:          quote
+				pos:            apos.extend(p.prev_tok.pos())
+				has_at:         is_at
+				call_name:      name
+				call_arg_idx:   call_arg_idx
 			}
 			positional_arg_idx++
 		}
@@ -117,16 +123,17 @@ fn (mut p Parser) parse_attr_call(name string, is_at bool, apos token.Pos) []ast
 	}
 	p.check(.rpar)
 	base_attr := ast.Attr{
-		name:          name
-		has_arg:       base_has_arg
-		arg:           base_arg
-		kind:          base_kind
-		quote:         base_quote
-		pos:           apos.extend(p.prev_tok.pos())
-		has_at:        is_at
-		call_name:     name
-		call_arg_name: base_arg_name
-		call_arg_idx:  base_call_arg_idx
+		name:           name
+		has_arg:        base_has_arg
+		arg:            base_arg
+		arg_opaque_pos: base_arg_opaque_pos
+		kind:           base_kind
+		quote:          base_quote
+		pos:            apos.extend(p.prev_tok.pos())
+		has_at:         is_at
+		call_name:      name
+		call_arg_name:  base_arg_name
+		call_arg_idx:   base_call_arg_idx
 	}
 	attrs.insert(0, base_attr)
 	return attrs
@@ -158,8 +165,10 @@ fn (mut p Parser) parse_attr(is_at bool) []ast.Attr {
 		]
 	}
 	mut name := ''
+	mut name_opaque_pos := []int{}
 	mut has_arg := false
 	mut arg := ''
+	mut arg_opaque_pos := []int{}
 	mut quote := u8(`'`)
 	mut comptime_cond := ast.empty_expr
 	mut comptime_cond_opt := false
@@ -179,6 +188,7 @@ fn (mut p Parser) parse_attr(is_at bool) []ast.Attr {
 		name = comptime_cond.str()
 	} else if p.tok.kind == .string {
 		name = p.tok.lit
+		name_opaque_pos = p.scanner.string_opaque_pos[p.tok.tidx]
 		quote = p.current_attr_string_quote()
 		kind = .string
 		p.next()
@@ -193,22 +203,24 @@ fn (mut p Parser) parse_attr(is_at bool) []ast.Attr {
 		if p.tok.kind == .colon {
 			has_arg = true
 			p.next()
-			kind, arg, quote = p.parse_attr_arg(' after `:`')
+			kind, arg, quote, arg_opaque_pos = p.parse_attr_arg(' after `:`')
 		} else if p.tok.kind == .lpar {
 			return p.parse_attr_call(name, is_at, apos)
 		}
 	}
 	return [
 		ast.Attr{
-			name:    name
-			has_arg: has_arg
-			arg:     arg
-			kind:    kind
-			quote:   quote
-			ct_expr: comptime_cond
-			ct_opt:  comptime_cond_opt
-			pos:     apos.extend(p.tok.pos())
-			has_at:  is_at
+			name:            name
+			name_opaque_pos: name_opaque_pos
+			has_arg:         has_arg
+			arg:             arg
+			arg_opaque_pos:  arg_opaque_pos
+			kind:            kind
+			quote:           quote
+			ct_expr:         comptime_cond
+			ct_opt:          comptime_cond_opt
+			pos:             apos.extend(p.tok.pos())
+			has_at:          is_at
 		},
 	]
 }

--- a/vlib/v/parser/parser.v
+++ b/vlib/v/parser/parser.v
@@ -4068,21 +4068,24 @@ fn (mut p Parser) string_expr() ast.Expr {
 	mut pos := p.tok.pos()
 	pos.last_line = pos.line_nr + val.count('\n')
 	if p.peek_tok.kind != .str_dollar {
+		val_opaque_pos := p.scanner.string_opaque_pos[p.tok.tidx]
 		p.next()
 		node = ast.StringLiteral{
-			val:      val
-			is_raw:   is_raw
-			language: match true {
+			val:        val
+			is_raw:     is_raw
+			language:   match true {
 				is_cstr { ast.Language.c }
 				is_js_str { ast.Language.js }
 				else { ast.Language.v }
 			}
-			pos:      pos
+			pos:        pos
+			opaque_pos: val_opaque_pos
 		}
 		return node
 	}
 	mut exprs := []ast.Expr{}
 	mut vals := []string{}
+	mut vals_opaque_pos := [][]int{}
 	mut has_fmts := []bool{}
 	mut fwidths := []int{}
 	mut precisions := []int{}
@@ -4096,6 +4099,7 @@ fn (mut p Parser) string_expr() ast.Expr {
 	p.inside_str_interp = true
 	for p.tok.kind == .string {
 		vals << p.tok.lit
+		vals_opaque_pos << p.scanner.string_opaque_pos[p.tok.tidx]
 		p.next()
 		if p.tok.kind != .str_dollar {
 			break
@@ -4186,6 +4190,7 @@ fn (mut p Parser) string_expr() ast.Expr {
 	pos = pos.extend(p.prev_tok.pos())
 	node = ast.StringInterLiteral{
 		vals:            vals
+		opaque_pos:      vals_opaque_pos
 		exprs:           exprs
 		has_fmts:        has_fmts.clone()
 		need_fmts:       has_fmts

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -81,6 +81,11 @@ pub mut:
 	u32_escapes_pos []int    = []int{cap: 10} // pos list of \UXXXXXXXX
 	h_escapes_pos   []int    = []int{cap: 10} // pos list of \xXX
 	str_segments    []string = []string{cap: 10}
+	// for each `.string` token (keyed by its `tidx`) that contains a decoded \xXX/\uXXXX/\UXXXXXXXX
+	// escape, the byte offsets in that token's `.lit` which are opaque, already-resolved bytes -
+	// consumed once by the parser when it builds the corresponding ast.StringLiteral/StringInterLiteral,
+	// so that cgen's util.smart_quote() knows never to reinterpret them as the start of another escape.
+	string_opaque_pos map[int][]int = map[int][]int{}
 }
 
 /*
@@ -1332,6 +1337,11 @@ pub fn (mut s Scanner) ident_string() string {
 	}
 	if start <= s.pos {
 		mut string_so_far := s.text[start..end]
+		// byte offsets (into the *decoded* literal below) that came straight out of
+		// decode_h_escape_single/decode_u16_escape_single/decode_u32_escape_single, i.e.
+		// bytes that are already fully resolved and must never be reinterpreted as the
+		// start of another escape sequence downstream (see util.smart_quote).
+		mut opaque_pos := []int{}
 		if !s.is_fmt {
 			mut segment_idx := 0
 			s.str_segments.clear()
@@ -1342,22 +1352,37 @@ pub fn (mut s Scanner) ident_string() string {
 				s.all_pos << s.h_escapes_pos
 				s.all_pos.sort()
 
+				mut out_len := 0
 				for pos in s.all_pos {
-					s.str_segments << string_so_far[segment_idx..(pos - start)]
+					literal_segment := string_so_far[segment_idx..(pos - start)]
+					s.str_segments << literal_segment
+					out_len += literal_segment.len
 					segment_idx = pos - start
 					if pos in s.u16_escapes_pos {
 						decoded := s.decode_u16_escape_single(string_so_far, segment_idx)
 						s.str_segments << decoded.segment
+						for i in 0 .. decoded.segment.len {
+							opaque_pos << out_len + i
+						}
+						out_len += decoded.segment.len
 						segment_idx = decoded.idx
 					}
 					if pos in s.u32_escapes_pos {
 						decoded := s.decode_u32_escape_single(string_so_far, segment_idx)
 						s.str_segments << decoded.segment
+						for i in 0 .. decoded.segment.len {
+							opaque_pos << out_len + i
+						}
+						out_len += decoded.segment.len
 						segment_idx = decoded.idx
 					}
 					if pos in s.h_escapes_pos {
 						decoded := s.decode_h_escape_single(string_so_far, segment_idx)
 						s.str_segments << decoded.segment
+						for i in 0 .. decoded.segment.len {
+							opaque_pos << out_len + i
+						}
+						out_len += decoded.segment.len
 						segment_idx = decoded.idx
 					}
 				}
@@ -1370,11 +1395,20 @@ pub fn (mut s Scanner) ident_string() string {
 
 		if n_cr_chars > 0 {
 			string_so_far = string_so_far.replace('\r', '')
+			// '\r' removal shifts every byte offset after it; bail out on the rare
+			// literal that mixes a hex/unicode escape with raw '\r' bytes, instead of
+			// risking marking the wrong byte as opaque.
+			opaque_pos.clear()
 		}
 		if !is_raw && string_so_far.contains('\\\n') {
 			lit = trim_slash_line_break(string_so_far)
+			// same reasoning as above: line-continuation trimming can also shift offsets.
+			opaque_pos.clear()
 		} else {
 			lit = string_so_far
+		}
+		if opaque_pos.len > 0 {
+			s.string_opaque_pos[s.tidx] = opaque_pos
 		}
 	}
 	if s.text[end] == quote {

--- a/vlib/v/scanner/scanner.v
+++ b/vlib/v/scanner/scanner.v
@@ -1314,7 +1314,10 @@ pub fn (mut s Scanner) ident_string() string {
 				s.u32_escapes_pos << s.pos - 1
 			}
 			// Unknown escape sequence
-			if !util.is_escape_sequence(c) && !digit_table[c] && c != `\n` {
+			is_crlf_line_break := c == b_cr && s.pos + 1 < s.text.len
+				&& s.text[s.pos + 1] == b_lf
+			if !util.is_escape_sequence(c) && !digit_table[c] && c != b_lf
+				&& !is_crlf_line_break {
 				s.error('`${c.ascii_str()}` unknown escape sequence')
 			}
 		}
@@ -1394,16 +1397,10 @@ pub fn (mut s Scanner) ident_string() string {
 		}
 
 		if n_cr_chars > 0 {
-			string_so_far = string_so_far.replace('\r', '')
-			// '\r' removal shifts every byte offset after it; bail out on the rare
-			// literal that mixes a hex/unicode escape with raw '\r' bytes, instead of
-			// risking marking the wrong byte as opaque.
-			opaque_pos.clear()
+			string_so_far, opaque_pos = remove_cr_chars(string_so_far, opaque_pos)
 		}
 		if !is_raw && string_so_far.contains('\\\n') {
-			lit = trim_slash_line_break(string_so_far)
-			// same reasoning as above: line-continuation trimming can also shift offsets.
-			opaque_pos.clear()
+			lit, opaque_pos = trim_slash_line_break(string_so_far, opaque_pos)
 		} else {
 			lit = string_so_far
 		}
@@ -1537,29 +1534,74 @@ fn (mut s Scanner) decode_u32erune(str string) string {
 	return ss.join('')
 }
 
-fn trim_slash_line_break(s string) string {
+fn remove_cr_chars(s string, opaque_pos []int) (string, []int) {
+	mut bytes := []u8{cap: s.len}
+	mut adjusted_opaque_pos := []int{cap: opaque_pos.len}
+	mut opaque_idx := 0
+	for i, b in s {
+		is_opaque := opaque_idx < opaque_pos.len && opaque_pos[opaque_idx] == i
+		// Only source CR bytes are normalized away. A CR produced by a decoded escape
+		// is already resolved data and must remain in the literal.
+		if b == b_cr && !is_opaque {
+			continue
+		}
+		if is_opaque {
+			adjusted_opaque_pos << bytes.len
+			opaque_idx++
+		}
+		bytes << b
+	}
+	return bytes.bytestr(), adjusted_opaque_pos
+}
+
+fn remove_string_range(s string, opaque_pos []int, start int, end int) (string, []int) {
+	mut adjusted_opaque_pos := []int{cap: opaque_pos.len}
+	for pos in opaque_pos {
+		if pos < start {
+			adjusted_opaque_pos << pos
+		} else if pos >= end {
+			adjusted_opaque_pos << pos - (end - start)
+		}
+	}
+	return s[..start] + s[end..], adjusted_opaque_pos
+}
+
+fn trim_slash_line_break(s string, opaque_pos []int) (string, []int) {
 	mut start := 0
 	mut ret_str := s
+	mut adjusted_opaque_pos := opaque_pos.clone()
 	for {
 		// find the position of the first `\` followed by a newline, after `start`:
 		idx := ret_str.index_after('\\\n', start) or { break }
 		start = idx
+		// Decoded backslashes/newlines are literal data, not continuation syntax.
+		if idx in adjusted_opaque_pos || idx + 1 in adjusted_opaque_pos {
+			start++
+			continue
+		}
 		// Here, ret_str[idx] is \, and ret_str[idx+1] is newline.
 		// Depending on the number of backslashes before the newline, we should either
 		// treat the last one and the whitespace after it as line-break, or just ignore it:
 		mut nbackslashes := 0
-		for eidx := idx; eidx >= 0 && ret_str[eidx] == `\\`; eidx-- {
+		for eidx := idx; eidx >= 0 && ret_str[eidx] == `\\`
+			&& eidx !in adjusted_opaque_pos; eidx-- {
 			nbackslashes++
 		}
 		// eprintln('>> start: ${start:-5} | nbackslashes: ${nbackslashes:-5} | ret_str: $ret_str')
 		if idx == 0 || (nbackslashes & 1) == 1 {
-			ret_str = ret_str[..idx] + ret_str[idx + 2..].trim_left(' \n\t\v\f\r')
+			mut end := idx + 2
+			for end < ret_str.len && ret_str[end] in [` `, `\n`, `\t`, `\v`, `\f`, `\r`]
+				&& end !in adjusted_opaque_pos {
+				end++
+			}
+			ret_str, adjusted_opaque_pos = remove_string_range(ret_str, adjusted_opaque_pos,
+				idx, end)
 		} else {
 			// ensure the loop will terminate, when we could not strip anything:
 			start++
 		}
 	}
-	return ret_str
+	return ret_str, adjusted_opaque_pos
 }
 
 /// ident_char is called when a backtick "single-char" is parsed from the code

--- a/vlib/v/scanner/scanner_test.v
+++ b/vlib/v/scanner/scanner_test.v
@@ -350,6 +350,46 @@ fn test_dollar_sign_is_literal_without_braces() {
 	assert result[0].lit == 'a$b'
 }
 
+fn scan_string_with_opaque_pos(source string) (token.Token, []int) {
+	mut scanner := new_plain_scanner(source, .skip_comments, &pref.Preferences{})
+	tok := scanner.text_scan()
+	return tok, scanner.string_opaque_pos[tok.tidx]
+}
+
+fn test_string_opaque_positions_survive_source_normalization() {
+	lf_tok, lf_opaque_pos := scan_string_with_opaque_pos([u8(39), 65, 92, 10, 92, 120, 53,
+		99, 110, 66, 39].bytestr())
+	assert lf_tok.lit.bytes() == [u8(65), 92, 110, 66]
+	assert lf_opaque_pos == [1]
+
+	crlf_tok, crlf_opaque_pos := scan_string_with_opaque_pos([u8(39), 65, 92, 13, 10, 92,
+		120, 53, 99, 110, 66, 39].bytestr())
+	assert crlf_tok.lit.bytes() == [u8(65), 92, 110, 66]
+	assert crlf_opaque_pos == [1]
+
+	cr_tok, cr_opaque_pos := scan_string_with_opaque_pos([u8(39), 65, 13, 92, 120, 53,
+		99, 110, 66, 39].bytestr())
+	assert cr_tok.lit.bytes() == [u8(65), 92, 110, 66]
+	assert cr_opaque_pos == [1]
+}
+
+fn test_source_normalization_does_not_remove_decoded_bytes() {
+	decoded_cr_tok, decoded_cr_opaque_pos := scan_string_with_opaque_pos([u8(39), 65, 92,
+		120, 48, 100, 66, 13, 67, 39].bytestr())
+	assert decoded_cr_tok.lit.bytes() == [u8(65), 13, 66, 67]
+	assert decoded_cr_opaque_pos == [1]
+
+	decoded_slash_tok, decoded_slash_opaque_pos := scan_string_with_opaque_pos([u8(39), 65,
+		92, 120, 53, 99, 10, 66, 39].bytestr())
+	assert decoded_slash_tok.lit.bytes() == [u8(65), 92, 10, 66]
+	assert decoded_slash_opaque_pos == [1]
+
+	decoded_space_tok, decoded_space_opaque_pos := scan_string_with_opaque_pos([u8(39), 65,
+		92, 10, 92, 120, 50, 48, 66, 39].bytestr())
+	assert decoded_space_tok.lit.bytes() == [u8(65), 32, 66]
+	assert decoded_space_opaque_pos == [1]
+}
+
 fn test_comment_string() {
 	mut result := scan_tokens('// single line comment will get an \\x01 prepended')
 	assert result[0].kind == .comment

--- a/vlib/v/tests/string_escape_opaque_backslash_test.v
+++ b/vlib/v/tests/string_escape_opaque_backslash_test.v
@@ -1,0 +1,267 @@
+import strings
+import v.reflection
+import json
+import db.sqlite
+
+// A \xXX/\uXXXX/\UXXXXXXXX escape that decodes to a backslash byte (0x5C) must never be
+// reinterpreted as the start of a different escape sequence, even when the byte(s) that follow
+// it in the source spell out a recognized escape letter (e.g. `n`, `t`).
+
+fn test_hex_escape_decoding_to_backslash_followed_by_letter() {
+	s := 'A\x5cnB'
+	assert s.len == 4
+	assert s.bytes() == [u8(65), 92, 110, 66]
+}
+
+fn test_u32_escape_decoding_to_backslash_followed_by_letter() {
+	s := 'A\U0000005crB'
+	assert s.len == 4
+	assert s.bytes() == [u8(65), 92, 114, 66]
+}
+
+fn test_trailing_decoded_backslash() {
+	s := 'A\x5c'
+	assert s.len == 2
+	assert s.bytes() == [u8(65), 92]
+}
+
+fn test_two_decoded_backslashes_back_to_back() {
+	s := 'A\x5c\x5cB'
+	assert s.len == 4
+	assert s.bytes() == [u8(65), 92, 92, 66]
+}
+
+fn test_interpolated_string_with_decoded_backslash() {
+	x := 42
+	s := 'A\x5cn${x}B'
+	assert s.len == 6
+	assert s.bytes() == [u8(65), 92, 110, 52, 50, 66]
+}
+
+// regression test for a gap found by adversarial review of the fix above: the transformer's
+// simplify_nested_interpolation_in_sb splits an interpolated string into per-segment literals
+// for @[expand_simple_interpolation] calls (like strings.Builder.write_string/writeln), and
+// must carry the same opaque-byte protection through to each split-out segment.
+fn test_string_builder_write_string_with_decoded_backslash_in_interpolation() {
+	x := 1
+	mut sb := strings.new_builder(16)
+	sb.write_string('A\x5cnB${x}')
+	s := sb.str()
+	assert s.len == 5
+	assert s.bytes() == [u8(65), 92, 110, 66, 49]
+}
+
+fn test_compile_time_string_concat_folding_with_decoded_backslash() {
+	s := 'A\x5c' + 'nB'
+	assert s.len == 4
+	assert s.bytes() == [u8(65), 92, 110, 66]
+}
+
+fn test_decoded_backslash_does_not_break_string_equality_and_match() {
+	s := 'A\x5cnB'
+	assert s == 'A\x5cnB'
+	mut matched := false
+	match s {
+		'A\x5cnB' { matched = true }
+		else {}
+	}
+	assert matched
+}
+
+fn test_ordinary_escapes_still_work() {
+	assert 'A\nB'.bytes() == [u8(65), 10, 66]
+	assert 'A\\B'.bytes() == [u8(65), 92, 66]
+	assert 'A\x22B'.bytes() == [u8(65), 34, 66]
+}
+
+// regression test for a second gap found and fixed after adversarial review: ast.Attr's `name`
+// and `arg` fields are populated from the same scanner-tokenized string literals as ordinary
+// strings (e.g. `@[mytag: 'A\x5cnB']` or the whole-attribute-is-a-string form `@['A\x5cnB']`),
+// but previously had no opaque_pos carrier, so the hazard reproduced there too.
+
+@[mytag: 'A\x5cnB']
+fn attr_tagged_fn() {}
+
+fn test_attr_arg_with_decoded_backslash_via_reflection() {
+	mut found := false
+	for f in reflection.get_funcs() {
+		if f.name.ends_with('attr_tagged_fn') {
+			for a in f.attrs {
+				if a.name == 'mytag' {
+					found = true
+					assert a.arg.len == 4
+					assert a.arg.bytes() == [u8(65), 92, 110, 66]
+				}
+			}
+		}
+	}
+	assert found
+}
+
+struct AttrHazardStruct {
+	a int @[mytag: 'A\x5cnB']
+	b int @['C\x5cnD']
+}
+
+fn test_attr_name_and_combined_string_with_decoded_backslash_via_comptime() {
+	mut seen := 0
+	$for field in AttrHazardStruct.fields {
+		for a in field.attrs {
+			if field.name == 'a' {
+				// combined "name: 'arg'" display string built by cgen_attrs()
+				assert a.bytes() == [u8(109), 121, 116, 97, 103, 58, 32, 39, 65, 92, 110, 66, 39]
+				seen++
+			}
+			if field.name == 'b' {
+				// whole-attribute-is-a-string form: the decoded backslash sits directly in `name`
+				assert a.bytes() == [u8(67), 92, 110, 68]
+				seen++
+			}
+		}
+	}
+	assert seen == 2
+}
+
+// regression test for a third gap found by a second adversarial review round (after the fix
+// above was fast-forwarded onto a newer master): comptime_for's `.attributes` branch (reached
+// via `$for attr in T.attributes`, distinct from the `.fields` path above) built its VAttribute's
+// `.name` field by interpolating attr.name raw, bypassing util.smart_quote()/name_opaque_pos
+// entirely, even though the sibling `.arg` field two lines below it was already correctly fixed.
+@['E\x5cnF']
+struct AttrWholeStringStruct {}
+
+fn test_attr_name_with_decoded_backslash_via_type_attributes() {
+	mut seen := false
+	$for attr in AttrWholeStringStruct.attributes {
+		assert attr.name.len == 4
+		assert attr.name.bytes() == [u8(69), 92, 110, 70]
+		seen = true
+	}
+	assert seen
+}
+
+// regression test for a fourth gap found in the same review round: `$for method in T.methods`
+// exposes a method's structured attributes via `.attributes` ([]VAttribute, built by
+// cgen_vattrs()), a separate code path from both `.attrs` ([]string, via cgen_attrs(), already
+// covered above) and v.reflection's function listing (via reflection.v's gen_attrs_array(),
+// already covered above) - none of those three cover this fourth path.
+struct MethodAttrHazardStruct {}
+
+@[mytag: 'A\x5cnB']
+fn (m MethodAttrHazardStruct) hazard_method() {}
+
+fn test_method_attr_arg_with_decoded_backslash_via_comptime_methods() {
+	mut found := false
+	$for method in MethodAttrHazardStruct.methods {
+		for a in method.attributes {
+			if a.name == 'mytag' {
+				found = true
+				assert a.arg.len == 4
+				assert a.arg.bytes() == [u8(65), 92, 110, 66]
+			}
+		}
+	}
+	assert found
+}
+
+// regression test for a fifth gap found in the same review round: an enum value's `@[json: ...]`
+// attribute arg is spliced directly into generated C by vlib/v/gen/c/json.v's gen_enum_to_str /
+// gen_str_to_enum, bypassing util.smart_quote()/arg_opaque_pos - a separate code path from every
+// ast.Attr consumer covered above, in a file the original fix never touched.
+enum JsonAttrHazardEnum {
+	red
+	blue @[json: 'A\x5cnB']
+}
+
+struct JsonAttrHazardWrap {
+	c JsonAttrHazardEnum
+}
+
+fn test_json_enum_attr_arg_with_decoded_backslash() {
+	encoded := json.encode(JsonAttrHazardWrap{ c: .blue })
+	// the true attr value is 4 bytes (A, 0x5C, 'n', B); a spec-compliant JSON encoding of that
+	// must double the backslash - a single backslash means the byte was corrupted before encode.
+	assert encoded.bytes() == [u8(123), 34, 99, 34, 58, 34, 65, 92, 92, 110, 66, 34, 125]
+
+	decoded := json.decode(JsonAttrHazardWrap, '{"c":"A\\\\nB"}') or { panic(err) }
+	assert decoded.c == .blue
+}
+
+// regression test for a sixth gap found in the same review round: get_table_name_by_struct_type()
+// (vlib/v/gen/c/orm.v) reads the ORM table name from a struct's @[table: ...] attribute arg but
+// was passing a hardcoded empty opaque_pos to smart_quote instead of attr.arg_opaque_pos - the
+// only smart_quote(attr.arg, ...) call site in orm.v that was missed during the original fix.
+@[table: 'T\x5cnU']
+struct OrmTableHazardItem {
+	id int @[primary; sql: serial]
+}
+
+fn test_orm_table_name_with_decoded_backslash() {
+	mut db := sqlite.connect(':memory:') or { panic(err) }
+	sql db {
+		create table OrmTableHazardItem
+	} or { panic(err) }
+	rows := db.exec('select name from sqlite_master where type = \'table\'') or { panic(err) }
+	mut found := false
+	for row in rows {
+		if row.vals.len > 0 {
+			found = true
+			assert row.vals[0].bytes() == [u8(84), 92, 110, 85]
+		}
+	}
+	assert found
+}
+
+// regression coverage for a gap identified but not itself a bug: parse_attr_call() (call-style
+// attributes like @[foo(a, b: 'c')]) has three separate ast.Attr{} construction sites (the base
+// attribute, a positional argument, and a named argument), none of which were exercised by any
+// test above - all three use the colon/whole-string forms instead of call-style syntax.
+@[mytag('A\x5cnB', 'C\x5cnD', extra: 'E\x5cnF')]
+fn attr_call_style_hazard_fn() {}
+
+fn test_attr_call_style_all_three_sites_with_decoded_backslash() {
+	mut seen := map[string]bool{}
+	for f in reflection.get_funcs() {
+		if f.name.ends_with('attr_call_style_hazard_fn') {
+			for a in f.attrs {
+				match a.name {
+					'mytag' {
+						// base attribute: the first call argument
+						assert a.arg.bytes() == [u8(65), 92, 110, 66]
+					}
+					'mytag_1' {
+						// positional argument construction site
+						assert a.arg.bytes() == [u8(67), 92, 110, 68]
+					}
+					'mytag_extra' {
+						// named argument construction site
+						assert a.arg.bytes() == [u8(69), 92, 110, 70]
+					}
+					else {}
+				}
+				seen[a.name] = true
+			}
+		}
+	}
+	assert seen.len == 3
+}
+
+// regression coverage for a gap identified but not itself a bug: every hazard-carrying attribute
+// test above uses single-quote syntax; attribute values can also use double quotes.
+@[mytag: "A\x5cnB"]
+fn attr_double_quoted_hazard_fn() {}
+
+fn test_attr_double_quoted_arg_with_decoded_backslash() {
+	mut found := false
+	for f in reflection.get_funcs() {
+		if f.name.ends_with('attr_double_quoted_hazard_fn') {
+			for a in f.attrs {
+				if a.name == 'mytag' {
+					found = true
+					assert a.arg.bytes() == [u8(65), 92, 110, 66]
+				}
+			}
+		}
+	}
+	assert found
+}

--- a/vlib/v/tests/string_escape_opaque_backslash_test.v
+++ b/vlib/v/tests/string_escape_opaque_backslash_test.v
@@ -38,6 +38,13 @@ fn test_interpolated_string_with_decoded_backslash() {
 	assert s.bytes() == [u8(65), 92, 110, 52, 50, 66]
 }
 
+fn test_line_continuation_before_decoded_backslash() {
+	s := 'A\
+\x5cnB'
+	assert s.len == 4
+	assert s.bytes() == [u8(65), 92, 110, 66]
+}
+
 // regression test for a gap found by adversarial review of the fix above: the transformer's
 // simplify_nested_interpolation_in_sb splits an interpolated string into per-segment literals
 // for @[expand_simple_interpolation] calls (like strings.Builder.write_string/writeln), and

--- a/vlib/v/tests/string_escape_opaque_backslash_test.v
+++ b/vlib/v/tests/string_escape_opaque_backslash_test.v
@@ -184,6 +184,10 @@ struct JsonAttrHazardWrap {
 	c JsonAttrHazardEnum
 }
 
+struct JsonFieldAttrHazard {
+	value string @[json: 'C\x5cnD']
+}
+
 fn test_json_enum_attr_arg_with_decoded_backslash() {
 	encoded := json.encode(JsonAttrHazardWrap{ c: .blue })
 	// the true attr value is 4 bytes (A, 0x5C, 'n', B); a spec-compliant JSON encoding of that
@@ -194,6 +198,14 @@ fn test_json_enum_attr_arg_with_decoded_backslash() {
 	assert decoded.c == .blue
 }
 
+fn test_json_field_attr_arg_with_decoded_backslash() {
+	encoded := json.encode(JsonFieldAttrHazard{ value: 'ok' })
+	assert encoded.bytes() == [u8(123), 34, 67, 92, 92, 110, 68, 34, 58, 34, 111, 107, 34, 125]
+
+	decoded := json.decode(JsonFieldAttrHazard, '{"C\\\\nD":"ok"}') or { panic(err) }
+	assert decoded.value == 'ok'
+}
+
 // regression test for a sixth gap found in the same review round: get_table_name_by_struct_type()
 // (vlib/v/gen/c/orm.v) reads the ORM table name from a struct's @[table: ...] attribute arg but
 // was passing a hardcoded empty opaque_pos to smart_quote instead of attr.arg_opaque_pos - the
@@ -201,6 +213,12 @@ fn test_json_enum_attr_arg_with_decoded_backslash() {
 @[table: 'T\x5cnU']
 struct OrmTableHazardItem {
 	id int @[primary; sql: serial]
+}
+
+@[table: 'orm_column_hazard_items']
+struct OrmColumnHazardItem {
+	id    int @[primary; sql: serial]
+	value string @[sql: 'A\x5cnB']
 }
 
 fn test_orm_table_name_with_decoded_backslash() {
@@ -214,6 +232,33 @@ fn test_orm_table_name_with_decoded_backslash() {
 		if row.vals.len > 0 {
 			found = true
 			assert row.vals[0].bytes() == [u8(84), 92, 110, 85]
+		}
+	}
+	assert found
+}
+
+fn test_orm_column_name_with_decoded_backslash() {
+	mut db := sqlite.connect(':memory:') or { panic(err) }
+	sql db {
+		create table OrmColumnHazardItem
+	} or { panic(err) }
+	item := OrmColumnHazardItem{
+		value: 'ok'
+	}
+	sql db {
+		insert item into OrmColumnHazardItem
+	} or { panic(err) }
+	items := sql db {
+		select from OrmColumnHazardItem where value == 'ok'
+	} or { panic(err) }
+	assert items.len == 1
+	assert items[0].value == 'ok'
+
+	columns := db.exec('pragma table_info(orm_column_hazard_items)') or { panic(err) }
+	mut found := false
+	for column in columns {
+		if column.vals.len > 1 && column.vals[1].bytes() == [u8(65), 92, 110, 66] {
+			found = true
 		}
 	}
 	assert found

--- a/vlib/v/transformer/transformer.v
+++ b/vlib/v/transformer/transformer.v
@@ -933,8 +933,11 @@ pub fn (mut t Transformer) infix_expr(mut node ast.InfixExpr) ast.Expr {
 								}
 							}
 							.plus {
+								folded_val := util.smart_quote(node.left.val, node.left.is_raw,
+									node.left.opaque_pos) +
+									util.smart_quote(node.right.val, node.right.is_raw, node.right.opaque_pos)
 								return if t.pref.backend == .c { ast.Expr(ast.StringLiteral{
-										val: util.smart_quote(node.left.val, node.left.is_raw) + util.smart_quote(node.right.val, node.right.is_raw)
+										val: folded_val
 										pos: pos
 									}) } else { ast.Expr(node) }
 							}
@@ -1454,7 +1457,7 @@ pub fn (mut t Transformer) simplify_nested_interpolation_in_sb(mut onode ast.Stm
 
 	// first, insert all the statements, for writing the static strings, that were parts of the original string interpolation:
 	mut calls := []ast.Stmt{}
-	for val in original.vals {
+	for idx, val in original.vals {
 		if val == '' {
 			// there is no point in appending empty strings
 			// so instead, just emit an empty statement, to be ignored by the backend
@@ -1463,6 +1466,7 @@ pub fn (mut t Transformer) simplify_nested_interpolation_in_sb(mut onode ast.Stm
 			}
 			continue
 		}
+		val_opaque_pos := if idx < original.opaque_pos.len { original.opaque_pos[idx] } else { []int{} }
 		mut ncall := ast.ExprStmt{
 			expr: ast.Expr(ast.CallExpr{
 				...nexpr
@@ -1470,7 +1474,8 @@ pub fn (mut t Transformer) simplify_nested_interpolation_in_sb(mut onode ast.Stm
 					ast.CallArg{
 						...nexpr.args[0]
 						expr: ast.StringLiteral{
-							val: val
+							val:        val
+							opaque_pos: val_opaque_pos
 						}
 					},
 				]

--- a/vlib/v/util/quote.v
+++ b/vlib/v/util/quote.v
@@ -15,7 +15,7 @@ const double_quote = 34
 const double_escape = '\\\\'
 
 @[direct_array_access]
-pub fn smart_quote(str string, raw bool) string {
+pub fn smart_quote(str string, raw bool, opaque_pos []int) string {
 	len := str.len
 	if len == 0 {
 		return ''
@@ -37,6 +37,19 @@ pub fn smart_quote(str string, raw bool) string {
 		}
 		if is_pure {
 			return str
+		}
+	}
+	// bytes at these offsets already came out of a \xXX/\uXXXX/\UXXXXXXXX decode (see
+	// scanner.Scanner.string_opaque_pos): they are final, resolved bytes, never the
+	// start of an as-yet-undecoded source escape sequence, even if the byte that follows
+	// them happens to spell out a recognized escape letter (e.g. `n`, `t`, `\`, ...).
+	mut is_opaque := []bool{}
+	if opaque_pos.len > 0 {
+		is_opaque = []bool{len: len}
+		for p in opaque_pos {
+			if p >= 0 && p < len {
+				is_opaque[p] = true
+			}
 		}
 	}
 	// ensure there is enough space for the potential expansion of several \\ or \n
@@ -69,6 +82,13 @@ pub fn smart_quote(str string, raw bool) string {
 			continue
 		}
 		if current == backslash {
+			if is_opaque.len > 0 && is_opaque[pos] {
+				// a final, literal backslash byte from a decoded escape - always \\,
+				// regardless of what follows it.
+				current = 0
+				result.write_string(double_escape)
+				continue
+			}
 			if raw {
 				result.write_string(double_escape)
 				continue


### PR DESCRIPTION
## Summary

A string literal containing a `\xXX`/`\uXXXX`/`\UXXXXXXXX` escape that decodes to byte `0x5C` (backslash), immediately followed by a character that spells a recognized C/V escape letter, was silently corrupted during C codegen.

```v
s := 'A\x5cnB'
println(s.len) // prints 3, should print 4
```

Root cause: the scanner decodes `\x`/`\u`/`\U` eagerly into raw bytes, but leaves every other escape undecoded for later resolution by `util.smart_quote()` at cgen time. `smart_quote()` had no way to distinguish a byte that was already resolved from one that's still an undecoded escape lead-in — both look identical once scanning finishes, so a decoded backslash byte sitting next to a letter like `n` gets misread as a fresh `\n` escape by the C compiler.

## Fix

- Track which byte offsets in a scanned string came directly out of a hex/unicode decode (`Scanner.string_opaque_pos`, keyed by token `tidx`).
- Thread that provenance through new `ast.StringLiteral.opaque_pos` / `ast.StringInterLiteral.opaque_pos` fields.
- `util.smart_quote()` gets a third parameter and always escapes an opaque backslash byte to `\`, regardless of what follows it.

The same hazard exists for `ast.Attr.name`/`.arg`, since attribute values (`@[tag: 'A\x5cnB']`, or the whole-string form `@['A\x5cnB']`) are scanned through the exact same path — gave `Attr` matching `name_opaque_pos`/`arg_opaque_pos` fields and wired every C-codegen site that embeds an attribute value into generated C: struct/enum/interface/method attribute dumps, ORM table/column attribute emission and the `@[table: ...]` table-name path, and enum `@[json: ...]` tag encode/decode.

Also fixes a related gap: the transformer's `simplify_nested_interpolation_in_sb` (the `@[expand_simple_interpolation]` pass behind `strings.Builder.write_string`) was splitting an interpolated string into per-segment literals without carrying `opaque_pos` along.

## Test plan

Added `vlib/v/tests/string_escape_opaque_backslash_test.v` (16 tests) covering:
- [x] Plain, interpolated, and compile-time-concatenated string literals
- [x] `strings.Builder.write_string` with interpolation
- [x] All three `ast.Attr` forms (colon-arg, whole-string, call-style), including double-quoted values
- [x] Comptime `$for` over both `.fields` and `.attributes`/`.methods`
- [x] JSON enum tag round-tripping (`@[json: ...]`)
- [x] ORM table-name generation (`@[table: ...]`) against a real sqlite DB
- [x] Ordinary escapes and equality/`match` are unaffected

Also ran the full `compiler_errors_test.v` (1697 passed, 3 skipped, 0 failed) and `test vlib/v/` after every change.

🧙 Built with [WOZCODE](https://wozcode.com)