### PR TITLE
v3: preserve parallel worker metadata

### DIFF
--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -4485,6 +4485,84 @@ fn main() {
 	assert run_module_cache_binary(second_output) == '7'
 }
 
+fn test_cold_module_cache_preserves_parallel_interface_indexes() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_parallel_interfaces_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'contract/contract.v', 'module contract
+
+pub interface JsonEncoder {
+	to_json() string
+}
+
+pub interface A {
+	a() int
+}
+
+pub interface B {
+	b() int
+}
+
+pub interface C {
+	c() int
+}
+
+pub struct Null {}
+
+pub fn (null Null) to_json() string {
+	_ = null
+	return "null"
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import contract
+
+fn main() {
+	println("hi")
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	output := os.join_path(root, 'app')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, output)
+	assert run_module_cache_binary(output) == 'hi'
+}
+
+fn test_cold_module_cache_preserves_parallel_monomorph_specs() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_parallel_monomorph_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import x.json2
+
+struct Result {
+	success bool
+	values  []string
+}
+
+fn main() {
+	result := json2.decode[Result](r\'{"success":true,"values":["A","B"]}\')!
+	println(result.success)
+	println(result.values.join(","))
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	output := os.join_path(root, 'app')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, output)
+	assert run_module_cache_binary(output) == 'true\nA,B'
+}
+
 fn test_cached_interface_implementer_with_embedded_body_has_forward_declaration() {
 	v3_bin := build_module_cache_v3()
 	root := os.join_path(os.temp_dir(), 'v3_module_cache_interface_embedded_body_${os.getpid()}')

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -656,10 +656,16 @@ fn (t &Transformer) sorted_monomorph_cache_specs() []MonomorphCacheSpec {
 	mut specs := []MonomorphCacheSpec{cap: keys.len}
 	for key in keys {
 		spec := t.monomorph_cache_specs[key]
+		// Spec arguments can come from monomorph workers whose arenas are
+		// released before the driver promotes this returned list.
+		mut args := []string{cap: spec.args.len}
+		for arg in spec.args {
+			args << arg.clone()
+		}
 		specs << MonomorphCacheSpec{
 			decl_key: spec.decl_key.clone()
 			module: spec.module.clone()
-			args: spec.args.clone()
+			args: args
 		}
 	}
 	return specs

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -117,7 +117,17 @@ fn (mut tc TypeChecker) prepare_interface_impl_indexes_parallel(iface_names []st
 		tc.restore_type_cache_base()
 		for i, iface_name in iface_names {
 			if !isnil(results.items[i]) {
-				tc.interface_impl_indexes[iface_name] = results.items[i]
+				// Worker indexes are backed by disposable worker arenas. Publish a
+				// parent-owned copy before those arenas are released.
+				worker_index := results.items[i]
+				mut names := []string{cap: worker_index.names.len}
+				for name in worker_index.names {
+					names << name.clone()
+				}
+				tc.interface_impl_indexes[iface_name] = &InterfaceImplIndex{
+					names: names
+					ids:   stable_interface_type_ids(names)
+				}
 			}
 		}
 		return true


### PR DESCRIPTION
## Summary

- copy parallel interface implementation indexes into the parent arena before worker storage is released
- deep-copy monomorph cache argument strings before monomorph worker arenas are released
- add cold-cache regressions for both the four-interface trigger and `json2.decode[T]`

The V3 preallocated build was publishing slices containing strings allocated in disposable worker arenas. Later cache preparation read those strings after the workers had shut down, causing the nondeterministic `memmove`/`wyhash` crashes reported on macOS arm64.

Fixes #28382

## Testing

- `./v -no-memory-limit -g -keepc -o ./vnew cmd/v`
- fresh-cache four-interface reproducer: prints `hi`
- fresh-cache issue JSON2 reproducer: prints `a`
- `VFLAGS='-no-memory-limit' VTEST_ONLY_FN='test_cold_module_cache_preserves_parallel_*' ./vnew -silent vlib/v3/tests/module_cache_test.v`
- `./vnew -silent vlib/v3/types/checker_parallel_test.v`
- `./vnew -silent vlib/v3/types/interface_impl_test.v`
- `./vnew -silent vlib/v3/transform/monomorphize_test.v`

The legacy `vlib/v/compiler_errors_test.v` corpus is not green under current V3-only master because of existing V3 diagnostic/output differences and three malformed-input hangs. `./vnew -silent test vlib/v/` also currently fails while building `vtest` because V3 cannot resolve its `testing` import. No expected outputs were changed.
