### PR TITLE
v3: implement memory-bounded parallel C builds

### DIFF
--- a/vlib/builtin/closure/closure_once_nix.h
+++ b/vlib/builtin/closure/closure_once_nix.h
@@ -13,8 +13,21 @@ typedef void (*v_closure_init_fn)(void);
 # endif
 #endif
 
+/* The parallel-C owner provides the single shared copy used by inline
+ * helpers in every generated translation unit. */
+#define V_PARALLEL_CC_STATIC_STORAGE_HANDLED 1
+#if defined(V_PARALLEL_CC)
+# if defined(V_PARALLEL_CC_OUT_0)
+pthread_mutex_t v_closure_once_mutex = PTHREAD_MUTEX_INITIALIZER;
+int v_closure_once_done = 0;
+# else
+extern pthread_mutex_t v_closure_once_mutex;
+extern int v_closure_once_done;
+# endif
+#else
 static pthread_mutex_t v_closure_once_mutex = PTHREAD_MUTEX_INITIALIZER;
 static int v_closure_once_done = 0;
+#endif
 
 V_CLOSURE_STATIC_INLINE void v_closure_init_once(v_closure_init_fn init_fn) {
 	pthread_mutex_lock(&v_closure_once_mutex);

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -1822,6 +1822,18 @@ struct V3CCompilerFlagPlan {
 	tcc_includes  string
 }
 
+const v3_parallel_cc_unit_marker = '/* V3PARALLEL_CC_UNIT */'
+const v3_parallel_cc_max_jobs = 2
+const v3_parallel_cc_units_per_job = 4
+
+struct V3ParallelCCompileTask {
+	compiler string
+	args     []string
+	dir      string
+mut:
+	result os.Result
+}
+
 fn (plan &V3CCompilerFlagPlan) compiler_args(output string, inputs []string, support_inputs []string) []string {
 	mut args := plan.before_inputs.clone()
 	args << ['-o', output]
@@ -1836,6 +1848,259 @@ fn (plan &V3CCompilerFlagPlan) all_flags(support_inputs []string) []string {
 	flags << support_inputs
 	flags << plan.after_inputs
 	return flags
+}
+
+fn run_v3_parallel_c_compile_task(raw_task voidptr) voidptr {
+	mut task := unsafe { &V3ParallelCCompileTask(raw_task) }
+	task.result = cmdexec.run_in(task.compiler, task.args, task.dir)
+	return unsafe { nil }
+}
+
+fn write_v3_parallel_c_source(path string, header_name string, body string, owner bool) ! {
+	mut file := os.create(path)!
+	defer {
+		file.close()
+	}
+	file.writeln('#define V3CACHE_PROGRAM_UNIT 1')!
+	file.writeln('#define V_PARALLEL_CC 1')!
+	file.writeln('#define _VPARALLELCC 1')!
+	if owner {
+		file.writeln('#define V_PARALLEL_CC_OUT_0 1')!
+		file.write_string(body)!
+		return
+	}
+	file.writeln('#include "${header_name}"')!
+	// These program lifecycle functions are emitted in the generated body rather
+	// than its declaration prefix, so later body units need explicit prototypes.
+	file.writeln('void _vinit(void);')!
+	file.writeln('void _vcleanup(void);')!
+	file.write_string(body)!
+}
+
+fn v3_parallel_local_include_path(line string, including_dir string) ?string {
+	trimmed := line.trim_space()
+	prefix := '#include "'
+	if !trimmed.starts_with(prefix) {
+		return none
+	}
+	rest := trimmed[prefix.len..]
+	end := rest.index_u8(`"`)
+	if end <= 0 {
+		return none
+	}
+	raw_path := rest[..end]
+	path := if os.is_abs_path(raw_path) {
+		raw_path
+	} else if including_dir.len > 0 {
+		os.join_path_single(including_dir, raw_path)
+	} else {
+		return none
+	}
+	if !os.is_file(path) {
+		return none
+	}
+	return os.real_path(path)
+}
+
+fn v3_parallel_expand_local_includes(path string, mut active map[string]bool) string {
+	real_path := os.real_path(path)
+	if active[real_path] {
+		return ''
+	}
+	source := os.read_file(real_path) or { return '' }
+	active[real_path] = true
+	mut expanded := strings.new_builder(source.len)
+	for line in source.split_into_lines() {
+		if include_path := v3_parallel_local_include_path(line, os.dir(real_path)) {
+			expanded.writeln(v3_parallel_expand_local_includes(include_path, mut active))
+		} else {
+			expanded.writeln(line)
+		}
+	}
+	active.delete(real_path)
+	return expanded.str()
+}
+
+fn v3_parallel_c_declaration_header(prefix string) string {
+	mut replacements := map[string]string{}
+	mut in_native_directives := false
+	for line in prefix.split_into_lines() {
+		trimmed := line.trim_space()
+		if trimmed == '/* V3CACHE_NATIVE_DIRECTIVES_BEGIN */' {
+			in_native_directives = true
+			continue
+		}
+		if trimmed == '/* V3CACHE_NATIVE_DIRECTIVES_END */' {
+			in_native_directives = false
+			continue
+		}
+		if !in_native_directives || trimmed in replacements {
+			continue
+		}
+		if include_path := v3_parallel_local_include_path(line, '') {
+			mut active := map[string]bool{}
+			expanded := v3_parallel_expand_local_includes(include_path, mut active)
+			replacements[trimmed] = modulecache.declaration_header(expanded)
+		}
+	}
+	header := modulecache.declaration_header(prefix)
+	if replacements.len == 0 {
+		return header
+	}
+	mut out := strings.new_builder(header.len)
+	for line in header.split_into_lines() {
+		if declarations := replacements[line.trim_space()] {
+			out.writeln(declarations)
+		} else {
+			out.writeln(line)
+		}
+	}
+	return out.str()
+}
+
+fn merge_v3_parallel_c_units(parts []string, max_units int) []string {
+	if max_units <= 0 || parts.len <= max_units {
+		return parts.clone()
+	}
+	mut remaining_size := 0
+	for part in parts {
+		remaining_size += part.len
+	}
+	mut groups_left := max_units
+	mut target_size := (remaining_size + groups_left - 1) / groups_left
+	mut merged := []string{cap: max_units}
+	mut current := []string{}
+	mut current_size := 0
+	for part_index, part in parts {
+		current << part
+		current_size += part.len
+		remaining_parts := parts.len - part_index - 1
+		if merged.len < max_units - 1
+			&& (current_size >= target_size || remaining_parts == groups_left - 1) {
+			merged << current.join('')
+			remaining_size -= current_size
+			groups_left--
+			target_size = (remaining_size + groups_left - 1) / groups_left
+			current = []string{}
+			current_size = 0
+		}
+	}
+	if current.len > 0 {
+		merged << current.join('')
+	}
+	return merged
+}
+
+fn split_v3_parallel_c_source(source string, max_units int) !(string, []string) {
+	split := modulecache.split_generated_c(source)!
+	body_begin := '/* V3CACHE_BODY_BEGIN */\n'
+	begin := source.index(body_begin) or { return error('missing v3 parallel C body marker') }
+	body_start := begin + body_begin.len
+	body_end := source.index_after('\n/* V3CACHE_BODY_END */', body_start) or {
+		return error('missing v3 parallel C body end marker')
+	}
+	mut units := []string{}
+	for part in source[body_start..body_end].split(v3_parallel_cc_unit_marker) {
+		if part.trim_space().len > 0 {
+			units << part
+		}
+	}
+	if units.len == 0 {
+		return error('missing v3 parallel C unit markers')
+	}
+	return split.prefix, merge_v3_parallel_c_units(units, max_units)
+}
+
+fn compile_v3_parallel_c(source_path string, c_compiler string, c_flag_plan &V3CCompilerFlagPlan, native_support_inputs []string, cached_objects []string, cached_dev_dylib string, objective_c bool, build_dir string, show_command bool) os.Result {
+	source := os.read_file(source_path) or {
+		return os.Result{
+			exit_code: 1
+			output: 'failed to read generated C source ${source_path}: ${err.msg()}'
+		}
+	}
+	job_count := int_max(1, int_min(v3_parallel_cc_max_jobs, runtime.nr_jobs()))
+	prefix, bodies := split_v3_parallel_c_source(source, job_count * v3_parallel_cc_units_per_job) or {
+		return os.Result{
+			exit_code: 1
+			output: 'failed to split generated C source: ${err.msg()}'
+		}
+	}
+	header_name := 'parallel.h'
+	header_path := os.join_path_single(build_dir, header_name)
+	header := v3_parallel_c_declaration_header(prefix)
+	os.write_file(header_path, header) or {
+		return os.Result{
+			exit_code: 1
+			output: 'failed to write parallel C header ${header_path}: ${err.msg()}'
+		}
+	}
+	mut tasks := []&V3ParallelCCompileTask{cap: bodies.len + 1}
+	mut objects := []string{cap: bodies.len + 1}
+	mut compile_flags := c_object_compile_flags(c_flag_plan.before_inputs)
+	compile_flags << c_object_compile_flags(c_flag_plan.after_inputs)
+	for unit_index := 0; unit_index <= bodies.len; unit_index++ {
+		source_name := 'unit_${unit_index}.c'
+		object_name := 'unit_${unit_index}.o'
+		unit_source := if unit_index == 0 { prefix } else { bodies[unit_index - 1] }
+		write_v3_parallel_c_source(os.join_path_single(build_dir, source_name), header_name, unit_source, unit_index == 0) or {
+			return os.Result{
+				exit_code: 1
+				output: 'failed to write parallel C unit ${source_name}: ${err.msg()}'
+			}
+		}
+		mut compile_args := compile_flags.clone()
+		compile_args << ['-x', if objective_c { 'objective-c' } else { 'c' }, '-c', '-o',
+			object_name, source_name]
+		if show_command {
+			println('  > ${cmdexec.display(c_compiler, compile_args)}')
+		}
+		tasks << &V3ParallelCCompileTask{
+			compiler: c_compiler
+			args: compile_args
+			dir: build_dir
+		}
+		objects << object_name
+	}
+	mut work := []workers.Task{cap: tasks.len}
+	for task in tasks {
+		work << workers.Task{
+			run: run_v3_parallel_c_compile_task
+			arg: voidptr(task)
+		}
+	}
+	mut pool := workers.new(job_count)
+	pool.run(work)
+	mut errors := strings.new_builder(1024)
+	mut failed := false
+	for task in tasks {
+		if task.result.exit_code != 0 {
+			failed = true
+			errors.write_string(task.result.output)
+			if task.result.output.len > 0 && !task.result.output.ends_with('\n') {
+				errors.writeln('')
+			}
+		}
+	}
+	if failed {
+		output := errors.str()
+		pool.close()
+		return os.Result{
+			exit_code: 1
+			output: output
+		}
+	}
+	pool.close()
+	mut link_inputs := objects.clone()
+	link_inputs << native_support_inputs
+	link_inputs << cached_objects
+	if cached_dev_dylib.len > 0 {
+		link_inputs << cached_dev_dylib
+	}
+	link_args := c_flag_plan.compiler_args('out', link_inputs, [])
+	if show_command {
+		println('  > ${cmdexec.display(c_compiler, link_args)}')
+	}
+	return cmdexec.run_in(c_compiler, link_args, build_dir)
 }
 
 fn v3_c_source_inputs(source string, objective_c bool) []string {
@@ -8905,12 +9170,14 @@ pub fn run(args []string) {
 	minimal_literal_output := !is_prof
 		&& input_uses_minimal_literal_output_builtin(input_file, prefs, is_test_command, is_checker_fixture)
 	host_target := pref.host_target()
+	use_parallel_c_compilation := parallel_cc && backend == 'c' && !c_only && !explicit_tcc
+		&& !is_o && target.os != 'windows'
 	// `-keepc` and explicit `-b c` promise a complete generated C translation unit.
 	// The module cache splits imported implementations into separate objects, so its main source
 	// alone cannot reproduce the build. Literal output uses a deliberately reduced
 	// builtin source set, which likewise must remain a monolithic translation unit.
 	cache_candidate_enabled := backend == 'c' && !c_only && !no_cache && !no_skip_unused
-		&& !no_builtin
+		&& !no_builtin && !parallel_cc
 		&& !keep_c && !backend_explicit && !c_compiler_explicit && !minimal_literal_output
 		&& c_compiler == 'cc' && target.os == host_target.os && target.arch == host_target.arch
 		&& !input_owns_builtin_bundle_module(input_file, prefs.vroot)
@@ -10699,7 +10966,8 @@ pub fn run(args []string) {
 			g.set_coverage(coverage_dir, args.join(' '))
 			g.set_compile_values(prefs.compile_values)
 			g.set_track_heap('track_heap' in prefs.user_defines)
-			g.set_cache_split(cache_state.manager.enabled)
+			g.set_cache_split(cache_state.manager.enabled || use_parallel_c_compilation)
+			g.set_parallel_cc(use_parallel_c_compilation)
 			g.set_cache_native_input_paths(cache_scoped_native_input_paths(cache_state))
 			g.set_program_body_only(generic_cache_hit)
 			g.set_cache_program_files(user_files)
@@ -10753,7 +11021,8 @@ pub fn run(args []string) {
 			g.set_coverage(coverage_dir, args.join(' '))
 			g.set_compile_values(prefs.compile_values)
 			g.set_track_heap('track_heap' in prefs.user_defines)
-			g.set_cache_split(cache_state.manager.enabled)
+			g.set_cache_split(cache_state.manager.enabled || use_parallel_c_compilation)
+			g.set_parallel_cc(use_parallel_c_compilation)
 			g.set_cache_native_input_paths(cache_scoped_native_input_paths(cache_state))
 			g.set_program_body_only(generic_cache_hit)
 			g.set_cache_program_files(user_files)
@@ -11306,11 +11575,6 @@ pub fn run(args []string) {
 				exit(1)
 			}
 		}
-		if parallel_cc && v3_parallel_cc_active_sources_include_external_definition(a, user_files) {
-			eprintln('failed to link after parallel C compilation')
-			cleanup_c_build_dir(cc_dir)
-			exit(1)
-		}
 		// Compile inside a per-output build dir, using constant relative source/output basenames,
 		// then move the result to bin_file. On macOS arm64 tcc bakes the -o basename into the
 		// ad-hoc code-signature identifier and the input .c path into the symbol table, so building
@@ -11476,11 +11740,16 @@ pub fn run(args []string) {
 			if cached_dev_dylib.len > 0 {
 				compiler_inputs << cached_dev_dylib
 			}
-			cc_args := c_flag_plan.compiler_args('out', compiler_inputs, [])
-			if !silent || show_cc {
-				println('  > ${cmdexec.display(c_compiler, cc_args)}')
+			if use_parallel_c_compilation && cached_program_main_object.len == 0
+				&& fallback_source == 'src.c' {
+				result = compile_v3_parallel_c(cc_src, c_compiler, &c_flag_plan, native_support_inputs, cached_objects, cached_dev_dylib, needs_objective_c, cc_dir, !silent || show_cc)
+			} else {
+				cc_args := c_flag_plan.compiler_args('out', compiler_inputs, [])
+				if !silent || show_cc {
+					println('  > ${cmdexec.display(c_compiler, cc_args)}')
+				}
+				result = cmdexec.run_in(c_compiler, cc_args, cc_dir)
 			}
-			result = cmdexec.run_in(c_compiler, cc_args, cc_dir)
 			show_v3_c_compiler_output(show_c_output, c_compiler, result)
 			if result.exit_code != 0 {
 				if retry_compilation && v3_is_tcc_compilation_failure(c_compiler, result.output) {
@@ -11691,47 +11960,6 @@ fn v3_is_tcc_compilation_failure(c_compiler string, output string) bool {
 	for line in output.split_into_lines() {
 		if line.trim_space().to_lower().starts_with('tcc:') {
 			return true
-		}
-	}
-	return false
-}
-
-fn v3_parallel_cc_active_sources_include_external_definition(a &flat.FlatAst, source_files []string) bool {
-	mut selected_files := map[string]bool{}
-	for file in source_files {
-		selected_files[os.real_path(file)] = true
-	}
-	mut current_file := ''
-	mut selected := false
-	// Checker/transform pruning replaces directives from inactive `$if` branches with empty
-	// nodes, so this stream matches the target selected for generated C.
-	for node in a.nodes {
-		if node.kind == .file {
-			current_file = node.value
-			selected = os.real_path(current_file) in selected_files
-			continue
-		}
-		if !selected || node.kind != .directive || node.value != 'include' {
-			continue
-		}
-		raw_target, _ := checker_fixture_include_target_message(node.typ)
-		if !raw_target.starts_with('"') {
-			continue
-		}
-		rest := raw_target[1..]
-		end := rest.index('"') or { continue }
-		header_path := rest[..end].replace('@DIR', os.dir(current_file))
-		header := os.read_file(header_path) or { continue }
-		for header_line in header.split_into_lines() {
-			declaration := header_line.trim_space()
-			if declaration.len == 0 || declaration.starts_with('#')
-				|| declaration.starts_with('static ') || declaration.starts_with('inline ')
-				|| declaration.starts_with('typedef ') {
-				continue
-			}
-			if declaration.contains('(') && declaration.contains(')') && declaration.contains('{') {
-				return true
-			}
 		}
 	}
 	return false

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -1825,6 +1825,9 @@ struct V3CCompilerFlagPlan {
 const v3_parallel_cc_unit_marker = '/* V3PARALLEL_CC_UNIT */'
 const v3_parallel_cc_max_jobs = 2
 const v3_parallel_cc_units_per_job = 4
+const v3_parallel_cc_monolithic_define = 'v3_parallel_cc_monolithic'
+const v3_parallel_cc_monolithic_exit_code = 125
+const v3_parallel_cc_monolithic_message = 'v3 parallel C source requires monolithic regeneration'
 
 struct V3ParallelCCompileTask {
 	compiler string
@@ -1877,53 +1880,102 @@ fn write_v3_parallel_c_source(path string, header_name string, body string, owne
 	file.write_string(body)!
 }
 
-fn v3_parallel_local_include_path(line string, including_dir string) ?string {
+fn v3_parallel_c_include_dirs(flags []string) []string {
+	mut dirs := []string{}
+	mut i := 0
+	for i < flags.len {
+		flag := flags[i]
+		mut path := ''
+		if flag in ['-I', '-iquote', '-isystem'] && i + 1 < flags.len {
+			path = flags[i + 1]
+			i += 2
+		} else if flag.starts_with('-I') && flag.len > 2 {
+			path = flag[2..]
+			i++
+		} else if flag.starts_with('-iquote') && flag.len > '-iquote'.len {
+			path = flag['-iquote'.len..]
+			i++
+		} else if flag.starts_with('-isystem') && flag.len > '-isystem'.len {
+			path = flag['-isystem'.len..]
+			i++
+		} else {
+			i++
+		}
+		if path.len > 0 {
+			real_path := os.real_path(path)
+			if os.is_dir(real_path) && real_path !in dirs {
+				dirs << real_path
+			}
+		}
+	}
+	return dirs
+}
+
+fn v3_parallel_local_include_path(line string, including_dir string, include_dirs []string) ?string {
 	trimmed := line.trim_space()
-	prefix := '#include "'
-	if !trimmed.starts_with(prefix) {
+	quoted_prefix := '#include "'
+	angle_prefix := '#include <'
+	quoted := trimmed.starts_with(quoted_prefix)
+	prefix := if quoted { quoted_prefix } else { angle_prefix }
+	if !quoted && !trimmed.starts_with(angle_prefix) {
 		return none
 	}
 	rest := trimmed[prefix.len..]
-	end := rest.index_u8(`"`)
+	end := rest.index_u8(if quoted { `"` } else { `>` })
 	if end <= 0 {
 		return none
 	}
 	raw_path := rest[..end]
-	path := if os.is_abs_path(raw_path) {
-		raw_path
-	} else if including_dir.len > 0 {
-		os.join_path_single(including_dir, raw_path)
-	} else {
+	if os.is_abs_path(raw_path) {
+		if os.is_file(raw_path) {
+			return os.real_path(raw_path)
+		}
 		return none
 	}
-	if !os.is_file(path) {
-		return none
+	mut search_dirs := []string{}
+	if quoted && including_dir.len > 0 {
+		search_dirs << including_dir
 	}
-	return os.real_path(path)
+	search_dirs << include_dirs
+	for dir in search_dirs {
+		path := os.join_path_single(dir, raw_path)
+		if os.is_file(path) {
+			return os.real_path(path)
+		}
+	}
+	return none
 }
 
-fn v3_parallel_expand_local_includes(path string, mut active map[string]bool) string {
+fn v3_parallel_expand_local_includes(path string, include_dirs []string, mut active map[string]bool) (string, bool) {
 	real_path := os.real_path(path)
 	if active[real_path] {
-		return ''
+		return '', true
 	}
-	source := os.read_file(real_path) or { return '' }
+	source := os.read_file(real_path) or { return '', false }
 	active[real_path] = true
 	mut expanded := strings.new_builder(source.len)
+	mut complete := true
 	for line in source.split_into_lines() {
-		if include_path := v3_parallel_local_include_path(line, os.dir(real_path)) {
-			expanded.writeln(v3_parallel_expand_local_includes(include_path, mut active))
+		if include_path := v3_parallel_local_include_path(line, os.dir(real_path), include_dirs) {
+			included, included_complete := v3_parallel_expand_local_includes(include_path, include_dirs, mut active)
+			expanded.writeln(included)
+			complete = complete && included_complete
 		} else {
+			if line.trim_space().starts_with('#include "') {
+				complete = false
+			}
 			expanded.writeln(line)
 		}
 	}
 	active.delete(real_path)
-	return expanded.str()
+	return expanded.str(), complete
 }
 
-fn v3_parallel_c_declaration_header(prefix string) string {
+fn v3_parallel_c_declaration_header(prefix string, include_dirs []string) (string, bool) {
 	mut replacements := map[string]string{}
 	mut in_native_directives := false
+	mut native_directives := strings.new_builder(1024)
+	mut safe := true
 	for line in prefix.split_into_lines() {
 		trimmed := line.trim_space()
 		if trimmed == '/* V3CACHE_NATIVE_DIRECTIVES_BEGIN */' {
@@ -1937,15 +1989,32 @@ fn v3_parallel_c_declaration_header(prefix string) string {
 		if !in_native_directives || trimmed in replacements {
 			continue
 		}
-		if include_path := v3_parallel_local_include_path(line, '') {
+		native_directives.writeln(line)
+		if include_path := v3_parallel_local_include_path(line, '', include_dirs) {
 			mut active := map[string]bool{}
-			expanded := v3_parallel_expand_local_includes(include_path, mut active)
+			expanded, complete := v3_parallel_expand_local_includes(include_path, include_dirs, mut active)
+			variables, variables_complete := modulecache.c_source_static_variable_identifiers(expanded)
+			if !complete || !variables_complete
+				|| (variables.len > 0
+					&& !expanded.contains('#define V_PARALLEL_CC_STATIC_STORAGE_HANDLED 1')) {
+				safe = false
+			}
 			replacements[trimmed] = modulecache.declaration_header(expanded)
+		} else if trimmed.starts_with('#include "') {
+			// An unresolved quoted include can still be found by the C compiler through
+			// an option that is opaque here. Its file-static state cannot be shared safely.
+			safe = false
 		}
+	}
+	native_source := native_directives.str()
+	variables, variables_complete := modulecache.c_source_static_variable_identifiers(native_source)
+	if !variables_complete
+		|| variables.keys().any(!it.starts_with('_v3_lit_') && !it.starts_with('_str_')) {
+		safe = false
 	}
 	header := modulecache.declaration_header(prefix)
 	if replacements.len == 0 {
-		return header
+		return header, safe
 	}
 	mut out := strings.new_builder(header.len)
 	for line in header.split_into_lines() {
@@ -1955,7 +2024,7 @@ fn v3_parallel_c_declaration_header(prefix string) string {
 			out.writeln(line)
 		}
 	}
-	return out.str()
+	return out.str(), safe
 }
 
 fn merge_v3_parallel_c_units(parts []string, max_units int) []string {
@@ -1999,11 +2068,27 @@ fn split_v3_parallel_c_source(source string, max_units int) !(string, []string) 
 	body_end := source.index_after('\n/* V3CACHE_BODY_END */', body_start) or {
 		return error('missing v3 parallel C body end marker')
 	}
+	body := source[body_start..body_end]
 	mut units := []string{}
-	for part in source[body_start..body_end].split(v3_parallel_cc_unit_marker) {
-		if part.trim_space().len > 0 {
-			units << part
+	mut unit_start := 0
+	mut line_start := 0
+	for line_start < body.len {
+		line_end := body.index_after('\n', line_start) or { body.len }
+		if body[line_start..line_end].trim_space() == v3_parallel_cc_unit_marker {
+			part := body[unit_start..line_start]
+			if part.trim_space().len > 0 {
+				units << part
+			}
+			unit_start = if line_end < body.len { line_end + 1 } else { line_end }
 		}
+		if line_end >= body.len {
+			break
+		}
+		line_start = line_end + 1
+	}
+	last := body[unit_start..]
+	if last.trim_space().len > 0 {
+		units << last
 	}
 	if units.len == 0 {
 		return error('missing v3 parallel C unit markers')
@@ -2025,9 +2110,17 @@ fn compile_v3_parallel_c(source_path string, c_compiler string, c_flag_plan &V3C
 			output: 'failed to split generated C source: ${err.msg()}'
 		}
 	}
-	header_name := 'parallel.h'
+	header_name := 'v3_parallel_cc_${tempname.unique_token()}.h'
 	header_path := os.join_path_single(build_dir, header_name)
-	header := v3_parallel_c_declaration_header(prefix)
+	mut c_flags := c_flag_plan.before_inputs.clone()
+	c_flags << c_flag_plan.after_inputs
+	header, header_is_safe := v3_parallel_c_declaration_header(prefix, v3_parallel_c_include_dirs(c_flags))
+	if !header_is_safe {
+		return os.Result{
+			exit_code: v3_parallel_cc_monolithic_exit_code
+			output: v3_parallel_cc_monolithic_message
+		}
+	}
 	os.write_file(header_path, header) or {
 		return os.Result{
 			exit_code: 1
@@ -9171,7 +9264,8 @@ pub fn run(args []string) {
 		&& input_uses_minimal_literal_output_builtin(input_file, prefs, is_test_command, is_checker_fixture)
 	host_target := pref.host_target()
 	use_parallel_c_compilation := parallel_cc && backend == 'c' && !c_only && !explicit_tcc
-		&& !is_o && target.os != 'windows'
+		&& !is_o && target.os != 'windows' && coverage_dir.len == 0 && profile_file.len == 0
+		&& v3_parallel_cc_monolithic_define !in user_defines
 	// `-keepc` and explicit `-b c` promise a complete generated C translation unit.
 	// The module cache splits imported implementations into separate objects, so its main source
 	// alone cannot reproduce the build. Literal output uses a deliberately reduced
@@ -11749,6 +11843,21 @@ pub fn run(args []string) {
 					println('  > ${cmdexec.display(c_compiler, cc_args)}')
 				}
 				result = cmdexec.run_in(c_compiler, cc_args, cc_dir)
+			}
+			if result.exit_code == v3_parallel_cc_monolithic_exit_code
+				&& result.output == v3_parallel_cc_monolithic_message {
+				cleanup_c_build_dir(cc_dir)
+				mut regeneration_args := ['-d', v3_parallel_cc_monolithic_define]
+				for arg in args {
+					if arg !in [macos_v3_compat_c99_flag, macos_v3_internal_quiet_flag] {
+						regeneration_args << arg
+					}
+				}
+				os.execvp(os.executable(), regeneration_args) or {
+					eprintln('failed to restart monolithic C compilation: ${err.msg()}')
+					exit(1)
+				}
+				return
 			}
 			show_v3_c_compiler_output(show_c_output, c_compiler, result)
 			if result.exit_code != 0 {

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -1995,6 +1995,7 @@ fn v3_parallel_c_declaration_header(prefix string, include_dirs []string) (strin
 			expanded, complete := v3_parallel_expand_local_includes(include_path, include_dirs, mut active)
 			variables, variables_complete := modulecache.c_source_static_variable_identifiers(expanded)
 			if !complete || !variables_complete
+				|| modulecache.c_source_replicated_function_has_static_storage(expanded)
 				|| (variables.len > 0
 					&& !expanded.contains('#define V_PARALLEL_CC_STATIC_STORAGE_HANDLED 1')) {
 				safe = false
@@ -2009,6 +2010,7 @@ fn v3_parallel_c_declaration_header(prefix string, include_dirs []string) (strin
 	native_source := native_directives.str()
 	variables, variables_complete := modulecache.c_source_static_variable_identifiers(native_source)
 	if !variables_complete
+		|| modulecache.c_source_replicated_function_has_static_storage(native_source)
 		|| variables.keys().any(!it.starts_with('_v3_lit_') && !it.starts_with('_str_')) {
 		safe = false
 	}

--- a/vlib/v3/driver/environment_test.v
+++ b/vlib/v3/driver/environment_test.v
@@ -3,7 +3,6 @@ module driver
 import os
 import crypto.sha256
 import v3.ansi
-import v3.flat
 import v3.parser
 import v3.pref
 import v3.types
@@ -280,34 +279,6 @@ fn test_v3_fallback_ignores_only_warmup_only_module_sources() {
 	// warm-up makes its source set part of the shared V3/V1 manifest again.
 	record_v3_fallback_module_use(mut state, 'hash', false)
 	assert hash_source !in v3_fallback_ignored_warmup_source_paths(state)
-}
-
-fn test_parallel_cc_external_definition_precheck_uses_active_ast_directives() {
-	root := os.join_path(os.temp_dir(), 'v3_parallel_cc_active_directive_${os.getpid()}')
-	os.rmdir_all(root) or {}
-	os.mkdir_all(root)!
-	defer {
-		os.rmdir_all(root) or {}
-	}
-	source := os.join_path(root, 'main.v')
-	os.write_file(source, 'fn main() {}\n')!
-	os.write_file(os.join_path(root, 'windows_impl.h'), 'int windows_impl(void) { return 1; }\n')!
-	mut a := &flat.FlatAst{
-		nodes: [
-			flat.Node{
-				kind: .file
-				value: source
-			},
-			flat.Node{
-				kind: .directive
-				value: 'include'
-				typ: '"@DIR/windows_impl.h"'
-			},
-		]
-	}
-	assert v3_parallel_cc_active_sources_include_external_definition(a, [source])
-	a.nodes[1] = flat.Node{}
-	assert !v3_parallel_cc_active_sources_include_external_definition(a, [source])
 }
 
 fn test_embedded_vroot_uses_baked_root_for_a_moved_compiler() {

--- a/vlib/v3/driver/parallel_cc_test.v
+++ b/vlib/v3/driver/parallel_cc_test.v
@@ -91,6 +91,29 @@ fn test_v3_parallel_cc_falls_back_for_native_static_state() {
 	}
 }
 
+fn test_v3_parallel_cc_falls_back_for_native_function_local_static_state() {
+	$if macos || linux {
+		root := os.join_path(os.vtmp_dir(), 'v3_parallel_cc_local_static_${os.getpid()}')
+		os.rmdir_all(root) or {}
+		os.mkdir_all(root)!
+		defer {
+			os.rmdir_all(root) or {}
+		}
+		source := os.join_path_single(root, 'main.v')
+		header := os.join_path_single(root, 'state.h')
+		output := os.join_path_single(root, 'main')
+		os.write_file(header, 'static inline int v3_parallel_local_next(void) {\n\tstatic int state;\n\treturn ++state;\n}\n')!
+		os.write_file(source, '#flag -I @DIR\n#include "state.h"\n\nfn C.v3_parallel_local_next() int\n\nfn first() int { return C.v3_parallel_local_next() }\nfn second() int { return C.v3_parallel_local_next() }\nfn main() { println(first())\nprintln(second()) }\n')!
+		build := cmdexec.run(@VEXE, ['-parallel-cc', '-nocache', '-showcc', '-o', output, source])
+		assert build.exit_code == 0, build.output
+		assert !build.output.contains('unit_0.c'), build.output
+		assert build.output.contains('src.c'), build.output
+		run_result := cmdexec.run(output, [])
+		assert run_result.exit_code == 0, run_result.output
+		assert run_result.output.trim_space() == '1\n2'
+	}
+}
+
 fn test_v3_parallel_cc_falls_back_for_coverage_and_profile_state() {
 	$if macos || linux {
 		root := os.join_path(os.vtmp_dir(), 'v3_parallel_cc_instrumentation_${os.getpid()}')

--- a/vlib/v3/driver/parallel_cc_test.v
+++ b/vlib/v3/driver/parallel_cc_test.v
@@ -1,0 +1,45 @@
+module driver
+
+import os
+import v3.cmdexec
+
+fn test_merge_v3_parallel_c_units_bounds_and_preserves_source() {
+	parts := ['a', 'bb', 'ccc', 'dddd', 'eeeee', 'ffffff']
+	merged := merge_v3_parallel_c_units(parts, 3)
+	assert merged.len == 3
+	assert merged.join('') == parts.join('')
+	assert merge_v3_parallel_c_units(parts, 0) == parts
+	assert merge_v3_parallel_c_units(parts[..2], 3) == parts[..2]
+}
+
+fn test_split_v3_parallel_c_source_uses_safe_unit_markers() {
+	source := '#include <stdio.h>\n/* V3CACHE_BODY_BEGIN */\n/* V3PARALLEL_CC_UNIT */\n/* V3CACHE_MODULE first */\nvoid first(void) {}\n/* V3PARALLEL_CC_UNIT */\n/* V3CACHE_MODULE second */\nvoid second(void) {}\n/* V3CACHE_BODY_END */\n'
+	prefix, units := split_v3_parallel_c_source(source, 1) or { panic(err) }
+	assert prefix == '#include <stdio.h>\n'
+	assert units.len == 1
+	assert units[0].contains('void first(void) {}')
+	assert units[0].contains('void second(void) {}')
+}
+
+fn test_v3_parallel_cc_compiles_and_runs_multiple_c_units() {
+	$if macos || linux {
+		root := os.join_path(os.vtmp_dir(), 'v3_parallel_cc_${os.getpid()}')
+		os.rmdir_all(root) or {}
+		os.mkdir_all(root)!
+		defer {
+			os.rmdir_all(root) or {}
+		}
+		source := os.join_path_single(root, 'main.v')
+		header := os.join_path_single(root, 'implementation.h')
+		output := os.join_path_single(root, 'main')
+		os.write_file(header, 'int v3_parallel_implementation(void) { return 21; }\n')!
+		os.write_file(source, '#insert "@DIR/implementation.h"\n\nfn C.v3_parallel_implementation() int\n\nfn twice(value int) int { return value * 2 }\nfn main() { println(twice(C.v3_parallel_implementation())) }\n')!
+		build := cmdexec.run(@VEXE, ['-parallel-cc', '-nocache', '-showcc', '-o', output, source])
+		assert build.exit_code == 0, build.output
+		assert build.output.contains('unit_0.c')
+		assert build.output.contains('unit_1.c')
+		run_result := cmdexec.run(output, [])
+		assert run_result.exit_code == 0, run_result.output
+		assert run_result.output.trim_space() == '42'
+	}
+}

--- a/vlib/v3/driver/parallel_cc_test.v
+++ b/vlib/v3/driver/parallel_cc_test.v
@@ -13,12 +13,14 @@ fn test_merge_v3_parallel_c_units_bounds_and_preserves_source() {
 }
 
 fn test_split_v3_parallel_c_source_uses_safe_unit_markers() {
-	source := '#include <stdio.h>\n/* V3CACHE_BODY_BEGIN */\n/* V3PARALLEL_CC_UNIT */\n/* V3CACHE_MODULE first */\nvoid first(void) {}\n/* V3PARALLEL_CC_UNIT */\n/* V3CACHE_MODULE second */\nvoid second(void) {}\n/* V3CACHE_BODY_END */\n'
-	prefix, units := split_v3_parallel_c_source(source, 1) or { panic(err) }
+	source := '#include <stdio.h>\n/* V3CACHE_BODY_BEGIN */\n\t/* V3PARALLEL_CC_UNIT */\n/* V3CACHE_MODULE first */\nvoid first(void) { puts("/* V3PARALLEL_CC_UNIT */"); }\n// /* V3PARALLEL_CC_UNIT */ inside a comment\n/* V3PARALLEL_CC_UNIT */\n/* V3CACHE_MODULE second */\nvoid second(void) {}\n/* V3CACHE_BODY_END */\n'
+	prefix, units := split_v3_parallel_c_source(source, 8) or { panic(err) }
 	assert prefix == '#include <stdio.h>\n'
-	assert units.len == 1
-	assert units[0].contains('void first(void) {}')
-	assert units[0].contains('void second(void) {}')
+	assert units.len == 2
+	assert units[0].contains('void first(void) {')
+	assert units[0].contains('puts("/* V3PARALLEL_CC_UNIT */")')
+	assert units[0].contains('inside a comment')
+	assert units[1].contains('void second(void) {}')
 }
 
 fn test_v3_parallel_cc_compiles_and_runs_multiple_c_units() {
@@ -41,5 +43,85 @@ fn test_v3_parallel_cc_compiles_and_runs_multiple_c_units() {
 		run_result := cmdexec.run(output, [])
 		assert run_result.exit_code == 0, run_result.output
 		assert run_result.output.trim_space() == '42'
+	}
+}
+
+fn test_v3_parallel_cc_does_not_shadow_user_parallel_header() {
+	$if macos || linux {
+		root := os.join_path(os.vtmp_dir(), 'v3_parallel_cc_header_${os.getpid()}')
+		os.rmdir_all(root) or {}
+		os.mkdir_all(root)!
+		defer {
+			os.rmdir_all(root) or {}
+		}
+		source := os.join_path_single(root, 'main.v')
+		header := os.join_path_single(root, 'parallel.h')
+		output := os.join_path_single(root, 'main')
+		os.write_file(header, '#ifndef V3_USER_PARALLEL_H\n#define V3_USER_PARALLEL_H\nstatic inline int v3_user_parallel_header_value(void) { return 42; }\n#endif\n')!
+		os.write_file(source, '#flag -I @DIR\n#include "parallel.h"\n\nfn C.v3_user_parallel_header_value() int\n\nfn main() { println(C.v3_user_parallel_header_value()) }\n')!
+		build := cmdexec.run(@VEXE, ['-parallel-cc', '-nocache', '-showcc', '-o', output, source])
+		assert build.exit_code == 0, build.output
+		assert build.output.contains('unit_0.c')
+		run_result := cmdexec.run(output, [])
+		assert run_result.exit_code == 0, run_result.output
+		assert run_result.output.trim_space() == '42'
+	}
+}
+
+fn test_v3_parallel_cc_falls_back_for_native_static_state() {
+	$if macos || linux {
+		root := os.join_path(os.vtmp_dir(), 'v3_parallel_cc_static_${os.getpid()}')
+		os.rmdir_all(root) or {}
+		os.mkdir_all(root)!
+		defer {
+			os.rmdir_all(root) or {}
+		}
+		source := os.join_path_single(root, 'main.v')
+		header := os.join_path_single(root, 'state.h')
+		output := os.join_path_single(root, 'main')
+		os.write_file(header, 'static int v3_parallel_state;\nstatic inline int v3_parallel_next(void) { return ++v3_parallel_state; }\n')!
+		os.write_file(source, '#flag -I @DIR\n#include "state.h"\n\nfn C.v3_parallel_next() int\n\nfn first() int { return C.v3_parallel_next() }\nfn second() int { return C.v3_parallel_next() }\nfn main() { println(first())\nprintln(second()) }\n')!
+		build := cmdexec.run(@VEXE, ['-parallel-cc', '-nocache', '-showcc', '-o', output, source])
+		assert build.exit_code == 0, build.output
+		assert !build.output.contains('unit_0.c'), build.output
+		assert build.output.contains('src.c'), build.output
+		run_result := cmdexec.run(output, [])
+		assert run_result.exit_code == 0, run_result.output
+		assert run_result.output.trim_space() == '1\n2'
+	}
+}
+
+fn test_v3_parallel_cc_falls_back_for_coverage_and_profile_state() {
+	$if macos || linux {
+		root := os.join_path(os.vtmp_dir(), 'v3_parallel_cc_instrumentation_${os.getpid()}')
+		os.rmdir_all(root) or {}
+		os.mkdir_all(root)!
+		defer {
+			os.rmdir_all(root) or {}
+		}
+		source := os.join_path_single(root, 'main.v')
+		os.write_file(source, "println('42')\n")!
+		for mode in ['coverage', 'profile'] {
+			output := os.join_path_single(root, 'main_${mode}')
+			state_path := os.join_path_single(root, mode)
+			option := if mode == 'coverage' { '-coverage' } else { '-profile' }
+			build := cmdexec.run(@VEXE, ['-parallel-cc', option, state_path, '-nocache', '-showcc',
+				'-o', output, source])
+			assert build.exit_code == 0, build.output
+			assert !build.output.contains('unit_0.c'), build.output
+			assert build.output.contains('src.c'), build.output
+			run_result := cmdexec.run(output, [])
+			assert run_result.exit_code == 0, run_result.output
+			assert run_result.output.trim_space() == '42'
+			if mode == 'coverage' {
+				counter_files := os.walk_ext(state_path, '.csv')
+				assert counter_files.len > 0, 'missing coverage counters in ${state_path}: ${os.walk_ext(root, '')}'
+				counter_data := os.read_file(counter_files[0])!
+				assert counter_data.split_into_lines().any(it.len > 0 && it[0].is_digit())
+			} else {
+				assert os.is_file(state_path)
+				assert os.file_size(state_path) > 0
+			}
+		}
 	}
 }

--- a/vlib/v3/driver/parallel_cc_test.v
+++ b/vlib/v3/driver/parallel_cc_test.v
@@ -114,6 +114,36 @@ fn test_v3_parallel_cc_falls_back_for_native_function_local_static_state() {
 	}
 }
 
+fn test_v3_parallel_cc_falls_back_for_macro_generated_function_local_static_state() {
+	$if macos || linux {
+		root := os.join_path(os.vtmp_dir(), 'v3_parallel_cc_macro_static_${os.getpid()}')
+		os.rmdir_all(root) or {}
+		os.mkdir_all(root)!
+		defer {
+			os.rmdir_all(root) or {}
+		}
+		source := os.join_path_single(root, 'main.v')
+		header := os.join_path_single(root, 'state.h')
+		output := os.join_path_single(root, 'main')
+		os.write_file(header, '#define DEF(name) \\
+	static inline int name(void) { \\
+		static int state; \\
+		return ++state; \\
+	}
+DEF(v3_parallel_macro_next)
+')!
+		os.write_file(source, '#flag -I @DIR\n#include "state.h"\n\nfn C.v3_parallel_macro_next() int\n\nfn first() int { return C.v3_parallel_macro_next() }\nfn second() int { return C.v3_parallel_macro_next() }\nfn main() { println(first())\nprintln(second()) }\n')!
+		build := cmdexec.run(@VEXE, ['-parallel-cc', '-nocache', '-showcc', '-o', output,
+			source])
+		assert build.exit_code == 0, build.output
+		assert !build.output.contains('unit_0.c'), build.output
+		assert build.output.contains('src.c'), build.output
+		run_result := cmdexec.run(output, [])
+		assert run_result.exit_code == 0, run_result.output
+		assert run_result.output.trim_space() == '1\n2'
+	}
+}
+
 fn test_v3_parallel_cc_falls_back_for_coverage_and_profile_state() {
 	$if macos || linux {
 		root := os.join_path(os.vtmp_dir(), 'v3_parallel_cc_instrumentation_${os.getpid()}')

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -618,6 +618,7 @@ mut:
 	qualified_struct_c_types_ready     bool
 	unused_param_seen                  &UnusedParamSeen = unsafe { nil }
 	cache_split                        bool
+	parallel_cc                        bool
 	cache_native_input_paths           map[string]bool
 	program_body_only                  bool
 	cached_support_identifiers         map[string]bool
@@ -1318,6 +1319,11 @@ pub fn (mut g FlatGen) set_track_heap(enabled bool) {
 // module objects without changing regular `-o file.c` output.
 pub fn (mut g FlatGen) set_cache_split(enabled bool) {
 	g.cache_split = enabled
+}
+
+// set_parallel_cc marks safe top-level function batches for split C compilation.
+pub fn (mut g FlatGen) set_parallel_cc(enabled bool) {
+	g.parallel_cc = enabled
 }
 
 // set_cache_native_input_paths assigns native headers and sources to their owning
@@ -3277,6 +3283,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 		// remain stable across function-body literal edits. Keep them with the
 		// program specialization cache instead of regenerating module globals in
 		// every edited translation unit.
+		g.write_parallel_cc_unit_marker()
 		g.writeln('/* V3CACHE_MODULE __v3_program_support */')
 		g.gen_json_decode_pointer_helper_defs(json_decode_pointer_helpers, false)
 		g.gen_json_encode_pointer_helper_defs(json_encode_pointer_helpers, false)
@@ -3326,12 +3333,14 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	}
 	if g.fn_segs.len > 0 {
 		for segment in g.fn_segs {
+			g.write_parallel_cc_unit_marker()
 			g.sb.write_string(segment)
 			unsafe { segment.free() }
 		}
 		g.fn_segs = []string{}
 	}
 	if fn_code.len > 0 {
+		g.write_parallel_cc_unit_marker()
 		g.sb.write_string(fn_code)
 		// The final builder now owns a copy of the function code.
 		unsafe { fn_code.free() }
@@ -3370,6 +3379,12 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	// Keep only the returned C string, not the builder's copied backing array.
 	unsafe { g.sb.free() }
 	return result
+}
+
+fn (mut g FlatGen) write_parallel_cc_unit_marker() {
+	if g.parallel_cc {
+		g.writeln('/* V3PARALLEL_CC_UNIT */')
+	}
 }
 
 fn (mut g FlatGen) gen_pre_body_support_declarations() {

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -1331,6 +1331,9 @@ fn (mut g FlatGen) enum_str_forward_decls() {
 			.enum_decl {
 				name := g.enum_decl_type_name(node, cur_module)
 				cn := g.cname(name)
+				if !g.enum_autostr_is_used(cn) {
+					continue
+				}
 				if emitted[cn] {
 					continue
 				}
@@ -1362,6 +1365,9 @@ fn (mut g FlatGen) enum_str_defs() {
 			.enum_decl {
 				name := g.enum_decl_type_name(node, cur_module)
 				cn := g.cname(name)
+				if !g.enum_autostr_is_used(cn) {
+					continue
+				}
 				if emitted[cn] {
 					continue
 				}
@@ -1407,6 +1413,10 @@ fn (mut g FlatGen) enum_str_defs() {
 			else {}
 		}
 	}
+}
+
+fn (g &FlatGen) enum_autostr_is_used(cname string) bool {
+	return !g.has_used_fn_filter() || g.used_fn_contains('${cname}__autostr')
 }
 
 fn (g &FlatGen) enum_decl_type_name(node flat.Node, module_name string) string {

--- a/vlib/v3/gen/c/types_test.v
+++ b/vlib/v3/gen/c/types_test.v
@@ -6,6 +6,44 @@ import v3.parser
 import v3.pref
 import v3.types
 
+fn test_enum_autostr_emission_follows_used_function_filter() {
+	test_dir := os.join_path(os.vtmp_dir(), 'v3_enum_autostr_used_${os.getpid()}')
+	os.rmdir_all(test_dir) or {}
+	os.mkdir_all(test_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(test_dir) or {}
+	}
+	source_path := os.join_path(test_dir, 'main.v')
+	os.write_file(source_path, 'module main
+
+enum Used {
+	one
+}
+
+enum Unused {
+	two
+}
+
+fn main() {}
+') or {
+		panic(err)
+	}
+	prefs := pref.new_preferences()
+	mut p := parser.Parser.new(prefs)
+	mut a := p.parse_file(source_path)
+	mut tc := types.TypeChecker.new(a)
+	tc.collect(a)
+	tc.check_semantics()
+	assert tc.errors.len == 0, tc.errors.str()
+	mut g := FlatGen.new()
+	c_source := g.gen_with_used_options(a, {
+		'main':          true
+		'Used__autostr': true
+	}, &tc, true)
+	assert c_source.contains('string Used__autostr(Used it)'), c_source
+	assert !c_source.contains('Unused__autostr'), c_source
+}
+
 fn test_json_helper_scan_requires_legacy_json_module() {
 	mut ast := flat.FlatAst.new()
 	mut tc := types.TypeChecker.new(&ast)

--- a/vlib/v3/markused/custom_str_test.v
+++ b/vlib/v3/markused/custom_str_test.v
@@ -223,6 +223,18 @@ fn test_optional_string_interpolation_seeds_imported_enum_str_method() {
 	assert used['colors.Color.str']
 }
 
+fn test_string_interpolation_seeds_imported_enum_autostr_helper() {
+	a, tc := parse_checked_two_file_source('imported_enum_interp_autostr', imported_enum_main_source('_ := "\${c}"'), 'colors/colors.v', 'module colors
+
+pub enum Color {
+	red
+	blue
+}
+')
+	used := mark_used(a, tc)
+	assert used['colors__Color__autostr']
+}
+
 // test_imported_operator_infix_seeds_operator_methods validates this v3 regression case.
 fn test_imported_operator_infix_seeds_operator_methods() {
 	a, tc := parse_checked_two_file_source('imported_operator_infix',
@@ -482,6 +494,29 @@ fn test_imported_optional_enum_interpolation_compile_keeps_str_method() {
 		panic(err)
 	}
 	bin := os.join_path(os.temp_dir(), 'v3_markused_imported_optional_enum_interp_input_bin')
+	compile := os.execute('${v3_bin} -o ${bin} ${root}')
+	assert compile.exit_code == 0, compile.output
+}
+
+fn test_imported_enum_direct_str_compile_keeps_autostr_helper() {
+	v3_bin := build_v3_bin('imported_enum_direct_autostr_test')
+
+	root := os.join_path(os.temp_dir(), 'v3_markused_imported_enum_direct_autostr_input')
+	if os.exists(root) {
+		os.rmdir_all(root) or { panic(err) }
+	}
+	os.mkdir_all(os.join_path(root, 'colors')) or { panic(err) }
+	os.write_file(os.join_path(root, 'main.v'), imported_enum_main_source('_ := c.str()')) or {
+		panic(err)
+	}
+	os.write_file(os.join_path(root, 'colors/colors.v'), 'module colors
+
+pub enum Color {
+	red
+	blue
+}
+') or { panic(err) }
+	bin := os.join_path(os.temp_dir(), 'v3_markused_imported_enum_direct_autostr_input_bin')
 	compile := os.execute('${v3_bin} -o ${bin} ${root}')
 	assert compile.exit_code == 0, compile.output
 }

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -3451,15 +3451,24 @@ fn enqueue_stringified_primitive_helpers(type_name string, mut used map[string]b
 
 // enqueue_enum_str_method supports enqueue enum str method handling for markused.
 fn enqueue_enum_str_method(type_name string, cur_module string, tc &types.TypeChecker, mut used map[string]bool, mut queue []string) {
+	mut has_custom_method := false
 	for candidate in stringification_type_candidates(type_name, cur_module) {
 		method := '${candidate}.str'
 		if method in tc.fn_ret_types {
+			has_custom_method = true
 			enqueue(method, mut used, mut queue)
 			lowered := markused_c_name(method)
 			if lowered != method {
 				enqueue(lowered, mut used, mut queue)
 			}
 		}
+	}
+	if has_custom_method {
+		return
+	}
+	parsed := tc.parse_type(type_name)
+	if parsed is types.Enum {
+		enqueue('${markused_c_name(parsed.name)}__autostr', mut used, mut queue)
 	}
 }
 

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -3287,6 +3287,7 @@ fn c_declaration_header_mode(prefix string, types_only bool) (string, bool, bool
 	static_storage_macros := c_sources_macro_identifiers_referencing([prefix], {
 		'static': true
 	})
+	definition_preserving_macros := c_definition_preserving_macro_names(prefix)
 	lines := prefix.split_into_lines()
 	for line_idx, raw_line in lines {
 		line := raw_line + '\n'
@@ -3412,7 +3413,8 @@ fn c_declaration_header_mode(prefix string, types_only bool) (string, bool, bool
 		}
 		declares_types = declares_types || item_declares_type
 		if !types_only || item_declares_type {
-			out.write_string(c_declaration_item(declaration, has_brace, types_only))
+			out.write_string(c_declaration_item(declaration, has_brace, types_only,
+				definition_preserving_macros))
 		}
 		item_head.clear()
 		brace_depth = 0
@@ -3435,7 +3437,8 @@ fn c_declaration_header_mode(prefix string, types_only bool) (string, bool, bool
 		}
 		declares_types = declares_types || item_declares_type
 		if !types_only || item_declares_type {
-			out.write_string(c_declaration_item(declaration, has_brace, types_only))
+			out.write_string(c_declaration_item(declaration, has_brace, types_only,
+				definition_preserving_macros))
 		}
 	}
 	return out.str(), has_static_storage, declares_types, types_complete
@@ -3693,7 +3696,7 @@ fn c_preprocessor_line_continues(line string) bool {
 	return line.trim_right('\r').ends_with('\\')
 }
 
-fn c_declaration_item(item string, has_brace bool, types_only bool) string {
+fn c_declaration_item(item string, has_brace bool, types_only bool, definition_preserving_macros map[string]bool) string {
 	trimmed := item.trim_space()
 	if trimmed.len == 0 {
 		return item
@@ -3719,7 +3722,8 @@ fn c_declaration_item(item string, has_brace bool, types_only bool) string {
 	}
 	if has_brace && brace > 0 {
 		if c_declaration_head_is_function(head) {
-			if c_declaration_head_keeps_definition(head) {
+			if c_declaration_head_keeps_definition(head)
+				|| c_declaration_head_uses_macro(head, definition_preserving_macros) {
 				return item
 			}
 			return '${head};\n'
@@ -3734,6 +3738,26 @@ fn c_declaration_item(item string, has_brace bool, types_only bool) string {
 		return item
 	}
 	return c_extern_storage_decl(clean.trim_right(';'))
+}
+
+fn c_definition_preserving_macro_names(source string) map[string]bool {
+	mut result := map[string]bool{}
+	for name, replacements in c_source_macro_replacements(source) {
+		if replacements.len > 0
+			&& replacements.all(c_declaration_head_keeps_definition(it.trim_space())) {
+			result[name] = true
+		}
+	}
+	return result
+}
+
+fn c_declaration_head_uses_macro(head string, macros map[string]bool) bool {
+	for name, present in macros {
+		if present && c_code_contains_identifier(head, name) {
+			return true
+		}
+	}
+	return false
 }
 
 fn c_declaration_item_has_static_storage(item string, has_brace bool) bool {

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -3775,7 +3775,8 @@ fn c_declaration_item_has_replicated_function_static_storage(item string, has_br
 			|| c_declaration_head_uses_macro(block.inner, static_storage_macros)
 	}
 	if !has_brace {
-		return false
+		macro_name := c_declaration_macro_invocation_name(item, false) or { return false }
+		return static_storage_macros[macro_name]
 	}
 	clean := trim_leading_c_comments(item.trim_space())
 	brace := clean.index_u8(`{`)

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -3258,16 +3258,23 @@ pub fn c_source_type_declarations(source string) string {
 // c_source_type_declarations_with_status also reports whether every declaration-like
 // file-scope macro invocation could be classified.
 pub fn c_source_type_declarations_with_status(source string) (string, bool) {
-	header, _, _, complete := c_declaration_header_mode(source, true)
+	header, _, _, _, complete := c_declaration_header_mode(source, true)
 	return header, complete
 }
 
 fn c_declaration_header(prefix string) (string, bool, bool) {
-	header, has_static_storage, declares_types, _ := c_declaration_header_mode(prefix, false)
+	header, has_static_storage, _, declares_types, _ := c_declaration_header_mode(prefix, false)
 	return header, has_static_storage, declares_types
 }
 
-fn c_declaration_header_mode(prefix string, types_only bool) (string, bool, bool, bool) {
+// c_source_replicated_function_has_static_storage reports whether a function
+// definition retained by declaration_header contains function-local static storage.
+pub fn c_source_replicated_function_has_static_storage(source string) bool {
+	_, _, has_replicated_function_static_storage, _, _ := c_declaration_header_mode(source, false)
+	return has_replicated_function_static_storage
+}
+
+fn c_declaration_header_mode(prefix string, types_only bool) (string, bool, bool, bool, bool) {
 	mut out := strings.new_builder(prefix.len / 2)
 	mut item := strings.new_builder(512)
 	mut item_head := strings.new_builder(512)
@@ -3277,6 +3284,7 @@ fn c_declaration_header_mode(prefix string, types_only bool) (string, bool, bool
 	mut function_has_conditionals := false
 	mut function_conditional_depth := 0
 	mut has_static_storage := false
+	mut has_replicated_function_static_storage := false
 	mut declares_types := false
 	mut types_complete := true
 	mut in_block_comment := false
@@ -3361,8 +3369,7 @@ fn c_declaration_header_mode(prefix string, types_only bool) (string, bool, bool
 			continue
 		}
 		item.write_string(line)
-		delta, saw_brace, next_comment, last_code, first_open := c_line_braces(raw_line,
-			in_block_comment)
+		delta, saw_brace, next_comment, last_code, first_open := c_line_braces(raw_line, in_block_comment)
 		in_block_comment = next_comment
 		brace_depth += delta
 		if !has_brace {
@@ -3406,6 +3413,8 @@ fn c_declaration_header_mode(prefix string, types_only bool) (string, bool, bool
 		has_static_storage = has_static_storage
 			|| c_declaration_item_has_static_storage(declaration, has_brace)
 			|| static_storage_macros[storage_macro_name]
+		has_replicated_function_static_storage = has_replicated_function_static_storage
+			|| c_declaration_item_has_replicated_function_static_storage(declaration, has_brace, definition_preserving_macros, static_storage_macros)
 		item_declares_type := c_declaration_item_declares_type(declaration, has_brace)
 			|| type_declaration_macros[macro_name]
 		if types_only && macro_name.len > 0 && !item_declares_type {
@@ -3413,8 +3422,7 @@ fn c_declaration_header_mode(prefix string, types_only bool) (string, bool, bool
 		}
 		declares_types = declares_types || item_declares_type
 		if !types_only || item_declares_type {
-			out.write_string(c_declaration_item(declaration, has_brace, types_only,
-				definition_preserving_macros))
+			out.write_string(c_declaration_item(declaration, has_brace, types_only, definition_preserving_macros))
 		}
 		item_head.clear()
 		brace_depth = 0
@@ -3430,6 +3438,8 @@ fn c_declaration_header_mode(prefix string, types_only bool) (string, bool, bool
 		has_static_storage = has_static_storage
 			|| c_declaration_item_has_static_storage(declaration, has_brace)
 			|| static_storage_macros[storage_macro_name]
+		has_replicated_function_static_storage = has_replicated_function_static_storage
+			|| c_declaration_item_has_replicated_function_static_storage(declaration, has_brace, definition_preserving_macros, static_storage_macros)
 		item_declares_type := c_declaration_item_declares_type(declaration, has_brace)
 			|| type_declaration_macros[macro_name]
 		if types_only && macro_name.len > 0 && !item_declares_type {
@@ -3437,11 +3447,10 @@ fn c_declaration_header_mode(prefix string, types_only bool) (string, bool, bool
 		}
 		declares_types = declares_types || item_declares_type
 		if !types_only || item_declares_type {
-			out.write_string(c_declaration_item(declaration, has_brace, types_only,
-				definition_preserving_macros))
+			out.write_string(c_declaration_item(declaration, has_brace, types_only, definition_preserving_macros))
 		}
 	}
-	return out.str(), has_static_storage, declares_types, types_complete
+	return out.str(), has_static_storage, has_replicated_function_static_storage, declares_types, types_complete
 }
 
 fn c_type_declaration_macro_names(source string) map[string]bool {
@@ -3703,7 +3712,7 @@ fn c_declaration_item(item string, has_brace bool, types_only bool, definition_p
 	}
 	clean := trim_leading_c_comments(trimmed)
 	if block := c_extern_c_block(item) {
-		inner_header, _, _, _ := c_declaration_header_mode(block.inner, types_only)
+		inner_header, _, _, _, _ := c_declaration_header_mode(block.inner, types_only)
 		mut result := block.before
 		if !result.ends_with('\n') && !inner_header.starts_with('\n') {
 			result += '\n'
@@ -3758,6 +3767,32 @@ fn c_declaration_head_uses_macro(head string, macros map[string]bool) bool {
 		}
 	}
 	return false
+}
+
+fn c_declaration_item_has_replicated_function_static_storage(item string, has_brace bool, definition_preserving_macros map[string]bool, static_storage_macros map[string]bool) bool {
+	if block := c_extern_c_block(item) {
+		return c_source_replicated_function_has_static_storage(block.inner)
+			|| c_declaration_head_uses_macro(block.inner, static_storage_macros)
+	}
+	if !has_brace {
+		return false
+	}
+	clean := trim_leading_c_comments(item.trim_space())
+	brace := clean.index_u8(`{`)
+	if brace <= 0 {
+		return false
+	}
+	head := clean[..brace].trim_space()
+	if !c_static_declaration_head_is_function(head) {
+		return false
+	}
+	if !c_declaration_head_keeps_definition(head)
+		&& !c_declaration_head_uses_macro(head, definition_preserving_macros) {
+		return false
+	}
+	body := clean[brace + 1..]
+	return c_code_contains_identifier(body, 'static')
+		|| c_declaration_head_uses_macro(body, static_storage_macros)
 }
 
 fn c_declaration_item_has_static_storage(item string, has_brace bool) bool {

--- a/vlib/v3/modulecache/modulecache_test.v
+++ b/vlib/v3/modulecache/modulecache_test.v
@@ -27,6 +27,26 @@ fn test_native_declaration_api_macro_definition_is_not_localized() {
 	assert declarations.contains('static int helper(void) {')
 }
 
+fn test_declaration_header_keeps_macro_static_inline_function() {
+	source := '#ifdef _MSC_VER
+#define V_TEST_STATIC_INLINE static __inline
+#else
+#define V_TEST_STATIC_INLINE static inline
+#endif
+V_TEST_STATIC_INLINE int local_helper(void) {
+	return 42;
+}
+int external_helper(void) {
+	return local_helper();
+}
+'
+	header := declaration_header(source)
+	assert header.contains('V_TEST_STATIC_INLINE int local_helper(void) {')
+	assert header.contains('return 42;')
+	assert header.contains('int external_helper(void);')
+	assert !header.contains('return local_helper();')
+}
+
 fn test_cached_file_line_uses_source_file_name() {
 	source := 'return [@FILE, @FILE_LINE, @LINE]'
 	source_file := os.join_path(os.vtmp_dir(), 'nested', 'origin.v')

--- a/vlib/v3/modulecache/modulecache_test.v
+++ b/vlib/v3/modulecache/modulecache_test.v
@@ -61,6 +61,13 @@ static inline int next_value(void) {
 ')
 	assert c_source_replicated_function_has_static_storage('extern "C" { static inline int next_value(void) { static int state; return ++state; } }
 ')
+	assert c_source_replicated_function_has_static_storage('#define DEF(name) \\
+	static inline int name(void) { \\
+		static int state; \\
+		return ++state; \\
+	}
+DEF(next_value)
+')
 	assert !c_source_replicated_function_has_static_storage('int next_value(void) {
 	static int state = 0;
 	return ++state;

--- a/vlib/v3/modulecache/modulecache_test.v
+++ b/vlib/v3/modulecache/modulecache_test.v
@@ -47,6 +47,33 @@ int external_helper(void) {
 	assert !header.contains('return local_helper();')
 }
 
+fn test_replicated_function_static_storage_detection() {
+	assert c_source_replicated_function_has_static_storage('static inline int next_value(void) {
+	static int state = 0;
+	return ++state;
+}
+')
+	assert c_source_replicated_function_has_static_storage('#define LOCAL_STORAGE static
+static inline int next_value(void) {
+	LOCAL_STORAGE int state = 0;
+	return ++state;
+}
+')
+	assert c_source_replicated_function_has_static_storage('extern "C" { static inline int next_value(void) { static int state; return ++state; } }
+')
+	assert !c_source_replicated_function_has_static_storage('int next_value(void) {
+	static int state = 0;
+	return ++state;
+}
+')
+	assert !c_source_replicated_function_has_static_storage('static inline int next_value(void) {
+	// static int comment_state;
+	const char *text = "static int string_state";
+	return text[0];
+}
+')
+}
+
 fn test_cached_file_line_uses_source_file_name() {
 	source := 'return [@FILE, @FILE_LINE, @LINE]'
 	source_file := os.join_path(os.vtmp_dir(), 'nested', 'origin.v')

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -4770,7 +4770,8 @@ fn (t &Transformer) enum_str_method_name(typ string) ?string {
 	}
 	for candidate in candidates {
 		method := '${candidate}.str'
-		if t.is_known_fn_name(method) {
+		if method in t.fn_ret_types
+			|| (!isnil(t.tc) && method in t.tc.fn_param_types) {
 			return method
 		}
 	}
@@ -4783,7 +4784,9 @@ fn (t &Transformer) enum_str_method_name(typ string) ?string {
 // one. Mirrors the struct-str qualification so the C name matches cgen's enum_decls naming.
 fn (mut t Transformer) enum_autostr_call(expr flat.NodeId, typ string) flat.NodeId {
 	qualified := t.enum_autostr_type_name(typ)
-	return t.make_call_typed('${c_name(qualified)}__autostr', [expr], 'string')
+	helper := '${c_name(qualified)}__autostr'
+	t.mark_fn_used_name(helper)
+	return t.make_call_typed(helper, [expr], 'string')
 }
 
 fn (t &Transformer) enum_autostr_type_name(typ string) string {
@@ -12379,6 +12382,14 @@ fn (mut t Transformer) try_lower_receiver_method_call(id flat.NodeId, node flat.
 	if method == 'str' {
 		if smartcast_str := t.smartcast_sum_str_call(base_id) {
 			return smartcast_str
+		}
+		if t.is_enum_stringify_type(base_type) && t.enum_str_method_name(base_type) == none {
+			mut value := t.transform_expr(base_id)
+			if base_is_pointer {
+				value = t.make_prefix(.mul, value)
+				t.set_node_typ(int(value), base_type)
+			}
+			return t.enum_autostr_call(value, base_type)
 		}
 		if !recovered_or_value_type {
 			if exact_call := t.lower_checker_selected_receiver_method(id, node, base_id, 'str') {

--- a/vlib/v3/transform/fn_test.v
+++ b/vlib/v3/transform/fn_test.v
@@ -3,6 +3,22 @@ module transform
 import v3.flat
 import v3.types
 
+fn test_enum_autostr_call_marks_synthesized_helper_used() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	mut t := new_transformer(mut a, &tc, {
+		'main': true
+	})
+	expr := a.add_node(flat.Node{
+		kind: .enum_val
+		value: 'ready'
+		typ: 'state.Status'
+	})
+	call := t.enum_autostr_call(expr, 'state.Status')
+	assert t.used_fns['state__Status__autostr']
+	assert a.node(call).kind == .call
+}
+
 fn test_cloned_worker_merge_replays_relocated_children_and_body_roots() {
 	// 'plain' copies and relocates inside the serial merge, 'relocated' relocates
 	// the worker region in parallel first, and 'absorbed' also writes it straight
@@ -800,4 +816,10 @@ fn test_transform_lane_budget_bounds_base_ast_clones() {
 	assert transform_clone_budget_jobs(8, 9_000_000_000) == 1
 	assert transform_clone_budget_jobs(18, 1) == 18
 	assert transform_clone_budget_jobs(1, 9_000_000_000) == 1
+}
+
+fn test_selfhost_transform_lane_count_is_memory_bounded() {
+	assert transform_job_count(18, 10_000, true) == 7
+	assert transform_job_count(18, 10_000, false) == 7
+	assert transform_job_count(4, 10_000, true) == 4
 }

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -15,9 +15,9 @@ import v3.workers
 
 const min_parallel_transform_items = 256
 const max_parallel_transform_jobs = 7
-// Disposable self-host scratch permits more growable workers within the same
-// memory ceiling. Ordinary generic builds keep the smaller clone limit.
-const max_selfhost_transform_jobs = 18
+// Every self-host helper owns a full base-AST clone. Seven lanes keep the
+// production compiler build below 4 GB while retaining useful parallelism.
+const max_selfhost_transform_jobs = 7
 // Every growable lane clones the base AST, so the lane count is also a memory
 // decision. Bound the combined clone size instead of trusting the lane cap
 // alone: a bigger program on the same machine then keeps its memory ceiling.


### PR DESCRIPTION
## Summary

- implement real `-parallel-cc` support in the V3 C backend by splitting generated C at safe top-level boundaries
- emit native/external implementations in one owner unit while providing declarations to worker units
- limit C compilation to two concurrent processes and self-host transform to seven AST-cloning lanes
- prune unused synthesized enum string helpers while retaining helpers reached through interpolation or direct `.str()` calls

## macOS measurements

Command: `v -prod -parallel-cc -nocache -no-memory-limit -o /tmp/v-self self`

- self-build peak RSS: 3,877,748,736 bytes (3.88 GB / 3.61 GiB), down from about 4.82 GB after the initial split implementation
- self-build wall time: 25.97 seconds
- isolated final link peak RSS: about 101 MB, down from the previously reported roughly 5 GB monolithic link
- generated V3 C: about 420k logical lines instead of the former combined V1+V3 700k-line build

## Validation

- rebuilt `vnew` with `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -silent vlib/v3/driver/parallel_cc_test.v`
- `./vnew -silent vlib/v3/driver/environment_test.v`
- `./vnew -silent vlib/v3/modulecache/modulecache_test.v`
- `./vnew -silent vlib/v3/gen/c/types_test.v`
- `./vnew -silent vlib/v3/transform/fn_test.v`
- `./vnew -silent vlib/v3/markused/custom_str_test.v`
- production self-build output reports `V 0.5.2`

The full suite was not run.