### PR TITLE
cgen, net.mbedtls, vpm: fix the build with glibc 2.42 and gcc 15

### DIFF
--- a/cmd/tools/vpm/parse.v
+++ b/cmd/tools/vpm/parse.v
@@ -265,9 +265,9 @@ fn is_local_repository(query string) bool {
 			// local repository. This keeps `v install vsl@<tag>` working when
 			// cwd happens to be the vmodules directory (the test setup for
 			// versioned installs does exactly this).
-			abs := os.real_path(path)
+			abs_path := os.real_path(path)
 			vmodules_real := os.real_path(settings.vmodules_path)
-			if abs.starts_with(vmodules_real + os.path_separator) || abs == vmodules_real {
+			if abs_path.starts_with(vmodules_real + os.path_separator) || abs_path == vmodules_real {
 				continue
 			}
 			return true

--- a/cmd/tools/vpm/update.v
+++ b/cmd/tools/vpm/update.v
@@ -20,7 +20,7 @@ fn vpm_update(query []string) {
 	idents := if query.len == 0 { get_installed_modules() } else { query.clone() }
 	mut pp := pool.new_pool_processor(callback: update_module)
 	ctx := UpdateSession{idents}
-	pp.set_shared_context(ctx)
+	pp.set_shared_context(&ctx)
 	pp.work_on_items(idents)
 	mut errors := 0
 	for res in pp.get_results[UpdateResult]() {

--- a/vlib/net/mbedtls/mbedtls_helpers.h
+++ b/vlib/net/mbedtls/mbedtls_helpers.h
@@ -30,14 +30,25 @@ static inline mbedtls_pk_context *v_mbedtls_x509_crt_get_pk(mbedtls_x509_crt *cr
  * (real mbedTLS API, not a V-side assumption) -- resolved here in C, where
  * the struct's size/layout are fully known, rather than attempting a V-side
  * by-value pass of an intentionally-opaque struct type.
+ *
+ * Returns plain `int` and takes a NON-const pointer, deliberately: this
+ * signature has to match the V-side declaration
+ * `fn C.v_mbedtls_pk_ec_group_id(pk &C.mbedtls_pk_context) int` EXACTLY.
+ * V emits its own prototype for a called C function into every translation
+ * unit that needs it, and that TU can also be one that includes this header
+ * (the v3 per-module build does exactly this), so a return type or a
+ * parameter const-qualifier that differs from the V declaration is a hard
+ * "conflicting types" C error, not a warning. V has no way to spell either
+ * `const T*` or a C enum return type in an `fn C.` declaration, so the C
+ * side is the side that must match.
  */
-static inline mbedtls_ecp_group_id v_mbedtls_pk_ec_group_id(const mbedtls_pk_context *pk)
+static inline int v_mbedtls_pk_ec_group_id(mbedtls_pk_context *pk)
 {
 	const mbedtls_ecp_keypair *kp = mbedtls_pk_ec(*pk);
 	if (kp == NULL) {
-		return MBEDTLS_ECP_DP_NONE;
+		return (int)MBEDTLS_ECP_DP_NONE;
 	}
-	return mbedtls_ecp_keypair_get_group_id(kp);
+	return (int)mbedtls_ecp_keypair_get_group_id(kp);
 }
 
 /* v_mbedtls_check_server_cert_usage verifies the leaf certificate's

--- a/vlib/v/gen/c/cheaders.v
+++ b/vlib/v/gen/c/cheaders.v
@@ -677,10 +677,31 @@ V_CRT_LINKAGE void * V_CRT_CALL memcpy(void *dest, const void *src, size_t n);
 V_CRT_LINKAGE void * V_CRT_CALL memmove(void *dest, const void *src, size_t n);
 V_CRT_LINKAGE void * V_CRT_CALL memset(void *dest, int ch, size_t n);
 V_CRT_LINKAGE int V_CRT_CALL memcmp(const void *left, const void *right, size_t n);
+// memchr/strchr/strrchr/strstr are the C23 type-generic string functions, and
+// glibc 2.42+ implements them as function-like macros over _Generic, so that a
+// const-qualified argument yields a const-qualified return type. If any include
+// above already pulled in <string.h> (mbedtls/net_sockets.h, netdb.h, dirent.h,
+// ... all do, and gcc 15 defaults to -std=gnu23), the name is already a macro
+// here, and a declaration like
+// `void *memchr(const void *str, int c, size_t n);` expands into the middle of
+// a _Generic expression, which fails to parse:
+// `error: expected identifier or ( before _Generic`.
+// A defined macro also means <string.h> has already declared the real function,
+// so skipping the declaration below loses nothing in that case. The reverse
+// order stays fine as-is: a <string.h> pulled in later by a module header
+// defines the macro after these declarations, which C permits.
+#ifndef memchr
 V_CRT_LINKAGE void * V_CRT_CALL memchr(const void *str, int c, size_t n);
+#endif
+#ifndef strchr
 V_CRT_LINKAGE char * V_CRT_CALL strchr(const char *str, int c);
+#endif
+#ifndef strrchr
 V_CRT_LINKAGE char * V_CRT_CALL strrchr(const char *str, int c);
+#endif
+#ifndef strstr
 V_CRT_LINKAGE char * V_CRT_CALL strstr(const char *haystack, const char *needle);
+#endif
 V_CRT_LINKAGE int V_CRT_CALL fseek(FILE *stream, long offset, int whence);
 V_CRT_LINKAGE isize V_CRT_CALL getline(char **lineptr, size_t *n, FILE *stream);
 #if defined(_WIN32) || defined(_WIN64)


### PR DESCRIPTION
Reported by a user whose `v install --git https://github.com/vlang/ui2.git` failed with `cannot compile cmd/tools/vpm`, on an up to date Linux distro. Two unrelated C errors, both hit while building `cmd/tools/vpm`.

### 1. `_Generic` clash on `memchr` / `strchr` / `strrchr` / `strstr`

```
error: expected identifier or '(' before '_Generic'
  450 | V_CRT_LINKAGE void * V_CRT_CALL memchr(const void *str, int c, size_t n);
```

glibc 2.42 implements C23's type-generic `memchr`/`strchr`/`strrchr`/`strstr` as function-like macros over `_Generic`, so that a const-qualified argument yields a const-qualified return type, and gcc 15 defaults to `-std=gnu23`, so they are active. `cheaders.v` declares those four manually instead of including `<string.h>`, but by then an earlier include (`mbedtls/net_sockets.h`, `netdb.h`, `dirent.h`, ...) has usually pulled `<string.h>` in already, so the declaration expands into the middle of a `_Generic` expression.

Guarded the four declarations with `#ifndef`. A defined macro also means `<string.h>` has already declared the real function, so skipping V's declaration loses nothing. The reverse order keeps working as before: a `<string.h>` pulled in later by a module header defines the macro *after* these declarations, which C permits.

### 2. `conflicting types for 'v_mbedtls_pk_ec_group_id'`

```
error: conflicting types for 'v_mbedtls_pk_ec_group_id'; have 'int(mbedtls_pk_context *)'
note: previous definition with type 'mbedtls_ecp_group_id(const mbedtls_pk_context *)'
```

The helper was `mbedtls_ecp_group_id f(const mbedtls_pk_context *)` in C, but `fn C.v_mbedtls_pk_ec_group_id(pk &C.mbedtls_pk_context) int` in V. V emits its own prototype for that function into translation units that also include `mbedtls_helpers.h`, and a prototype differing in return type or in a parameter's const qualifier is a hard error, not a warning. V cannot spell `const T*` or a C enum return type in an `fn C.` declaration, so the C side is the one that has to match.

The other four `v_mbedtls_*` helpers were checked against their V declarations and already agree.

### Also

The two diagnostics `vpm` printed on the way there: an `abs` variable shadowing a function declaration (`parse.v`), and a deprecated implicit reference to voidptr in `set_shared_context` (`update.v`).

### Verification

Error 2 was reproduced directly and is clean after the fix. Error 1 needs glibc 2.42, so it was reproduced by injecting the equivalent `_Generic` macros into generated C: the old codegen fails with exactly the reported error, the new codegen compiles clean. `vlib/net/mbedtls` (9/9) and `vlib/net/quic/tls13_certificate_chain_test.v` (which covers the changed helper, both the P-256 and the non-EC case) pass, `cheaders_manual_stdlib_decls_test.v` passes, V self-builds, and `vpm` now builds with no notice or warning.