### PR TITLE
v3: include virtual module sources for direct tests

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -13527,7 +13527,20 @@ fn expand_single_test_file_inputs(user_files []string, prefs &pref.Preferences) 
 
 fn same_dir_module_source_files(test_file string, module_name string, prefs &pref.Preferences) []string {
 	dir := os.dir(test_file)
-	all_files := pref.get_v_files_from_dir_for_target(dir, prefs.user_defines, prefs.target)
+	mut all_files := pref.get_v_files_from_dir_for_target(dir, prefs.user_defines, prefs.target)
+	// A `subdirs` manifest makes several directories one source module. When a
+	// test file sits beside a source in one of those virtual directories, include
+	// the complete module instead of only its physical-directory siblings.
+	vmod_root := nearest_vmod_root_for_file(test_file)
+	if vmod_root.len > 0 {
+		virtual_module_files := v3_directory_user_files(vmod_root, prefs, false, false) or {
+			[]string{}
+		}
+		real_dir := os.real_path(dir)
+		if virtual_module_files.any(os.real_path(os.dir(it)) == real_dir) {
+			all_files = virtual_module_files.clone()
+		}
+	}
 	mut files := []string{}
 	mut imported_modules := map[string]bool{}
 	if module_name.len > 0 {

--- a/vlib/v3/tests/test_file_cli_run_test.v
+++ b/vlib/v3/tests/test_file_cli_run_test.v
@@ -62,6 +62,49 @@ fn test_implicit_result_propagation() {
 	assert propagation_test.exit_code == 0, propagation_test.output
 }
 
+// A test beside a source in a v.mod `subdirs` directory needs every source in
+// that virtual module, not only files in the test's physical directory.
+fn test_direct_test_file_in_virtual_module_directory_includes_sibling_subdirs() {
+	v3_bin := build_v3_test_file_cli_runner()
+	root := os.join_path(os.temp_dir(), 'v3_virtual_module_test_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(os.join_path(root, 'ui'))!
+	os.mkdir_all(os.join_path(root, 'platform'))!
+	defer {
+		os.rmdir_all(root) or {}
+	}
+
+	os.write_file(os.join_path(root, 'v.mod'), "Module {
+	name: 'virtual_module_test'
+	subdirs: ['ui', 'platform']
+}
+")!
+	os.write_file(os.join_path(root, 'ui', 'ui.v'), 'module virtual_module_test
+
+fn ui_value() int {
+	return 40
+}
+')!
+	os.write_file(os.join_path(root, 'platform', 'platform.v'), 'module virtual_module_test
+
+fn platform_value() int {
+	return 2
+}
+')!
+	test_file := os.join_path(root, 'ui', 'ui_test.v')
+	os.write_file(test_file, 'module virtual_module_test
+
+fn test_virtual_module_sources_are_available() {
+	assert ui_value() + platform_value() == 42
+}
+')!
+	test_bin := os.join_path(root, 'virtual_module_test')
+	build := os.execute('${os.quoted_path(v3_bin)} -o ${os.quoted_path(test_bin)} ${os.quoted_path(test_file)}')
+	assert build.exit_code == 0, build.output
+	run := os.execute(os.quoted_path(test_bin))
+	assert run.exit_code == 0, run.output
+}
+
 fn test_directory_test_command_sets_test_define_before_collecting_inputs() {
 	v3_bin := build_v3_test_file_cli_runner()
 	tmp_dir := os.join_path(os.temp_dir(), 'v3_test_directory_define_${os.getpid()}')


### PR DESCRIPTION
## Summary
- include all `v.mod` virtual-module source directories when compiling a direct test file next to one of those sources
- add a regression covering a test in `ui/` using a source from sibling virtual directory `platform/`

## Testing
- `./vnew -silent test vlib/v3/tests/test_file_cli_run_test.v`
- `./vnew -silent test vlib/v3/driver/environment_test.v`