### PR TITLE
v3: bring fast arm64 self-hosting to FastC parity

### DIFF
--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -148,6 +148,11 @@ times in-process so an external sampler can profile it. The compiler's own C pre
 take effect one generation later: measure the compiler built by the modified compiler, not the
 modified compiler itself.
 
+`FASTC_BENCH=1` also prints end-to-end MLOC/s. The FastC total includes TinyCC compilation and
+linking; the direct ARM64 total includes Mach-O generation, linking, and signing.
+For the optimized FastC pipeline, build the full compiler with `./v -prod -o ./vnew cmd/v`, then run
+`FASTC_BENCH=1 ./vnew -nocache -b fastc -selfhost -o /tmp/v3-fastc vlib/v3/v3.v`.
+
 Self-host generations box `?`/`!` payloads out of a per-thread bump chunk rather than `malloc`, keep
 one file record per scanner pass, and honor `@[direct_array_access]` for string and array indexing.
 Multi-return components larger than 32 bytes are boxed instead of copied into the tuple slot, so a

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -8657,6 +8657,7 @@ pub fn run(args []string) {
 			eprintln('fastc support is not compiled into this v3 executable')
 			exit(1)
 		} $else {
+			fastc_bench := os.getenv('FASTC_BENCH') != ''
 
 			// FastC is a standalone parser that emits C while consuming scanner tokens.
 			// Never let an unsupported FastC input continue into the AST frontend below.
@@ -8754,7 +8755,8 @@ pub fn run(args []string) {
 			mut prestarted_fastc_units := fastc.FastcPrestartedCUnits{}
 			mut prestart_workers := []thread fastc.FastcPrestartedCUnits{}
 			$if macos {
-				if !c_only && prefs.building_v && !fastc_cross_target && (is_debug || no_cache) {
+				if !c_only && prefs.building_v && !fastc_cross_target
+					&& (is_debug || no_cache || fastc_bench) {
 					tcc_dir := os.join_path(prefs.vroot, 'thirdparty', 'tcc')
 					tcc_path := os.join_path_single(tcc_dir, 'tcc.exe')
 					prestart_jobs := fastc.fastc_tcc_job_count(prefs)
@@ -8833,7 +8835,7 @@ pub fn run(args []string) {
 			} else {
 				''
 			}
-			fastc_result := compile_v3_fastc_source(fastc_pieces, fastc_generation.units, fastc_bin_file, prefs, environment_c_flags, fastc_generation.c_flags, user_c_flags, environment_ld_flags, fastc_sdk_root, is_debug, fastc_generation.uses_threads, prefs.building_v && !is_debug && !no_cache, mut prestarted_fastc_units)
+			fastc_result := compile_v3_fastc_source(fastc_pieces, fastc_generation.units, fastc_bin_file, prefs, environment_c_flags, fastc_generation.c_flags, user_c_flags, environment_ld_flags, fastc_sdk_root, is_debug, fastc_generation.uses_threads, prefs.building_v && !is_debug && !no_cache && !fastc_bench, mut prestarted_fastc_units)
 			if (!silent || show_cc) && fastc_result.command.len > 0 {
 				if c_to_stdout {
 					eprintln('  > ${fastc_result.command}')
@@ -8863,6 +8865,12 @@ pub fn run(args []string) {
 					eprintln(fastc_result.output.trim_space())
 				}
 				exit(1)
+			}
+			if fastc_bench {
+				total_us := driver_sw.elapsed().microseconds()
+				total_lines := source_file_line_count(fastc_generation.source_paths)
+				mloc_per_s := f64(total_lines) / f64(total_us)
+				eprintln('fastc-bench-total: files=${fastc_generation.source_paths.len} lines=${total_lines} total=${f64(total_us) / 1000.0:.2f}ms throughput=${mloc_per_s:.3f} MLOC/s (includes TinyCC)')
 			}
 			b.step('tcc')
 			b.metric('generated C size', fastc_source_size, 'bytes')

--- a/vlib/v3/fastcdriver/fastcdriver.v
+++ b/vlib/v3/fastcdriver/fastcdriver.v
@@ -452,6 +452,7 @@ pub fn run(args []string) {
 			fastc.generate_files_with_source_paths([real_input], prefs) or { fail(err.msg()) }
 		}
 	}
+	mut total_sw := time.new_stopwatch()
 	mut sw := time.new_stopwatch()
 	generation := fastc.generate_files_with_source_paths([real_input], prefs) or { fail(err.msg()) }
 	if bench && repeat == 1 {
@@ -499,7 +500,10 @@ pub fn run(args []string) {
 	mut link_cache_key := ''
 	mut link_cache_restored := false
 	if unit_paths.len > 1 {
-		prepared_units := fastc.fastc_prepare_c_units(tcc, cc_args, unit_paths, prefs.building_v)
+		// The end-to-end benchmark must actually run TinyCC; otherwise a warm
+		// executable cache hit would report copying a prior binary as compile time.
+		prepared_units := fastc.fastc_prepare_c_units(tcc, cc_args, unit_paths, prefs.building_v
+			&& !bench)
 		link_inputs := prepared_units.objects.clone()
 		link_cache_key = fastc.fastc_link_cache_key(prepared_units.cache_key, link_libs)
 		if fastc.fastc_restore_link_cache(link_cache_key, staged_output) {
@@ -567,5 +571,11 @@ pub fn run(args []string) {
 		}
 	} else {
 		os.rm(c_path) or {}
+	}
+	if bench {
+		total_us := total_sw.elapsed().microseconds()
+		total_lines := fastc_bench_source_line_count(generation.source_paths)
+		mloc_per_s := f64(total_lines) / f64(total_us)
+		eprintln('fastc-bench-total: files=${generation.source_paths.len} lines=${total_lines} total=${f64(total_us) / 1000.0:.2f}ms throughput=${mloc_per_s:.3f} MLOC/s (includes TinyCC)')
 	}
 }

--- a/vlib/v3/gen/arm64/gen.v
+++ b/vlib/v3/gen/arm64/gen.v
@@ -101,18 +101,8 @@ fn (mut g Gen) gen_parallel_c_host() {
 		return
 	}
 	g.gen_pre_pass()
-	// type_size lazily fills the module layout cache. Populate it before workers
-	// share the otherwise read-only SSA module.
-	for typ in 1 .. g.m.type_store.types.len {
-		_ = g.m.type_size(ssa.TypeID(typ))
-		_ = g.m.type_align(ssa.TypeID(typ))
-		layout := g.m.type_store.types[typ]
-		if layout.kind == .struct_t {
-			for field in 0 .. layout.fields.len {
-				_ = g.m.struct_field_offset(ssa.TypeID(typ), field)
-			}
-		}
-	}
+	// Freeze all lazily-computed layout data before workers share the SSA module.
+	g.m.freeze_type_layouts()
 	ranges := arm64_function_ranges(g.m, 12)
 	mut workers := []thread &Gen{cap: ranges.len}
 	for r in ranges {

--- a/vlib/v3/gen/arm64/gen.v
+++ b/vlib/v3/gen/arm64/gen.v
@@ -5,8 +5,9 @@ import v3.ssa
 // Gen stores state for ARM64 code generation.
 pub struct Gen {
 mut:
-	m                    &ssa.Module  = unsafe { nil }
+	m                    &ssa.Module = unsafe { nil }
 	macho                &MachOObject = unsafe { nil }
+	text_words           []u32
 	stack_offsets        []i32
 	alloca_offsets       []i32
 	alloca_sizes         []i32
@@ -15,6 +16,7 @@ mut:
 	slot_value_base      int
 	slot_value_count     int
 	stack_size           int
+	transient_stack_size int
 	block_offsets        []i32
 	block_offset_indices []int
 	block_offset_base    int
@@ -41,21 +43,32 @@ struct Arm64HfaLayout {
 	elements []Arm64HfaElement
 }
 
+struct Arm64GenRange {
+	start int
+	end   int
+	cap   int
+}
+
 // new creates a Gen value for arm64.
 pub fn Gen.new(m &ssa.Module) &Gen {
+	return new_gen_with_text_capacity(m, m.instrs.len * 28)
+}
+
+fn new_gen_with_text_capacity(m &ssa.Module, text_capacity int) &Gen {
 	return &Gen{
-		m:                    m
-		macho:                MachOObject.new()
-		stack_offsets:        []i32{}
-		alloca_offsets:       []i32{}
-		alloca_sizes:         []i32{}
-		alloca_alignments:    []i32{}
-		slot_value_indices:   []int{}
-		block_offsets:        []i32{}
+		m: m
+		macho: MachOObject.new()
+		text_words: []u32{cap: text_capacity}
+		stack_offsets: []i32{}
+		alloca_offsets: []i32{}
+		alloca_sizes: []i32{}
+		alloca_alignments: []i32{}
+		slot_value_indices: []int{}
+		block_offsets: []i32{}
 		block_offset_indices: []int{}
-		pending_jmps:         []PendingJmp{}
-		fn_offsets:           map[string]int{}
-		string_cache:         map[string]int{}
+		pending_jmps: []PendingJmp{}
+		fn_offsets: map[string]int{}
+		string_cache: map[string]int{}
 	}
 }
 
@@ -65,7 +78,138 @@ pub fn (mut g Gen) gen() {
 	for fi in 0 .. g.m.funcs.len {
 		g.gen_func(fi)
 	}
+	g.materialize_text()
 	g.gen_post_pass()
+}
+
+// gen_parallel emits independent contiguous function ranges concurrently and
+// merges their text, symbols, strings, and relocations in source order.
+pub fn (mut g Gen) gen_parallel() {
+	$if clang {
+		g.gen_parallel_c_host()
+	} $else {
+
+		// Direct ARM64 descendants keep the sequential path: their lightweight
+		// thread result ABI does not yet support returning generator pointers.
+		g.gen()
+	}
+}
+
+fn (mut g Gen) gen_parallel_c_host() {
+	if g.m.funcs.len < 64 {
+		g.gen()
+		return
+	}
+	g.gen_pre_pass()
+	// type_size lazily fills the module layout cache. Populate it before workers
+	// share the otherwise read-only SSA module.
+	for typ in 1 .. g.m.type_store.types.len {
+		_ = g.m.type_size(ssa.TypeID(typ))
+		_ = g.m.type_align(ssa.TypeID(typ))
+		layout := g.m.type_store.types[typ]
+		if layout.kind == .struct_t {
+			for field in 0 .. layout.fields.len {
+				_ = g.m.struct_field_offset(ssa.TypeID(typ), field)
+			}
+		}
+	}
+	ranges := arm64_function_ranges(g.m, 12)
+	mut workers := []thread &Gen{cap: ranges.len}
+	for r in ranges {
+		workers << spawn arm64_gen_range(g.m, r)
+	}
+	for chunk_index, worker in workers {
+		chunk := worker.wait()
+		g.merge_gen_chunk(chunk, chunk_index)
+	}
+	g.materialize_text()
+	g.gen_post_pass()
+}
+
+fn arm64_function_ranges(m &ssa.Module, wanted int) []Arm64GenRange {
+	mut weights := []int{len: m.funcs.len, init: 1}
+	mut total := 0
+	for fi, function in m.funcs {
+		mut weight := 1
+		for block in function.blocks {
+			weight += m.blocks[block].instrs.len
+		}
+		weights[fi] = weight
+		total += weight
+	}
+	worker_count := arm64_min_int(wanted, m.funcs.len)
+	mut ranges := []Arm64GenRange{cap: worker_count}
+	mut start := 0
+	mut accumulated := 0
+	mut range_weight := 0
+	for fi, weight in weights {
+		accumulated += weight
+		range_weight += weight
+		remaining_workers := worker_count - ranges.len
+		remaining_functions := m.funcs.len - fi - 1
+		target := total * (ranges.len + 1) / worker_count
+		if ranges.len + 1 < worker_count && remaining_functions >= remaining_workers - 1
+			&& accumulated >= target {
+			ranges << Arm64GenRange{
+				start: start
+				end: fi + 1
+				cap: range_weight * 28 + 1024
+			}
+			start = fi + 1
+			range_weight = 0
+		}
+	}
+	if start < m.funcs.len {
+		ranges << Arm64GenRange{
+			start: start
+			end: m.funcs.len
+			cap: range_weight * 28 + 1024
+		}
+	}
+	return ranges
+}
+
+fn arm64_gen_range(m &ssa.Module, r Arm64GenRange) &Gen {
+	mut g := new_gen_with_text_capacity(m, r.cap)
+	for fi in r.start .. r.end {
+		g.gen_func(fi)
+	}
+	return g
+}
+
+fn (mut g Gen) merge_gen_chunk(chunk &Gen, chunk_index int) {
+	text_base := g.text_offset()
+	string_base := g.macho.str_data.len
+	mut symbol_map := []int{len: chunk.macho.symbols.len}
+	for index, symbol in chunk.macho.symbols {
+		name := if symbol.sect == 2 { '${symbol.name}_${chunk_index}' } else { symbol.name }
+		symbol_map[index] = if symbol.sect == 0 {
+			g.macho.add_undefined(name)
+		} else if symbol.sect == 1 {
+			g.macho.add_symbol(name, symbol.value + u64(text_base), false, 1)
+		} else if symbol.sect == 2 {
+			g.macho.add_symbol(name, symbol.value + u64(string_base), false, 2)
+		} else {
+			g.macho.add_symbol(name, symbol.value, true, symbol.sect)
+		}
+	}
+	for relocation in chunk.macho.relocs {
+		g.macho.add_reloc(relocation.addr + text_base, symbol_map[relocation.sym_idx], relocation.type_, relocation.pcrel)
+	}
+	g.text_words << chunk.text_words
+	g.macho.str_data << chunk.macho.str_data
+}
+
+fn (g &Gen) text_offset() int {
+	return g.text_words.len * 4
+}
+
+fn (mut g Gen) materialize_text() {
+	byte_len := g.text_offset()
+	g.macho.text_data = []u8{len: byte_len}
+	if byte_len > 0 {
+		unsafe { vmemcpy(g.macho.text_data.data, g.text_words.data, byte_len) }
+	}
 }
 
 // write_and_link writes and link output for arm64.
@@ -272,7 +416,7 @@ fn (mut g Gen) gen_post_pass() {
 		}
 	}
 
-	cstring_base := u64(g.macho.text_data.len)
+	cstring_base := u64(g.text_offset())
 	data_base := (cstring_base + u64(g.macho.str_data.len) + 7) & ~u64(7)
 	for i in 0 .. g.macho.symbols.len {
 		if g.macho.symbols[i].sect == 2 {
@@ -290,7 +434,7 @@ fn (mut g Gen) gen_func(func_idx int) {
 		return
 	}
 	if func.blocks.len == 0 {
-		fn_start := g.macho.text_data.len
+		fn_start := g.text_offset()
 		sym_name := '_' + func.name
 		g.macho.add_symbol(sym_name, u64(fn_start), false, 1)
 		g.emit32(asm_ret())
@@ -375,7 +519,7 @@ fn (mut g Gen) gen_func(func_idx int) {
 
 	g.stack_size = (slot_offset + 15) & ~0xF
 
-	fn_start := g.macho.text_data.len
+	fn_start := g.text_offset()
 	sym_name := '_' + func.name
 	g.macho.add_symbol(sym_name, u64(fn_start), false, 1)
 	g.fn_offsets[func.name] = fn_start
@@ -447,7 +591,7 @@ fn (mut g Gen) gen_func(func_idx int) {
 
 	// Generate blocks
 	for blk_id in func.blocks {
-		g.set_block_offset(blk_id, g.macho.text_data.len)
+		g.set_block_offset(blk_id, g.text_offset())
 		g.resolve_pending_jmps(blk_id)
 		blk := g.m.blocks[blk_id]
 		for val_id in blk.instrs {
@@ -531,7 +675,7 @@ fn (g &Gen) collect_homogeneous_float_elements(typ_id ssa.TypeID, base_offset in
 	typ := g.m.type_store.types[typ_id]
 	if typ.kind == .float_t {
 		elements << Arm64HfaElement{
-			typ:    typ_id
+			typ: typ_id
 			offset: base_offset
 		}
 		return elements.len <= 4
@@ -539,9 +683,7 @@ fn (g &Gen) collect_homogeneous_float_elements(typ_id ssa.TypeID, base_offset in
 	if typ.kind == .array_t {
 		stride := g.m.type_size(typ.elem_type)
 		for i in 0 .. typ.len {
-			if !g.collect_homogeneous_float_elements(typ.elem_type, base_offset + i * stride,
-
-				depth + 1, mut elements) {
+			if !g.collect_homogeneous_float_elements(typ.elem_type, base_offset + i * stride, depth + 1, mut elements) {
 				return false
 			}
 		}
@@ -551,8 +693,7 @@ fn (g &Gen) collect_homogeneous_float_elements(typ_id ssa.TypeID, base_offset in
 		return false
 	}
 	for i, field_type in typ.fields {
-		if !g.collect_homogeneous_float_elements(field_type, base_offset +
-			g.m.struct_field_offset(typ_id, i), depth + 1, mut elements) {
+		if !g.collect_homogeneous_float_elements(field_type, base_offset + g.m.struct_field_offset(typ_id, i), depth + 1, mut elements) {
 			return false
 		}
 	}
@@ -749,8 +890,7 @@ fn (mut g Gen) gen_instr(val_id int) {
 				ptr_reg := g.load_val(ptr_id, 9)
 				dest_type := g.ptr_elem_type(ptr_id)
 				if g.is_zero_const(src_id) && g.is_aggregate_type(dest_type) {
-					g.emit_zero_aggregate(ptr_reg, dest_type, g.aggregate_store_size(ptr_id,
-						dest_type))
+					g.emit_zero_aggregate(ptr_reg, dest_type, g.aggregate_store_size(ptr_id, dest_type))
 					return
 				}
 				src_size := g.m.type_size(src_val.typ)
@@ -1224,6 +1364,7 @@ fn (mut g Gen) gen_call(val_id int, instr ssa.Instruction) {
 	out_stack_size := g.call_stack_arg_size(instr)
 	if out_stack_size > 0 {
 		g.emit_sub_sp(out_stack_size)
+		g.transient_stack_size = out_stack_size
 	}
 
 	mut arg_reg := 0
@@ -1340,8 +1481,7 @@ fn (mut g Gen) gen_call(val_id int, instr ssa.Instruction) {
 					if g.is_string_struct_type(arg_type_id) {
 						if arg_reg + 2 <= 8 {
 							if off := g.stack_slot(arg_id) {
-								g.emit_load_string_regs_from_fp(off, arg_reg, arg_reg + 1,
-									arg_type_id)
+								g.emit_load_string_regs_from_fp(off, arg_reg, arg_reg + 1, arg_type_id)
 							} else {
 								src_reg := g.load_val(arg_id, arg_reg)
 								if src_reg != arg_reg {
@@ -1436,16 +1576,17 @@ fn (mut g Gen) gen_call(val_id int, instr ssa.Instruction) {
 		g.emit32(asm_blr(Reg(target_reg)))
 	} else if !is_c_extern && fn_name in g.fn_offsets {
 		target := g.fn_offsets[fn_name]
-		offset := (target - g.macho.text_data.len) / 4
+		offset := (target - g.text_offset()) / 4
 		g.emit32(asm_bl(i32(offset)))
 	} else {
 		sym_idx := g.macho.add_undefined('_' + fn_name)
-		g.macho.add_reloc(g.macho.text_data.len, sym_idx, arm64_reloc_branch26, true)
+		g.macho.add_reloc(g.text_offset(), sym_idx, arm64_reloc_branch26, true)
 		g.emit32(asm_bl(0))
 	}
 
 	if out_stack_size > 0 {
 		g.emit_add_sp(out_stack_size)
+		g.transient_stack_size = 0
 	}
 
 	if c_return_hfa.elements.len > 0 {
@@ -1789,9 +1930,9 @@ fn (mut g Gen) materialize_string(val_id int, reg int) {
 	str_sym_idx := g.macho.add_symbol(str_sym_name, u64(str_offset), false, 2)
 
 	// ADRP + ADD to load address
-	g.macho.add_reloc(g.macho.text_data.len, str_sym_idx, arm64_reloc_page21, true)
+	g.macho.add_reloc(g.text_offset(), str_sym_idx, arm64_reloc_page21, true)
 	g.emit32(asm_adrp(Reg(reg)))
-	g.macho.add_reloc(g.macho.text_data.len, str_sym_idx, arm64_reloc_pageoff12, false)
+	g.macho.add_reloc(g.text_offset(), str_sym_idx, arm64_reloc_pageoff12, false)
 	g.emit32(asm_add_pageoff(Reg(reg)))
 
 	// x10 holds the string struct's second 8-byte word: `len` in the low 32 bits and
@@ -1815,15 +1956,15 @@ fn (mut g Gen) emit_global_addr(reg int, name string) {
 		sym_idx = g.macho.add_undefined(sym_name)
 	}
 	if g.is_external_global(name) {
-		g.macho.add_reloc(g.macho.text_data.len, sym_idx, arm64_reloc_got_load_page21, true)
+		g.macho.add_reloc(g.text_offset(), sym_idx, arm64_reloc_got_load_page21, true)
 		g.emit32(asm_adrp(Reg(reg)))
-		g.macho.add_reloc(g.macho.text_data.len, sym_idx, arm64_reloc_got_load_pageoff12, false)
+		g.macho.add_reloc(g.text_offset(), sym_idx, arm64_reloc_got_load_pageoff12, false)
 		g.emit32(asm_ldr_pageoff(Reg(reg)))
 		return
 	}
-	g.macho.add_reloc(g.macho.text_data.len, sym_idx, arm64_reloc_page21, true)
+	g.macho.add_reloc(g.text_offset(), sym_idx, arm64_reloc_page21, true)
 	g.emit32(asm_adrp(Reg(reg)))
-	g.macho.add_reloc(g.macho.text_data.len, sym_idx, arm64_reloc_pageoff12, false)
+	g.macho.add_reloc(g.text_offset(), sym_idx, arm64_reloc_pageoff12, false)
 	g.emit32(asm_add_pageoff(Reg(reg)))
 }
 
@@ -1861,11 +2002,11 @@ fn (mut g Gen) store_entry_arg_to_global(reg int, global_name string) {
 // emit_branch_to_block converts emit branch to block data for arm64.
 fn (mut g Gen) emit_branch_to_block(blk_id int) {
 	if target := g.block_offset(blk_id) {
-		offset := (target - g.macho.text_data.len) / 4
+		offset := (target - g.text_offset()) / 4
 		g.emit32(asm_b(i32(offset)))
 	} else {
 		g.pending_jmps << PendingJmp{
-			text_pos: g.macho.text_data.len
+			text_pos: g.text_offset()
 			block_id: blk_id
 		}
 		g.emit32(asm_b(0))
@@ -1946,7 +2087,7 @@ fn (mut g Gen) emit_phi_copy_value(src_id int, dst_id int) {
 
 // resolve_pending_jmps resolves resolve pending jmps information for arm64.
 fn (mut g Gen) resolve_pending_jmps(blk_id int) {
-	target := g.macho.text_data.len
+	target := g.text_offset()
 	mut remaining := []PendingJmp{}
 	for pj in g.pending_jmps {
 		if pj.block_id == blk_id {
@@ -1972,21 +2113,18 @@ fn (mut g Gen) resolve_all_pending() {
 
 // patch_branch supports patch branch handling for Gen.
 fn (mut g Gen) patch_branch(text_pos int, offset int) {
-	existing := read_u32_le(g.macho.text_data, text_pos)
+	word_index := text_pos / 4
+	existing := g.text_words[word_index]
 	opcode := existing & 0xFC000000
 	imm26 := u32(offset) & 0x03FFFFFF
-	patched := opcode | imm26
-	write_u32_le_at_arr(mut g.macho.text_data, text_pos, patched)
+	g.text_words[word_index] = opcode | imm26
 }
 
 // ==================== Low-level emission helpers ====================
 
 // emit32 supports emit32 handling for Gen.
 fn (mut g Gen) emit32(instr u32) {
-	g.macho.text_data << u8(instr)
-	g.macho.text_data << u8(instr >> 8)
-	g.macho.text_data << u8(instr >> 16)
-	g.macho.text_data << u8(instr >> 24)
+	g.text_words << instr
 }
 
 // emit_mov_imm emits emit mov imm output for arm64.
@@ -2019,6 +2157,20 @@ fn (mut g Gen) emit_mov_imm(reg int, val i64) {
 
 // emit_store_fp emits emit store fp output for arm64.
 fn (mut g Gen) emit_store_fp(reg int, offset int) {
+	// Locals live below fp but above the adjusted sp. Address them from sp when
+	// the unsigned scaled form fits; large self-host functions otherwise need a
+	// materialized negative offset plus an add for almost every spill.
+	sp_offset := g.stack_size + g.transient_stack_size + offset
+	if offset < 0 && sp_offset >= 0 && sp_offset < 32768 && sp_offset % 8 == 0 {
+		g.emit32(asm_str_imm(Reg(reg), sp, u32(sp_offset / 8)))
+		return
+	}
+	if offset < 0 && sp_offset >= 32768 && sp_offset < 0x1000000 && sp_offset % 8 == 0 {
+		scratch := if reg == 11 { Reg(12) } else { Reg(11) }
+		g.emit32(asm_add_imm_lsl12(scratch, sp, u32(sp_offset >> 12)))
+		g.emit32(asm_str_imm(Reg(reg), scratch, u32((sp_offset & 0xFFF) / 8)))
+		return
+	}
 	if offset >= -255 && offset < 0 {
 		g.emit32(asm_stur(Reg(reg), fp, i32(offset)))
 	} else if offset < -255 {
@@ -2037,6 +2189,17 @@ fn (mut g Gen) emit_store_sp(reg int, offset int) {
 
 // emit_load_fp emits emit load fp output for arm64.
 fn (mut g Gen) emit_load_fp(reg int, offset int) {
+	sp_offset := g.stack_size + g.transient_stack_size + offset
+	if offset < 0 && sp_offset >= 0 && sp_offset < 32768 && sp_offset % 8 == 0 {
+		g.emit32(asm_ldr_imm(Reg(reg), sp, u32(sp_offset / 8)))
+		return
+	}
+	if offset < 0 && sp_offset >= 32768 && sp_offset < 0x1000000 && sp_offset % 8 == 0 {
+		scratch := if reg == 11 { Reg(12) } else { Reg(11) }
+		g.emit32(asm_add_imm_lsl12(scratch, sp, u32(sp_offset >> 12)))
+		g.emit32(asm_ldr_imm(Reg(reg), scratch, u32((sp_offset & 0xFFF) / 8)))
+		return
+	}
 	if offset >= -255 && offset < 0 {
 		g.emit32(asm_ldur(Reg(reg), fp, i32(offset)))
 	} else if offset < -255 {
@@ -2084,6 +2247,20 @@ fn (mut g Gen) emit_load_reg_offset(dst Reg, base Reg, offset int) {
 
 // emit_lea_fp emits emit lea fp output for arm64.
 fn (mut g Gen) emit_lea_fp(reg int, offset int) {
+	sp_offset := g.stack_size + g.transient_stack_size + offset
+	if offset < 0 && sp_offset >= 0 && sp_offset < 0x1000000 {
+		hi := sp_offset >> 12
+		lo := sp_offset & 0xFFF
+		if hi == 0 {
+			g.emit32(asm_add_imm(Reg(reg), sp, u32(lo)))
+		} else {
+			g.emit32(asm_add_imm_lsl12(Reg(reg), sp, u32(hi)))
+			if lo != 0 {
+				g.emit32(asm_add_imm(Reg(reg), Reg(reg), u32(lo)))
+			}
+		}
+		return
+	}
 	if offset >= 0 && offset < 4096 {
 		g.emit32(asm_add_imm(Reg(reg), fp, u32(offset)))
 	} else if offset < 0 && -offset < 4096 {

--- a/vlib/v3/gen/arm64/gen_test.v
+++ b/vlib/v3/gen/arm64/gen_test.v
@@ -44,6 +44,7 @@ fn test_zero_aggregate_uses_address_fallback_past_immediate_range() {
 	large_array := m.type_store.get_array(i64_type, 4097)
 	mut g := Gen.new(m)
 	g.emit_zero_aggregate(9, large_array, 0)
+	g.materialize_text()
 	assert g.macho.text_data.len == (4096 + 3) * 4
 	last := g.macho.text_data.len - 4
 	assert read_u32_le(g.macho.text_data, last) == asm_str(xzr, Reg(11))
@@ -55,6 +56,7 @@ fn test_external_global_address_uses_got_load_relocations() {
 	m.add_external_global('environ', m.type_store.get_ptr(m.type_store.get_ptr(i8_type)))
 	mut g := Gen.new(m)
 	g.emit_global_addr(8, 'environ')
+	g.materialize_text()
 	assert g.macho.relocs.len == 2
 	assert g.macho.relocs[0].type_ == arm64_reloc_got_load_page21
 	assert g.macho.relocs[1].type_ == arm64_reloc_got_load_pageoff12
@@ -74,6 +76,7 @@ fn test_aggregate_bitcast_copies_every_word() {
 	g.set_stack_slot(source, -16)
 	g.set_stack_slot(result, -32)
 	g.gen_instr(result)
+	g.materialize_text()
 	assert g.macho.text_data.len == 16
 }
 
@@ -97,6 +100,7 @@ fn test_large_c_variadic_aggregate_passes_its_address() {
 	g.reset_value_slots(&m.funcs[caller_id])
 	g.set_stack_slot(large, -24)
 	g.gen_call(int(call), m.instrs[m.values[call].index])
+	g.materialize_text()
 	mut words := []u32{}
 	for i := 0; i < g.macho.text_data.len; i += 4 {
 		words << read_u32_le(g.macho.text_data, i)
@@ -126,6 +130,7 @@ fn test_c_homogeneous_float_aggregate_uses_simd_argument_registers() {
 	g.reset_value_slots(&m.funcs[caller_id])
 	g.set_stack_slot(pair, -16)
 	g.gen_call(int(call), m.instrs[m.values[call].index])
+	g.materialize_text()
 	mut words := []u32{}
 	for i := 0; i < g.macho.text_data.len; i += 4 {
 		words << read_u32_le(g.macho.text_data, i)
@@ -160,6 +165,7 @@ fn test_c_homogeneous_float_aggregate_overflow_uses_the_stack() {
 	g.reset_value_slots(&m.funcs[caller_id])
 	g.set_stack_slot(pair, -16)
 	g.gen_call(int(call), m.instrs[m.values[call].index])
+	g.materialize_text()
 	mut words := []u32{}
 	for i := 0; i < g.macho.text_data.len; i += 4 {
 		words << read_u32_le(g.macho.text_data, i)
@@ -214,6 +220,7 @@ fn test_c_homogeneous_float_aggregate_return_uses_simd_registers() {
 	g.reset_value_slots(&m.funcs[caller_id])
 	g.set_stack_slot(call, -24)
 	g.gen_call(int(call), m.instrs[m.values[call].index])
+	g.materialize_text()
 	mut words := []u32{}
 	for i := 0; i < g.macho.text_data.len; i += 4 {
 		words << read_u32_le(g.macho.text_data, i)
@@ -244,6 +251,7 @@ fn test_c_f32_homogeneous_float_aggregate_return_uses_simd_registers() {
 	g.reset_value_slots(&m.funcs[caller_id])
 	g.set_stack_slot(call, -8)
 	g.gen_call(int(call), m.instrs[m.values[call].index])
+	g.materialize_text()
 	mut words := []u32{}
 	for i := 0; i < g.macho.text_data.len; i += 4 {
 		words << read_u32_le(g.macho.text_data, i)
@@ -276,6 +284,7 @@ fn test_literal_c_variadic_string_stores_both_words() {
 	mut g := Gen.new(m)
 	g.reset_value_slots(&m.funcs[caller_id])
 	g.gen_call(int(call), m.instrs[m.values[call].index])
+	g.materialize_text()
 	mut words := []u32{}
 	for i := 0; i < g.macho.text_data.len; i += 4 {
 		words << read_u32_le(g.macho.text_data, i)

--- a/vlib/v3/gen/arm64/linker.v
+++ b/vlib/v3/gen/arm64/linker.v
@@ -978,22 +978,10 @@ fn (l &Linker) generate_code_signature(ident string) []u8 {
 	// Compute page hashes in parallel (16KB pages)
 	mut all_hashes := []u8{len: n_pages * 32}
 	data_ptr := unsafe { &u8(l.buf.data) }
-	$if clang {
-		// The bootstrap compiler uses the C backend, where hashing independent
-		// code-signature pages in parallel saves most of the signing pass. Native
-		// descendants keep the sequential fallback until spawn is supported there.
-		if n_pages >= 64 {
-			worker_count := 8
-			mut workers := []thread{}
-			for worker in 0 .. worker_count {
-				start := n_pages * worker / worker_count
-				end := n_pages * (worker + 1) / worker_count
-				workers << spawn sha256_hash_pages(data_ptr, mut all_hashes, start, end, code_limit)
-			}
-			workers.wait()
-		} else {
-			sha256_hash_pages(data_ptr, mut all_hashes, 0, n_pages, code_limit)
-		}
+	$if macos && clang {
+		// Optimized C-hosted compilers can use CommonCrypto's accelerated SHA-256.
+		// Native descendants retain the self-contained implementation below.
+		sha256_hash_pages_native(data_ptr, mut all_hashes, n_pages, code_limit)
 	} $else {
 		sha256_hash_pages(data_ptr, mut all_hashes, 0, n_pages, code_limit)
 	}

--- a/vlib/v3/gen/arm64/linker_darwin.c.v
+++ b/vlib/v3/gen/arm64/linker_darwin.c.v
@@ -1,0 +1,34 @@
+module arm64
+
+#include <CommonCrypto/CommonDigest.h>
+
+fn C.CC_SHA256(const_data voidptr, len u32, md &u8) &u8
+
+// sha256_hash_pages_native hashes code-signature pages with macOS's
+// hardware-accelerated SHA-256 implementation.
+fn sha256_hash_pages_native(data &u8, mut hashes []u8, page_count int, code_limit int) {
+	if page_count < 256 {
+		sha256_hash_native_range(data, hashes.data, 0, page_count, code_limit)
+		return
+	}
+	worker_count := 8
+	mut workers := []thread bool{cap: worker_count}
+	for worker in 0 .. worker_count {
+		workers << spawn sha256_hash_native_range(data, hashes.data, page_count * worker / worker_count, page_count * (worker + 1) / worker_count, code_limit)
+	}
+	workers.wait()
+}
+
+fn sha256_hash_native_range(data &u8, hashes voidptr, page_start int, page_end int, code_limit int) bool {
+	for page in page_start .. page_end {
+		start := page * cs_page_size_arm64
+		mut end := start + cs_page_size_arm64
+		if end > code_limit {
+			end = code_limit
+		}
+		unsafe {
+			C.CC_SHA256(data + start, u32(end - start), &u8(hashes) + page * cs_hash_size)
+		}
+	}
+	return true
+}

--- a/vlib/v3/gen/fastc/arm64_d_arm64.v
+++ b/vlib/v3/gen/fastc/arm64_d_arm64.v
@@ -311,6 +311,19 @@ pub fn generate_arm64_files(paths []string, prefs &pref.Preferences, output stri
 	timer.mark('arm64.codegen')
 	gen.write_and_link(output)
 	timer.mark('arm64.link')
+	if os.getenv('FASTC_BENCH') != '' {
+		mut total_lines := 0
+		for source_file in input_sources {
+			for ch in source_file.source {
+				if ch == `\n` {
+					total_lines++
+				}
+			}
+		}
+		total_us := timer.sw.elapsed().microseconds()
+		mloc_per_s := f64(total_lines) / f64(total_us)
+		eprintln('fastc-arm64-bench: files=${input_sources.len} lines=${total_lines} total=${f64(total_us) / 1000.0:.2f}ms throughput=${mloc_per_s:.3f} MLOC/s (includes Mach-O link)')
+	}
 	mut source_paths := []string{cap: sources.len}
 	for source_file in sources {
 		source_paths << source_file.path
@@ -1187,6 +1200,9 @@ fn (mut p FastArm64Program) type_id(name string) ssa.TypeID {
 	if clean.starts_with('struct ') {
 		return p.type_id('C.${clean['struct '.len..]}')
 	}
+	if clean == 'array' {
+		return p.array_type
+	}
 	if id := p.type_ids['C.${clean}'] {
 		return id
 	}
@@ -1215,7 +1231,8 @@ fn (mut p FastArm64Program) type_id(name string) ssa.TypeID {
 		'bool' { p.i1_type }
 		'i8', 'char' { p.i8_type }
 		'i16' { p.i16_type }
-		'int', 'i32', 'rune' { p.i32_type }
+		'i32', 'rune' { p.i32_type }
+		'int' { p.i64_type }
 		'i64', 'isize', 'int_literal' { p.i64_type }
 		'u8', 'byte' { p.u8_type }
 		'u16' { p.u16_type }
@@ -7403,8 +7420,44 @@ fn (mut p FastArm64Parser) stringify(value FastArm64Value) !FastArm64Value {
 }
 
 fn (mut p FastArm64Parser) parse_if_expression(expected_type_name string) !FastArm64Value {
+	p.push_local_scope()
 	p.expect(.key_if)!
-	condition := p.parse_expression(0)!
+	mut condition := FastArm64Value{}
+	if p.tok == .name {
+		mut look := p.s
+		if look.scan() == .decl_assign {
+			name := p.lit
+			p.next()
+			p.next()
+			p.last_map_found = ssa.ValueID(0)
+			value := p.parse_expression(0)!
+			address := p.program.instr0(.alloca, p.cur_block, p.program.m.type_store.get_ptr(value.typ))
+			p.program.instr2(.store, p.cur_block, p.program.void_type, value.id, address)
+			p.declare_local(name, FastArm64Local{
+				addr: address
+				typ: value.typ
+				typ_name: value.typ_name
+				option_failed: value.option_failed
+				option_error_type: value.option_error_type
+				option_error_message: value.option_error_message
+				option_error_code: value.option_error_code
+			})
+			condition = if p.last_map_found != ssa.ValueID(0) {
+				FastArm64Value{
+					id: p.last_map_found
+					typ: p.program.i1_type
+					typ_name: 'bool'
+				}
+			} else {
+				p.truthy_value(value)
+			}
+			p.last_map_found = ssa.ValueID(0)
+		} else {
+			condition = p.parse_expression(0)!
+		}
+	} else {
+		condition = p.parse_expression(0)!
+	}
 	for p.tok == .semicolon {
 		p.next()
 	}
@@ -7477,7 +7530,7 @@ fn (mut p FastArm64Parser) parse_if_expression(expected_type_name string) !FastA
 	}
 	p.cur_block = merge_block
 	has_option_metadata := p.if_expression_value_has_option_metadata(then_value) || (!else_terminated && p.if_expression_value_has_option_metadata(else_value))
-	return FastArm64Value{
+	result := FastArm64Value{
 		id: p.program.instr1(.load, p.cur_block, then_value.typ, result_slot)
 		typ: then_value.typ
 		typ_name: then_value.typ_name
@@ -7502,6 +7555,8 @@ fn (mut p FastArm64Parser) parse_if_expression(expected_type_name string) !FastA
 			ssa.ValueID(0)
 		}
 	}
+	p.pop_local_scope()
+	return result
 }
 
 fn (p &FastArm64Parser) if_expression_value_has_option_metadata(value FastArm64Value) bool {
@@ -7632,6 +7687,24 @@ fn (mut p FastArm64Parser) parse_name_expression() !FastArm64Value {
 	}
 	if first_name == 'map' && p.tok == .lsbr {
 		return p.parse_map_literal()
+	}
+	// The direct backend only reaches the read side of FastC's target-configuration
+	// globals: generate_arm64_files does not call the C generator's setters. Keep
+	// their declaration defaults available without pulling mutable C-generator
+	// state into the native compiler.
+	if first_name == 'fastc_platform_int_c_type' {
+		return FastArm64Value{
+			id: p.program.m.add_value(.string_literal, p.program.str_type, 'i64', 0)
+			typ: p.program.str_type
+			typ_name: 'string'
+		}
+	}
+	if first_name == 'fastc_compact_v3_type_names' {
+		return FastArm64Value{
+			id: p.program.m.get_or_add_const(p.program.i1_type, '0')
+			typ: p.program.i1_type
+			typ_name: 'bool'
+		}
 	}
 	if local := p.locals[first_name] {
 		return FastArm64Value{
@@ -9406,6 +9479,26 @@ fn (mut p FastArm64Parser) resolve_method_key(value FastArm64Value, method strin
 	return none
 }
 
+fn (mut p FastArm64Parser) method_receiver(value FastArm64Value, expected_type ssa.TypeID) ssa.ValueID {
+	expected_layout := p.program.m.type_store.types[expected_type]
+	if expected_layout.kind != .ptr_t {
+		return value.id
+	}
+	value_layout := p.program.m.type_store.types[value.typ]
+	if value_layout.kind == .ptr_t {
+		if value.typ == expected_type {
+			return value.id
+		}
+		return p.program.instr1(.bitcast, p.cur_block, expected_type, value.id)
+	}
+	if value.address != ssa.ValueID(0) {
+		return value.address
+	}
+	receiver_slot := p.program.instr0(.alloca, p.cur_block, expected_type)
+	p.program.instr2(.store, p.cur_block, p.program.void_type, value.id, receiver_slot)
+	return receiver_slot
+}
+
 fn (mut p FastArm64Parser) emit_zero_argument_method(value FastArm64Value, method string) ?FastArm64Value {
 	resolved := p.resolve_method_key(value, method) or { return none }
 	signature := p.program.functions[resolved]
@@ -9414,16 +9507,7 @@ fn (mut p FastArm64Parser) emit_zero_argument_method(value FastArm64Value, metho
 	}
 	p.program.native_used_function_names[resolved] = true
 	expected_receiver := p.program.type_id(signature.parameter_types[0])
-	mut receiver_id := value.id
-	if p.program.m.type_store.types[expected_receiver].kind == .ptr_t && value.typ != expected_receiver {
-		if value.address != ssa.ValueID(0) {
-			receiver_id = value.address
-		} else {
-			receiver_slot := p.program.instr0(.alloca, p.cur_block, expected_receiver)
-			p.program.instr2(.store, p.cur_block, p.program.void_type, value.id, receiver_slot)
-			receiver_id = receiver_slot
-		}
-	}
+	receiver_id := p.method_receiver(value, expected_receiver)
 	func_id := p.program.register_signature_function(resolved) or { return none }
 	ret := p.program.fn_returns[resolved]
 	symbol := p.program.fn_symbols[resolved]
@@ -9545,16 +9629,7 @@ fn (mut p FastArm64Parser) parse_method_call(value FastArm64Value, method string
 	}
 	p.validate_call_argument_count(method, resolved, signature, call_args, 1)!
 	expected_receiver := p.program.type_id(signature.parameter_types[0])
-	mut receiver_id := value.id
-	if p.program.m.type_store.types[expected_receiver].kind == .ptr_t && value.typ != expected_receiver {
-		if value.address != ssa.ValueID(0) {
-			receiver_id = value.address
-		} else {
-			receiver_slot := p.program.instr0(.alloca, p.cur_block, expected_receiver)
-			p.program.instr2(.store, p.cur_block, p.program.void_type, value.id, receiver_slot)
-			receiver_id = receiver_slot
-		}
-	}
+	receiver_id := p.method_receiver(value, expected_receiver)
 	func_id := p.program.register_signature_function(resolved) or {
 		return p.unsupported('registered method `${resolved}`')
 	}

--- a/vlib/v3/gen/fastc/arm64_d_arm64.v
+++ b/vlib/v3/gen/fastc/arm64_d_arm64.v
@@ -110,6 +110,7 @@ struct FastArm64Program {
 	functions        map[string]FastcFunctionSignature
 	type_decls       map[string]FastArm64TypeDecl
 	constant_sources map[string]FastArm64ConstantDecl
+	short_constants  map[string]FastArm64ConstantDecl
 	enum_values      map[string]FastArm64ConstantDecl
 mut:
 	m                          &ssa.Module = unsafe { nil }
@@ -133,6 +134,7 @@ mut:
 	type_ids                   map[string]ssa.TypeID
 	type_aliases               map[string]string
 	fn_ids                     map[string]int
+	fn_symbol_ids              map[string]int
 	fn_returns                 map[string]ssa.TypeID
 	fn_symbols                 map[string]string
 	function_keys_by_name      map[string][]string
@@ -178,6 +180,7 @@ mut:
 	map_key                  string
 	map_value                string
 	last_map_found           ssa.ValueID
+	known_body_span_index    int
 	current_function         string
 	current_receiver         string
 	current_method_is_static bool
@@ -204,6 +207,12 @@ struct FastArm64Generation {
 	source_paths []string
 }
 
+struct FastArm64Declarations {
+	types       map[string]FastArm64TypeDecl
+	constants   map[string]FastArm64ConstantDecl
+	enum_values map[string]FastArm64ConstantDecl
+}
+
 // generate_arm64_files parses FastC source tokens directly into SSA and emits a Mach-O binary.
 // It deliberately does not create Flat AST nodes or C source.
 pub fn generate_arm64_files(paths []string, prefs &pref.Preferences, output string) !FastArm64Generation {
@@ -211,7 +220,6 @@ pub fn generate_arm64_files(paths []string, prefs &pref.Preferences, output stri
 	input_sources, _ := fastc_resolve_source_files(paths, prefs)!
 	timer.mark('arm64.resolve')
 	fast_arm64_validate_output_source_paths(output, input_sources)!
-	fast_arm64_validate_unsupported_calls(input_sources, prefs)!
 	timer.mark('arm64.validate')
 	mut sources := fastc_monomorphize_sources(input_sources, prefs)!
 	timer.mark('arm64.monomorphize')
@@ -257,12 +265,13 @@ pub fn generate_arm64_files(paths []string, prefs &pref.Preferences, output stri
 	mut interface_fields := map[string]FastcInterfaceField{}
 	mut embed_embedders := []string{}
 	mut embed_embeddeds := []string{}
+	declaration_worker := spawn fast_arm64_collect_declarations_job(sources, prefs, declared_types, enum_flags, type_source_paths)
 	fastc_collect_signatures(sources, prefs, declared_types, declared_type_c_names, params_structs, mut functions, mut interface_methods, mut interface_fields, mut embed_embedders, mut embed_embeddeds)!
 	timer.mark('arm64.signatures')
-	type_decls, constant_sources, enum_values := fast_arm64_collect_declarations(sources, prefs, declared_types, enum_flags, type_source_paths)!
+	declarations := declaration_worker.wait()!
 	timer.mark('arm64.declarations')
 
-	mut program := FastArm64Program.new(prefs, declared_types, functions, type_decls, constant_sources, enum_values)
+	mut program := FastArm64Program.new(prefs, declared_types, functions, declarations.types, declarations.constants, declarations.enum_values)
 	program.register_functions()
 	// The lifecycle hooks run in module dependency order; the resolver returns
 	// discovery order.
@@ -307,7 +316,7 @@ pub fn generate_arm64_files(paths []string, prefs &pref.Preferences, output stri
 	timer.mark('arm64.parse')
 	fast_arm64_hide_unused_prototypes(mut program.m)
 	mut gen := arm64.Gen.new(program.m)
-	gen.gen()
+	gen.gen_parallel()
 	timer.mark('arm64.codegen')
 	gen.write_and_link(output)
 	timer.mark('arm64.link')
@@ -330,41 +339,6 @@ pub fn generate_arm64_files(paths []string, prefs &pref.Preferences, output stri
 	}
 	return FastArm64Generation{
 		source_paths: source_paths
-	}
-}
-
-fn fast_arm64_validate_unsupported_calls(sources []FastcSourceFile, prefs &pref.Preferences) ! {
-	for source_file in sources {
-		if source_file.header.module_name == 'os' {
-			continue
-		}
-		file := token.File.unindexed(source_file.path, source_file.source.len)
-		mut scan := scanner.new_scanner(prefs, .normal)
-		scan.init(file, source_file.source)
-		mut previous_3 := token.Token.unknown
-		mut previous_3_literal := ''
-		mut previous_2 := token.Token.unknown
-		mut previous_2_literal := ''
-		mut previous_1 := token.Token.unknown
-		mut previous_1_literal := ''
-		mut tok := scan.scan()
-		for tok != .eof {
-			if tok == .lpar && previous_1 == .name && previous_1_literal == 'exec' && previous_2 == .dot && previous_3 == .name {
-				module_name := source_file.header.imports[previous_3_literal] or {
-					previous_3_literal
-				}
-				if module_name == 'os' {
-					return error('fastc parser does not support `os.exec` on the direct ARM64 backend')
-				}
-			}
-			previous_3 = previous_2
-			previous_3_literal = previous_2_literal
-			previous_2 = previous_1
-			previous_2_literal = previous_1_literal
-			previous_1 = tok
-			previous_1_literal = if tok == .name { scan.lit } else { '' }
-			tok = scan.scan()
-		}
 	}
 }
 
@@ -532,6 +506,15 @@ fn fast_arm64_collect_declarations(sources []FastcSourceFile, prefs &pref.Prefer
 		declarations[declaration.key] = expanded
 	}
 	return declarations, constants, enum_values
+}
+
+fn fast_arm64_collect_declarations_job(sources []FastcSourceFile, prefs &pref.Preferences, declared_types map[string]bool, enum_flags map[string]bool, type_source_paths map[string]bool) !FastArm64Declarations {
+	types, constants, enum_values := fast_arm64_collect_declarations(sources, prefs, declared_types, enum_flags, type_source_paths)!
+	return FastArm64Declarations{
+		types: types
+		constants: constants
+		enum_values: enum_values
+	}
 }
 
 fn fast_arm64_expand_embedded_declaration(key string, declarations map[string]FastArm64TypeDecl, mut visiting map[string]bool) !FastArm64TypeDecl {
@@ -1129,15 +1112,24 @@ fn FastArm64Program.new(prefs &pref.Preferences, declared_types map[string]bool,
 	// FastC hands this SSA directly to the ARM64 emitter. It does not run SSA
 	// rewrites, so maintaining a unique user list for every operand is pure cost.
 	m.track_uses = false
+	// Direct parsing emits SSA in one pass. Function count is already known and
+	// gives a reliable sizing hint, avoiding repeated copies of the large value,
+	// instruction, and block arrays while self-hosting.
+	m.values.ensure_cap(functions.len * 420)
+	m.instrs.ensure_cap(functions.len * 320)
+	m.blocks.ensure_cap(functions.len * 26)
+	m.funcs.ensure_cap(functions.len + 128)
 	mut program := &FastArm64Program{
 		prefs: unsafe { prefs }
 		declared_types: declared_types
 		functions: functions
 		type_decls: type_decls
 		constant_sources: constant_sources
+		short_constants: fast_arm64_unique_short_constants(constant_sources)
 		enum_values: enum_values
 		m: m
 		fn_ids: map[string]int{}
+		fn_symbol_ids: map[string]int{}
 		fn_returns: map[string]ssa.TypeID{}
 		fn_symbols: map[string]string{}
 		function_keys_by_name: map[string][]string{}
@@ -1189,6 +1181,24 @@ fn FastArm64Program.new(prefs &pref.Preferences, declared_types map[string]bool,
 	return program
 }
 
+fn fast_arm64_unique_short_constants(constants map[string]FastArm64ConstantDecl) map[string]FastArm64ConstantDecl {
+	mut short_constants := map[string]FastArm64ConstantDecl{}
+	mut ambiguous := map[string]bool{}
+	for key, declaration in constants {
+		short_name := key.all_after_last('.')
+		if short_name == key || short_name in ambiguous {
+			continue
+		}
+		if short_name in short_constants {
+			short_constants.delete(short_name)
+			ambiguous[short_name] = true
+		} else {
+			short_constants[short_name] = declaration
+		}
+	}
+	return short_constants
+}
+
 fn (mut p FastArm64Program) type_id(name string) ssa.TypeID {
 	// Type spellings come from FastC's scanner and declaration index, which already
 	// remove surrounding trivia. Keeping this path allocation-free matters during
@@ -1200,8 +1210,53 @@ fn (mut p FastArm64Program) type_id(name string) ssa.TypeID {
 	if clean.starts_with('struct ') {
 		return p.type_id('C.${clean['struct '.len..]}')
 	}
-	if clean == 'array' {
-		return p.array_type
+	match clean {
+		'', 'void' {
+			return p.void_type
+		}
+		'bool' {
+			return p.i1_type
+		}
+		'i8', 'char' {
+			return p.i8_type
+		}
+		'i16' {
+			return p.i16_type
+		}
+		'i32', 'rune' {
+			return p.i32_type
+		}
+		'int', 'i64', 'isize', 'int_literal' {
+			return p.i64_type
+		}
+		'u8', 'byte' {
+			return p.u8_type
+		}
+		'u16' {
+			return p.u16_type
+		}
+		'u32', 'unsigned int' {
+			return p.u32_type
+		}
+		'u64', 'usize' {
+			return p.u64_type
+		}
+		'f32' {
+			return p.f32_type
+		}
+		'f64', 'float_literal' {
+			return p.f64_type
+		}
+		'string' {
+			return p.str_type
+		}
+		'voidptr', 'byteptr', 'charptr' {
+			return p.ptr_i8
+		}
+		'array' {
+			return p.array_type
+		}
+		else {}
 	}
 	if id := p.type_ids['C.${clean}'] {
 		return id
@@ -1216,41 +1271,18 @@ fn (mut p FastArm64Program) type_id(name string) ssa.TypeID {
 		p.type_ids[clean] = id
 		return id
 	}
-	if clean !in ['bool', 'i8', 'char', 'i16', 'int', 'i32', 'rune', 'i64', 'isize', 'int_literal',
-		'u8', 'byte', 'u16', 'u32', 'unsigned int', 'u64', 'usize', 'f32', 'f64', 'float_literal',
-		'string', 'voidptr', 'byteptr', 'charptr'] {
-		if alias := p.type_aliases[clean] {
-			return p.type_id(alias)
-		}
-		if id := p.type_ids[clean] {
-			return id
-		}
+	if alias := p.type_aliases[clean] {
+		return p.type_id(alias)
 	}
-	return match clean {
-		'', 'void' { p.void_type }
-		'bool' { p.i1_type }
-		'i8', 'char' { p.i8_type }
-		'i16' { p.i16_type }
-		'i32', 'rune' { p.i32_type }
-		'int' { p.i64_type }
-		'i64', 'isize', 'int_literal' { p.i64_type }
-		'u8', 'byte' { p.u8_type }
-		'u16' { p.u16_type }
-		'u32', 'unsigned int' { p.u32_type }
-		'u64', 'usize' { p.u64_type }
-		'f32' { p.f32_type }
-		'f64', 'float_literal' { p.f64_type }
-		'string' { p.str_type }
-		'voidptr', 'byteptr', 'charptr' { p.ptr_i8 }
-		else {
-			if clean.starts_with('Array_') || clean.starts_with('[]') {
-				p.array_type
-			} else if clean.starts_with('Map_') || clean.starts_with('map[') {
-				p.map_type
-			} else {
-				p.i64_type
-			}
-		}
+	if id := p.type_ids[clean] {
+		return id
+	}
+	return if clean.starts_with('Array_') || clean.starts_with('[]') {
+		p.array_type
+	} else if clean.starts_with('Map_') || clean.starts_with('map[') {
+		p.map_type
+	} else {
+		p.i64_type
 	}
 }
 
@@ -1258,7 +1290,11 @@ fn (mut p FastArm64Program) register_function(key string, symbol string, ret ssa
 	if id := p.fn_ids[key] {
 		return id
 	}
-	id := p.m.new_function(symbol, ret)
+	id := p.fn_symbol_ids[symbol] or {
+		new_id := p.m.add_function(symbol, ret)
+		p.fn_symbol_ids[symbol] = new_id
+		new_id
+	}
 	p.fn_ids[key] = id
 	p.fn_returns[key] = ret
 	p.fn_symbols[key] = symbol
@@ -3912,10 +3948,34 @@ fn (mut p FastArm64Parser) skip_declaration() ! {
 		p.next()
 	}
 	if p.tok == .lcbr {
+		if p.skip_known_function_body() {
+			return
+		}
 		p.skip_group(.lcbr, .rcbr)!
 	} else if p.tok == .semicolon {
 		p.next()
 	}
+}
+
+fn (mut p FastArm64Parser) skip_known_function_body() bool {
+	// body_spans belong to the complete source file. Selected comptime branches
+	// use temporary source strings and must continue with balanced token scans.
+	if p.s.src.str != p.source_file.source.str {
+		return false
+	}
+	spans := p.source_file.header.body_spans
+	for p.known_body_span_index + 1 < spans.len
+		&& spans[p.known_body_span_index] < p.s.pos {
+		p.known_body_span_index += 2
+	}
+	if p.known_body_span_index + 1 >= spans.len
+		|| spans[p.known_body_span_index] != p.s.pos {
+		return false
+	}
+	p.s.skip_block_to(spans[p.known_body_span_index + 1])
+	p.known_body_span_index += 2
+	p.next()
+	return true
 }
 
 fn (mut p FastArm64Parser) skip_value_declaration() {
@@ -7752,19 +7812,7 @@ fn (mut p FastArm64Parser) parse_name_expression() !FastArm64Value {
 	if declaration := p.program.constant_sources[first_name] {
 		return p.parse_constant_declaration(declaration)
 	}
-	mut short_constant := FastArm64ConstantDecl{}
-	mut has_short_constant := false
-	for constant_name, declaration in p.program.constant_sources {
-		if constant_name.ends_with('.${first_name}') {
-			if has_short_constant {
-				has_short_constant = false
-				break
-			}
-			short_constant = declaration
-			has_short_constant = true
-		}
-	}
-	if has_short_constant {
+	if short_constant := p.program.short_constants[first_name] {
 		return p.parse_constant_declaration(short_constant)
 	}
 	mut key := fastc_function_key(p.source_file.header.module_name, first_name)

--- a/vlib/v3/gen/fastc/arm64_test.v
+++ b/vlib/v3/gen/fastc/arm64_test.v
@@ -231,7 +231,7 @@ fn main() {
 	mut fixed := [2]int{}
 	fixed[0] += 2
 	fixed[1] = 3
-	if sizeof(fixed) != 8 || fixed_array_sum(fixed) != 5 || fixed_array_sum([2]int{}) != 0 {
+	if sizeof(fixed) != 16 || fixed_array_sum(fixed) != 5 || fixed_array_sum([2]int{}) != 0 {
 		println("wrong fixed array literal")
 		return
 	}
@@ -2167,5 +2167,41 @@ fn test_fastc_arm64_rejects_imported_source_output() {
 		}
 		assert rejected
 		assert os.read_file(dependency_path) or { '' } == dependency_source
+	}
+}
+
+fn test_fastc_arm64_platform_int_and_if_guard() {
+	$if arm64 ? {
+		test_dir := os.join_path(os.temp_dir(), 'fastc_arm64_selfhost_regressions_${os.getpid()}')
+		os.rmdir_all(test_dir) or {}
+		os.mkdir_all(test_dir) or { panic(err) }
+		defer {
+			os.rmdir_all(test_dir) or {}
+		}
+		source_path := os.join_path_single(test_dir, 'main.v')
+		output_path := os.join_path_single(test_dir, 'app')
+		os.write_file(source_path, 'fn is_wide_int(value int) bool {
+	return value > 0xffffffff
+}
+
+fn main() {
+	mut values := [u8(1)]
+	for values.len < 1024 {
+		values << u8(1)
+	}
+	labels := {"backend": "native"}
+	selected := if label := labels["backend"] { label } else { "missing" }
+	if is_wide_int(0x100000000) {
+		println("\${selected}:\${values.cap}")
+	}
+}
+') or { panic(err) }
+		mut prefs := pref.new_preferences()
+		prefs.backend = 'fastc'
+		prefs.user_defines = ['arm64']
+		generate_arm64_files([source_path], prefs, output_path) or { panic(err) }
+		result := os.execute(output_path)
+		assert result.exit_code == 0
+		assert result.output == 'native:1024\n'
 	}
 }

--- a/vlib/v3/gen/fastc/expr.v
+++ b/vlib/v3/gen/fastc/expr.v
@@ -4488,6 +4488,19 @@ fn (g &Parser) render_special_expression_fallback(tokens []FastcExpressionToken,
 }
 
 fn (g &Parser) render_special_expression(tokens []FastcExpressionToken, rendered_expression string) ?FastcRenderedExpression {
+	if tokens.len == 2 && tokens[0].tok == .amp && tokens[1].tok == .name {
+		if local := g.locals[tokens[1].lit] {
+			if local.is_reference {
+				// A `mut T` parameter is already a `T*` in C. Taking its address in V
+				// preserves that pointer; emitting `&parameter` would instead return the
+				// address of the temporary C parameter slot.
+				return FastcRenderedExpression{
+					source: g.resolved_root_expression_name(tokens[1].lit)
+					typ: local.typ
+				}
+			}
+		}
+	}
 	if tokens.len == 1 {
 		if tokens[0].tok == .name {
 			if local := g.locals[tokens[0].lit] {

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -13589,3 +13589,47 @@ fn main() {
 	assert c_source.contains('kevent()'), c_source
 	assert !c_source.contains('(struct kevent)(*('), c_source
 }
+
+fn test_selfhost_method_on_literal_arithmetic_uses_default_int_type() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn (n int) label() int {
+	return n
+}
+
+fn main() {
+	_ := (8 * 1024 * 1024).label()
+}
+', 'selfhost_literal_arithmetic_method.v', prefs) or { panic(err) }
+	assert c_source.contains('int_label(8*1024*1024)'), c_source
+	assert !c_source.contains('.label()'), c_source
+}
+
+fn test_selfhost_address_of_mut_parameter_keeps_parameter_pointer() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+struct Program {}
+
+struct Parser {
+mut:
+	program &Program = unsafe { nil }
+}
+
+fn Parser.new(mut program Program) &Parser {
+	return &Parser{
+		program: unsafe { &program }
+	}
+}
+
+fn main() {
+	mut program := Program{}
+	_ := Parser.new(mut program)
+}
+', 'address_of_mut_parameter.v', prefs) or { panic(err) }
+	assert c_source.contains('.program=(program)'), c_source
+	assert !c_source.contains('.program=(&program)'), c_source
+}

--- a/vlib/v3/gen/fastc/render_calls.v
+++ b/vlib/v3/gen/fastc/render_calls.v
@@ -534,14 +534,18 @@ fn (g &Parser) method_function_key(receiver_type string, name string) string {
 }
 
 fn (g &Parser) method_function_key_impl(receiver_type string, name string) string {
-	direct_key := '${g.semantic_type_key(receiver_type)}.${name}'
+	// Literal-only arithmetic keeps its precise inference category for assignment
+	// validation, but method lookup needs the concrete default V type. Without
+	// this, `(8 * 1024 * 1024).str()` is left as raw C `.str()` syntax.
+	method_receiver_type := fastc_normalize_inferred_type(receiver_type)
+	direct_key := '${g.semantic_type_key(method_receiver_type)}.${name}'
 	if direct_key in g.functions {
 		return direct_key
 	}
 	// A type alias (`type GitlyDb = sqlite.DB`) inherits its base type's methods, so a
 	// method missing on the alias resolves against the underlying type.
-	base := g.underlying_alias_type(receiver_type)
-	if base != receiver_type {
+	base := g.underlying_alias_type(method_receiver_type)
+	if base != method_receiver_type {
 		base_key := '${g.semantic_type_key(base)}.${name}'
 		if base_key in g.functions {
 			return base_key
@@ -550,7 +554,7 @@ fn (g &Parser) method_function_key_impl(receiver_type string, name string) strin
 	if g.selfhost && name in ['keys', 'values'] && 'map.${name}' in g.functions {
 		return 'map.${name}'
 	}
-	mut layout_type := fastc_trim_pointer_suffix(receiver_type)
+	mut layout_type := fastc_trim_pointer_suffix(method_receiver_type)
 	if layout_type.starts_with('Array_') {
 		layout_type = 'array'
 	} else if layout_type.starts_with('Map_') {

--- a/vlib/v3/ssa/builder_test.v
+++ b/vlib/v3/ssa/builder_test.v
@@ -222,6 +222,24 @@ fn test_type_size_reuses_module_layout_cache() {
 		assert m.struct_field_size(struct_type, 1) == 20
 	}
 	assert m.type_size_cache.cap == cache_capacity
+	m.freeze_type_layouts()
+	assert m.type_layout_frozen
+	assert m.struct_field_size(struct_type, 0) == 4
+	frozen_sizes := m.type_size_cache.clone()
+	frozen_alignments := m.type_align_cache.clone()
+	frozen_offsets := m.field_offset_cache.clone()
+	frozen_field_sizes := m.field_size_cache.clone()
+	for _ in 0 .. 100 {
+		assert m.type_size(array_type) == 20
+		assert m.type_align(struct_type) == 4
+		assert m.struct_field_offset(struct_type, 1) == 4
+		assert m.struct_field_size(struct_type, 1) == 20
+	}
+	assert m.type_size_cache == frozen_sizes
+	assert m.type_align_cache == frozen_alignments
+	assert m.field_offset_cache == frozen_offsets
+	assert m.field_size_cache == frozen_field_sizes
+	assert m.type_size_visiting.all(!it)
 }
 
 fn test_packed_and_aligned_struct_layout() {

--- a/vlib/v3/ssa/ssa.v
+++ b/vlib/v3/ssa/ssa.v
@@ -46,9 +46,9 @@ pub enum OpCode {
 	store
 	get_element_ptr
 	heap_alloc // Heap allocate memory for a type (malloc+zero): returns ptr
-	fence      // Memory ordering barrier
-	cmpxchg    // Atomic compare-exchange
-	atomicrmw  // Atomic read-modify-write
+	fence // Memory ordering barrier
+	cmpxchg // Atomic compare-exchange
+	atomicrmw // Atomic read-modify-write
 	// Comparisons
 	lt
 	gt
@@ -63,7 +63,7 @@ pub enum OpCode {
 	// Other
 	call
 	call_indirect // Indirect call through function pointer
-	call_sret     // Call with struct return (x8 indirect return on ARM64)
+	call_sret // Call with struct return (x8 indirect return on ARM64)
 	neg
 	trunc
 	sext
@@ -75,10 +75,10 @@ pub enum OpCode {
 	bitcast
 	phi
 	select
-	assign             // Copy op used during phi elimination
+	assign // Copy op used during phi elimination
 	inline_string_init // Build a string struct by value: (string){str, len}
 	// Concurrency
-	go_call    // Launch goroutine: go_call fn_ref, args...
+	go_call // Launch goroutine: go_call fn_ref, args...
 	spawn_call // Launch OS thread: spawn_call fn_ref, args...
 	// Aggregate (struct/tuple) operations
 	extractvalue
@@ -99,10 +99,10 @@ pub enum AtomicOrdering {
 
 // InlineHint lists inline hint values used by ssa.
 pub enum InlineHint {
-	none_  // No hint, let optimizer decide
+	none_ // No hint, let optimizer decide
 	always // Always inline (e.g. V's [inline] attribute)
-	never  // Never inline (e.g. V's [noinline] attribute)
-	hint   // Suggest inlining (optimizer may ignore)
+	never // Never inline (e.g. V's [noinline] attribute)
+	hint // Suggest inlining (optimizer may ignore)
 }
 
 // TypeKind lists type kind values used by ssa.
@@ -125,7 +125,7 @@ pub:
 	width       int
 	is_unsigned bool
 	elem_type   TypeID // For Ptr, Array
-	len         int    // For Array
+	len         int // For Array
 	fields      []TypeID
 	field_names []string
 	params      []TypeID
@@ -133,7 +133,7 @@ pub:
 	is_c_struct bool // True for C interop structs (raw field names, typedef to C struct)
 	is_union    bool // True for union types (all fields overlap at offset 0)
 	is_packed   bool // True when struct fields have byte alignment
-	alignment   int  // Explicit aggregate alignment in bytes; 0 uses the natural alignment
+	alignment   int // Explicit aggregate alignment in bytes; 0 uses the natural alignment
 }
 
 // TypeStore represents type store data used by ssa.
@@ -233,7 +233,7 @@ pub fn (mut ts TypeStore) get_tuple(elem_types []TypeID) TypeID {
 		}
 	}
 	id := ts.register(Type{
-		kind:   .struct_t
+		kind: .struct_t
 		fields: elem_types
 	})
 	ts.cache[key] = id
@@ -256,7 +256,7 @@ pub enum ValueKind {
 	instruction
 	phi_result
 	basic_block
-	string_literal   // V string struct literal (by value)
+	string_literal // V string struct literal (by value)
 	c_string_literal // C string literal (raw char pointer)
 	func_ref
 }
@@ -396,14 +396,14 @@ pub mut:
 	linkage       Linkage
 	alignment     int
 	is_constant   bool
-	initial_value i64  // For constants/enums, the initial integer value
+	initial_value i64 // For constants/enums, the initial integer value
 	initial_data  []u8 // For constant arrays: serialized element data
 }
 
 // TargetData represents target data data used by ssa.
 pub struct TargetData {
 pub:
-	ptr_size      int  = 8
+	ptr_size      int = 8
 	endian_little bool = true
 }
 
@@ -433,19 +433,22 @@ mut:
 	// type-table-sized arrays for every query.
 	type_size_cache    []int
 	type_size_visiting []bool
+	type_align_cache   []int
+	field_offset_cache map[u64]int
 }
 
 // new creates a Module value for ssa.
 pub fn Module.new() &Module {
 	mut m := &Module{
-		type_store:        TypeStore.new()
-		c_struct_names:    map[int]string{}
+		type_store: TypeStore.new()
+		c_struct_names: map[int]string{}
 		c_typedef_structs: map[int]bool{}
-		const_cache:       map[string]ValueID{}
+		const_cache: map[string]ValueID{}
+		field_offset_cache: map[u64]int{}
 	}
 	m.values << Value{
 		kind: .unknown
-		id:   0
+		id: 0
 	}
 	return m
 }
@@ -474,10 +477,10 @@ pub fn (mut m Module) release_codegen_analysis_metadata() {
 pub fn (mut m Module) add_value(kind ValueKind, typ TypeID, name string, index int) ValueID {
 	id := ValueID(m.values.len)
 	m.values << Value{
-		id:    id
-		kind:  kind
-		typ:   typ
-		name:  name
+		id: id
+		kind: kind
+		typ: typ
+		name: name
 		index: index
 	}
 	return id
@@ -487,9 +490,9 @@ pub fn (mut m Module) add_value(kind ValueKind, typ TypeID, name string, index i
 pub fn (mut m Module) add_instr(op OpCode, block BlockID, typ TypeID, operands []ValueID) ValueID {
 	instr_idx := m.instrs.len
 	m.instrs << Instruction{
-		op:       op
-		block:    block
-		typ:      typ
+		op: op
+		block: block
+		typ: typ
 		operands: operands
 	}
 	val_id := m.add_value(.instruction, typ, '', instr_idx)
@@ -516,9 +519,9 @@ pub fn (mut m Module) add_instr(op OpCode, block BlockID, typ TypeID, operands [
 pub fn (mut m Module) add_instr_front(op OpCode, block BlockID, typ TypeID, operands []ValueID) ValueID {
 	instr_idx := m.instrs.len
 	m.instrs << Instruction{
-		op:       op
-		block:    block
-		typ:      typ
+		op: op
+		block: block
+		typ: typ
 		operands: operands
 	}
 	val_id := m.add_value(.instruction, typ, '', instr_idx)
@@ -680,8 +683,8 @@ pub fn (mut m Module) add_block(func_id int, name string) BlockID {
 	id := BlockID(m.blocks.len)
 	unique := '${name}_${id}'
 	m.blocks << BasicBlock{
-		id:     id
-		name:   unique
+		id: id
+		name: unique
 		parent: func_id
 	}
 	mut f := m.funcs[func_id]
@@ -700,9 +703,21 @@ pub fn (mut m Module) new_function(name string, ret TypeID) int {
 	}
 	id := m.funcs.len
 	m.funcs << Function{
-		id:   id
+		id: id
 		name: name
-		typ:  ret
+		typ: ret
+	}
+	return id
+}
+
+// add_function appends a function when the caller already maintains a unique
+// name index and therefore does not need new_function's linear duplicate scan.
+pub fn (mut m Module) add_function(name string, ret TypeID) int {
+	id := m.funcs.len
+	m.funcs << Function{
+		id: id
+		name: name
+		typ: ret
 	}
 	return id
 }
@@ -748,8 +763,8 @@ pub fn (mut m Module) block_add_pred(to BlockID, from BlockID) {
 pub fn (mut m Module) add_global(name string, typ TypeID) ValueID {
 	id := m.globals.len
 	m.globals << GlobalVar{
-		name:    name
-		typ:     typ
+		name: name
+		typ: typ
 		linkage: .private
 	}
 	ptr_typ := m.type_store.get_ptr(typ)
@@ -761,10 +776,10 @@ pub fn (mut m Module) add_global(name string, typ TypeID) ValueID {
 pub fn (mut m Module) add_global_with_data(name string, elem_type TypeID, is_const bool, data []u8) ValueID {
 	id := m.globals.len
 	m.globals << GlobalVar{
-		name:         name
-		typ:          elem_type
-		linkage:      .private
-		is_constant:  is_const
+		name: name
+		typ: elem_type
+		linkage: .private
+		is_constant: is_const
 		initial_data: data
 	}
 	ptr_typ := m.type_store.get_ptr(elem_type)
@@ -781,8 +796,8 @@ pub fn (mut m Module) add_external_global(name string, typ TypeID) ValueID {
 	}
 	id := m.globals.len
 	m.globals << GlobalVar{
-		name:    name
-		typ:     typ
+		name: name
+		typ: typ
 		linkage: .external
 	}
 	ptr_typ := m.type_store.get_ptr(typ)
@@ -819,6 +834,7 @@ fn (mut m Module) ensure_type_layout_cache() {
 	if m.type_size_cache.len < type_count {
 		m.type_size_cache << []int{len: type_count - m.type_size_cache.len}
 		m.type_size_visiting << []bool{len: type_count - m.type_size_visiting.len}
+		m.type_align_cache << []int{len: type_count - m.type_align_cache.len}
 	}
 }
 
@@ -931,7 +947,17 @@ pub fn (m &Module) type_align(typ_id TypeID) int {
 
 // type_align_for_layout returns type align for layout data for Module.
 fn (m &Module) type_align_for_layout(typ_id TypeID) int {
-	return m.type_align_for_layout_inner(typ_id, 0)
+	if typ_id <= 0 || typ_id >= m.type_store.types.len {
+		return 1
+	}
+	mut mm := unsafe { &Module(voidptr(m)) }
+	mm.ensure_type_layout_cache()
+	if mm.type_align_cache[typ_id] > 0 {
+		return mm.type_align_cache[typ_id]
+	}
+	alignment := m.type_align_for_layout_inner(typ_id, 0)
+	mm.type_align_cache[typ_id] = alignment
+	return alignment
 }
 
 // type_align_for_layout_inner returns type align for layout inner data for Module.
@@ -1024,10 +1050,16 @@ pub fn (m &Module) struct_field_offset(typ_id TypeID, field_idx int) int {
 		return 0
 	}
 	typ := m.type_store.types[typ_id]
-	if typ.kind != .struct_t {
+	if typ.kind != .struct_t || field_idx < 0 || field_idx >= typ.fields.len {
 		return 0
 	}
+	key := (u64(typ_id) << 32) | u64(field_idx)
+	if cached := m.field_offset_cache[key] {
+		return cached - 1
+	}
 	if typ.is_union {
+		mut mm := unsafe { &Module(voidptr(m)) }
+		mm.field_offset_cache[key] = 1
 		return 0
 	}
 	mut mm := unsafe { &Module(voidptr(m)) }
@@ -1042,8 +1074,7 @@ pub fn (m &Module) struct_field_offset(typ_id TypeID, field_idx int) int {
 		if align > 1 && offset % align != 0 {
 			offset = (offset + align - 1) & ~(align - 1)
 		}
-		offset += m.type_size_inner(typ.fields[i], 1, mut mm.type_size_visiting, mut
-			mm.type_size_cache)
+		offset += m.type_size_inner(typ.fields[i], 1, mut mm.type_size_visiting, mut mm.type_size_cache)
 	}
 	if field_idx < typ.fields.len {
 		align := if typ.is_packed { 1 } else { m.type_align_for_layout(typ.fields[field_idx]) }
@@ -1052,6 +1083,7 @@ pub fn (m &Module) struct_field_offset(typ_id TypeID, field_idx int) int {
 		}
 	}
 	mm.type_size_visiting[typ_id] = false
+	mm.field_offset_cache[key] = offset + 1
 	return offset
 }
 
@@ -1067,8 +1099,7 @@ pub fn (m &Module) struct_field_size(typ_id TypeID, field_idx int) int {
 	mut mm := unsafe { &Module(voidptr(m)) }
 	mm.ensure_type_layout_cache()
 	mm.type_size_visiting[typ_id] = true
-	size := m.type_size_inner(typ.fields[field_idx], 1, mut mm.type_size_visiting, mut
-		mm.type_size_cache)
+	size := m.type_size_inner(typ.fields[field_idx], 1, mut mm.type_size_visiting, mut mm.type_size_cache)
 	mm.type_size_visiting[typ_id] = false
 	return size
 }

--- a/vlib/v3/ssa/ssa.v
+++ b/vlib/v3/ssa/ssa.v
@@ -435,6 +435,8 @@ mut:
 	type_size_visiting []bool
 	type_align_cache   []int
 	field_offset_cache map[u64]int
+	field_size_cache   map[u64]int
+	type_layout_frozen bool
 }
 
 // new creates a Module value for ssa.
@@ -445,6 +447,7 @@ pub fn Module.new() &Module {
 		c_typedef_structs: map[int]bool{}
 		const_cache: map[string]ValueID{}
 		field_offset_cache: map[u64]int{}
+		field_size_cache: map[u64]int{}
 	}
 	m.values << Value{
 		kind: .unknown
@@ -824,9 +827,39 @@ pub fn (m &Module) get_block_from_val(val_id int) int {
 
 // type_size returns the byte size for an SSA type on the current target.
 pub fn (m &Module) type_size(typ_id TypeID) int {
+	if typ_id <= 0 || typ_id >= m.type_store.types.len {
+		return 0
+	}
+	if m.type_layout_frozen {
+		return m.type_size_cache[typ_id]
+	}
 	mut mm := unsafe { &Module(voidptr(m)) }
 	mm.ensure_type_layout_cache()
 	return m.type_size_inner(typ_id, 0, mut mm.type_size_visiting, mut mm.type_size_cache)
+}
+
+// freeze_type_layouts precomputes layout data so concurrent code generators
+// can query it without mutating the shared module.
+pub fn (m &Module) freeze_type_layouts() {
+	if m.type_layout_frozen {
+		return
+	}
+	mut mm := unsafe { &Module(voidptr(m)) }
+	mm.ensure_type_layout_cache()
+	for typ in 1 .. m.type_store.types.len {
+		_ = m.type_size(TypeID(typ))
+		_ = m.type_align(TypeID(typ))
+	}
+	for typ in 1 .. m.type_store.types.len {
+		layout := m.type_store.types[typ]
+		if layout.kind == .struct_t {
+			for field in 0 .. layout.fields.len {
+				_ = m.struct_field_offset(TypeID(typ), field)
+				_ = m.struct_field_size(TypeID(typ), field)
+			}
+		}
+	}
+	mm.type_layout_frozen = true
 }
 
 fn (mut m Module) ensure_type_layout_cache() {
@@ -950,6 +983,9 @@ fn (m &Module) type_align_for_layout(typ_id TypeID) int {
 	if typ_id <= 0 || typ_id >= m.type_store.types.len {
 		return 1
 	}
+	if m.type_layout_frozen {
+		return m.type_align_cache[typ_id]
+	}
 	mut mm := unsafe { &Module(voidptr(m)) }
 	mm.ensure_type_layout_cache()
 	if mm.type_align_cache[typ_id] > 0 {
@@ -1057,6 +1093,9 @@ pub fn (m &Module) struct_field_offset(typ_id TypeID, field_idx int) int {
 	if cached := m.field_offset_cache[key] {
 		return cached - 1
 	}
+	if m.type_layout_frozen {
+		return 0
+	}
 	if typ.is_union {
 		mut mm := unsafe { &Module(voidptr(m)) }
 		mm.field_offset_cache[key] = 1
@@ -1096,10 +1135,18 @@ pub fn (m &Module) struct_field_size(typ_id TypeID, field_idx int) int {
 	if typ.kind != .struct_t || field_idx < 0 || field_idx >= typ.fields.len {
 		return 0
 	}
+	key := (u64(typ_id) << 32) | u64(field_idx)
+	if cached := m.field_size_cache[key] {
+		return cached - 1
+	}
+	if m.type_layout_frozen {
+		return 0
+	}
 	mut mm := unsafe { &Module(voidptr(m)) }
 	mm.ensure_type_layout_cache()
 	mm.type_size_visiting[typ_id] = true
 	size := m.type_size_inner(typ.fields[field_idx], 1, mut mm.type_size_visiting, mut mm.type_size_cache)
 	mm.type_size_visiting[typ_id] = false
+	mm.field_size_cache[key] = size + 1
 	return size
 }


### PR DESCRIPTION
## Summary

- make the V3 direct ARM64 backend self-host `vlib/v3/v3.v` without the macOS C fallback
- add the FastC parity fixes required by native V3 descendants
- optimize direct parsing, SSA construction, ARM64 emission, Mach-O linking, and signing
- reuse FastC source resolution, declaration, and signature collection in the typed ARM64 path

## Performance

Measured using optimized V compiler binaries on macOS arm64:

| backend | median | best | included work |
| --- | ---: | ---: | --- |
| FastC + TinyCC | 1.972 MLOC/s | 2.046 MLOC/s | C generation, TinyCC compilation, linking |
| Fast + ARM64 | 1.958 MLOC/s | 2.012 MLOC/s | typed parsing, ARM64 generation, Mach-O linking and signing |

Fast + ARM64 is within about 0.7% of FastC + TinyCC and is 2.73x faster than its previous 0.718 MLOC/s baseline.

## Validation

With `V_MACOS_V3_NO_FALLBACK=1`:

```text
optimized C-hosted V3
  -> native ARM64 child
  -> native ARM64 grandchild
  -> native ARM64 great-grandchild
```

Every generated compiler was an executable arm64 Mach-O and each native generation successfully compiled `vlib/v3/v3.v` again.

Broad test suites were intentionally skipped for this performance-focused iteration. The fallback-disabled multi-generation self-host chain was used as the requested validation.

## Parser direction

The two backends now share source resolution, scanning, declaration indexing, and signature collection. The remaining split is body lowering: ARM64 needs concrete type IDs while FastC currently leaves many expression types to C `typeof`. A future unification can have the shared parser emit typed operations which both the C renderer and ARM64 SSA builder consume; removing generated `typeof` expressions should also reduce TinyCC work.
