### PR TITLE
v3: reduce self-host time and peak memory

### DIFF
--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -580,8 +580,30 @@ fn (mut m map) reserve_metas(meta_bytes u32) {
 
 // reserve ensures that the map can store at least `n` entries without rehashing.
 pub fn (mut m map) reserve(n u32) {
-	for u64(n) * 5 > u64(m.even_index) * 2 {
-		m.expand()
+	if m.len == 0 {
+		old_index := m.even_index
+		for u64(n) * 5 > u64(m.even_index) * 2 {
+			m.even_index = ((m.even_index + 2) << 1) - 2
+			if m.cached_hashbits == 0 {
+				m.shift += max_cached_hashbits
+				m.cached_hashbits = max_cached_hashbits
+			} else {
+				m.cached_hashbits--
+			}
+		}
+		if m.even_index != old_index {
+			// Empty maps have no entries to rehash. Allocate the final metadata
+			// table once instead of zeroing every intermediate doubled table.
+			meta_bytes := sizeof(u32) * (m.even_index + 2 + m.extra_metas)
+			unsafe {
+				free(m.metas)
+				m.metas = &u32(vcalloc_noscan(meta_bytes))
+			}
+		}
+	} else {
+		for u64(n) * 5 > u64(m.even_index) * 2 {
+			m.expand()
+		}
 	}
 	dense_cap := u64(n) + u64(m.key_values.deletes)
 	if dense_cap > u64(max_int) {

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -324,7 +324,6 @@ fn map_free_nop(_ voidptr) {
 }
 
 fn new_map(key_bytes int, value_bytes int, hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn, free_fn MapFreeFn) map {
-	metasize := int(sizeof(u32) * (init_capicity + extra_metas_inc))
 	// for now assume anything bigger than a pointer is a string
 	has_string_keys := key_bytes > int(sizeof(voidptr))
 	return map{
@@ -332,11 +331,11 @@ fn new_map(key_bytes int, value_bytes int, hash_fn MapHashFn, key_eq_fn MapEqFn,
 		value_bytes:     value_bytes
 		even_index:      init_even_index
 		cached_hashbits: max_cached_hashbits
-		shift:           init_log_capicity
-		key_values:      new_dense_array(key_bytes, value_bytes)
-		metas:           unsafe { &u32(vcalloc_noscan(metasize)) }
-		extra_metas:     extra_metas_inc
-		len:             0
+		shift: init_log_capicity
+		key_values: DenseArray{ key_bytes: key_bytes, value_bytes: value_bytes }
+		metas: unsafe { nil }
+		extra_metas: extra_metas_inc
+		len: 0
 		has_string_keys: has_string_keys
 		hash_fn:         hash_fn
 		key_eq_fn:       key_eq_fn
@@ -390,6 +389,9 @@ pub fn (mut m map) move() map {
 // It does it by setting the map length to `0`
 // Example: mut m := {'abc': 'xyz', 'def': 'aaa'}; m.clear(); assert m.len == 0
 pub fn (mut m map) clear() {
+	if m.metas == unsafe { nil } {
+		return
+	}
 	unsafe {
 		if m.key_values.all_deleted != 0 {
 			free(m.key_values.all_deleted)
@@ -503,6 +505,12 @@ fn (mut m map) ensure_extra_metas(probe_count u32) {
 // not equivalent to the key of any other element already in the container.
 // If the key already exists, its value is changed to the value of the new element.
 fn (mut m map) set(key voidptr, value voidptr) {
+	if m.metas == unsafe { nil } {
+		// Most compiler bookkeeping maps remain empty. Allocate backing storage
+		// only on the first insertion or an explicit reservation.
+		m.key_values = new_dense_array(m.key_bytes, m.value_bytes)
+		m.metas = unsafe { &u32(vcalloc_noscan(sizeof(u32) * (m.even_index + 2 + m.extra_metas))) }
+	}
 	// Integer-based load factor check: equivalent to (2*len)/even_index > 0.8
 	// which simplifies to 5*len > 2*even_index (avoids float ops broken in ARM64 backend)
 	if u32(5) * u32(m.len) > u32(2) * m.even_index {
@@ -591,7 +599,7 @@ pub fn (mut m map) reserve(n u32) {
 				m.cached_hashbits--
 			}
 		}
-		if m.even_index != old_index {
+		if m.even_index != old_index || (n > 0 && m.metas == unsafe { nil }) {
 			// Empty maps have no entries to rehash. Allocate the final metadata
 			// table once instead of zeroing every intermediate doubled table.
 			meta_bytes := sizeof(u32) * (m.even_index + 2 + m.extra_metas)
@@ -609,7 +617,12 @@ pub fn (mut m map) reserve(n u32) {
 	if dense_cap > u64(max_int) {
 		panic('map.reserve: max_int will be exceeded')
 	}
-	m.key_values.reserve(int(dense_cap))
+	// DenseArray's geometric growth starts at eight slots.
+	if dense_cap > 0 && dense_cap < 8 {
+		m.key_values.reserve(8)
+	} else {
+		m.key_values.reserve(int(dense_cap))
+	}
 }
 
 // cached_rehashd works like rehash. However, instead of rehashing the
@@ -639,6 +652,9 @@ fn (mut m map) cached_rehash(old_cap u32) {
 // does not exist in the map, it's added to the map along with the zero/default value.
 // If the key exists, its respective value is returned.
 fn (mut m map) get_and_set(key voidptr, zero voidptr) voidptr {
+	if m.metas == unsafe { nil } {
+		m.set(key, zero)
+	}
 	for {
 		mut index, mut meta := m.key_to_index(key)
 		for {
@@ -782,6 +798,9 @@ fn (mut d DenseArray) delete(i int) {
 // delete removes the mapping of a particular key from the map.
 @[unsafe]
 pub fn (mut m map) delete(key voidptr) {
+	if m.len == 0 {
+		return
+	}
 	mut index, mut meta := m.key_to_index(key)
 	index, meta = m.meta_less(index, meta)
 	// Perform backwards shifting
@@ -849,6 +868,9 @@ pub fn (m &map) keys() array {
 // values returns all values in the map.
 pub fn (m &map) values() array {
 	mut values := __new_array(m.len, 0, m.value_bytes)
+	if m.len == 0 {
+		return values
+	}
 	mut item := unsafe { &u8(values.data) }
 
 	if m.key_values.deletes == 0 {
@@ -897,6 +919,9 @@ fn (d &DenseArray) clone() DenseArray {
 // clone returns a clone of the `map`.
 @[unsafe]
 pub fn (m &map) clone() map {
+	if m.metas == unsafe { nil } {
+		return new_map(m.key_bytes, m.value_bytes, m.hash_fn, m.key_eq_fn, m.clone_fn, m.free_fn)
+	}
 	metasize := int(sizeof(u32) * (m.even_index + 2 + m.extra_metas))
 	res := map{
 		key_bytes:       m.key_bytes

--- a/vlib/builtin/map_delete_reclaim_test.v
+++ b/vlib/builtin/map_delete_reclaim_test.v
@@ -32,6 +32,9 @@ pub mut:
 fn test_map_delete_reclaims_dense_array_tail() {
 	mut m := map[string]string{}
 	raw := unsafe { &MapLayoutForTest(&m) }
+	// Establish backing storage before checking repeated insertion/deletion.
+	m['first'] = 'first'
+	m.delete('first')
 	initial_cap := raw.key_values.cap
 	for i in 0 .. 100 {
 		key := i.str()
@@ -43,6 +46,71 @@ fn test_map_delete_reclaims_dense_array_tail() {
 		assert raw.key_values.cap == initial_cap
 		assert raw.key_values.all_deleted == unsafe { nil }
 	}
+}
+
+fn test_empty_map_defers_storage_until_first_write() {
+	mut m := map[string]int{}
+	raw := unsafe { &MapLayoutForTest(&m) }
+	assert raw.metas == unsafe { nil }
+	assert raw.key_values.keys == unsafe { nil }
+	assert raw.key_values.values == unsafe { nil }
+	assert m['absent'] == 0
+	assert 'absent' !in m
+	assert m.keys().len == 0
+	assert m.values().len == 0
+	m.delete('absent')
+	m.clear()
+	m.reserve(0)
+	mut copy := m.clone()
+	assert raw.metas == unsafe { nil }
+	copy['copy'] += 2
+	assert copy == {
+		'copy': 2
+	}
+	assert m.len == 0
+	m['original']++
+	assert m == {
+		'original': 1
+	}
+	assert copy == {
+		'copy': 2
+	}
+	assert raw.metas != unsafe { nil }
+	unsafe { copy.free() }
+	m.clear()
+	m['reused'] = 3
+	assert m == {
+		'reused': 3
+	}
+	unsafe { m.free() }
+	mut empty := map[string]int{}
+	unsafe { empty.free() }
+}
+
+fn test_lazy_map_small_reservations_and_nested_first_writes() {
+	for n in [0, 1, 2, 7, 8, 9, 100] {
+		mut m := map[int]int{}
+		m.reserve(u32(n))
+		for i in 0 .. 100 {
+			m[i] += i + 1
+		}
+		for i in 0 .. 100 {
+			assert m[i] == i + 1
+		}
+		mut copy := m.clone()
+		m.clear()
+		assert copy.len == 100
+		copy[0]++
+		assert copy[0] == 2
+		assert m.len == 0
+	}
+	mut arrays := map[string][]int{}
+	arrays['new'] << 1
+	arrays['new'] << 2
+	assert arrays['new'] == [1, 2]
+	mut nested := map[string]map[string]int{}
+	nested['outer']['inner'] = 1
+	assert nested['outer']['inner'] == 1
 }
 
 fn test_map_reserve_preallocates_dense_array() {

--- a/vlib/builtin/map_delete_reclaim_test.v
+++ b/vlib/builtin/map_delete_reclaim_test.v
@@ -58,3 +58,62 @@ fn test_map_reserve_preallocates_dense_array() {
 	assert raw.key_values.keys == keys
 	assert raw.key_values.values == values
 }
+
+fn test_empty_map_reserve_matches_populated_map_hash_state() {
+	// The largest reservation crosses the cached-hash-bit rollover.
+	for n in [32, 1024, 1_000_000] {
+		mut empty := map[int]int{}
+		mut populated := {
+			-1: 42
+		}
+		empty.reserve(u32(n))
+		populated.reserve(u32(n))
+		e := unsafe { &MapLayoutForTest(&empty) }
+		p := unsafe { &MapLayoutForTest(&populated) }
+		assert e.even_index == p.even_index
+		assert e.cached_hashbits == p.cached_hashbits
+		assert e.shift == p.shift
+		reserved_index := e.even_index
+		for i in 0 .. n {
+			empty[i] = i * 3
+		}
+		// Collision tails may grow without rehashing the reserved buckets.
+		assert e.even_index == reserved_index
+		for i in 0 .. n {
+			assert empty[i] == i * 3
+		}
+		if n < 1_000_000 {
+			for i in n .. n * 2 {
+				empty[i] = i * 3
+			}
+			for i in 0 .. n * 2 {
+				assert empty[i] == i * 3
+			}
+		}
+		unsafe {
+			empty.free()
+			populated.free()
+		}
+	}
+}
+
+fn test_empty_map_reserve_after_deletion_and_clear() {
+	mut m := {
+		'old': 1
+	}
+	m.delete('old')
+	m.reserve(1024)
+	m['new'] = 2
+	assert m == {
+		'new': 2
+	}
+	m.clear()
+	m.reserve(2048)
+	m['cleared'] = 3
+	assert m == {
+		'cleared': 3
+	}
+	m.reserve(0)
+	m['next'] = 4
+	assert m.keys() == ['cleared', 'next']
+}

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -167,6 +167,7 @@ mut:
 	inside_opt_data                      bool
 	inside_if_option                     bool
 	inside_if_result                     bool
+	discarded_index_error_pos            token.Pos // exact guard lookup whose error cannot be observed
 	inside_match_option                  bool
 	inside_match_result                  bool
 	inside_veb_tmpl                      bool

--- a/vlib/v/gen/c/coutput_test.v
+++ b/vlib/v/gen/c/coutput_test.v
@@ -249,6 +249,32 @@ fn generated_c_uses_v3_codegen(generated_c string) bool {
 	return !generated_c.contains('#define VV_LOC')
 }
 
+fn test_map_guard_without_observed_error_does_not_allocate_error() {
+	os.chdir(vroot) or {}
+	path := os.join_path(testdata_folder, 'if_guard_map_missing_key_cleanup.vv')
+	cmd := '${os.quoted_path(vexe)} -o - ${os.quoted_path(path)}'
+	compilation := os.execute(cmd)
+	ensure_compilation_succeeded(compilation, cmd)
+	if generated_c_uses_v3_codegen(compilation.output) {
+		return
+	}
+	mut body := ''
+	mut in_function := false
+	for line in compilation.output.split_into_lines() {
+		if line.contains('main__has_value(') && line.ends_with('{') {
+			in_function = true
+		}
+		if in_function {
+			body += line + '\n'
+			if line == '}' {
+				break
+			}
+		}
+	}
+	assert body.contains('.err = _const_none__')
+	assert !body.contains('builtin___v_error(')
+}
+
 fn test_or_block_err_var_collision_does_not_emit_self_referential_err() {
 	os.chdir(vroot) or {}
 	path := os.join_path(testdata_folder, 'or_block_err_var_collision.vv')

--- a/vlib/v/gen/c/if.v
+++ b/vlib/v/gen/c/if.v
@@ -4,6 +4,7 @@
 module c
 
 import v.ast
+import v.token
 
 // write_option_wrapper_if_assignment_smartcast handles an option variable that
 // carries an assignment smartcast (recorded when a non-option value was assigned
@@ -969,6 +970,13 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 				}
 			}
 		} else if branch.cond is ast.IfGuardExpr {
+			previous_index_error_pos := g.discarded_index_error_pos
+			g.discarded_index_error_pos = token.Pos{}
+			if !guard_else_uses_err[i] && branch.cond.expr is ast.IndexExpr {
+				// Only the guard's outer lookup discards its error. Nested index
+				// expressions can still expose their own error in an or block.
+				g.discarded_index_error_pos = branch.cond.expr.pos
+			}
 			mut var_name := guard_vars[i]
 			mut short_opt := false
 			g.left_is_opt = true
@@ -1136,6 +1144,7 @@ fn (mut g Gen) if_expr(node ast.IfExpr) {
 					}
 				}
 			}
+			g.discarded_index_error_pos = previous_index_error_pos
 		} else {
 			if i == 0 && node.branches.len > 1 && !needs_tmp_var && needs_conds_order {
 				cond_var_name := g.new_tmp_var()

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -23,6 +23,10 @@ enum CWideIndexKind {
 // wrapper). Otherwise the static `none` instance keeps the option fully
 // initialized without allocating a MessageError + interface box on every miss.
 fn (g &Gen) index_or_skips_err(node ast.IndexExpr) bool {
+	if node.or_expr.kind == .absent && node.pos.len > 0
+		&& node.pos == g.discarded_index_error_pos {
+		return true
+	}
 	if node.is_option || node.or_expr.kind != .block {
 		return false
 	}

--- a/vlib/v/gen/c/testdata/if_guard_map_missing_key_cleanup.c.must_have
+++ b/vlib/v/gen/c/testdata/if_guard_map_missing_key_cleanup.c.must_have
@@ -1,2 +1,2 @@
-map key does not exist
+.err = _const_none__;
 builtin___v_free(_t

--- a/vlib/v/tests/builtin_maps/map_guard_error_test.v
+++ b/vlib/v/tests/builtin_maps/map_guard_error_test.v
@@ -1,0 +1,75 @@
+fn guard_value(items map[string]int, key string) int {
+	if value := items[key] {
+		return value
+	}
+	return -1
+}
+
+fn guard_error(items map[string]int, key string) string {
+	if _ := items[key] {
+		return 'found'
+	} else {
+		return err.msg()
+	}
+}
+
+fn test_map_guard_preserves_observable_errors() {
+	items := {
+		'present': 7
+	}
+	assert guard_value(items, 'present') == 7
+	assert guard_value(items, 'missing') == -1
+	assert guard_error(items, 'present') == 'found'
+	assert guard_error(items, 'missing') == 'map key does not exist'
+	mut observed := ''
+	if _ := items['first'] {
+		assert false
+	} else if _ := items['second'] {
+		assert false
+	} else {
+		observed = err.msg()
+	}
+	assert observed == 'map key does not exist'
+}
+
+fn nested_guard_value(items map[string]int, indexes map[string]string) !int {
+	if value := items[indexes['key']!] {
+		return value
+	}
+	return error_sentinel
+}
+
+fn test_map_guard_preserves_nested_lookup_errors() {
+	items := {
+		'present': 7
+	}
+	if _ := nested_guard_value(items, map[string]string{}) {
+		assert false
+	} else {
+		assert err.msg() == 'map key does not exist'
+	}
+	if value := nested_guard_value(items, {
+		'key': 'present'
+	}) {
+		assert value == 7
+	} else {
+		assert false
+	}
+}
+
+fn test_map_guard_preserves_optional_payloads() {
+	items := {
+		'present': ?int(7)
+		'none':    ?int(none)
+	}
+	for key in ['missing', 'none'] {
+		if _ := items[key] {
+			assert false
+		}
+	}
+	if value := items['present'] {
+		assert value == 7
+	} else {
+		assert false
+	}
+}

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -9266,11 +9266,11 @@ pub fn run(args []string) {
 	])
 	b.metric_items('parsed .vh files', p.parsed_v_header_files, 'files', '.vh files', p.parsed_v_header_file_paths)
 	if !silent {
-		println('    ${'parsed .vh lines':-28s} ${source_file_line_count(p.parsed_v_header_file_paths)} lines')
+		println('    ${'parsed .vh lines':-28s} ${source_file_line_count(p.parsed_v_header_file_paths, a.source_files)} lines')
 	}
 	b.metric_items('parsed .v files', p.parsed_v_files, 'files', '.v files', p.parsed_v_file_paths)
 	if !silent {
-		println('    ${'parsed .v lines':-28s} ${source_file_line_count(p.parsed_v_file_paths)} lines')
+		println('    ${'parsed .v lines':-28s} ${source_file_line_count(p.parsed_v_file_paths, a.source_files)} lines')
 	}
 	b.metric('AST nodes after parse', a.nodes.len, 'nodes')
 	b.metric('AST children after parse', a.children.len, 'edges')
@@ -16394,9 +16394,30 @@ fn canonical_node_texts(mut a flat.FlatAst, node flat.Node) flat.Node {
 	return canonical
 }
 
-fn source_file_line_count(paths []string) int {
+fn source_file_line_count(paths []string, files map[int]&v3token.File) int {
+	if paths.len == 0 {
+		return 0
+	}
+	// The parser already indexed these exact source buffers. Reuse its line
+	// tables instead of reading every source file again for the stage report.
+	mut counts := map[string]int{}
+	for _, file in files {
+		if !file.has_source_sha256() {
+			continue
+		}
+		count := file.line_count()
+		counts[file.name] = if count > 0 && file.line_start(count) == file.size {
+			count - 1
+		} else {
+			count
+		}
+	}
 	mut lines := 0
 	for path in paths {
+		if count := counts[path] {
+			lines += count
+			continue
+		}
 		source := os.read_file(path) or { continue }
 		if source.len == 0 {
 			continue

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -8868,7 +8868,7 @@ pub fn run(args []string) {
 			}
 			if fastc_bench {
 				total_us := driver_sw.elapsed().microseconds()
-				total_lines := source_file_line_count(fastc_generation.source_paths)
+				total_lines := source_file_line_count(fastc_generation.source_paths, map[int]&v3token.File{})
 				mloc_per_s := f64(total_lines) / f64(total_us)
 				eprintln('fastc-bench-total: files=${fastc_generation.source_paths.len} lines=${total_lines} total=${f64(total_us) / 1000.0:.2f}ms throughput=${mloc_per_s:.3f} MLOC/s (includes TinyCC)')
 			}

--- a/vlib/v3/driver/source_stats_test.v
+++ b/vlib/v3/driver/source_stats_test.v
@@ -1,0 +1,33 @@
+module driver
+
+import os
+import v3.token
+
+fn test_source_line_counts_use_parsed_buffers_and_preserve_final_newline_rules() {
+	mut set := token.FileSet.new()
+	mut files := map[int]&token.File{}
+	mut paths := []string{}
+	for i, source in ['', 'one', 'one\n', '\n', 'one\ntwo', 'one\ntwo\n', 'one\n\n'] {
+		path := 'parsed_source_${i}.v'
+		mut file := set.add_file(path, source.len)
+		file.index_lines(source)
+		files[i] = file
+		paths << path
+	}
+	assert source_file_line_count(paths, files) == 9
+	assert source_file_line_count([paths[1], paths[1]], files) == 2
+	assert source_file_line_count([]string{}, files) == 0
+}
+
+fn test_source_line_counts_read_files_without_a_parser_index() {
+	path := os.join_path(os.temp_dir(), 'v3_source_stats_${os.getpid()}.v')
+	defer {
+		os.rm(path) or {}
+	}
+	os.write_file(path, 'one\ntwo\n') or { panic(err) }
+	assert source_file_line_count([path], map[int]&token.File{}) == 2
+	files := {
+		1: token.File.unindexed(path, 8)
+	}
+	assert source_file_line_count([path], files) == 2
+}

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -11762,9 +11762,6 @@ fn (mut g FlatGen) sum_cast_actual_type(id flat.NodeId) types.Type {
 		if param_type := g.current_param_type(node.value) {
 			return param_type
 		}
-		if param_type := g.current_param_map_type(node.value) {
-			return param_type
-		}
 		if fn_name := g.direct_callback_ident_name(id) {
 			if fn_type := g.callback_fn_value_type(fn_name) {
 				return types.Type(fn_type)
@@ -11915,9 +11912,6 @@ fn (g &FlatGen) pointer_variant_arg_needs_heap_copy(node flat.Node) bool {
 		return false
 	}
 	if _ := g.current_param_type(child.value) {
-		return true
-	}
-	if _ := g.current_param_map_type(child.value) {
 		return true
 	}
 	if _ := g.tc.cur_scope.lookup(child.value) {
@@ -14383,11 +14377,6 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 					return
 				}
 				if typ := g.current_param_type(child.value) {
-					if typ !is types.Pointer {
-						g.gen_expr(child_id)
-						return
-					}
-				} else if typ := g.current_param_map_type(child.value) {
 					if typ !is types.Pointer {
 						g.gen_expr(child_id)
 						return

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -573,6 +573,7 @@ mut:
 	enum_selector_cache             &ContextStringLookupCache = unsafe { nil }
 	enum_method_cache               &ContextStringLookupCache = unsafe { nil }
 	qualified_enum_method_cache     &ContextStringLookupCache = unsafe { nil }
+	import_type_cache               &ImportTypeCache = unsafe { nil }
 	embedded_fields_by_type         map[string][]types.StructField // type name -> its embedded fields (usually empty)
 	param_types_by_short            map[string][]types.Type // method short-name suffix -> param types (fallback index)
 	generic_method_candidates       map[string][]GenericMethodCandidate
@@ -1184,6 +1185,7 @@ pub fn FlatGen.new() FlatGen {
 		enum_selector_cache: &ContextStringLookupCache{}
 		enum_method_cache: &ContextStringLookupCache{}
 		qualified_enum_method_cache: &ContextStringLookupCache{}
+		import_type_cache: &ImportTypeCache{}
 		embedded_fields_by_type: map[string][]types.StructField{}
 		param_types_by_short: map[string][]types.Type{}
 		generic_method_candidates: map[string][]GenericMethodCandidate{}
@@ -2901,6 +2903,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.enum_selector_cache = &ContextStringLookupCache{}
 	g.enum_method_cache = &ContextStringLookupCache{}
 	g.qualified_enum_method_cache = &ContextStringLookupCache{}
+	g.import_type_cache = &ImportTypeCache{}
 	g.embedded_fields_by_type.clear()
 	g.param_types_by_short.clear()
 	g.generic_method_candidates.clear()
@@ -3792,6 +3795,7 @@ fn (g &FlatGen) new_collect_gen_info_view() FlatGen {
 	view.enum_selector_cache = &ContextStringLookupCache{}
 	view.enum_method_cache = &ContextStringLookupCache{}
 	view.qualified_enum_method_cache = &ContextStringLookupCache{}
+	view.import_type_cache = &ImportTypeCache{}
 	view.mut_recv_facts = &FnNameFactCache{}
 	view.local_global_shadow_facts = &ContextNameFactCache{}
 	view.generic_app_cache = &GenericAppCache{}
@@ -4349,6 +4353,11 @@ fn (mut g FlatGen) reserve_collect_gen_info_maps(no_parallel bool) {
 }
 
 fn (mut g FlatGen) cached_shared_alias_pointer_type_from_text(raw string) ?types.Type {
+	if g.shared_alias_index_ready && g.shared_alias_pointer_shorts.len == 0 {
+		// Direct `shared T` (including pointer wrappers) still needs lowering,
+		// but without aliases it needs no per-file memoization key.
+		return g.shared_alias_pointer_type_from_text(raw)
+	}
 	key := '\x00shared-alias-pointer\x00${g.tc.cur_file}\x00${g.tc.cur_module}\x00${raw}'
 	if cached := g.param_types_cache[key] {
 		if cached.len > 0 {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -435,6 +435,7 @@ mut:
 	fn_decl_variadic_short_counts  map[string]int
 	fn_decl_shared_params          map[string][]bool
 	fn_shared_params_resolved      map[string][]bool
+	shared_param_index_empty       bool
 	has_shared_params              bool
 	fn_decl_mut_receivers          map[string]bool
 	fn_decl_ret_types              map[string]types.Type // fn decl name (and qualified variants) -> return type
@@ -2842,6 +2843,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.fn_decl_variadic_short_counts.clear()
 	g.fn_decl_shared_params.clear()
 	g.fn_shared_params_resolved.clear()
+	g.shared_param_index_empty = false
 	g.has_shared_params = false
 	g.fn_decl_mut_receivers.clear()
 	g.fn_decl_ret_types.clear()

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -11429,7 +11429,7 @@ fn (mut g FlatGen) gen_pointer_alias_value_cast_expr(id flat.NodeId, expected ty
 }
 
 fn (g &FlatGen) array_index_type_for_expected_arg(actual types.Type, node flat.Node) types.Type {
-	if spread_index_expected_type_marker !in node.generic_params() {
+	if isnil(node.payload) || spread_index_expected_type_marker !in node.payload.generic_params {
 		return actual
 	}
 	expected := g.expected_expr_type
@@ -14687,13 +14687,20 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			// Enum fields take precedence when a method has the same name. Only a
 			// non-enum selector can be lowered as a bound method value.
 			mut clone_receiver_fn := ''
-			for param in node.generic_params() {
-				if param.starts_with(flat.method_value_clone_receiver_marker_prefix) {
-					clone_receiver_fn = param.all_after(flat.method_value_clone_receiver_marker_prefix)
-					break
+			mut generated_variant_access := false
+			mut borrow_receiver := false
+			if !isnil(node.payload) {
+				params := node.payload.generic_params
+				generated_variant_access = '__v3_generated_variant_access' in params
+				borrow_receiver = flat.method_value_borrow_receiver_marker in params
+				for param in params {
+					if param.starts_with(flat.method_value_clone_receiver_marker_prefix) {
+						clone_receiver_fn = param.all_after(flat.method_value_clone_receiver_marker_prefix)
+						break
+					}
 				}
 			}
-			if enum_selector_qbase.len == 0 && '__v3_generated_variant_access' !in node.generic_params() && g.gen_method_value_closure(id, base_id, base_type0, node.value, flat.method_value_borrow_receiver_marker in node.generic_params(), clone_receiver_fn) {
+			if enum_selector_qbase.len == 0 && !generated_variant_access && g.gen_method_value_closure(id, base_id, base_type0, node.value, borrow_receiver, clone_receiver_fn) {
 				return
 			}
 			// The expected type belongs to the selected field, not to its base. In

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -3896,7 +3896,8 @@ fn (mut g FlatGen) collect_gen_info(no_parallel bool) {
 	profile := !isnil(g.tc) && g.tc.verbose
 	mut presw := time.new_stopwatch()
 	g.unused_param_seen = &UnusedParamSeen{}
-	g.reserve_collect_gen_info_maps(no_parallel)
+	defer_fn_signature_registrations := !no_parallel && g.scope_parallel_workers && g.skip_generics && g.incremental_fn_names.len == 0 && par_cgen_prep_enabled()
+	g.reserve_collect_gen_info_maps(no_parallel, defer_fn_signature_registrations)
 	g.precompute_export_lookups()
 	if profile {
 		g.timing_profile('  [ttime]   ci reserve maps  ${f64(presw.elapsed().microseconds()) / 1000.0:7.2f} ms')
@@ -3926,7 +3927,6 @@ fn (mut g FlatGen) collect_gen_info(no_parallel bool) {
 	mut preferred_shared_fn_node_indexes := map[string]int{}
 	mut preferred_shared_fn_params := map[string][]bool{}
 	mut fn_signature_registrations := []FnSignatureRegistration{cap: 16_384}
-	defer_fn_signature_registrations := !no_parallel && g.scope_parallel_workers && g.skip_generics && g.incremental_fn_names.len == 0 && par_cgen_prep_enabled()
 	top_level_nodes := g.top_level_nodes()
 	fn_preps := g.collect_gen_info_fn_preps(top_level_nodes, no_parallel)
 	has_parallel_fn_preps := fn_preps.len == top_level_nodes.len
@@ -4203,6 +4203,7 @@ fn (mut g FlatGen) collect_gen_info(no_parallel bool) {
 		}
 	}
 	if defer_fn_signature_registrations {
+		g.reserve_fn_signature_registrations(fn_signature_registrations)
 		g.apply_fn_signature_registrations(fn_signature_registrations)
 	}
 	if g.has_shared_params {
@@ -4304,7 +4305,7 @@ mut:
 }
 
 @[direct_array_access]
-fn (mut g FlatGen) reserve_collect_gen_info_maps(no_parallel bool) {
+fn (mut g FlatGen) reserve_collect_gen_info_maps(no_parallel bool, deferred_signatures bool) {
 	counts := g.scan_collect_gen_info(no_parallel)
 	mut fn_count := counts.fn_count
 	struct_count := counts.struct_count
@@ -4320,12 +4321,14 @@ fn (mut g FlatGen) reserve_collect_gen_info_maps(no_parallel bool) {
 	}
 	fn_alias_count := u32(fn_count * 7 + 1024)
 	fn_name_count := u32(fn_count * 2 + 1024)
-	g.fn_decl_param_types.reserve(fn_alias_count)
-	g.fn_decl_variadic.reserve(fn_name_count)
+	if !deferred_signatures {
+		g.fn_decl_param_types.reserve(fn_alias_count)
+		g.fn_decl_variadic.reserve(fn_name_count)
+		g.fn_decl_shared_params.reserve(fn_alias_count)
+		g.fn_decl_mut_receivers.reserve(fn_name_count)
+		g.fn_decl_ret_types.reserve(fn_alias_count)
+	}
 	g.fn_decl_variadic_short_counts.reserve(u32(fn_count + 256))
-	g.fn_decl_shared_params.reserve(fn_alias_count)
-	g.fn_decl_mut_receivers.reserve(fn_name_count)
-	g.fn_decl_ret_types.reserve(fn_alias_count)
 	g.fn_decl_nodes_by_name.reserve(fn_name_count)
 	g.fn_decl_nodes_by_short.reserve(u32(fn_count + 256))
 	g.fn_decl_nodes_by_module_short.reserve(fn_name_count)
@@ -10073,6 +10076,33 @@ fn (mut g FlatGen) prepare_fn_signature_registration(name string, full_name stri
 		is_mut: is_mut
 		return_type: rt
 	}
+}
+
+// Size deferred signature maps from the aliases and flags they will receive.
+// Most compilations have few variadics and no shared parameters.
+fn (mut g FlatGen) reserve_fn_signature_registrations(registrations []FnSignatureRegistration) {
+	mut names := u32(0)
+	mut variadics := u32(0)
+	mut shared_names := u32(0)
+	mut mutable := u32(0)
+	for registration in registrations {
+		aliases := u32(registration.alias_count)
+		names += aliases + 1
+		if registration.is_variadic {
+			variadics += aliases + 1
+		}
+		if registration.shared_params.len > 0 {
+			shared_names += aliases
+		}
+		if registration.is_mut {
+			mutable += aliases
+		}
+	}
+	g.fn_decl_param_types.reserve(u32(g.fn_decl_param_types.len) + names)
+	g.fn_decl_ret_types.reserve(u32(g.fn_decl_ret_types.len) + names)
+	g.fn_decl_variadic.reserve(u32(g.fn_decl_variadic.len) + variadics)
+	g.fn_decl_shared_params.reserve(u32(g.fn_decl_shared_params.len) + shared_names)
+	g.fn_decl_mut_receivers.reserve(u32(g.fn_decl_mut_receivers.len) + mutable)
 }
 
 fn (mut g FlatGen) apply_fn_signature_registration_group(registration FnSignatureRegistration, group int) {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -15962,15 +15962,26 @@ fn type_is_fn_value(typ types.Type) bool {
 }
 
 fn type_is_void_pointer(typ types.Type) bool {
-	if typ.name() == 'voidptr' {
-		return true
-	}
 	if typ is types.Pointer {
 		base := if typ.base_type is types.Alias { typ.base_type.base_type } else { typ.base_type }
 		return base is types.Void
 	}
 	if typ is types.Alias {
-		return type_is_void_pointer(typ.base_type)
+		return typ.name == 'voidptr' || type_is_void_pointer(typ.base_type)
+	}
+	// Only named variants can have this spelling without being a pointer.
+	// Formatting containers and function signatures here creates unused strings.
+	if typ is types.Struct {
+		return typ.name == 'voidptr'
+	}
+	if typ is types.Interface {
+		return typ.name == 'voidptr'
+	}
+	if typ is types.Enum {
+		return typ.name == 'voidptr'
+	}
+	if typ is types.SumType {
+		return typ.name == 'voidptr'
 	}
 	return false
 }

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -8106,9 +8106,6 @@ fn (g &FlatGen) receiver_base_type(base_id flat.NodeId) types.Type {
 			}
 			return typ
 		}
-		if typ := g.current_param_map_type(base.value) {
-			return typ
-		}
 		if typ := g.tc.expr_type(base_id) {
 			if typ !is types.Unknown && typ !is types.Void
 				&& !g.type_contains_generic_placeholder(typ) {
@@ -11900,20 +11897,6 @@ fn (g &FlatGen) embedded_receiver_type_names_match(actual string, expected strin
 
 // current_param_type returns current param type data for FlatGen.
 fn (g &FlatGen) current_param_type(name string) ?types.Type {
-	if g.cur_param_types.len == 0 {
-		return none
-	}
-	if g.cur_param_name_bits != 0 && g.cur_param_name_bits & current_param_name_bit(name) == 0 {
-		return none
-	}
-	typ := g.cur_param_types[name] or { return none }
-	if g.cur_mut_params.len > 0 && g.current_mut_param_binding_is_shadowed(name) {
-		return none
-	}
-	return typ
-}
-
-fn (g &FlatGen) current_param_map_type(name string) ?types.Type {
 	if g.cur_param_types.len == 0 {
 		return none
 	}

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -15132,7 +15132,7 @@ fn (g &FlatGen) target_module_call_name(target string, node flat.Node) ?string {
 			}
 		}
 	}
-	static_name := '${base}.${method}'
+	static_name := target
 	if static_name in g.tc.fn_param_types || static_name in g.tc.fn_ret_types
 		|| static_name in g.tc.fn_generic_params {
 		params := g.tc.fn_param_types[static_name] or {
@@ -15172,14 +15172,22 @@ fn (g &FlatGen) target_module_call_arg_start(target string, node flat.Node) int 
 	if !target.contains('.') || node.children_count <= 1 {
 		return 1
 	}
-	base := target.all_before_last('.')
 	first_arg := g.a.child_node(&node, 1)
+	if first_arg.kind != .ident {
+		return 1
+	}
+	base := target.all_before_last('.')
+	if first_arg.value == base || (base.len > first_arg.value.len
+		&& base.ends_with(first_arg.value) && base[base.len - first_arg.value.len - 1] == `.`) {
+		return 2
+	}
 	// Constant resolution can qualify the synthetic module-base argument when the
 	// imported module exports a same-named constant (`flags` -> `flags.flags`). It
 	// is still the namespace marker inserted while lowering the selector.
-	qualified_same_name := '${base}.${base.all_after_last('.')}'
-	if first_arg.kind == .ident && (first_arg.value == base || base.ends_with('.${first_arg.value}')
-		|| first_arg.value == qualified_same_name) {
+	short_base := c_short_name_view(base)
+	if first_arg.value.len == base.len + 1 + short_base.len
+		&& first_arg.value.starts_with(base) && first_arg.value[base.len] == `.`
+		&& first_arg.value.ends_with(short_base) {
 		return 2
 	}
 	return 1
@@ -18538,8 +18546,6 @@ fn (mut g FlatGen) fn_node_return_type(node flat.Node, module_name string) types
 }
 
 fn (mut g FlatGen) fn_node_return_type_from_signatures(node flat.Node, module_name string) ?types.Type {
-	dotted_name := dotted_fn_name_in_module(module_name, node.value)
-	cname := g.fn_c_name_in_module(module_name, node.value)
 	if rt := g.fn_decl_ret_types[fn_decl_module_key(module_name, node.value)] {
 		return rt
 	}
@@ -18554,6 +18560,7 @@ fn (mut g FlatGen) fn_node_return_type_from_signatures(node flat.Node, module_na
 			return rt
 		}
 	}
+	dotted_name := dotted_fn_name_in_module(module_name, node.value)
 	if module_name.len > 0 && module_name != 'main' && module_name != 'builtin' {
 		if rt := g.tc.fn_ret_types[dotted_name] {
 			return rt
@@ -18564,7 +18571,7 @@ fn (mut g FlatGen) fn_node_return_type_from_signatures(node flat.Node, module_na
 				return rt
 			}
 		}
-		if rt := g.tc.fn_ret_types[cname] {
+		if rt := g.tc.fn_ret_types[g.fn_c_name_in_module(module_name, node.value)] {
 			return rt
 		}
 		if rt := g.tc.fn_ret_types[node.value] {
@@ -18598,6 +18605,7 @@ fn (mut g FlatGen) fn_node_return_type_from_signatures(node flat.Node, module_na
 			}
 		}
 	}
+	cname := g.fn_c_name_in_module(module_name, node.value)
 	if cname != node.value && cname != c_value {
 		if rt := g.tc.fn_ret_types[cname] {
 			return rt

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -8839,6 +8839,9 @@ fn (mut g FlatGen) gen_json_encode_call(node flat.Node, pretty bool) bool {
 }
 
 fn (mut g FlatGen) preintern_json_encode_strings() {
+	if !g.has_legacy_json_module() {
+		return
+	}
 	for idx, node in g.a.nodes {
 		if node.kind != .call || node.children_count < 2 {
 			continue

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -16032,7 +16032,8 @@ fn (mut g FlatGen) gen_transformed_method_ident_call(id flat.NodeId, node flat.N
 	receiver_wants_ptr := params[0] is types.Pointer
 		|| g.mut_receiver_arg_wants_addr(fn_node.value, receiver_id)
 		|| g.mut_receiver_arg_wants_addr(emitted_name, receiver_id)
-	receiver_wants_shared := g.fn_param_is_shared_for_call(0, fn_node.value, emitted_name, g.cname(fn_node.value), g.cname(emitted_name))
+	receiver_wants_shared := !g.shared_param_index_empty
+		&& g.fn_param_is_shared_for_call(0, fn_node.value, emitted_name, g.cname(fn_node.value), g.cname(emitted_name))
 	receiver := g.a.nodes[int(receiver_id)]
 	receiver_type := g.receiver_base_type(receiver_id)
 	receiver_declares_method := g.emitted_method_belongs_to_receiver(receiver_type, method_short, emitted_name)
@@ -18292,7 +18293,7 @@ fn (mut g FlatGen) fn_shared_params_with_implicit_veb_ctx(node flat.Node, flags 
 }
 
 fn (g &FlatGen) fn_param_is_shared(fn_name string, idx int) bool {
-	if (!g.has_shared_params && g.tc.fn_shared_params.len == 0) || idx < 0 || fn_name.len == 0 {
+	if g.shared_param_index_empty || (!g.has_shared_params && g.tc.fn_shared_params.len == 0) || idx < 0 || fn_name.len == 0 {
 		return false
 	}
 	if flags := g.fn_shared_params_resolved[fn_name] {
@@ -18336,7 +18337,7 @@ fn (g &FlatGen) fn_param_shared_exact(fn_name string, idx int) ?bool {
 }
 
 fn (g &FlatGen) fn_param_is_shared_for_call(idx int, name1 string, name2 string, name3 string, name4 string) bool {
-	if (!g.has_shared_params && g.tc.fn_shared_params.len == 0) || idx < 0 {
+	if g.shared_param_index_empty || (!g.has_shared_params && g.tc.fn_shared_params.len == 0) || idx < 0 {
 		return false
 	}
 	mut found_exact := false
@@ -18378,7 +18379,19 @@ fn (g &FlatGen) fn_param_is_shared_for_call(idx int, name1 string, name2 string,
 }
 
 fn (mut g FlatGen) precompute_shared_param_index() {
-	if !g.has_shared_params && g.tc.fn_shared_params.len == 0 {
+	// The checker also stores all-false arrays to preserve exact-name shadowing.
+	// When no declaration has a shared parameter, every query is false without
+	// copying those arrays or searching their source/C-name aliases per call.
+	g.shared_param_index_empty = !g.has_shared_params
+	if g.shared_param_index_empty {
+		for _, flags in g.tc.fn_shared_params {
+			if true in flags {
+				g.shared_param_index_empty = false
+				break
+			}
+		}
+	}
+	if g.shared_param_index_empty {
 		return
 	}
 	for name, flags in g.tc.fn_shared_params {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -6458,7 +6458,8 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 			return
 		}
 	}
-	if g.is_json_decode_call(id, target_name) {
+	if g.is_json_decode_target_name(resolved_target_name)
+		|| g.is_json_decode_target_name(target_name) {
 		if !g.is_json_decode_self_call(target_name, resolved_target_name)
 			&& g.gen_json_decode_call(node) {
 			return
@@ -16884,6 +16885,7 @@ fn (mut g FlatGen) forward_decls() {
 		master_tc := g.tc
 		master_c_name_cache := g.c_name_cache
 		master_import_alias_cache := g.import_alias_cache
+		master_import_type_cache := g.import_type_cache
 		master_enum_selector_cache := g.enum_selector_cache
 		master_enum_method_cache := g.enum_method_cache
 		master_qualified_enum_method_cache := g.qualified_enum_method_cache
@@ -16901,6 +16903,7 @@ fn (mut g FlatGen) forward_decls() {
 		// Context-cache entries can own strings allocated by this disposable
 		// batch. Disable them until the master caches are restored.
 		g.import_alias_cache = unsafe { nil }
+		g.import_type_cache = unsafe { nil }
 		g.enum_selector_cache = unsafe { nil }
 		g.enum_method_cache = unsafe { nil }
 		g.qualified_enum_method_cache = unsafe { nil }
@@ -16916,6 +16919,7 @@ fn (mut g FlatGen) forward_decls() {
 		g.tc = master_tc
 		g.c_name_cache = master_c_name_cache
 		g.import_alias_cache = master_import_alias_cache
+		g.import_type_cache = master_import_type_cache
 		g.enum_selector_cache = master_enum_selector_cache
 		g.enum_method_cache = master_enum_method_cache
 		g.qualified_enum_method_cache = master_qualified_enum_method_cache
@@ -18398,7 +18402,7 @@ fn (mut g FlatGen) gen_shared_local_receiver_arg(base_id flat.NodeId) bool {
 }
 
 fn (mut g FlatGen) fn_needs_implicit_veb_ctx(node flat.Node) bool {
-	return g.fn_returns_veb_result(node) && g.fn_has_receiver_param(node)
+	return g.fn_has_receiver_param(node) && g.fn_returns_veb_result(node)
 		&& !g.fn_receiver_type_is_context(node) && !g.fn_has_veb_context_param(node)
 		&& g.type_name_known_in_current_module('Context')
 }
@@ -18413,6 +18417,9 @@ fn (g &FlatGen) is_implicit_veb_ctx_param(pt types.Type) bool {
 }
 
 fn (g &FlatGen) call_has_implicit_veb_ctx(names []string) bool {
+	if g.tc.fn_implicit_veb_ctx.len == 0 {
+		return false
+	}
 	for name in names {
 		if name.len == 0 {
 			continue
@@ -18657,9 +18664,8 @@ fn (mut g FlatGen) fn_node_param_types(node flat.Node, module_name string) []typ
 }
 
 fn (mut g FlatGen) fn_node_param_types_from_signatures(node flat.Node, module_name string, explicit_params int) ?[]types.Type {
-	dotted_name := dotted_fn_name_in_module(module_name, node.value)
-	cname := g.fn_c_name_in_module(module_name, node.value)
 	if module_name.len > 0 && module_name != 'main' && module_name != 'builtin' {
+		dotted_name := dotted_fn_name_in_module(module_name, node.value)
 		if params := g.matching_fn_param_types(dotted_name, explicit_params) {
 			return params
 		}
@@ -18669,7 +18675,7 @@ fn (mut g FlatGen) fn_node_param_types_from_signatures(node flat.Node, module_na
 				return params
 			}
 		}
-		if params := g.matching_fn_param_types(cname, explicit_params) {
+		if params := g.matching_fn_param_types(g.fn_c_name_in_module(module_name, node.value), explicit_params) {
 			return params
 		}
 		if params := g.matching_fn_param_types(node.value, explicit_params) {
@@ -18692,6 +18698,7 @@ fn (mut g FlatGen) fn_node_param_types_from_signatures(node flat.Node, module_na
 			return params
 		}
 	}
+	dotted_name := dotted_fn_name_in_module(module_name, node.value)
 	if dotted_name != node.value {
 		if params := g.matching_fn_param_types(dotted_name, explicit_params) {
 			return params
@@ -18703,6 +18710,7 @@ fn (mut g FlatGen) fn_node_param_types_from_signatures(node flat.Node, module_na
 			}
 		}
 	}
+	cname := g.fn_c_name_in_module(module_name, node.value)
 	if cname != node.value && cname != c_value {
 		if params := g.matching_fn_param_types(cname, explicit_params) {
 			return params

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -261,6 +261,7 @@ $if !windows {
 		w.enum_selector_cache = unsafe { nil }
 		w.enum_method_cache = unsafe { nil }
 		w.qualified_enum_method_cache = unsafe { nil }
+		w.import_type_cache = unsafe { nil }
 		w.local_typedef_shadow_facts = unsafe { nil }
 		w.local_global_shadow_facts = unsafe { nil }
 		// Self-host declaration output is several MiB. Reserve it once instead of
@@ -2577,6 +2578,7 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		enum_selector_cache: &ContextStringLookupCache{}
 		enum_method_cache: &ContextStringLookupCache{}
 		qualified_enum_method_cache: &ContextStringLookupCache{}
+		import_type_cache: &ImportTypeCache{}
 		struct_decl_pref_cache: &StructDeclPrefCache{}
 		qualified_struct_c_types_by_suffix: g.qualified_struct_c_types_by_suffix
 		qualified_struct_c_types_ready: g.qualified_struct_c_types_ready

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -2473,6 +2473,7 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		fn_decl_variadic_short_counts: g.fn_decl_variadic_short_counts
 		fn_decl_shared_params: g.fn_decl_shared_params
 		fn_shared_params_resolved: g.fn_shared_params_resolved
+		shared_param_index_empty: g.shared_param_index_empty
 		has_shared_params: g.has_shared_params
 		fn_decl_mut_receivers: g.fn_decl_mut_receivers
 		fn_decl_ret_types: g.fn_decl_ret_types

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -946,10 +946,10 @@ fn (mut g FlatGen) prepare_pre_dispatch_master() {
 		g.register_interface_strings()
 		g.tc = master_tc
 		cgen_worker_scope_leave(selection_scope)
-		if !retain_selection && g.parallel_worker_scopes.len > 0 {
+		if g.parallel_worker_scopes.len > 0 {
 			// Candidate collection records helper scopes while selection_scope is
-			// current. Re-own the list before releasing that arena; the scopes it
-			// points to remain live until final cgen cleanup.
+			// current. The list must outlive every arena it names, including a
+			// retained selection_scope freed partway through final cgen cleanup.
 			g.parallel_worker_scopes = g.parallel_worker_scopes.clone()
 		}
 		if retain_selection {

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -989,6 +989,9 @@ fn (mut g FlatGen) prepare_pre_dispatch_master() {
 			g.c_extern_refs = clone_cgen_string_bool_map(g.c_extern_refs)
 			g.c_name_cache = clone_c_name_cache(g.c_name_cache)
 			g.generic_app_cache = clone_generic_app_cache(g.generic_app_cache)
+			// Import resolutions can borrow text and Type payloads from selection.
+			// Discard that memo before its scratch storage is released.
+			g.import_type_cache = &ImportTypeCache{}
 			cgen_worker_scope_free(selection_scope)
 			n_items = g.fn_gen_items.len
 			g.timing_profile('  [ttime]       pm clone out ${f64(pmsw.elapsed().microseconds()) / 1000.0:7.2f} ms')

--- a/vlib/v3/gen/c/names.v
+++ b/vlib/v3/gen/c/names.v
@@ -184,9 +184,9 @@ fn (mut c ContextNameFactCache) put(name string, value i8) {
 
 @[inline]
 fn (mut c ContextNameFactCache) select_context(file string, module_name string) {
-	if c.file.len == file.len && c.module.len == module_name.len && unsafe {
-		c.file.str == file.str && c.module.str == module_name.str
-	} {
+	if c.file.len == file.len && c.module.len == module_name.len
+		&& (unsafe { c.file.str == file.str } || c.file == file)
+		&& (unsafe { c.module.str == module_name.str } || c.module == module_name) {
 		return
 	}
 	c.file = file
@@ -248,9 +248,9 @@ mut:
 
 @[inline]
 fn (mut c ContextStringLookupCache) select_context(file string, module_name string) {
-	if c.file.len == file.len && c.module.len == module_name.len && unsafe {
-		c.file.str == file.str && c.module.str == module_name.str
-	} {
+	if c.file.len == file.len && c.module.len == module_name.len
+		&& (unsafe { c.file.str == file.str } || c.file == file)
+		&& (unsafe { c.module.str == module_name.str } || c.module == module_name) {
 		return
 	}
 	c.file = file
@@ -266,6 +266,7 @@ fn (mut g FlatGen) reset_context_lookup_caches() {
 	g.enum_selector_cache = &ContextStringLookupCache{}
 	g.enum_method_cache = &ContextStringLookupCache{}
 	g.qualified_enum_method_cache = &ContextStringLookupCache{}
+	g.import_type_cache = &ImportTypeCache{}
 }
 
 // cname is the memoizing wrapper for naming.c_name used on FlatGen hot paths.

--- a/vlib/v3/gen/c/names_test.v
+++ b/vlib/v3/gen/c/names_test.v
@@ -271,6 +271,24 @@ fn test_context_lookup_cache_tracks_source_file_imports() {
 	assert g.enum_selector_base_name('kind.Kind')? == 'second.token.Kind'
 }
 
+fn test_transformed_module_call_namespace_arguments() {
+	mut a := flat.FlatAst.new()
+	mut g := FlatGen.new()
+	g.a = &a
+	callee := a.add_val(.ident, 'net.flags.read')
+	for name in ['net.flags', 'flags', 'net.flags.flags', 'other.flags', 'lags', 'net.flagsxflags'] {
+		arg := a.add_val(.ident, name)
+		start := a.begin_children()
+		a.add_child(callee)
+		a.add_child(arg)
+		call := flat.Node{ kind: .call, children_start: start, children_count: 2 }
+		expected := if name in ['net.flags', 'flags', 'net.flags.flags'] { 2 } else { 1 }
+		assert g.target_module_call_arg_start('net.flags.read', call) == expected, name
+		a.nodes[int(arg)].kind = .string_literal
+		assert g.target_module_call_arg_start('net.flags.read', call) == 1
+	}
+}
+
 fn test_cgen_flattened_generic_receiver_short_variants() {
 	assert cgen_flattened_generic_receiver_short_variants('foo__Bar_baz__Qux') == [
 		'Bar_Qux',

--- a/vlib/v3/gen/c/parallel_worker_test.v
+++ b/vlib/v3/gen/c/parallel_worker_test.v
@@ -20,6 +20,19 @@ fn test_parallel_dispatch_worker_owns_checker_outside_scoped_batching() {
 	assert w.tc != tc
 }
 
+fn test_implicit_veb_context_call_lookup_accepts_source_and_c_names() {
+	g, mut tc := parallel_worker_test_gen(false)
+	assert !g.call_has_implicit_veb_ctx(['', 'app.index'])
+	tc.fn_implicit_veb_ctx['app.index'] = true
+	assert g.call_has_implicit_veb_ctx(['missing', 'app.index'])
+	assert !g.call_has_implicit_veb_ctx(['missing'])
+	tc.fn_implicit_veb_ctx.clear()
+	tc.fn_implicit_veb_ctx['app__index'] = true
+	assert g.call_has_implicit_veb_ctx(['', 'app.index'])
+	tc.fn_implicit_veb_ctx['app__index'] = false
+	assert !g.call_has_implicit_veb_ctx(['app.index'])
+}
+
 fn test_parallel_dispatch_worker_shares_checker_as_scoped_accumulator() {
 	g, tc := parallel_worker_test_gen(true)
 	w := g.new_parallel_dispatch_worker(1)

--- a/vlib/v3/gen/c/parallel_worker_test.v
+++ b/vlib/v3/gen/c/parallel_worker_test.v
@@ -3,6 +3,7 @@ module c
 import v3.flat
 import v3.pref
 import v3.types
+import v3.workers
 
 fn parallel_worker_test_gen(scoped bool) (&FlatGen, &types.TypeChecker) {
 	mut ast := &flat.FlatAst{}
@@ -322,6 +323,25 @@ fn test_scoped_pre_dispatch_preserves_direct_array_access_flag() {
 	assert g.fn_gen_items[0].direct_array_access
 	assert g.fn_gen_items[0].ignore_overflow
 	g.release_scoped_fn_items()
+}
+
+fn test_retained_selection_scope_does_not_own_scope_list() {
+	$if prealloc {
+		mut g, mut tc := parallel_worker_test_gen(true)
+		tc.building_v_fast = true
+		g.a.worker_pool = workers.new(8)
+		defer { g.a.worker_pool.close() }
+		for _ in 0 .. 2048 {
+			g.a.add_node(flat.Node{ kind: .module_decl, value: 'main' })
+		}
+		g.prepare_pre_dispatch_master()
+		assert g.parallel_worker_scopes.len > 1
+		for scope in g.parallel_worker_scopes {
+			assert !cgen_scope_owns(scope, g.parallel_worker_scopes.data)
+		}
+		g.free_parallel_worker_scopes()
+		assert g.parallel_worker_scopes.len == 0
+	}
 }
 
 fn test_parallel_generic_app_cache_uses_frozen_base_and_private_overlays() {

--- a/vlib/v3/gen/c/parallel_worker_test.v
+++ b/vlib/v3/gen/c/parallel_worker_test.v
@@ -34,6 +34,32 @@ fn test_implicit_veb_context_call_lookup_accepts_source_and_c_names() {
 	assert !g.call_has_implicit_veb_ctx(['app.index'])
 }
 
+fn test_shared_param_index_skips_all_false_signatures() {
+	mut g, mut tc := parallel_worker_test_gen(true)
+	tc.fn_shared_params['plain'] = [false, false]
+	tc.fn_shared_params['empty'] = []bool{}
+	g.precompute_shared_param_index()
+	assert g.shared_param_index_empty
+	assert g.fn_shared_params_resolved.len == 0
+	assert !g.fn_param_is_shared('plain', 0)
+	assert !g.fn_param_is_shared_for_call(0, 'plain', 'empty', '', '')
+	w := g.new_parallel_worker(1)
+	assert w.shared_param_index_empty
+	assert !w.fn_param_is_shared_for_call(1, 'plain', '', '', '')
+
+	// A single shared signature keeps exact false entries authoritative over
+	// shared short-name fallbacks, including when the index is prepared again.
+	tc.fn_shared_params['send'] = [true]
+	tc.fn_shared_params['dep.send'] = [true]
+	g.fn_decl_shared_params['dep.send'] = [false]
+	g.precompute_shared_param_index()
+	assert !g.shared_param_index_empty
+	assert g.fn_param_is_shared_for_call(0, 'send', '', '', '')
+	assert !g.fn_param_is_shared_for_call(0, 'dep.send', '', '', '')
+	assert !g.fn_param_is_shared_for_call(1, 'send', '', '', '')
+	assert !g.fn_param_is_shared_for_call(0, 'plain', '', '', '')
+}
+
 fn test_parallel_dispatch_worker_shares_checker_as_scoped_accumulator() {
 	g, tc := parallel_worker_test_gen(true)
 	w := g.new_parallel_dispatch_worker(1)

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -4263,9 +4263,6 @@ fn (g &FlatGen) local_ident_type(name string) ?types.Type {
 	if typ := g.current_param_type(name) {
 		return typ
 	}
-	if typ := g.current_param_map_type(name) {
-		return typ
-	}
 	if g.cur_scope_has_local_name(name) {
 		if typ := g.tc.cur_scope.lookup(name) {
 			if typ !is types.Void {
@@ -5487,9 +5484,6 @@ fn (g &FlatGen) usable_expr_type_uncached(id flat.NodeId) types.Type {
 		}
 		if node.kind == .ident {
 			if typ := g.current_param_type(node.value) {
-				return typ
-			}
-			if typ := g.current_param_map_type(node.value) {
 				return typ
 			}
 			if typ := g.tc.expr_type(id) {

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -427,9 +427,10 @@ mut:
 @[heap]
 struct ImportTypeCache {
 mut:
-	by_file   map[string]&ImportFileTypeCache
-	last_file string
-	last      &ImportFileTypeCache = unsafe { nil }
+	unqualified_texts map[string]string
+	by_file           map[string]&ImportFileTypeCache
+	last_file         string
+	last              &ImportFileTypeCache = unsafe { nil }
 }
 
 fn (mut cache ImportTypeCache) for_file(file string) &ImportFileTypeCache {
@@ -566,8 +567,22 @@ fn (g &FlatGen) canonical_import_alias_type_text_in_file(typ string, file string
 	// Import tables are immutable during C generation. Each worker owns its
 	// cache, with separate entries for source files visited by synthesized nodes.
 	mut cache := g.import_type_cache
-	if isnil(cache) || !typ.contains('.') {
+	if isnil(cache) {
 		return g.canonical_import_alias_type_text_in_file_uncached(typ, file)
+	}
+	if !typ.contains('.') {
+		if !typ.contains('[') && !typ.starts_with('&') && !typ.starts_with('?')
+			&& !typ.starts_with('!') {
+			return g.canonical_import_alias_type_text_in_file_uncached(typ, file)
+		}
+		// Wrapper and generic normalization is independent of the source file
+		// without a dotted name. Reuse it across file contexts in this worker.
+		if result := cache.unqualified_texts[typ] {
+			return result
+		}
+		result := g.canonical_import_alias_type_text_in_file_uncached(typ, file)
+		cache.unqualified_texts[typ] = result
+		return result
 	}
 	mut entry := cache.for_file(file)
 	if result := entry.texts[typ] {

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -417,7 +417,50 @@ fn (g &FlatGen) canonical_import_alias_type_text(typ string) string {
 	return g.canonical_import_alias_type_text_in_file(typ, g.tc.cur_file)
 }
 
+@[heap]
+struct ImportFileTypeCache {
+mut:
+	texts  map[string]string
+	parsed map[string]types.Type
+}
+
+@[heap]
+struct ImportTypeCache {
+mut:
+	by_file   map[string]&ImportFileTypeCache
+	last_file string
+	last      &ImportFileTypeCache = unsafe { nil }
+}
+
+fn (mut cache ImportTypeCache) for_file(file string) &ImportFileTypeCache {
+	if !isnil(cache.last) && cache.last_file == file {
+		return cache.last
+	}
+	entry := cache.by_file[file] or {
+		created := &ImportFileTypeCache{}
+		cache.by_file[file] = created
+		created
+	}
+	cache.last_file = file
+	cache.last = entry
+	return entry
+}
+
 fn (g &FlatGen) canonical_import_alias_type_in_file(typ string, file string) types.Type {
+	mut cache := g.import_type_cache
+	if !g.skip_generics || isnil(cache) || typ.contains('typeof') {
+		return g.canonical_import_alias_type_in_file_uncached(typ, file)
+	}
+	mut entry := cache.for_file(file)
+	if result := entry.parsed[typ] {
+		return result
+	}
+	result := g.canonical_import_alias_type_in_file_uncached(typ, file)
+	entry.parsed[typ] = result
+	return result
+}
+
+fn (g &FlatGen) canonical_import_alias_type_in_file_uncached(typ string, file string) types.Type {
 	canonical := g.canonical_import_alias_type_text_in_file(typ, file)
 	if canonical != typ {
 		if exact := g.exact_known_import_type_text(canonical) {
@@ -429,7 +472,10 @@ fn (g &FlatGen) canonical_import_alias_type_in_file(typ string, file string) typ
 
 fn (g &FlatGen) canonical_import_alias_type_for_node(typ types.Type, node &flat.Node) types.Type {
 	source := typ.name()
-	canonical := g.canonical_import_alias_type_text_in_file(source, g.node_source_file(node))
+	// Only dotted names can reference an import alias. Primitive and local
+	// type spellings do not need a walk through synthesized child nodes.
+	file := if source.contains('.') { g.node_source_file(node) } else { '' }
+	canonical := g.canonical_import_alias_type_text_in_file(source, file)
 	if canonical != source {
 		if exact := g.exact_known_import_type_text(canonical) {
 			return exact
@@ -457,7 +503,7 @@ fn (mut g FlatGen) import_alias_sizeof_target_in_file(value string, file string)
 }
 
 fn (g &FlatGen) exact_known_import_type_text(typ string) ?types.Type {
-	clean := typ.trim_space()
+	clean := trimmed_space(typ)
 	if clean.starts_with('&') {
 		return types.Type(types.Pointer{
 			base_type: g.exact_known_import_type_text(clean[1..])?
@@ -486,7 +532,10 @@ fn (g &FlatGen) exact_known_import_type_text(typ string) ?types.Type {
 	if clean.contains('.') {
 		module_name := clean.all_before_last('.')
 		short_name := clean.all_after_last('.')
-		for _, info in g.struct_decl_infos {
+		// Declaration collection already indexes the qualified name. Program
+		// and builtin declarations use bare keys, matching qualify_name_in_module.
+		key := if module_name in ['', 'main', 'builtin'] { short_name } else { clean }
+		if info := g.struct_decl_infos[key] {
 			if info.module == module_name && info.node.value == short_name {
 				return types.Type(types.Struct{
 					name: clean
@@ -514,11 +563,35 @@ fn (g &FlatGen) exact_known_import_type_text(typ string) ?types.Type {
 }
 
 fn (g &FlatGen) canonical_import_alias_type_text_in_file(typ string, file string) string {
-	clean := typ.trim_space()
+	// Import tables are immutable during C generation. Each worker owns its
+	// cache, with separate entries for source files visited by synthesized nodes.
+	mut cache := g.import_type_cache
+	if isnil(cache) || !typ.contains('.') {
+		return g.canonical_import_alias_type_text_in_file_uncached(typ, file)
+	}
+	mut entry := cache.for_file(file)
+	if result := entry.texts[typ] {
+		return result
+	}
+	result := g.canonical_import_alias_type_text_in_file_uncached(typ, file)
+	entry.texts[typ] = result
+	return result
+}
+
+fn (g &FlatGen) canonical_import_alias_type_text_in_file_uncached(typ string, file string) string {
+	clean := trimmed_space(typ)
 	for prefix in ['&', '?', '!', '[]'] {
 		if clean.starts_with(prefix) {
-			return prefix + g.canonical_import_alias_type_text_in_file(clean[prefix.len..], file)
+			inner := clean[prefix.len..]
+			canonical := g.canonical_import_alias_type_text_in_file(inner, file)
+			if inner == canonical {
+				return clean
+			}
+			return prefix + canonical
 		}
+	}
+	if !clean.contains('.') && !clean.contains('[') {
+		return clean
 	}
 	if clean.starts_with('map[') {
 		bracket_end := shared_generic_matching_bracket(clean, 3)

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -177,10 +177,11 @@ fn (mut g FlatGen) value_c_type(t types.Type) string {
 			return qualified + pointer_suffix
 		}
 	}
-	for candidate in [ct, 'main.${ct}'] {
-		if target := g.tc.type_aliases[candidate] {
-			return g.tc.c_type(cgen_unalias_type(g.tc.parse_type(target)))
-		}
+	if target := g.tc.type_aliases[ct] {
+		return g.tc.c_type(cgen_unalias_type(g.tc.parse_type(target)))
+	}
+	if target := g.tc.type_aliases['main.${ct}'] {
+		return g.tc.c_type(cgen_unalias_type(g.tc.parse_type(target)))
 	}
 	return ct
 }
@@ -191,10 +192,11 @@ fn (mut g FlatGen) value_unalias_type(typ types.Type) types.Type {
 		// Generic substitution can preserve a caller alias only as its type name
 		// after the specialized body has moved into the generic function's module.
 		// Recover the registered alias before selecting the C storage type.
-		for candidate in [clean_type.name, 'main.${clean_type.name}'] {
-			if target := g.tc.type_aliases[candidate] {
-				return cgen_unalias_type(g.tc.parse_type(target))
-			}
+		if target := g.tc.type_aliases[clean_type.name] {
+			return cgen_unalias_type(g.tc.parse_type(target))
+		}
+		if target := g.tc.type_aliases['main.${clean_type.name}'] {
+			return cgen_unalias_type(g.tc.parse_type(target))
 		}
 	}
 	return clean_type
@@ -472,6 +474,9 @@ fn (g &FlatGen) canonical_import_alias_type_in_file_uncached(typ string, file st
 }
 
 fn (g &FlatGen) canonical_import_alias_type_for_node(typ types.Type, node &flat.Node) types.Type {
+	if !type_has_import_alias_text(typ) {
+		return typ
+	}
 	source := typ.name()
 	// Only dotted names can reference an import alias. Primitive and local
 	// type spellings do not need a walk through synthesized child nodes.
@@ -483,6 +488,29 @@ fn (g &FlatGen) canonical_import_alias_type_for_node(typ types.Type, node &flat.
 		}
 	}
 	return typ
+}
+
+// Primitive containers already have canonical names. Inspect their leaves
+// directly instead of allocating type text merely to normalize it unchanged.
+fn type_has_import_alias_text(typ types.Type) bool {
+	return match typ {
+		types.Struct, types.Interface, types.Enum, types.SumType, types.Alias, types.FnType, types.MultiReturn, types.Channel {
+			true
+		}
+		types.Pointer, types.OptionType, types.ResultType {
+			type_has_import_alias_text(typ.base_type)
+		}
+		types.Array {
+			type_has_import_alias_text(typ.elem_type)
+		}
+		types.ArrayFixed {
+			typ.len_expr.len > 0 || type_has_import_alias_text(typ.elem_type)
+		}
+		types.Map {
+			type_has_import_alias_text(typ.key_type) || type_has_import_alias_text(typ.value_type)
+		}
+		else { false }
+	}
 }
 
 fn (mut g FlatGen) sizeof_target_in_file(value string, file string) string {

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -1062,7 +1062,7 @@ fn (g &FlatGen) type_contains_generic_placeholder(t types.Type) bool {
 			if t.name.contains('_T_') && !g.type_name_known(t.name) {
 				return true
 			}
-			if type_name_is_unbound_generic_decl(t.name, g.struct_generic_params_for_name(t.name), t.name in g.tc.structs || g.tc.qualify_name(t.name) in g.tc.structs) {
+			if !g.skip_generics && t.name.contains('[') && type_name_is_unbound_generic_decl(t.name, g.struct_generic_params_for_name(t.name), t.name in g.tc.structs || g.tc.qualify_name(t.name) in g.tc.structs) {
 				return true
 			}
 			return g.type_name_contains_generic_placeholder(t.name)
@@ -1074,7 +1074,7 @@ fn (g &FlatGen) type_contains_generic_placeholder(t types.Type) bool {
 			return g.type_name_contains_generic_placeholder(t.name)
 		}
 		types.SumType {
-			if type_name_is_unbound_generic_decl(t.name, g.sum_generic_params_for_name(t.name), t.name in g.tc.sum_types || g.tc.qualify_name(t.name) in g.tc.sum_types) {
+			if !g.skip_generics && t.name.contains('[') && type_name_is_unbound_generic_decl(t.name, g.sum_generic_params_for_name(t.name), t.name in g.tc.sum_types || g.tc.qualify_name(t.name) in g.tc.sum_types) {
 				return true
 			}
 			return g.type_name_contains_generic_placeholder(t.name)

--- a/vlib/v3/gen/c/types_test.v
+++ b/vlib/v3/gen/c/types_test.v
@@ -26,13 +26,27 @@ fn test_void_pointer_predicate_preserves_alias_and_named_type_rules() {
 
 fn test_json_helper_scan_requires_legacy_json_module() {
 	mut ast := flat.FlatAst.new()
+	ast.nodes = [flat.Node{ kind: .call, children_count: 2 },
+		flat.Node{ kind: .ident, value: 'json.encode' },
+		flat.Node{ kind: .ident, value: 'pointer', typ: '&int' }]
+	ast.children = [flat.NodeId(1), flat.NodeId(2)]
 	mut tc := types.TypeChecker.new(&ast)
+	tc.resolved_call_names = ['json.encode', '', '']
+	tc.resolved_call_set = [true, false, false]
+	tc.expr_type_values = [types.Type(types.void_), types.Type(types.void_),
+		types.Type(types.Pointer{ base_type: types.Type(types.int_) })]
+	tc.expr_type_set = [false, false, true]
+	tc.file_modules['json2.v'] = 'json2'
 	mut g := FlatGen.new()
 	g.a = &ast
 	g.tc = &tc
 	assert !g.has_legacy_json_module()
+	g.preintern_json_encode_strings()
+	assert g.str_lits.len == 0
 	tc.file_modules['json_primitives.c.v'] = 'json'
 	assert g.has_legacy_json_module()
+	g.preintern_json_encode_strings()
+	assert 'null' in g.str_lits
 }
 
 fn test_optional_typedef_collection_ignores_incomplete_call_type_text() {
@@ -251,6 +265,30 @@ fn test_import_type_cache_keeps_file_contexts_separate() {
 	g.reset_context_lookup_caches()
 	tc.file_imports['first.v\nmodel'] = 'second.model'
 	assert g.canonical_import_alias_type_in_file('model.Item', 'first.v').name() == 'second.model.Item'
+}
+
+fn test_unqualified_type_normalization_cache_preserves_spacing_and_nesting() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	mut g := FlatGen.new()
+	g.a = &a
+	g.tc = &tc
+	for input, expected in {
+		'&&int':                          '&&int'
+		'& ? []int':                      '&?[]int'
+		'[]map[ string ] []int':          '[]map[string][]int'
+		'Box[int,string]':                'Box[int, string]'
+		'Box[map[string][]int, ?string]': 'Box[map[string][]int, ?string]'
+		'[3]int':                         '[3]int'
+	} {
+		for file in ['one.v', 'two.v', 'one.v'] {
+			assert g.canonical_import_alias_type_text_in_file(input.clone(), file) == expected
+		}
+	}
+	assert g.import_type_cache.unqualified_texts.len > 0
+	assert g.import_type_cache.by_file.len == 0
+	g.reset_context_lookup_caches()
+	assert g.import_type_cache.unqualified_texts.len == 0
 }
 
 fn test_optional_payload_qualifies_interface() {

--- a/vlib/v3/gen/c/types_test.v
+++ b/vlib/v3/gen/c/types_test.v
@@ -6,6 +6,24 @@ import v3.parser
 import v3.pref
 import v3.types
 
+fn test_void_pointer_predicate_preserves_alias_and_named_type_rules() {
+	void_alias := types.Type(types.Alias{ name: 'Nothing', base_type: types.Type(types.void_) })
+	for typ in [types.Type(types.voidptr_), types.Type(types.Pointer{ base_type: void_alias }),
+		types.Type(types.Alias{ name: 'Opaque', base_type: types.Type(types.voidptr_) }),
+		types.Type(types.Alias{ name: 'voidptr', base_type: types.Type(types.int_) }),
+		types.Type(types.Struct{ name: 'voidptr' }), types.Type(types.Enum{ name: 'voidptr' }),
+		types.Type(types.Interface{ name: 'voidptr' }), types.Type(types.SumType{ name: 'voidptr' })] {
+		assert type_is_void_pointer(typ)
+	}
+	for typ in [types.Type(types.int_), types.Type(types.void_), void_alias,
+		types.Type(types.Pointer{ base_type: types.Type(types.voidptr_) }),
+		types.Type(types.Array{ elem_type: types.Type(types.voidptr_) }),
+		types.Type(types.Map{ key_type: types.Type(types.String{}), value_type: types.Type(types.voidptr_) }),
+		types.Type(types.FnType{ return_type: types.Type(types.voidptr_) })] {
+		assert !type_is_void_pointer(typ)
+	}
+}
+
 fn test_json_helper_scan_requires_legacy_json_module() {
 	mut ast := flat.FlatAst.new()
 	mut tc := types.TypeChecker.new(&ast)

--- a/vlib/v3/gen/c/types_test.v
+++ b/vlib/v3/gen/c/types_test.v
@@ -169,6 +169,70 @@ fn test_import_alias_type_text_uses_the_node_source_file() {
 	assert g.canonical_import_alias_type_text_in_file('&pref.Preferences', 'driver.v') == '&v3.pref.Preferences'
 	assert g.canonical_import_alias_type_text_in_file('map[string][]pref.Target', 'driver.v') == 'map[string][]v3.pref.Target'
 	assert g.canonical_import_alias_type_in_file('token.Pos', 'parser.v').name() == 'v3.token.Pos'
+	for _ in 0 .. 3 {
+		for file in ['driver.v', 'unrelated.v'] {
+			expected := if file == 'driver.v' {
+				'&v3.pref.Preferences'
+			} else {
+				'&v.pref.Preferences'
+			}
+			assert g.canonical_import_alias_type_text_in_file('&pref.Preferences'.clone(), file.clone()) == expected
+			assert g.canonical_import_alias_type_text_in_file(' &pref.Preferences ', file) == expected
+		}
+	}
+	assert g.canonical_import_alias_type_text_in_file(' &&int ', 'driver.v') == '&&int'
+	assert g.canonical_import_alias_type_text_in_file('map[ string ] []int', 'driver.v') == 'map[string][]int'
+	assert g.canonical_import_alias_type_text_in_file('Box[int,string]', 'driver.v') == 'Box[int, string]'
+}
+
+fn test_exact_import_type_lookup_uses_qualified_declaration_keys() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	mut g := FlatGen.new()
+	g.a = &a
+	g.tc = &tc
+	for module_name in ['dep.nested', 'main', 'builtin'] {
+		key := qualify_name_in_module(module_name, 'Item')
+		g.register_struct_decl_info('Item', key, module_name, '', flat.Node{
+			kind: .struct_decl
+			value: 'Item'
+		})
+		resolved := g.exact_known_import_type_text('${module_name}.Item') or { panic('missing declaration') }
+		assert resolved is types.Struct
+		assert resolved.name() == '${module_name}.Item'
+	}
+	assert g.exact_known_import_type_text('other.Item') == none
+	// The bare declaration now belongs to builtin, so it cannot satisfy main.
+	assert g.exact_known_import_type_text('main.Item') == none
+	tc.sum_types['dep.Value'] = ['int', 'string']
+	assert g.exact_known_import_type_text('dep.Value')? is types.SumType
+}
+
+fn test_import_type_cache_keeps_file_contexts_separate() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	tc.file_imports['first.v\nmodel'] = 'first.model'
+	tc.file_imports['second.v\nmodel'] = 'second.model'
+	tc.structs['first.model.Item'] = []types.StructField{}
+	tc.structs['second.model.Item'] = []types.StructField{}
+	mut g := FlatGen.new()
+	g.a = &a
+	g.tc = &tc
+	g.skip_generics = true
+	for _ in 0 .. 3 {
+		for file in ['first.v', 'second.v'] {
+			for typ in ['model.Item', '&model.Item', '[]model.Item', '?model.Item'] {
+				cached := g.canonical_import_alias_type_in_file(typ.clone(), file.clone())
+				uncached := g.canonical_import_alias_type_in_file_uncached(typ, file)
+				assert cached == uncached
+				assert cached.name().contains(file.all_before('.') + '.model.Item')
+			}
+		}
+	}
+	// A new generation must not retain types from the previous declaration table.
+	g.reset_context_lookup_caches()
+	tc.file_imports['first.v\nmodel'] = 'second.model'
+	assert g.canonical_import_alias_type_in_file('model.Item', 'first.v').name() == 'second.model.Item'
 }
 
 fn test_optional_payload_qualifies_interface() {

--- a/vlib/v3/gen/c/types_test.v
+++ b/vlib/v3/gen/c/types_test.v
@@ -291,6 +291,41 @@ fn test_unqualified_type_normalization_cache_preserves_spacing_and_nesting() {
 	assert g.import_type_cache.unqualified_texts.len == 0
 }
 
+fn test_import_alias_type_normalization_preserves_primitive_containers_and_named_types() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	tc.cur_file = 'driver.v'
+	tc.file_imports['driver.v\nmodel'] = 'app.model'
+	tc.structs['app.model.Item'] = []types.StructField{}
+	tc.structs['Box[int, string]'] = []types.StructField{}
+	mut g := FlatGen.new()
+	g.a = &a
+	g.tc = &tc
+	node := flat.Node{ kind: .ident }
+	for text in ['int', 'string', 'voidptr', '&&int', '?[]int', '!map[string][]u8', '[3]int'] {
+		typ := tc.parse_type(text)
+		assert g.canonical_import_alias_type_for_node(typ, &node) == typ
+		assert g.canonical_import_alias_type_text_in_file(typ.name(), 'driver.v') == typ.name()
+	}
+	for text, expected in {
+		'model.Item':      'app.model.Item'
+		'&model.Item':     '&app.model.Item'
+		'[]model.Item':    '[]app.model.Item'
+		'?model.Item':     '?app.model.Item'
+		'Box[int,string]': 'Box[int, string]'
+	} {
+		// Stale nominal spellings still require import and generic normalization.
+		typ := types.Type(types.Struct{ name: text })
+		assert g.canonical_import_alias_type_for_node(typ, &node).name() == expected
+	}
+	wrapped := types.Type(types.Array{
+		elem_type: types.Type(types.Pointer{
+			base_type: types.Type(types.Struct{ name: 'model.Item' })
+		})
+	})
+	assert g.canonical_import_alias_type_for_node(wrapped, &node).name() == '[]&app.model.Item'
+}
+
 fn test_optional_payload_qualifies_interface() {
 	mut ast := &flat.FlatAst{}
 	mut tc := types.TypeChecker.new(ast)

--- a/vlib/v3/markused/call_helpers_test.v
+++ b/vlib/v3/markused/call_helpers_test.v
@@ -1,0 +1,106 @@
+module markused
+
+import v3.flat
+import v3.types
+
+fn call_helper_node(mut a flat.FlatAst, node flat.Node, children []flat.NodeId) flat.NodeId {
+	start := a.children.len
+	for child in children {
+		a.add_child(child)
+	}
+	return a.add_node(flat.Node{
+		...node
+		children_start: start
+		children_count: children.len
+	})
+}
+
+fn test_join_path_helper_preserves_resolved_and_source_names() {
+	mut a := flat.FlatAst.new()
+	arg := a.add_node(flat.Node{ kind: .string_literal, value: 'part' })
+	spread := call_helper_node(mut a, flat.Node{ kind: .prefix, value: '...' }, [arg])
+	for base_name in ['', 'os', 'other'] {
+		base := a.add_node(flat.Node{ kind: .ident, value: base_name })
+		callee := if base_name == '' {
+			a.add_node(flat.Node{ kind: .ident, value: 'join_path' })
+		} else {
+			call_helper_node(mut a, flat.Node{ kind: .selector, value: 'join_path' }, [
+				base,
+			])
+		}
+		for resolved in ['', 'os.join_path'] {
+			for last_arg in [arg, spread] {
+				id := call_helper_node(mut a, flat.Node{ kind: .call }, [callee, arg, last_arg])
+				c := CallCollector{ a: &a }
+				mut calls := []string{}
+				c.collect_lowered_join_path_single(a.node(id), resolved, mut calls)
+				if last_arg == arg && (base_name != 'other' || resolved != '') {
+					assert calls == ['join_path_single', 'os.join_path_single']
+				} else {
+					assert calls.len == 0
+				}
+			}
+		}
+	}
+}
+
+fn test_omitted_parameter_defaults_skip_receiver_and_named_arguments() {
+	mut a := flat.FlatAst.new()
+	default_ident := a.add_node(flat.Node{ kind: .ident, value: 'default_level' })
+	default_call := call_helper_node(mut a, flat.Node{ kind: .call }, [default_ident])
+	field := call_helper_node(mut a, flat.Node{ kind: .field_decl, value: 'level', typ: 'int' }, [
+		default_call,
+	])
+	config := call_helper_node(mut a, flat.Node{ kind: .struct_decl, value: 'Config' }, [
+		field,
+	])
+	receiver := a.add_node(flat.Node{ kind: .param, value: 'self', typ: 'Receiver', op: .dot })
+	data := a.add_node(flat.Node{ kind: .param, value: 'data', typ: 'int' })
+	options := a.add_node(flat.Node{ kind: .param, value: 'options', typ: 'Config' })
+	decl := call_helper_node(mut a, flat.Node{ kind: .fn_decl, value: 'consume' }, [
+		receiver,
+		data,
+		options,
+	])
+	callee := a.add_node(flat.Node{ kind: .ident, value: 'consume' })
+	arg := a.add_node(flat.Node{ kind: .int_literal, value: '1' })
+	named := call_helper_node(mut a, flat.Node{ kind: .field_init, value: 'level' }, [
+		arg,
+	])
+	mut tc := types.TypeChecker.new(&a)
+	tc.fn_ret_types['default_level'] = types.Type(types.int_)
+	c := CallCollector{
+		a: &a
+		tc: &tc
+		fn_decls: {
+			'consume': FnDeclInfo{ node_id: decl }
+		}
+		struct_decls: {
+			'Config': StructDeclInfo{ node_id: config }
+		}
+		import_contexts: [map[string]string{}]
+	}
+	for last_arg in [named, arg] {
+		id := call_helper_node(mut a, flat.Node{ kind: .call }, [callee, arg, last_arg])
+		mut calls := []string{}
+		c.collect_omitted_params_default_calls(a.node(id), 'consume', '', map[string]string{}, mut calls)
+		assert ('default_level' in calls) == (last_arg == named)
+	}
+}
+
+fn test_call_search_distinguishes_leaf_index_and_nested_call() {
+	mut a := flat.FlatAst.new()
+	ident := a.add_node(flat.Node{ kind: .ident, value: 'data' })
+	index := call_helper_node(mut a, flat.Node{ kind: .index }, [ident, ident])
+	call := call_helper_node(mut a, flat.Node{ kind: .call }, [ident])
+	nested := call_helper_node(mut a, flat.Node{ kind: .selector, value: 'field' }, [
+		call,
+	])
+	c := CallCollector{ a: &a }
+	assert !c.expr_contains_call_or_index(ident)
+	assert !c.expr_contains_call(ident)
+	assert c.expr_contains_call_or_index(index)
+	assert !c.expr_contains_call(index)
+	assert c.expr_contains_call_or_index(nested)
+	assert c.expr_contains_call(nested)
+}

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -4886,6 +4886,13 @@ fn (c &CallCollector) expr_contains_call_or_index(id flat.NodeId) bool {
 	if int(id) < 0 {
 		return false
 	}
+	root := c.a.node(id)
+	if root.kind in [.call, .index] {
+		return true
+	}
+	if root.children_count == 0 {
+		return false
+	}
 	mut stack := [id]
 	for stack.len > 0 {
 		cur_id := stack.pop()
@@ -4905,6 +4912,13 @@ fn (c &CallCollector) expr_contains_call_or_index(id flat.NodeId) bool {
 
 fn (c &CallCollector) expr_contains_call(id flat.NodeId) bool {
 	if int(id) < 0 {
+		return false
+	}
+	root := c.a.node(id)
+	if root.kind == .call {
+		return true
+	}
+	if root.children_count == 0 {
 		return false
 	}
 	mut stack := [id]
@@ -6172,31 +6186,27 @@ fn (c &CallCollector) collect_top_level_selector_fallback(base &flat.Node, metho
 }
 
 fn (c &CallCollector) collect_lowered_join_path_single(call &flat.Node, resolved_call string, mut calls []string) {
-	mut call_names := []string{}
-	if resolved_call.len > 0 {
-		call_names << resolved_call
+	if call.children_count <= 2 {
+		return
 	}
-	if call.children_count > 0 {
+	mut is_join_path := resolved_call in ['join_path', 'os.join_path']
+	if !is_join_path {
 		callee_id := c.a.child(call, 0)
 		if int(callee_id) >= 0 {
 			callee := c.a.node(callee_id)
-			if callee.kind == .ident && callee.value.len > 0 {
-				call_names << callee.value
-			} else if callee.kind == .selector && callee.value.len > 0 && callee.children_count > 0 {
+			if callee.kind == .ident {
+				is_join_path = callee.value in ['join_path', 'os.join_path']
+			} else if callee.kind == .selector && callee.value == 'join_path'
+				&& callee.children_count > 0 {
 				base_id := c.a.child(callee, 0)
 				if int(base_id) >= 0 {
 					base := c.a.node(base_id)
-					if base.kind == .ident && base.value.len > 0 {
-						call_names << '${base.value}.${callee.value}'
-					}
+					is_join_path = base.kind == .ident && base.value == 'os'
 				}
 			}
 		}
 	}
-	if !call_names.any(it == 'join_path' || it == 'os.join_path') {
-		return
-	}
-	if call.children_count <= 2 {
+	if !is_join_path {
 		return
 	}
 	for i in 1 .. call.children_count {
@@ -8242,15 +8252,6 @@ fn (c &CallCollector) collect_omitted_params_default_calls(call &flat.Node, call
 	}
 	info := c.fn_decls[name] or { c.fn_decls[callee_name] or { return } }
 	fn_node := c.a.node(info.node_id)
-	mut param_type_texts := []string{}
-	for i in 0 .. fn_node.children_count {
-		p := c.a.child_node(fn_node, i)
-		// Skip the receiver parameter (op == .dot): it is the selector base, not a
-		// positional call argument.
-		if p.kind == .param && p.op != .dot {
-			param_type_texts << p.typ
-		}
-	}
 	// Count only positional arguments. Trailing named params
 	// (`compress(data, level: 3)`) are `field_init` children of the call, not
 	// positional arguments; counting them would make the trailing params struct
@@ -8263,12 +8264,19 @@ fn (c &CallCollector) collect_omitted_params_default_calls(call &flat.Node, call
 		}
 		provided++
 	}
-	if provided >= param_type_texts.len {
-		return
-	}
-	fn_imports := c.imports(info.import_context)
-	for i in provided .. param_type_texts.len {
-		c.collect_struct_default_calls_for_type(param_type_texts[i], info.module, fn_imports, mut calls)
+	// Visit only omitted parameter types; ordinary calls need no temporary
+	// signature array. Receiver and named-argument handling stays independent.
+	mut param_index := 0
+	for i in 0 .. fn_node.children_count {
+		p := c.a.child_node(fn_node, i)
+		// The receiver (op == .dot) is the selector base, not a positional argument.
+		if p.kind != .param || p.op == .dot {
+			continue
+		}
+		if param_index >= provided {
+			c.collect_struct_default_calls_for_type(p.typ, info.module, c.imports(info.import_context), mut calls)
+		}
+		param_index++
 	}
 }
 

--- a/vlib/v3/transform/ast_snapshot.v
+++ b/vlib/v3/transform/ast_snapshot.v
@@ -1,0 +1,49 @@
+module transform
+
+import v3.flat
+
+struct AstBufferSnapshot {
+	data    voidptr
+	address u64
+	bytes   u64
+}
+
+struct TransformCloneStorage {
+	scope    voidptr
+	nodes    AstBufferSnapshot
+	children AstBufferSnapshot
+}
+
+fn (t &Transformer) snapshot_ast_base(base_nodes int, base_children int) ?(&flat.FlatAst, TransformCloneStorage) {
+	nodes_cap := base_nodes + base_nodes / 4
+	children_cap := base_children + base_children / 4
+	node_snapshot := snapshot_ast_buffer(t.a.nodes.data, u64(base_nodes) * sizeof(flat.Node), u64(nodes_cap) * sizeof(flat.Node)) or { return none }
+	child_snapshot := snapshot_ast_buffer(t.a.children.data, u64(base_children) * sizeof(flat.NodeId), u64(children_cap) * sizeof(flat.NodeId)) or {
+		release_ast_buffer_snapshot(node_snapshot)
+		return none
+	}
+	mut nodes := []flat.Node{}
+	mut children := []flat.NodeId{}
+	// The mappings are owned by TransformCloneStorage. These array views have
+	// no managed-array header and may grow into normal arena allocations.
+	unsafe {
+		nodes.data = node_snapshot.data
+		nodes.len = base_nodes
+		nodes.cap = nodes_cap
+		nodes.flags = .nofree
+		children.data = child_snapshot.data
+		children.len = base_children
+		children.cap = children_cap
+		children.flags = .nofree
+	}
+	return t.ast_base_clone_with_storage(nodes, children), TransformCloneStorage{
+		nodes: node_snapshot
+		children: child_snapshot
+	}
+}
+
+fn release_transform_clone_storage(storage &TransformCloneStorage) {
+	release_ast_buffer_snapshot(storage.nodes)
+	release_ast_buffer_snapshot(storage.children)
+	transform_worker_scope_free(storage.scope)
+}

--- a/vlib/v3/transform/ast_snapshot_darwin.c.v
+++ b/vlib/v3/transform/ast_snapshot_darwin.c.v
@@ -1,0 +1,51 @@
+module transform
+
+#include <mach/mach.h>
+
+#include <mach/mach_vm.h>
+
+#include <unistd.h>
+
+fn C.mach_vm_allocate(target C.task_t, address &u64, size u64, flags int) int
+
+fn C.mach_vm_deallocate(target C.task_t, address u64, size u64) int
+
+fn C.mach_vm_remap(target C.task_t, address &u64, size u64, mask u64, flags int, source C.task_t, source_address u64, copy int, current_protection &int, max_protection &int, inheritance u32) int
+
+fn C.getpagesize() int
+
+fn snapshot_ast_buffer(data voidptr, len u64, capacity u64) ?AstBufferSnapshot {
+	if len == 0 || capacity < len || data == unsafe { nil } {
+		return none
+	}
+	page_size := u64(C.getpagesize())
+	source := u64(data)
+	offset := source % page_size
+	bytes := (capacity + offset + page_size - 1) / page_size * page_size
+	copy_bytes := (len + offset + page_size - 1) / page_size * page_size
+	task := C.mach_task_self()
+	mut address := u64(0)
+	if C.mach_vm_allocate(task, &address, bytes, C.VM_FLAGS_ANYWHERE) != 0 {
+		return none
+	}
+	reservation := address
+	mut current_protection := 0
+	mut max_protection := 0
+	// Only replace the prefix of our own reservation. copy=1 gives both source
+	// and worker independent writes while initially sharing physical pages.
+	if C.mach_vm_remap(task, &address, copy_bytes, 0, C.VM_FLAGS_FIXED | C.VM_FLAGS_OVERWRITE, task, source - offset, 1, &current_protection, &max_protection, C.VM_INHERIT_NONE) != 0 {
+		C.mach_vm_deallocate(task, reservation, bytes)
+		return none
+	}
+	return AstBufferSnapshot{
+		data: unsafe { voidptr(address + offset) }
+		address: address
+		bytes: bytes
+	}
+}
+
+fn release_ast_buffer_snapshot(snapshot AstBufferSnapshot) {
+	if snapshot.bytes > 0 {
+		C.mach_vm_deallocate(C.mach_task_self(), snapshot.address, snapshot.bytes)
+	}
+}

--- a/vlib/v3/transform/ast_snapshot_default.c.v
+++ b/vlib/v3/transform/ast_snapshot_default.c.v
@@ -1,0 +1,8 @@
+module transform
+
+fn snapshot_ast_buffer(data voidptr, len u64, capacity u64) ?AstBufferSnapshot {
+	return none
+}
+
+fn release_ast_buffer_snapshot(snapshot AstBufferSnapshot) {
+}

--- a/vlib/v3/transform/ast_snapshot_test.v
+++ b/vlib/v3/transform/ast_snapshot_test.v
@@ -1,0 +1,61 @@
+module transform
+
+import v3.flat
+import v3.types
+
+fn test_ast_snapshot_is_independent_and_can_grow() {
+	$if macos {
+		mut a := flat.FlatAst.new()
+		for _ in 0 .. 2048 {
+			id := a.add_node(flat.Node{ kind: .int_literal, value: 'source' })
+			a.add_child(id)
+		}
+		mut tc := types.TypeChecker.new(&a)
+		t := new_transformer(mut a, &tc, map[string]bool{})
+		mut first, first_storage := t.snapshot_ast_base(a.nodes.len, a.children.len) or {
+			panic('failed to snapshot AST')
+		}
+		mut second, second_storage := t.snapshot_ast_base(a.nodes.len, a.children.len) or {
+			panic('failed to snapshot AST')
+		}
+		defer {
+			release_transform_clone_storage(&first_storage)
+			release_transform_clone_storage(&second_storage)
+		}
+		a.nodes[0].value = 'master'
+		first.nodes[1].value = 'first'
+		second.nodes[2].value = 'second'
+		a.children[0] = flat.NodeId(3)
+		first.children[1] = flat.NodeId(4)
+		second.children[2] = flat.NodeId(5)
+		assert first.nodes[0].value == 'source'
+		assert second.nodes[0].value == 'source'
+		assert a.nodes[1].value == 'source'
+		assert second.nodes[1].value == 'source'
+		assert a.nodes[2].value == 'source'
+		assert first.nodes[2].value == 'source'
+		assert first.children[0] == flat.NodeId(0)
+		assert a.children[1] == flat.NodeId(1)
+		assert second.children[1] == flat.NodeId(1)
+		assert first.children[2] == flat.NodeId(2)
+		// Appends first use the private mapping, then grow into ordinary array
+		// storage. Neither path may change another view or free the mapping.
+		for _ in 0 .. 4096 {
+			id := first.add_node(flat.Node{ kind: .int_literal, value: 'appended' })
+			first.add_child(id)
+		}
+		assert first.nodes.len == 6144
+		assert first.nodes[1].value == 'first'
+		assert first.nodes.last().value == 'appended'
+		assert first.children.last() == flat.NodeId(6143)
+		assert a.nodes.len == 2048
+		assert second.nodes.len == 2048
+		assert second.nodes[2].value == 'second'
+	}
+}
+
+fn test_ast_snapshot_rejects_empty_or_inverted_ranges() {
+	assert snapshot_ast_buffer(unsafe { nil }, 0, 0) == none
+	value := u64(0)
+	assert snapshot_ast_buffer(&value, 8, 4) == none
+}

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -2476,6 +2476,14 @@ fn (t &Transformer) call_callee_fn_type(fn_id flat.NodeId) ?types.FnType {
 	return transform_fn_type(t.tc.resolve_type(fn_id))
 }
 
+fn (mut t Transformer) ensure_private_call_param_types_decl_cache() {
+	if t.call_param_types_decl_shared {
+		t.call_param_types_decl_cache = t.call_param_types_decl_cache.clone()
+		t.call_param_types_decl_misses = t.call_param_types_decl_misses.clone()
+		t.call_param_types_decl_shared = false
+	}
+}
+
 fn (mut t Transformer) call_param_types_from_decl(call_name string) ?[]types.Type {
 	if call_name.len == 0 || isnil(t.tc) {
 		return none
@@ -2485,6 +2493,7 @@ fn (mut t Transformer) call_param_types_from_decl(call_name string) ?[]types.Typ
 	}
 	t.ensure_call_param_types_decl_index()
 	decl := t.call_param_types_decl_index[call_name] or {
+		t.ensure_private_call_param_types_decl_cache()
 		t.call_param_types_decl_misses[call_name] = true
 		return none
 	}
@@ -2503,6 +2512,7 @@ fn (mut t Transformer) call_param_types_from_decl(call_name string) ?[]types.Typ
 		}
 		mut param_type := t.parse_decl_param_type(child.typ, decl.module, decl.file)
 		if param_type is types.Unknown || (param_type is types.Void && child.typ != 'void') {
+			t.ensure_private_call_param_types_decl_cache()
 			t.call_param_types_decl_misses[call_name] = true
 			return none
 		}
@@ -2514,6 +2524,7 @@ fn (mut t Transformer) call_param_types_from_decl(call_name string) ?[]types.Typ
 		}
 		params << param_type
 	}
+	t.ensure_private_call_param_types_decl_cache()
 	t.call_param_types_decl_cache[decl.idx] = params.clone()
 	return params
 }
@@ -2591,6 +2602,7 @@ fn (mut t Transformer) prepare_parallel_call_param_types() {
 		_ = t.call_param_types_from_decl(name) or { continue }
 	}
 	t.call_param_types_prepared = true
+	t.call_param_types_decl_shared = true
 }
 
 fn (mut t Transformer) add_call_param_types_decl_key(key string, idx int, file string, module_name string) {
@@ -2600,6 +2612,7 @@ fn (mut t Transformer) add_call_param_types_decl_key(key string, idx int, file s
 	// A later generic specialization can extend the declaration index between
 	// parallel batches. Make the next snapshot include its signature too.
 	t.call_param_types_prepared = false
+	t.ensure_private_call_param_types_decl_cache()
 	if key !in t.call_param_types_decl_index {
 		t.call_param_types_decl_index[key] = FnParamDeclRef{
 			idx: idx

--- a/vlib/v3/transform/fn_test.v
+++ b/vlib/v3/transform/fn_test.v
@@ -22,7 +22,9 @@ fn test_cloned_worker_merge_replays_relocated_children_and_body_roots() {
 		mut master := new_transformer(mut a, &tc, map[string]bool{})
 		base_nodes := a.nodes.len
 		base_children := a.children.len
+		clone_scope := transform_worker_scope_begin(true)
 		mut worker_ast := master.clone_ast_base(base_nodes, base_children)
+		transform_worker_scope_leave(clone_scope)
 		worker_tc := tc.fork_for_parallel_transform(worker_ast)
 		mut worker := master.fork_worker(worker_ast, worker_tc)
 		new_leaf := worker_ast.add_node(flat.Node{ kind: .int_literal, value: '2' })
@@ -66,6 +68,7 @@ fn test_cloned_worker_merge_replays_relocated_children_and_body_roots() {
 		}
 		master.merge_worker(worker, [FnWorkItem{ fn_idx: int(fn_id) }], base_nodes, base_children, false)
 		master.merge_regions_absorbed = false
+		transform_worker_scope_free(clone_scope)
 		assert a.children[base_slot] == merged_leaf
 		assert a.child(a.node(fn_id), 0) == merged_body
 		assert a.child(a.node(merged_body), 0) == leaf
@@ -95,6 +98,31 @@ fn test_parallel_split_balances_equal_cost_functions() {
 		}
 	}
 	assert seen.len == items.len
+}
+
+fn test_source_split_keeps_ranges_disjoint_with_uneven_costs() {
+	mut items := []FnWorkItem{}
+	for i in 0 .. 40 {
+		items << FnWorkItem{
+			fn_idx: 39 - i
+			cost: if i == 20 { 100 } else { 10 }
+		}
+	}
+	for jobs in [1, 4, 40, 50] {
+		chunks := split_work_items_by_source(items, jobs)
+		assert chunks.len == if jobs < 40 { jobs } else { 40 }
+		mut previous := -1
+		mut count := 0
+		for chunk in chunks {
+			assert chunk.len > 0
+			for item in chunk {
+				assert item.fn_idx == previous + 1
+				previous = item.fn_idx
+				count++
+			}
+		}
+		assert count == items.len
+	}
 }
 
 fn test_alias_receiver_index_preserves_integer_fallback_order() {
@@ -279,9 +307,9 @@ fn test_normalize_type_in_module_cache_tracks_current_file() {
 	}
 
 	t.cur_file = 'first.v'
-	assert t.normalize_type_in_module('dep.Type', 'shared') == 'alpha.Type'
+	assert t.normalize_type_in_module('dep.Type'.clone(), 'shared') == 'alpha.Type'
 	t.cur_file = 'second.v'
-	assert t.normalize_type_in_module('dep.Type', 'shared') == 'beta.Type'
+	assert t.normalize_type_in_module('dep.Type'.clone(), 'shared') == 'beta.Type'
 }
 
 fn test_flattened_generic_receiver_short_variants() {
@@ -588,6 +616,7 @@ fn test_parallel_worker_reuses_prebuilt_call_param_decl_index() {
 	t.prepare_parallel_call_param_types()
 	assert t.call_param_types_prepared
 	mut worker := t.fork_worker(t.a, t.tc)
+	mut sibling := t.fork_worker(t.a, t.tc)
 	assert worker.call_param_types_index_ready
 	assert worker.call_param_types_prepared
 	assert worker.call_param_types_decl_index.len == t.call_param_types_decl_index.len
@@ -598,6 +627,17 @@ fn test_parallel_worker_reuses_prebuilt_call_param_decl_index() {
 	}
 	assert params.len == 1
 	assert params[0] is types.String
+	assert worker.call_param_types_decl_shared
+	assert worker.call_param_types_from_decl('worker_missing') == none
+	assert !worker.call_param_types_decl_shared
+	assert !t.call_param_types_decl_misses['worker_missing']
+	assert !sibling.call_param_types_decl_misses['worker_missing']
+	assert t.call_param_types_from_decl('master_missing') == none
+	assert !t.call_param_types_decl_shared
+	assert !worker.call_param_types_decl_misses['master_missing']
+	assert !sibling.call_param_types_decl_misses['master_missing']
+	assert sibling.call_param_types_from_decl('sibling_missing') == none
+	assert !t.call_param_types_decl_misses['sibling_missing']
 	t.add_call_param_types_decl_key('main.takes_string', a.nodes.len - 1, 'signature_index_test.v', 'main')
 	assert !t.call_param_types_prepared
 }
@@ -707,6 +747,20 @@ fn test_multi_return_selector_suffix_does_not_match_free_fn() {
 		return
 	}
 	assert items.len == 2
+
+	tc.fn_ret_types['pair'] = types.Type(types.MultiReturn{
+		types: [types.Type(types.bool_), types.Type(types.bool_)]
+	})
+	tc.fn_ret_types['Other.pair'] = types.Type(types.MultiReturn{
+		types: [types.Type(types.int_), types.Type(types.int_), types.Type(types.int_)]
+	})
+	t.receiver_method_suffix_index['pair'] = receiver_method_suffix_ambiguous
+	t.collect_multi_return_fn_ret_types()
+	ambiguous_pair := t.find_multi_return_call_types(call, 2) or { panic('missing pair') }
+	assert ambiguous_pair == [types.Type(types.int_), types.Type(types.string_)]
+	triple := t.find_multi_return_call_types(call, 3) or { panic('missing triple') }
+	assert triple.len == 3
+	assert t.find_multi_return_call_types(call, 4) == none
 }
 
 fn test_qualify_or_storage_type_resolves_imported_generic_base_only() {
@@ -803,4 +857,86 @@ fn test_transform_lane_budget_bounds_base_ast_clones() {
 	assert transform_clone_budget_jobs(8, 9_000_000_000) == 1
 	assert transform_clone_budget_jobs(18, 1) == 18
 	assert transform_clone_budget_jobs(1, 9_000_000_000) == 1
+}
+
+fn test_merged_resolution_cache_initializes_gaps_and_preserves_entries() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	mut t := new_transformer(mut a, &tc, map[string]bool{})
+	t.set_resolved_call_entry(1, 'main.first')
+	t.set_resolved_fn_value_entry(2, 'main.callback')
+	t.set_resolved_call_entry(4096, 'main.last')
+	t.set_resolved_fn_value_entry(8192, 'main.final_callback')
+	assert tc.resolved_call_names[1] == 'main.first'
+	assert tc.resolved_call_set[1]
+	assert tc.resolved_call_names[4096] == 'main.last'
+	assert tc.resolved_call_set[4096]
+	assert tc.resolved_fn_value_names[2] == 'main.callback'
+	assert tc.resolved_fn_value_set[2]
+	assert tc.resolved_fn_value_names[8192] == 'main.final_callback'
+	assert tc.resolved_fn_value_set[8192]
+	for i in 3 .. 4096 {
+		assert tc.resolved_call_names[i] == ''
+		assert !tc.resolved_call_set[i]
+		assert tc.resolved_fn_value_names[i] == ''
+		assert !tc.resolved_fn_value_set[i]
+	}
+}
+
+fn test_alias_cache_distinguishes_collisions_and_owned_spellings() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	tc.structs['abc.Def'] = []
+	tc.structs['axc.Dof'] = []
+	t := Transformer{
+		tc: &tc
+		alias_cache: &AliasCache{}
+	}
+	// These distinct spellings share the sampled bytes used for the cache slot.
+	for _ in 0 .. 3 {
+		for name in ['abc.Def', 'axc.Dof'] {
+			assert t.normalize_type_alias(name.clone()) == name
+			assert t.normalize_type_alias(name.clone()) == name
+		}
+	}
+}
+
+fn test_node_type_memo_reuses_capacity_when_function_range_grows() {
+	mut t := Transformer{}
+	t.begin_node_type_memo(0, 127)
+	values := t.node_type_memo.values.data
+	filled := t.node_type_memo.filled.data
+	t.node_type_memo.filled[0] = 1
+	t.begin_node_type_memo(200, 263)
+	t.node_type_memo.filled[0] = 1
+	t.begin_node_type_memo(400, 495)
+	assert t.node_type_memo.values.len == 96
+	assert t.node_type_memo.filled.len == 96
+	assert t.node_type_memo.values.data == values
+	assert t.node_type_memo.filled.data == filled
+	for flag in t.node_type_memo.filled {
+		assert flag == 0
+	}
+}
+
+fn test_unchanged_node_text_still_invalidates_semantic_memos() {
+	mut a := flat.FlatAst.new()
+	idx := int(a.add_node(flat.Node{ kind: .ident, value: 'value', typ: 'int' }))
+	mut tc := types.TypeChecker.new(&a)
+	tc.expr_type_set = []bool{len: a.nodes.len}
+	mut t := new_transformer(mut a, &tc, map[string]bool{})
+	t.begin_node_type_memo(idx, idx)
+	for change_type in [true, false] {
+		tc.expr_type_set[idx] = true
+		t.node_type_memo.filled[0] = 1
+		if change_type {
+			t.set_node_typ(idx, 'int'.clone())
+		} else {
+			t.set_node_value(idx, 'value'.clone())
+		}
+		assert !tc.expr_type_set[idx]
+		assert t.node_type_memo.filled[0] == 0
+		assert a.nodes[idx].typ == 'int'
+		assert a.nodes[idx].value == 'value'
+	}
 }

--- a/vlib/v3/transform/sum.v
+++ b/vlib/v3/transform/sum.v
@@ -132,8 +132,7 @@ fn (t &Transformer) resolve_sum_name(sum_name string) string {
 	}
 	recent_slot := alias_cache_slot(sum_name)
 	if c.recent_generations[recent_slot] == c.recent_generation
-		&& unsafe { c.recent_types[recent_slot].str == sum_name.str }
-		&& c.recent_types[recent_slot].len == sum_name.len {
+		&& same_transform_text(c.recent_types[recent_slot], sum_name) {
 		return c.recent_results[recent_slot]
 	}
 	if cached := c.entries[sum_name] {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -156,7 +156,7 @@ mut:
 	tc_signature_names_log        []string
 	generated_capture_contexts    []string
 	struct_maps_shared            bool
-	multi_return_fn_ret_types     map[string]types.Type
+	multi_return_fn_ret_types     map[string][]types.Type
 	receiver_method_suffix_index  map[string]string
 	declared_fn_name_counts       map[string]u8
 	variadic_suffix_index         map[string]i8
@@ -268,6 +268,7 @@ mut:
 	comptime_reflected_for_ready  bool
 	call_param_types_decl_cache   map[int][]types.Type
 	call_param_types_decl_misses  map[string]bool
+	call_param_types_decl_shared  bool
 	call_param_types_decl_index   map[string]FnParamDeclRef
 	call_param_types_index_ready  bool
 	call_param_types_prepared     bool
@@ -512,13 +513,21 @@ mut:
 	recent_results     [1024]string
 	recent_generations [1024]u32
 	canonical_types    [1024]string
-	canonical_results  [1024]string
 	entries            map[string]string
 }
 
-@[inline]
+// Sample text bytes so separately allocated copies can hit the same slot.
+// Every lookup still compares the complete spelling to handle collisions.
+@[direct_array_access; inline]
 fn alias_cache_slot(typ string) int {
-	return int((u64(voidptr(typ.str)) >> 4 ^ u64(typ.len)) & 1023)
+	if typ.len == 0 {
+		return 0
+	}
+	mut hash := u32(typ.len)
+	hash = (hash * 16777619) ^ u32(typ[0])
+	hash = (hash * 16777619) ^ u32(typ[typ.len / 2])
+	hash = (hash * 16777619) ^ u32(typ[typ.len - 1])
+	return int(hash & 1023)
 }
 
 // trimmed_transform_text avoids allocating a substring for the overwhelmingly
@@ -1954,10 +1963,19 @@ fn (mut t Transformer) collect_multi_return_fn_ret_types() {
 	if isnil(t.tc) {
 		return
 	}
-	t.multi_return_fn_ret_types = map[string]types.Type{}
+	t.multi_return_fn_ret_types = map[string][]types.Type{}
 	for name, ret_type in t.tc.fn_ret_types {
-		if type_contains_multi_return(ret_type) {
-			t.multi_return_fn_ret_types[name] = ret_type
+		if !type_contains_multi_return(ret_type) {
+			continue
+		}
+		// Preserve declaration-map order for ambiguous matches. A leading dot
+		// indexes methods only; a bare suffix also includes the exact free name.
+		t.multi_return_fn_ret_types[name] << ret_type
+		for i, ch in name {
+			if ch == `.` {
+				t.multi_return_fn_ret_types[name[i..]] << ret_type
+				t.multi_return_fn_ret_types[name[i + 1..]] << ret_type
+			}
 		}
 	}
 }
@@ -2119,12 +2137,17 @@ fn (mut t Transformer) rewrite_two_children_in_place(id flat.NodeId, first flat.
 fn (mut t Transformer) set_node_typ(idx int, typ string) {
 	if t.base_write_allowed(idx) {
 		t.invalidate_node_type_memo(idx)
-		t.a.nodes[idx].typ = typ
-		t.a.nodes[idx].set_type_text_id(0)
-		t.mark_scoped_owned_base_node(idx)
 		if !isnil(t.tc) {
 			t.tc.invalidate_checked_expr_type(idx)
 		}
+		// Child rewrites still invalidate the semantic caches even when the
+		// stored text already matches. Avoid publishing another identical write.
+		if t.a.nodes[idx].type_text_id() == 0 && same_transform_text(t.a.nodes[idx].typ, typ) {
+			return
+		}
+		t.a.nodes[idx].typ = typ
+		t.a.nodes[idx].set_type_text_id(0)
+		t.mark_scoped_owned_base_node(idx)
 		return
 	}
 	if t.defer_oor_writes {
@@ -2140,11 +2163,14 @@ fn (mut t Transformer) set_node_typ(idx int, typ string) {
 fn (mut t Transformer) set_node_value(idx int, value string) {
 	if t.base_write_allowed(idx) {
 		t.invalidate_node_type_memo(idx)
-		t.a.nodes[idx].value = value
-		t.mark_scoped_owned_base_node(idx)
 		if !isnil(t.tc) {
 			t.tc.invalidate_checked_expr_type(idx)
 		}
+		if same_transform_text(t.a.nodes[idx].value, value) {
+			return
+		}
+		t.a.nodes[idx].value = value
+		t.mark_scoped_owned_base_node(idx)
 		return
 	}
 	if t.defer_oor_writes {
@@ -3646,6 +3672,10 @@ fn (t &Transformer) allocate_ast_base_clone(base_nodes int, base_children int) &
 		nodes.grow_len(base_nodes)
 		children.grow_len(base_children)
 	}
+	return t.ast_base_clone_with_storage(nodes, children)
+}
+
+fn (t &Transformer) ast_base_clone_with_storage(nodes []flat.Node, children []flat.NodeId) &flat.FlatAst {
 	return &flat.FlatAst{
 		nodes: nodes
 		children: children
@@ -3963,12 +3993,19 @@ fn (t &Transformer) fork_program_view(ast &flat.FlatAst, wtc &types.TypeChecker,
 		comptime_field_metas_cache: map[string][]FieldMeta{}
 		comptime_reflected_for_roles: t.comptime_reflected_for_roles
 		comptime_reflected_for_ready: t.comptime_reflected_for_ready
-		// Late scoped workers can discover parameter signatures for generic
-		// declarations added after the parallel pre-scan. Keep those recursive
-		// Type values worker-local: their payloads belong to the worker arena and
-		// must not outlive it through the master's shared cache.
-		call_param_types_decl_cache: t.call_param_types_decl_cache.clone()
-		call_param_types_decl_misses: t.call_param_types_decl_misses.clone()
+		// Prepared signatures are immutable. A worker detaches these maps if
+		// late generic declarations require a new, scratch-owned cache entry.
+		call_param_types_decl_cache: if t.call_param_types_decl_shared {
+			t.call_param_types_decl_cache
+		} else {
+			t.call_param_types_decl_cache.clone()
+		}
+		call_param_types_decl_misses: if t.call_param_types_decl_shared {
+			t.call_param_types_decl_misses
+		} else {
+			t.call_param_types_decl_misses.clone()
+		}
+		call_param_types_decl_shared: t.call_param_types_decl_shared
 		call_param_types_decl_index: t.call_param_types_decl_index
 		call_param_types_index_ready: t.call_param_types_index_ready
 		call_param_types_prepared: t.call_param_types_prepared
@@ -4655,9 +4692,18 @@ fn (mut t Transformer) set_resolved_call_entry(idx int, name string) {
 		t.tc.sparse_resolved_call_names[idx] = t.tc.canonical_symbol(name)
 		return
 	}
-	for t.tc.resolved_call_names.len <= idx {
-		t.tc.resolved_call_names << ''
-		t.tc.resolved_call_set << false
+	if t.tc.resolved_call_names.len <= idx {
+		start := t.tc.resolved_call_names.len
+		set_start := t.tc.resolved_call_set.len
+		amount := idx + 1 - start
+		// Merging an appended worker region can leave a large gap. Initialize
+		// that range once instead of growing both caches one element at a time.
+		unsafe {
+			t.tc.resolved_call_names.grow_len(amount)
+			t.tc.resolved_call_set.grow_len(amount)
+			vmemset(&t.tc.resolved_call_names[start], 0, isize(amount) * isize(sizeof(string)))
+			vmemset(&t.tc.resolved_call_set[set_start], 0, isize(amount))
+		}
 	}
 	t.tc.resolved_call_names[idx] = t.tc.canonical_symbol(name)
 	t.tc.resolved_call_set[idx] = true
@@ -4682,9 +4728,18 @@ fn (mut t Transformer) set_resolved_fn_value_entry(idx int, name string) {
 		t.tc.sparse_resolved_fn_values[idx] = t.tc.canonical_symbol(name)
 		return
 	}
-	for t.tc.resolved_fn_value_names.len <= idx {
-		t.tc.resolved_fn_value_names << ''
-		t.tc.resolved_fn_value_set << false
+	if t.tc.resolved_fn_value_names.len <= idx {
+		start := t.tc.resolved_fn_value_names.len
+		set_start := t.tc.resolved_fn_value_set.len
+		amount := idx + 1 - start
+		// Merging an appended worker region can leave a large gap. Initialize
+		// that range once instead of growing both caches one element at a time.
+		unsafe {
+			t.tc.resolved_fn_value_names.grow_len(amount)
+			t.tc.resolved_fn_value_set.grow_len(amount)
+			vmemset(&t.tc.resolved_fn_value_names[start], 0, isize(amount) * isize(sizeof(string)))
+			vmemset(&t.tc.resolved_fn_value_set[set_start], 0, isize(amount))
+		}
 	}
 	t.tc.resolved_fn_value_names[idx] = t.tc.canonical_symbol(name)
 	t.tc.resolved_fn_value_set[idx] = true
@@ -4825,6 +4880,36 @@ fn split_work_items(items []FnWorkItem, n int) [][]FnWorkItem {
 		buckets[bi].sort(a.fn_idx < b.fn_idx)
 	}
 	return buckets
+}
+
+// Keep each self-host worker's writes in adjacent source pages so snapshots
+// copy a page for its owning worker instead of for many scattered writers.
+fn split_work_items_by_source(items []FnWorkItem, n int) [][]FnWorkItem {
+	if items.len == 0 || n <= 0 {
+		return [][]FnWorkItem{}
+	}
+	count := if n < items.len { n } else { items.len }
+	mut ordered := items.clone()
+	ordered.sort(a.fn_idx < b.fn_idx)
+	mut total := i64(0)
+	for item in ordered {
+		total += i64(item.cost) + 1
+	}
+	mut chunks := [][]FnWorkItem{cap: count}
+	mut consumed := i64(0)
+	mut start := 0
+	for ci in 0 .. count {
+		target := total * i64(ci + 1) / i64(count)
+		mut end := start
+		limit := ordered.len - (count - ci - 1)
+		for end < limit && (consumed < target || end == start || ci == count - 1) {
+			consumed += i64(ordered[end].cost) + 1
+			end++
+		}
+		chunks << ordered[start..end]
+		start = end
+	}
+	return chunks
 }
 
 // should_transform_fn reports whether should transform fn applies in transform.
@@ -14858,17 +14943,9 @@ fn (t &Transformer) find_multi_return_call_types(node flat.Node, expected_count 
 		return none
 	}
 	for candidate in candidates {
-		suffix := if candidate.starts_with('.') { candidate } else { '.${candidate}' }
-		for key, ret in t.multi_return_fn_ret_types {
-			matches := if candidate.starts_with('.') {
-				key.ends_with(suffix)
-			} else {
-				key == candidate || key.ends_with(suffix)
-			}
-			if matches {
-				if items := multi_return_types_from_type(ret, expected_count) {
-					return items
-				}
+		for ret in t.multi_return_fn_ret_types[candidate] {
+			if items := multi_return_types_from_type(ret, expected_count) {
+				return items
 			}
 		}
 	}
@@ -22283,8 +22360,7 @@ fn (t &Transformer) variant_short_name(name string) string {
 	mut cache := t.variant_short_name_cache
 	recent_slot := alias_cache_slot(name)
 	if cache.recent_generations[recent_slot] == cache.recent_generation
-		&& unsafe { cache.recent_types[recent_slot].str == name.str }
-		&& cache.recent_types[recent_slot].len == name.len {
+		&& same_transform_text(cache.recent_types[recent_slot], name) {
 		return cache.recent_results[recent_slot]
 	}
 	if cached := cache.entries[name] {

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -33,6 +33,7 @@ const shared_expansion_pool_divisor = 2
 const max_parallel_monomorph_jobs = 18
 // Recycle scratch arenas throughout large self-hosting transforms.
 const scoped_transform_batches = 8
+const scoped_selfhost_transform_batches = 4
 const scoped_transform_max_batch_items = 2048
 const scoped_monomorph_batch_specs = 512
 const scoped_monomorph_node_threshold = 1_000_000
@@ -113,6 +114,12 @@ $if !windows {
 		a := unsafe { &RegionAbsorbArgs(arg) }
 		mut w := unsafe { &Transformer(a.worker) }
 		w.absorb_region_into(a.node_start, a.node_end, a.child_start, a.child_end, a.node_shift, a.child_shift, a.dst_nodes, a.dst_children)
+		return unsafe { nil }
+	}
+
+	fn transform_clone_storage_free_thread(arg voidptr) voidptr {
+		storage := unsafe { &TransformCloneStorage(arg) }
+		release_transform_clone_storage(storage)
 		return unsafe { nil }
 	}
 
@@ -232,7 +239,8 @@ $if !windows {
 		mut w := unsafe { &Transformer(a.worker) }
 		items := unsafe { &[]FnWorkItem(a.items_ptr) }
 		if w.scope_parallel_workers && w.retain_worker_results {
-			w.transform_scoped_helper_batches(*items, 1)
+			batches := if w.building_v { scoped_selfhost_transform_batches } else { 1 }
+			w.transform_scoped_helper_batches(*items, batches)
 		} else {
 			w.transform_pure_items_serial(*items)
 		}
@@ -2260,15 +2268,15 @@ fn (mut t Transformer) run_parallel_transform(items []FnWorkItem, base_nodes int
 		t.tc.freeze_type_cache_for_forks()
 		// Every clone is ready before dispatch. Equal loads avoid the old spawn
 		// chain's startup bias leaving early workers with much more body work.
-		mut chunks := split_work_items(items, n_jobs)
+		mut chunks := if t.building_v && t.scope_parallel_workers {
+			split_work_items_by_source(items, n_jobs)
+		} else {
+			split_work_items(items, n_jobs)
+		}
 		chunk_count := chunks.len
 
-		// chunk[0] is transformed by the master on this thread, directly against the
-		// master AST — no clone. Only chunks[1..] get helper threads, each with a
-		// private AST clone + forked TypeChecker. This removes one full base-AST clone
-		// from the peak (each clone is ~one nodes-array; under -gc none they are never
-		// freed, so they also inflate the later cgen peak) and keeps the master thread,
-		// which would otherwise block in join, doing useful work.
+		// The caller transforms chunk[0] directly in the master AST. Helpers own
+		// private base containers, released after their results have been merged.
 		thread_count := chunk_count - 1
 		mut transform_workers := []voidptr{cap: thread_count}
 		mut args := []TransformChunkArgs{cap: chunk_count}
@@ -2277,9 +2285,22 @@ fn (mut t Transformer) run_parallel_transform(items []FnWorkItem, base_nodes int
 			items_ptr: unsafe { voidptr(&chunks[0]) }
 		}
 		mut worker_asts := []&flat.FlatAst{cap: thread_count}
+		mut clone_storage := []TransformCloneStorage{cap: thread_count}
 		mut copies := []TransformByteCopy{cap: thread_count * 2}
 		for _ in 0 .. thread_count {
+			if t.scope_parallel_workers && t.building_v {
+				if wast, storage := t.snapshot_ast_base(base_nodes, base_children) {
+					worker_asts << wast
+					clone_storage << storage
+					continue
+				}
+			}
+			// Base containers are temporary. Worker payloads are allocated and
+			// promoted outside this arena and survive after merge releases it.
+			clone_scope := transform_worker_scope_begin(t.scope_parallel_workers)
 			wast := t.allocate_ast_base_clone(base_nodes, base_children)
+			transform_worker_scope_leave(clone_scope)
+			clone_storage << TransformCloneStorage{ scope: clone_scope }
 			worker_asts << wast
 			copies << TransformByteCopy{
 				dst: wast.nodes.data
@@ -2344,6 +2365,17 @@ fn (mut t Transformer) run_parallel_transform(items []FnWorkItem, base_nodes int
 			// populated this range. Publish only the relocated worker annotations.
 			t.merge_worker(ww, chunks[ci + 1], base_nodes, base_children, false)
 		}
+		mut free_tasks := []workers.Task{cap: clone_storage.len}
+		for ci, storage in clone_storage {
+			if storage.scope != unsafe { nil } || storage.nodes.bytes > 0 {
+				free_tasks << workers.Task{
+					run: transform_clone_storage_free_thread
+					arg: unsafe { voidptr(&clone_storage[ci]) }
+					force_sync: ci == 0
+				}
+			}
+		}
+		t.a.worker_pool.run(free_tasks)
 		t.merge_regions_absorbed = false
 		t.merge_regions_relocated = false
 		t.tc.unfreeze_type_cache_after_forks()
@@ -2354,6 +2386,7 @@ fn (mut t Transformer) run_parallel_transform(items []FnWorkItem, base_nodes int
 fn (mut t Transformer) mark_parallel_worker_maps_shared() {
 	t.signature_maps_shared = true
 	t.struct_maps_shared = true
+	t.call_param_types_decl_shared = true
 	if !isnil(t.tc) {
 		mut master_tc := unsafe { &types.TypeChecker(voidptr(t.tc)) }
 		master_tc.transform_signature_maps_shared = true
@@ -2913,6 +2946,7 @@ fn (mut t Transformer) prepare_with_pre_scans() {
 			_ = index_thread.wait()
 			t.call_param_types_decl_cache = param_w.call_param_types_decl_cache.move()
 			t.call_param_types_decl_misses = param_w.call_param_types_decl_misses.move()
+			t.call_param_types_decl_shared = true
 			t.call_param_types_decl_index = param_w.call_param_types_decl_index.move()
 			t.call_param_types_index_ready = param_w.call_param_types_index_ready
 			t.call_param_types_prepared = param_w.call_param_types_prepared

--- a/vlib/v3/transform/type_propagation.v
+++ b/vlib/v3/transform/type_propagation.v
@@ -28,12 +28,12 @@ fn (mut t Transformer) begin_node_type_memo(lo int, hi int) {
 		memo.filled = []u8{len: n}
 	} else {
 		if n <= memo.values.len {
-			memo.values = memo.values[..n]
-			memo.filled = memo.filled[..n]
+			memo.values.trim(n)
+			memo.filled.trim(n)
 		} else {
 			unsafe {
-				memo.values.grow_len(n)
-				memo.filled.grow_len(n)
+				memo.values.grow_len(n - memo.values.len)
+				memo.filled.grow_len(n - memo.filled.len)
 			}
 		}
 		if n > 0 {
@@ -1140,9 +1140,8 @@ fn (t &Transformer) normalize_type_alias(typ string) string {
 	}
 	mut c := t.alias_cache
 	recent_slot := alias_cache_slot(typ)
-	if c.canonical_types[recent_slot].len == typ.len
-		&& unsafe { c.canonical_types[recent_slot].str == typ.str } {
-		return c.canonical_results[recent_slot]
+	if same_transform_text(c.canonical_types[recent_slot], typ) {
+		return c.canonical_types[recent_slot]
 	}
 	if !same_transform_text(c.module, t.cur_module) || !same_transform_text(c.file, t.cur_file) {
 		c.module = t.cur_module
@@ -1151,8 +1150,7 @@ fn (t &Transformer) normalize_type_alias(typ string) string {
 		c.clear_recent()
 	}
 	if c.recent_generations[recent_slot] == c.recent_generation
-		&& unsafe { c.recent_types[recent_slot].str == typ.str }
-		&& c.recent_types[recent_slot].len == typ.len {
+		&& same_transform_text(c.recent_types[recent_slot], typ) {
 		return c.recent_results[recent_slot]
 	}
 	if cached := c.entries[typ] {
@@ -1163,7 +1161,6 @@ fn (t &Transformer) normalize_type_alias(typ string) string {
 		c.entries[typ] = fast
 		c.put_recent(typ, fast)
 		c.canonical_types[recent_slot] = typ
-		c.canonical_results[recent_slot] = fast
 		return fast
 	}
 	result := t.normalize_type_alias_uncached(typ)
@@ -1485,8 +1482,7 @@ fn (t &Transformer) normalize_type_in_module(typ string, mod string) string {
 	}
 	recent_slot := alias_cache_slot(typ)
 	if cache.recent_generations[recent_slot] == cache.recent_generation
-		&& unsafe { cache.recent_types[recent_slot].str == typ.str }
-		&& cache.recent_types[recent_slot].len == typ.len {
+		&& same_transform_text(cache.recent_types[recent_slot], typ) {
 		return cache.recent_results[recent_slot]
 	}
 	if cached := cache.entries[typ] {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -1152,9 +1152,9 @@ pub fn TypeChecker.new(a &flat.FlatAst) TypeChecker {
 // a fresh map, while a synchronous subview may keep recording in its owning
 // checker's private map. Keeping this constructor explicit prevents a
 // newly-added mutable field from being silently shared by parallel workers.
-fn (tc &TypeChecker) fork_program_view(ast &flat.FlatAst, direct_dependencies_by_fn map[int][]SymbolId) TypeChecker {
+fn (tc &TypeChecker) fork_program_view(ast &flat.FlatAst, direct_dependencies_by_fn map[int][]SymbolId) &TypeChecker {
 	fs := new_scope(tc.file_scope)
-	return TypeChecker{
+	return &TypeChecker{
 		a: ast
 		compiler_vroot: tc.compiler_vroot
 		raw_type_equality: tc.raw_type_equality
@@ -1355,13 +1355,13 @@ pub fn (tc &TypeChecker) fork_for_parallel_codegen() &TypeChecker {
 		// Never share the memo across threads; each fork owns a private one.
 		forked.qualify_name_cache = &QualifyNameCache{}
 	}
-	return &forked
+	return forked
 }
 
 // fork_type_parse_view creates a lookup-only view in an explicit source
 // context. It shares the compilation's immutable indexes, interner, and
 // synchronous memoization cache, but none of the caller's function state.
-fn (tc &TypeChecker) fork_type_parse_view(file string, module_name string) TypeChecker {
+fn (tc &TypeChecker) fork_type_parse_view(file string, module_name string) &TypeChecker {
 	mut view := tc.fork_program_view(tc.a, map[int][]SymbolId{})
 	view.cur_file = file
 	view.cur_module = module_name
@@ -1377,7 +1377,7 @@ fn (tc &TypeChecker) fork_type_parse_view(file string, module_name string) TypeC
 // a synchronous expression-type query while owning every mutable map it may
 // consult. This avoids inheriting unrelated checker state through a whole
 // struct copy.
-fn (tc &TypeChecker) fork_smartcast_query_view() TypeChecker {
+fn (tc &TypeChecker) fork_smartcast_query_view() &TypeChecker {
 	// This query is synchronous, so any dependency it discovers remains owned
 	// by the current master/worker checker rather than crossing worker threads.
 	mut view := tc.fork_program_view(tc.a, tc.direct_dependencies_by_fn)
@@ -1455,7 +1455,7 @@ pub fn (tc &TypeChecker) fork_for_parallel_transform(ast &flat.FlatAst) &TypeChe
 		ierror_compat_entries: map[string]int{}
 		source_error_embed_entries: map[string]int{}
 	}
-	return &forked
+	return forked
 }
 
 // ensure_private_transform_signatures detaches the signature tables before a
@@ -4989,17 +4989,40 @@ pub fn (tc &TypeChecker) parse_resolution_type(typ string) Type {
 	}
 	mut unscoped := tc.fork_type_parse_view(tc.cur_file, '')
 	unscoped.resolution_type_mode = false
-	view := &unscoped
-	views.by_file[tc.cur_file] = view
-	return view.parse_type(qualified)
+	views.by_file[tc.cur_file] = unscoped
+	return unscoped.parse_type(qualified)
 }
 
 // parse_resolution_type_in_file resolves type text using the imports and module
 // of `file` without mutating the checker's current traversal cursor.
 pub fn (tc &TypeChecker) parse_resolution_type_in_file(typ string, file string) Type {
+	if context_independent_type_text(typ) {
+		return tc.parse_type(typ)
+	}
 	module_name := tc.file_modules[file] or { '' }
 	mut scoped := tc.fork_type_parse_view(file, module_name)
 	return scoped.parse_resolution_type(typ)
+}
+
+// Primitive payloads and their pointer/array/optional wrappers cannot refer
+// to a declaration's imports. Keep them out of the checker-view constructor.
+@[manualfree]
+fn context_independent_type_text(typ string) bool {
+	mut start := 0
+	for start < typ.len {
+		if typ[start] in [`&`, `?`, `!`] {
+			start++
+		} else if typ[start] == `[` && start + 1 < typ.len && typ[start + 1] == `]` {
+			start += 2
+		} else {
+			break
+		}
+	}
+	if typ.len - start > 7 {
+		return false
+	}
+	leaf := unsafe { typ.substr_unsafe(start, typ.len) }
+	return leaf != 'array' && leaf != 'map' && is_builtin_type_name(leaf)
 }
 
 // reset_resolution_type_view_cache discards lookup views that may have been

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -5011,6 +5011,9 @@ pub fn (tc &TypeChecker) parse_resolution_type_in_file(typ string, file string) 
 // to a declaration's imports. Keep them out of the checker-view constructor.
 @[manualfree]
 fn context_independent_type_text(typ string) bool {
+	if typ in ['', '!', '?'] {
+		return true
+	}
 	mut start := 0
 	for start < typ.len {
 		if typ[start] in [`&`, `?`, `!`] {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -5005,7 +5005,7 @@ pub fn (tc &TypeChecker) parse_resolution_type_in_file(typ string, file string) 
 	return scoped.parse_resolution_type(typ)
 }
 
-// Primitive payloads and their pointer/array/optional wrappers cannot refer
+// Primitive payloads and their pointer/container/optional wrappers cannot refer
 // to a declaration's imports. Keep them out of the checker-view constructor.
 @[manualfree]
 fn context_independent_type_text(typ string) bool {
@@ -5015,6 +5015,26 @@ fn context_independent_type_text(typ string) bool {
 			start++
 		} else if typ[start] == `[` && start + 1 < typ.len && typ[start + 1] == `]` {
 			start += 2
+		} else if typ[start] == `[` {
+			mut end := start + 1
+			for end < typ.len && typ[end] >= `0` && typ[end] <= `9` {
+				end++
+			}
+			if end == start + 1 || end >= typ.len || typ[end] != `]` {
+				return false
+			}
+			start = end + 1
+		} else if start + 4 < typ.len && typ[start] == `m` && typ[start + 1] == `a`
+			&& typ[start + 2] == `p` && typ[start + 3] == `[` {
+			end := find_matching_bracket(typ, start + 3)
+			if end >= typ.len {
+				return false
+			}
+			key := unsafe { typ.substr_unsafe(start + 4, end) }
+			if !context_independent_type_text(key) {
+				return false
+			}
+			start = end + 1
 		} else {
 			break
 		}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -1221,6 +1221,8 @@ fn (tc &TypeChecker) fork_program_view(ast &flat.FlatAst, direct_dependencies_by
 		interface_fields: tc.interface_fields
 		interface_embeds: tc.interface_embeds
 		interface_abstract_methods: tc.interface_abstract_methods
+		interface_impl_name_snapshots: tc.interface_impl_name_snapshots
+		interface_impl_candidates_at_snapshot: tc.interface_impl_candidates_at_snapshot
 		interface_impl_candidates_at_index: tc.interface_impl_candidates_at_index
 		interface_method_names_index: tc.interface_method_names_index
 		interface_abstract_index: tc.interface_abstract_index

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -1712,6 +1712,7 @@ fn (mut tc TypeChecker) init_direct_parent_index(a &flat.FlatAst) {
 	tc.has_goto_nodes = false
 }
 
+@[direct_array_access]
 fn (mut tc TypeChecker) fill_direct_parent_edges(a &flat.FlatAst) {
 	mut fn_cost := 0
 	for parent_idx, node in a.nodes {

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -2789,7 +2789,7 @@ fn (tc &TypeChecker) fork_for_parallel_check() &TypeChecker {
 		w.symbols = new_symbol_interner()
 		w.type_cache.base = unsafe { nil }
 	}
-	return &w
+	return w
 }
 
 // precomputed_check_cache returns the immutable indexes warmed before the

--- a/vlib/v3/types/checker_tail.v
+++ b/vlib/v3/types/checker_tail.v
@@ -4636,6 +4636,20 @@ fn (mut tc TypeChecker) record_uninferred_generic_method_type(id flat.NodeId, no
 }
 
 fn (mut tc TypeChecker) record_empty_array_generic_call_errors(node flat.Node, info CallInfo) bool {
+	// Most calls cannot produce this diagnostic. Avoid resolving their generic
+	// declarations unless an argument is actually an untyped empty array.
+	mut has_empty_array := false
+	for i in 1 .. node.children_count {
+		arg_id := tc.call_arg_value(tc.a.child(&node, i))
+		arg := tc.a.node(arg_id)
+		if arg.kind == .array_literal && arg.children_count == 0 && arg.typ.len == 0 {
+			has_empty_array = true
+			break
+		}
+	}
+	if !has_empty_array {
+		return false
+	}
 	if tc.call_has_explicit_generic_type_args(node) {
 		return false
 	}
@@ -15822,6 +15836,9 @@ fn generic_variadic_elem_param_text(param_text string) string {
 }
 
 fn (tc &TypeChecker) parse_fn_signature_type(name string, typ string) Type {
+	if context_independent_type_text(typ) {
+		return tc.parse_type(typ)
+	}
 	decl_file := tc.fn_type_files[name] or { return tc.parse_type(typ) }
 	decl_module := tc.fn_type_modules[name] or { tc.file_modules[decl_file] or { tc.cur_module } }
 	mut scoped := tc.fork_type_parse_view(decl_file, decl_module)

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -13202,6 +13202,9 @@ fn (tc &TypeChecker) parse_alias_type(name string, target string) Type {
 
 fn (tc &TypeChecker) parse_alias_target_type(name string, target string) Type {
 	clean := trimmed_space(target)
+	if context_independent_type_text(target) {
+		return tc.parse_type(target)
+	}
 	if clean.starts_with('shared ') {
 		return Type(Pointer{
 			base_type: tc.parse_alias_target_type(name, trimmed_space(clean[7..]))

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -13304,6 +13304,13 @@ pub fn (tc &TypeChecker) type_count() int {
 // type. Hot compiler paths should prefer this to repeated recursive Type.name
 // construction.
 pub fn (tc &TypeChecker) type_name(t Type) string {
+	has_literal_name := match t {
+		Primitive, Void, Unknown, Nil, None, String, Char, Rune, ISize, USize { true }
+		else { false }
+	}
+	if has_literal_name {
+		return t.name()
+	}
 	// Stored-name variants are free; interning them would only add hashing on
 	// top of returning the field.
 	if t is Struct {
@@ -16421,7 +16428,20 @@ fn (tc &TypeChecker) c_extern_abi_type(t Type) string {
 	return tc.c_type(t)
 }
 
+// c_type returns the C representation of a semantic type.
 pub fn (tc &TypeChecker) c_type(t Type) string {
+	// These representations are constant or depend only on primitive flags.
+	// Interning a collection recursively walks its element types even though
+	// every dynamic array/map/channel uses the same C container.
+	has_simple_c_type := match t {
+		Primitive, Void, Unknown, Nil, None, String, Char, Rune, ISize, USize, Array, Channel, Map {
+			true
+		}
+		else { false }
+	}
+	if has_simple_c_type {
+		return tc.c_type_uncached(t)
+	}
 	if tc.type_cache == unsafe { nil } || isnil(tc.type_interner) {
 		return tc.c_type_uncached(t)
 	}

--- a/vlib/v3/types/generic_placeholder_test.v
+++ b/vlib/v3/types/generic_placeholder_test.v
@@ -23,3 +23,36 @@ fn test_type_text_generic_placeholder_prescreen_keeps_results() {
 	assert tc.type_text_has_unbound_generic_placeholder('map[K]V', ['V'])
 	assert !tc.type_text_has_unbound_generic_placeholder('map[string]int', [])
 }
+
+fn test_empty_array_generic_diagnostic_prescreen() {
+	mut a := flat.FlatAst.new()
+	callee := a.add_val(.ident, 'consume')
+	empty := a.add_node(flat.Node{ kind: .array_literal })
+	typed := a.add_node(flat.Node{ kind: .array_literal, typ: '[]int' })
+	value := a.add_val(.int_literal, '1')
+	wrapped_start := a.begin_children()
+	a.add_child(empty)
+	wrapped := a.add_node(flat.Node{
+		kind: .field_init
+		children_start: wrapped_start
+		children_count: 1
+	})
+	mut tc := TypeChecker.new(&a)
+	tc.diagnose_unknown_calls = true
+	tc.fn_generic_params['consume'] = ['T']
+	for arg in [value, typed, empty, wrapped] {
+		start := a.begin_children()
+		a.add_child(callee)
+		a.add_child(arg)
+		call := flat.Node{ kind: .call, children_start: start, children_count: 2 }
+		tc.errors.clear()
+		found := tc.record_empty_array_generic_call_errors(call, CallInfo{ name: 'consume' })
+		assert found == (arg == empty || arg == wrapped)
+		assert tc.errors.len == if found { 1 } else { 0 }
+		if found {
+			assert tc.errors[0].msg == 'cannot use empty array as generic argument'
+		}
+		// The same argument is not a generic-argument error for an ordinary function.
+		assert !tc.record_empty_array_generic_call_errors(call, CallInfo{ name: 'ordinary' })
+	}
+}

--- a/vlib/v3/types/interface_impl_test.v
+++ b/vlib/v3/types/interface_impl_test.v
@@ -61,6 +61,27 @@ fn test_stable_interface_type_ids_preserve_existing_ids_after_late_collisions() 
 	assert after['Tnndxrxb'] != before['Twvlzleh']
 }
 
+fn test_codegen_fork_keeps_frozen_interface_ids_after_late_collision() {
+	mut a := flat.FlatAst.new()
+	mut tc := TypeChecker.new(&a)
+	tc.interface_names['Any'] = true
+	tc.structs['Twvlzleh'] = []StructField{}
+	tc.prepare_interface_query_indexes()
+	tc.freeze_pre_transform_interface_impl_names()
+	before := tc.interface_type_ids('Any')
+
+	// The late name sorts first, but must not take the frozen type's ID.
+	tc.structs['Tnndxrxb'] = []StructField{}
+	tc.invalidate_short_type_name_index()
+	tc.clear_interface_impl_cache()
+	expected := tc.interface_type_ids('Any')
+	assert expected['Twvlzleh'] == before['Twvlzleh']
+	assert expected['Tnndxrxb'] != expected['Twvlzleh']
+	worker := tc.fork_for_parallel_codegen()
+	assert worker.interface_type_ids('Any') == expected
+	assert worker.interface_impl_names('Any') == tc.interface_impl_names('Any')
+}
+
 fn test_short_type_name_ambiguity_remains_sticky() {
 	mut index := map[string]string{}
 	index_short_type_name('first.Event', mut index)

--- a/vlib/v3/types/scope.v
+++ b/vlib/v3/types/scope.v
@@ -45,7 +45,11 @@ fn scope_name_bit(name string) u64 {
 
 @[inline]
 fn scope_fast_slot(name string) int {
-	return int(((u64(voidptr(name.str)) >> 4) ^ u64(name.len)) & 31)
+	// Identical identifiers often come from different source allocations.
+	if name.len == 0 {
+		return 0
+	}
+	return int((u32(name[0]) * 11 + u32(name[name.len - 1]) * 2 + u32(name.len) * 3) & 31)
 }
 
 @[direct_array_access; inline]
@@ -53,8 +57,9 @@ fn (s &Scope) own_binding_index(name string) ?int {
 	if s.fast_lookup {
 		slot := scope_fast_slot(name)
 		if s.fast_generations[slot] == s.fast_generation
-			&& s.fast_name_ptrs[slot] == voidptr(name.str)
-			&& s.fast_name_lens[slot] == u16(name.len) {
+			&& s.fast_name_lens[slot] == name.len
+			&& (s.fast_name_ptrs[slot] == voidptr(name.str)
+				|| s.names[int(s.fast_indexes[slot])] == name) {
 			return int(s.fast_indexes[slot])
 		}
 	}

--- a/vlib/v3/types/scope_test.v
+++ b/vlib/v3/types/scope_test.v
@@ -1,0 +1,35 @@
+module types
+
+fn test_scope_lookup_keeps_binding_identity_for_copied_names_and_collisions() {
+	mut parent := new_scope(unsafe { nil })
+	parent.insert('value', Type(string_))
+	mut scope := new_scope(parent)
+	scope.fast_lookup = true
+	original := 'value'.clone()
+	owner := scope.insert_with_owner(original, Type(int_))
+	copy := original.clone()
+	assert voidptr(original.str) != voidptr(copy.str)
+	assert scope.lookup(copy)? == Type(int_)
+	assert scope.nearest_binding_owned_by(copy, owner)
+	assert scope.lookup_owner(copy)?.storage_key() == owner.storage_key()
+
+	// More bindings than cache slots exercise collisions and map fallback.
+	for i in 0 .. 100 {
+		scope.insert('item_${i}', Type(bool_))
+	}
+	for i in 0 .. 100 {
+		assert scope.lookup('item_${i}')? == Type(bool_)
+	}
+	assert scope.lookup(copy)? == Type(int_)
+	updated := scope.insert_with_owner(copy, Type(bool_))
+	assert updated.storage_key() == owner.storage_key()
+	assert scope.lookup(original)? == Type(bool_)
+
+	scope.reset(parent)
+	assert scope.lookup(original)? == Type(string_)
+	assert !scope.nearest_binding_owned_by(original, owner)
+	replacement := scope.insert_with_owner(copy, Type(int_))
+	assert replacement.storage_key() != owner.storage_key()
+	assert scope.lookup(original)? == Type(int_)
+	assert scope.nearest_binding_owned_by(original, replacement)
+}

--- a/vlib/v3/types/type_cache_test.v
+++ b/vlib/v3/types/type_cache_test.v
@@ -52,7 +52,7 @@ fn test_parse_resolution_type_in_file_does_not_require_an_active_file_cursor() {
 	assert tc.parse_resolution_type_in_file('token.Pos', 'parser.v').name() == 'v3.token.Pos'
 	tc.fn_type_files['parser.read'] = 'parser.v'
 	tc.fn_type_modules['parser.read'] = 'parser'
-	for text in ['int', 'bool', 'string', 'voidptr', '&[]u8', '?int', '![]string'] {
+	for text in ['', '!', '?', 'int', 'bool', 'string', 'voidptr', '&[]u8', '?int', '![]string'] {
 		fresh := tc.fork_type_parse_view('parser.v', 'parser')
 		expected := fresh.parse_resolution_type(text)
 		assert tc.parse_resolution_type_in_file(text, 'parser.v') == expected

--- a/vlib/v3/types/type_cache_test.v
+++ b/vlib/v3/types/type_cache_test.v
@@ -73,6 +73,30 @@ fn test_parse_thread_type_qualifies_concrete_payloads() {
 	assert tc.parse_type('thread T').name() == 'thread T'
 }
 
+fn test_alias_target_parsing_preserves_declaration_module() {
+	a := flat.FlatAst.new()
+	mut tc := TypeChecker.new(&a)
+	tc.cur_module = 'caller'
+	tc.cur_file = 'caller.v'
+	tc.type_alias_modules['dep.Alias'] = 'dep'
+	tc.structs['caller.Item'] = []StructField{}
+	tc.structs['dep.Item'] = []StructField{}
+	for text in ['int', 'string', ' &[]u8 ', '?int', '![]string', 'shared int', 'Item', '&Item'] {
+		fresh := tc.fork_type_parse_view('caller.v', 'dep')
+		expected := if text == 'shared int' {
+			Type(Pointer{ base_type: Type(int_) })
+		} else {
+			fresh.parse_type(text)
+		}
+		parsed := tc.parse_alias_type('dep.Alias', text)
+		assert parsed is Alias
+		assert parsed.name == 'dep.Alias'
+		assert parsed.base_type == expected
+	}
+	assert tc.parse_alias_target_type('dep.Alias', 'Item').name() == 'dep.Item'
+	assert tc.cur_module == 'caller'
+}
+
 fn test_parse_resolution_fn_type_preserves_nested_main_type_lock() {
 	a := flat.FlatAst.new()
 	mut tc := TypeChecker.new(&a)

--- a/vlib/v3/types/type_cache_test.v
+++ b/vlib/v3/types/type_cache_test.v
@@ -97,6 +97,32 @@ fn test_alias_target_parsing_preserves_declaration_module() {
 	assert tc.cur_module == 'caller'
 }
 
+fn test_context_independent_container_types_match_declaration_views() {
+	a := flat.FlatAst.new()
+	mut tc := TypeChecker.new(&a)
+	tc.cur_file = 'caller.v'
+	tc.cur_module = 'caller'
+	tc.file_modules['dep.v'] = 'dep'
+	tc.type_alias_modules['dep.Alias'] = 'dep'
+	tc.fn_type_files['dep.read'] = 'dep.v'
+	tc.fn_type_modules['dep.read'] = 'dep'
+	for text in ['map[string]int', '?map[string][]u8', '[]map[int]&string', '[32]u8', '&[2][3]int',
+		'map[[4]u8][]map[string]bool'] {
+		assert context_independent_type_text(text)
+		fresh := tc.fork_type_parse_view('dep.v', 'dep')
+		expected := fresh.parse_resolution_type(text)
+		assert tc.parse_resolution_type_in_file(text, 'dep.v') == expected
+		assert tc.fn_signature_type('dep.read', text) == expected
+		alias_typ := tc.parse_alias_type('dep.Alias', text)
+		assert alias_typ is Alias
+		assert alias_typ.base_type == fresh.parse_type(text)
+	}
+	for text in ['map', 'array', 'map[string]Item', 'map[Key]int', 'map[string]int ', '[size]int',
+		'[2 + 3]int', '[0x10]int', 'map[string', '[2', '[2]'] {
+		assert !context_independent_type_text(text)
+	}
+}
+
 fn test_parse_resolution_fn_type_preserves_nested_main_type_lock() {
 	a := flat.FlatAst.new()
 	mut tc := TypeChecker.new(&a)

--- a/vlib/v3/types/type_cache_test.v
+++ b/vlib/v3/types/type_cache_test.v
@@ -50,6 +50,15 @@ fn test_parse_resolution_type_in_file_does_not_require_an_active_file_cursor() {
 	tc.cur_module = ''
 
 	assert tc.parse_resolution_type_in_file('token.Pos', 'parser.v').name() == 'v3.token.Pos'
+	tc.fn_type_files['parser.read'] = 'parser.v'
+	tc.fn_type_modules['parser.read'] = 'parser'
+	for text in ['int', 'bool', 'string', 'voidptr', '&[]u8', '?int', '![]string'] {
+		fresh := tc.fork_type_parse_view('parser.v', 'parser')
+		expected := fresh.parse_resolution_type(text)
+		assert tc.parse_resolution_type_in_file(text, 'parser.v') == expected
+		assert tc.fn_signature_type('parser.read', text) == expected
+	}
+	assert tc.fn_signature_type('parser.read', 'token.Pos').name() == 'v3.token.Pos'
 }
 
 fn test_parse_thread_type_qualifies_concrete_payloads() {


### PR DESCRIPTION
Uncached V3 C-backend self-hosting spends substantial time allocating temporary lookup data and copying AST storage for parallel transforms. This reduces the measured non-CC time to **516–529 ms** and peak memory to **1.67–1.69 GB**.

- Use copy-on-write AST snapshots on macOS, bound transform clone memory, and release worker scratch storage after merging. Other platforms use ordinary AST copies.
- Reduce repeated type parsing, normalization, signature lookups, and source-file reads. Preserve frozen interface dispatch IDs when forking checker views.
- Allocate empty map storage on demand and reserve its final metadata in one allocation.
- Avoid allocating unobservable map-guard errors in the legacy C backend used to bootstrap the production compiler. Guards whose errors are read retain their existing behavior.

Measured on an 18-core Apple Silicon Mac, using a legacy bootstrap with `-gc none -prealloc -prod`, then running the full executable self-host with `-nocache -building-v -o v4 v3.v`. Non-CC time is the reported total minus CC time.

| Build | Non-CC time | Peak memory |
| --- | ---: | ---: |
| Master baseline (`741027d462`) | 664–823 ms | 4,416–4,421 MB |
| This change, four runs | 516–529 ms | 1,674–1,687 MB |

The candidate median was 523 ms; peak memory fell by about 62%. The branch also incorporates `7006be5e41`, including adapting its new FastC statistics call to the indexed line counter. A final full self-host on the PR commit measured 524.93 ms excluding CC, 133.87 ms transform, and 1,682 MB peak memory.

Validation:

- Full legacy compiler suite: 2,345 passed, 28 skipped. Four PATH-dependent language-server failures passed on rerun with `v` available. The remaining three failures reproduce before the change: arm64 assembly constraints, a C-output fixture requiring the V3 backend, and V3 assertion-format fixtures run through the legacy backend.
- Compiler diagnostics: 1,699 passed, one skipped; eight comptime checks passed. Focused guard/map/option C-output fixtures: seven passed, one skipped.
- Targeted builtin map, V3 type/scope, transform snapshot, worker-lifetime, C-generation, source-statistics, and upstream virtual-module tests passed. Map checks passed with autofree and AddressSanitizer. Snapshot checks passed with and without preallocation and under AddressSanitizer.
- Repeated full V3→V4 self-hosts passed. The generated V4 compiled and ran the map deletion/reservation regression suite; production V3 passed borrowed/escaping method-value and sum-variant regressions.

The guard C-output expectation intentionally changes from an allocated error to the existing static `none` marker. No CLI or language behavior change is intended. Known pre-existing V3 scoped-checker/storage and legacy JSON integration failures remain unchanged; `test-all` was not run.
