### PR TITLE
v3: accept `-ldflags` and append it to the link command

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -1793,27 +1793,27 @@ fn safe_default_bin_file_name(filename string) string {
 }
 
 struct V3CCompilerFlagOptions {
-	environment_c_flags  []string
-	environment_ld_flags []string
-	target_args          []string
-	link_c_standard      string
-	dependencies         []string
-	warn_args            []string
-	vroot                string
-	target_os            string
-	target_arch          string
-	macos_sdk_root       string
-	pic_flag             string
-	is_prod              bool
-	no_prod_options      bool
-	is_shared            bool
-	parallel_cc          bool
-	large_c_unit         bool
-	limit_inlining       bool
-	explicit_tcc         bool
-	is_c_debug           bool
-	is_o                 bool
-	is_liveshared        bool
+	environment_c_flags []string
+	link_ld_flags       []string
+	target_args         []string
+	link_c_standard     string
+	dependencies        []string
+	warn_args           []string
+	vroot               string
+	target_os           string
+	target_arch         string
+	macos_sdk_root      string
+	pic_flag            string
+	is_prod             bool
+	no_prod_options     bool
+	is_shared           bool
+	parallel_cc         bool
+	large_c_unit        bool
+	limit_inlining      bool
+	explicit_tcc        bool
+	is_c_debug          bool
+	is_o                bool
+	is_liveshared       bool
 }
 
 struct V3CCompilerFlagPlan {
@@ -2353,7 +2353,7 @@ fn v3_c_compiler_flag_plan(options V3CCompilerFlagOptions) V3CCompilerFlagPlan {
 	mut after_inputs := options.dependencies.clone()
 	add_v3_default_linker_flags(mut after_inputs, options.target_os, options.is_o)
 	if !options.is_o {
-		after_inputs << options.environment_ld_flags
+		after_inputs << options.link_ld_flags
 	}
 	return V3CCompilerFlagPlan{
 		before_inputs: before_inputs
@@ -2608,7 +2608,7 @@ fn write_v3_crun_cache_marker(bin_file string, build_identity string) ! {
 	}
 }
 
-fn v3_crun_build_identity(state &V3ModuleCacheState, prefs &pref.Preferences, user_files []string, user_c_flags []string, is_strict bool, enable_globals bool, direct_vsh string) string {
+fn v3_crun_build_identity(state &V3ModuleCacheState, prefs &pref.Preferences, user_files []string, user_c_flags []string, link_ld_flags []string, is_strict bool, enable_globals bool, direct_vsh string) string {
 	direct_vsh_path := os.real_path(direct_vsh)
 	mut source_paths := map[string]bool{}
 	for file in user_files {
@@ -2639,6 +2639,7 @@ fn v3_crun_build_identity(state &V3ModuleCacheState, prefs &pref.Preferences, us
 		is_strict.str(),
 		enable_globals.str(),
 		user_c_flags.join('\x00'),
+		link_ld_flags.join('\x00'),
 		source_signature,
 		prefs.vhash,
 		prefs.vcurrent_hash,
@@ -2690,7 +2691,7 @@ fn v3_crun_build_identity(state &V3ModuleCacheState, prefs &pref.Preferences, us
 }
 
 fn cli_usage() string {
-	return 'usage: v3 [run|test] <file.v|directory> [options]\n' + '  -o <output>                 output binary or C file\n' + '  -b <c|fastc|arm64|wasm|eval> backend\n' + '  -os <name> -arch <name>     target platform\n' + '  -cc <compiler>               C compiler executable\n' + '  -thread-stack-size <bytes>   spawned-thread stack size\n' + '  -prod -c99 -shared -strict  C build modes\n' + '  -v                           verbose stage profiling\n' + '  -silent                      suppress benchmark output\n' + '  -showcc                      print C compiler commands\n' + '  -profile [file]              write V1-compatible function profile data\n' + '  -profile-fns <names>         profile only named functions and their callees\n' + '  -profile-no-inline           omit @[inline] functions from the profile\n' + '  -no-memory-limit             disable the 10176 MiB user-build memory safety limit\n' + '  -d <name>                    compile-time define'
+	return 'usage: v3 [run|test] <file.v|directory> [options]\n' + '  -o <output>                 output binary or C file\n' + '  -b <c|fastc|arm64|wasm|eval> backend\n' + '  -os <name> -arch <name>     target platform\n' + '  -cc <compiler>               C compiler executable\n' + '  -cflags <flags>              extra C compiler options\n' + '  -ldflags <flags>             extra options appended to the link command\n' + '  -thread-stack-size <bytes>   spawned-thread stack size\n' + '  -prod -c99 -shared -strict  C build modes\n' + '  -v                           verbose stage profiling\n' + '  -silent                      suppress benchmark output\n' + '  -showcc                      print C compiler commands\n' + '  -profile [file]              write V1-compatible function profile data\n' + '  -profile-fns <names>         profile only named functions and their callees\n' + '  -profile-no-inline           omit @[inline] functions from the profile\n' + '  -no-memory-limit             disable the 10176 MiB user-build memory safety limit\n' + '  -d <name>                    compile-time define'
 }
 
 fn shared_library_postfix(target_os string) string {
@@ -7655,7 +7656,8 @@ fn v3_driver_option_requires_value(option string) bool {
 }
 
 fn v3_driver_option_consumes_value(option string) bool {
-	return v3_driver_option_requires_value(option) || option in ['-cflags', '-dump-c-flags']
+	return v3_driver_option_requires_value(option) || option in ['-cflags', '-ldflags',
+		'-dump-c-flags']
 }
 
 fn apply_v3_diagnostic_color_option(option string) {
@@ -7737,7 +7739,7 @@ $if !skip_fastc ? {
 		return os.join_path_single(canonical_parent, os.file_name(absolute_path))
 	}
 
-	fn compile_v3_fastc_source(pieces []string, units fastc.FastcUnitLayout, bin_file string, prefs &pref.Preferences, environment_c_flags []string, source_c_flags []string, user_c_flags []string, environment_ld_flags []string, macos_sdk_root string, is_debug bool, uses_threads bool, cache_enabled bool, mut prestarted fastc.FastcPrestartedCUnits) V3FastCCompileResult {
+	fn compile_v3_fastc_source(pieces []string, units fastc.FastcUnitLayout, bin_file string, prefs &pref.Preferences, environment_c_flags []string, source_c_flags []string, user_c_flags []string, link_ld_flags []string, macos_sdk_root string, is_debug bool, uses_threads bool, cache_enabled bool, mut prestarted fastc.FastcPrestartedCUnits) V3FastCCompileResult {
 		bench_phases := os.getenv('FASTC_BENCH_PHASES') != ''
 		cc_sw := time.new_stopwatch()
 		tcc_dir := os.join_path(prefs.vroot, 'thirdparty', 'tcc')
@@ -7841,7 +7843,7 @@ $if !skip_fastc ? {
 		if atomic_arg.len > 0 {
 			final_args << atomic_arg
 		}
-		final_args << environment_ld_flags
+		final_args << link_ld_flags
 		generation_link_cache_key := fastc.fastc_generation_link_cache_key(tcc_path, compile_args, final_args, pieces, units, jobs, cache_enabled)
 		if fastc.fastc_restore_link_cache(generation_link_cache_key, staged_binary) {
 			if bench_phases {
@@ -8115,6 +8117,7 @@ pub fn run(args []string) {
 	mut user_defines := []string{}
 	mut compile_values := map[string]string{}
 	mut user_c_flags := []string{}
+	mut user_ld_flags := []string{}
 	mut should_run := false
 	mut is_direct_vsh := false
 	mut is_test_command := false
@@ -8158,8 +8161,8 @@ pub fn run(args []string) {
 			eprintln('option `${args[i]}` requires a value')
 			exit(1)
 		}
-		if args[i] == '-cflags' && i + 1 >= args.len {
-			eprintln('option `-cflags` requires a value')
+		if args[i] in ['-cflags', '-ldflags'] && i + 1 >= args.len {
+			eprintln('option `${args[i]}` requires a value')
 			exit(1)
 		}
 		if args[i] == 'run' && input_file.len == 0 && !should_run {
@@ -8361,6 +8364,15 @@ pub fn run(args []string) {
 			}
 			user_c_flags << parsed_c_flags
 			i += 2
+		} else if args[i] == '-ldflags' && i + 1 < args.len {
+			// Linker-only options; unlike `-cflags` they are never passed to the
+			// per-object C compilations, only appended to the final link command.
+			parsed_ld_flags := cmdexec.split_args(args[i + 1]) or {
+				eprintln('invalid `-ldflags` value: ${err.msg()}')
+				exit(1)
+			}
+			user_ld_flags << parsed_ld_flags
+			i += 2
 		} else if args[i] in ['-g', '-cg', '-cdebug'] {
 			is_debug = true
 			if args[i] in ['-cg', '-cdebug'] {
@@ -8542,6 +8554,10 @@ pub fn run(args []string) {
 		// `-no-bounds-checking`, matching the established parser contract.
 		user_defines = user_defines.filter(it.all_before('=').trim_space() != 'no_bounds_checking')
 	}
+	// `-ldflags` comes after the ambient `LDFLAGS`, so an explicitly passed option
+	// wins, exactly like V1 orders `env_ldflags` before the `-ldflags` value.
+	mut link_ld_flags := environment_ld_flags.clone()
+	link_ld_flags << user_ld_flags
 	if is_prof && backend !in ['c', 'fastc'] {
 		eprintln('option `-profile` is only supported by the C backend')
 		exit(1)
@@ -9195,7 +9211,7 @@ pub fn run(args []string) {
 			} else {
 				''
 			}
-			fastc_result := compile_v3_fastc_source(fastc_pieces, fastc_generation.units, fastc_bin_file, prefs, environment_c_flags, fastc_generation.c_flags, user_c_flags, environment_ld_flags, fastc_sdk_root, is_debug, fastc_generation.uses_threads, prefs.building_v && !is_debug && !no_cache && !fastc_bench, mut prestarted_fastc_units)
+			fastc_result := compile_v3_fastc_source(fastc_pieces, fastc_generation.units, fastc_bin_file, prefs, environment_c_flags, fastc_generation.c_flags, user_c_flags, link_ld_flags, fastc_sdk_root, is_debug, fastc_generation.uses_threads, prefs.building_v && !is_debug && !no_cache && !fastc_bench, mut prestarted_fastc_units)
 			if (!silent || show_cc) && fastc_result.command.len > 0 {
 				if c_to_stdout {
 					eprintln('  > ${fastc_result.command}')
@@ -9649,7 +9665,7 @@ pub fn run(args []string) {
 			mut crun_c_flags := user_c_flags.clone()
 			crun_c_flags << cgen.cache_directive_flags(a, prefs.vroot, prefs.target, prefs.compile_values)
 			_ = prepare_v3_cache_external_inputs_scoped(mut cache_state, a, prefs, user_files, crun_c_flags, scope_prealloc_stages)
-			crun_build_identity = v3_crun_build_identity(&cache_state, prefs, user_files, crun_c_flags, is_strict, enable_globals_compat, input_file)
+			crun_build_identity = v3_crun_build_identity(&cache_state, prefs, user_files, crun_c_flags, link_ld_flags, is_strict, enable_globals_compat, input_file)
 			if crun_build_identity.len > 0 {
 				os.setenv(v3_crun_build_identity_env, crun_build_identity, true)
 			}
@@ -11243,7 +11259,7 @@ pub fn run(args []string) {
 		}
 		c_flag_plan := v3_c_compiler_flag_plan(V3CCompilerFlagOptions{
 			environment_c_flags: environment_c_flags
-			environment_ld_flags: environment_ld_flags
+			link_ld_flags: link_ld_flags
 			target_args: target_args
 			link_c_standard: link_c_standard
 			dependencies: resolved_c_flags
@@ -11807,7 +11823,7 @@ pub fn run(args []string) {
 			tcc_args << resolved_c_flags
 			add_v3_default_linker_flags(mut tcc_args, prefs.normalized_target_os(), is_o)
 			if !is_o {
-				tcc_args << environment_ld_flags
+				tcc_args << link_ld_flags
 			}
 			if !silent || show_cc {
 				println('  > ${cmdexec.display(tcc_path, tcc_args)}')

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -11737,6 +11737,11 @@ pub fn run(args []string) {
 			tcc_args << cached_dev_dylib
 			tcc_args << tcc_dynamic_link_flags(resolved_c_flags)
 			add_v3_default_linker_flags(mut tcc_args, prefs.normalized_target_os(), is_o)
+			if !is_o {
+				// Added before the cache key is derived from `tcc_args`, so a cached
+				// executable is never reused across a change of the link flags.
+				tcc_args << link_ld_flags
+			}
 			program_source_identity := '${prefix_source_identity}\n${modulecache.file_signature(tcc_main_file)}\n${if cached_program_body_source.len > 0 {
 				modulecache.file_signature(cached_program_body_source)
 			} else {

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -539,6 +539,15 @@ fn main() {
 	assert missing.exit_code != 0, missing.output
 	assert !os.exists(missing_output)
 
+	// A cached `run` (no `-o`) links through its own path on macOS, so the flags
+	// have to reach that link command and its executable cache key as well.
+	warm_run := cmdexec.run(v3_bin, ['-silent', 'run', source])
+	assert warm_run.exit_code == 0, warm_run.output
+	assert warm_run.output.trim_space() == '73'
+	cached_missing := cmdexec.run(v3_bin, ['-silent', '-ldflags', '-lv3_missing_link_library',
+		'run', source])
+	assert cached_missing.exit_code != 0, cached_missing.output
+
 	assert_driver_cli_failure(v3_bin, ['-ldflags'], 'option `-ldflags` requires a value')
 }
 

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -489,6 +489,59 @@ fn main() {
 	assert run.output.trim_space() == '73'
 }
 
+fn test_driver_ldflags_are_appended_to_the_link_command() {
+	root := os.join_path(os.vtmp_dir(), 'v3_driver_ldflags_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	v3_bin := build_driver_cli_v3(root)
+	// `make LDFLAGS=...` bootstraps V with `-ldflags`, so the driver has to accept
+	// the option instead of rejecting it as unknown.
+	library_dir := os.join_path(root, 'link libs')
+	os.mkdir_all(library_dir) or { panic(err) }
+	environment_library_dir := os.join_path(root, 'env libs')
+	os.mkdir_all(environment_library_dir) or { panic(err) }
+	source := os.join_path(root, 'main.v')
+	os.write_file(source, 'module main
+
+fn main() {
+	println(73)
+}
+') or { panic(err) }
+	output := os.join_path(root, 'ldflags_program')
+	mut environment := os.environ()
+	environment['LDFLAGS'] = '-L "${environment_library_dir}"'
+	compile := run_driver_with_environment(v3_bin, ['-silent', '-showcc', '-nocache', '-ldflags',
+		'-L "${library_dir}"', '-o', output, source], environment)
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('unknown option'), compile.output
+	// The ambient LDFLAGS come first, so an explicitly passed `-ldflags` wins, the
+	// same order V1 uses for `env_ldflags` and `-ldflags`.
+	environment_index := compile.output.index(environment_library_dir) or {
+		assert false, compile.output
+		return
+	}
+	option_index := compile.output.index(library_dir) or {
+		assert false, compile.output
+		return
+	}
+	assert environment_index < option_index, compile.output
+	run := cmdexec.run(output, [])
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '73'
+
+	// The flags really reach the linker, so an unknown library still fails the build.
+	missing_output := os.join_path(root, 'ldflags_missing_library')
+	missing := cmdexec.run(v3_bin, ['-silent', '-nocache', '-ldflags', '-lv3_missing_link_library',
+		'-o', missing_output, source])
+	assert missing.exit_code != 0, missing.output
+	assert !os.exists(missing_output)
+
+	assert_driver_cli_failure(v3_bin, ['-ldflags'], 'option `-ldflags` requires a value')
+}
+
 fn run_driver_with_stdin_file(v3_bin string, args []string, stdin_path string) os.Result {
 	mut process := os.new_process(v3_bin)
 	process.set_args(args)


### PR DESCRIPTION
The V3 driver had no `-ldflags` case, so the option fell through to the
catch-all `starts_with('-')` branch in `vlib/v3/driver/driver.v` and the build
died with:

```
unknown option `-ldflags`
```

before compiling anything. `make LDFLAGS=...` bootstraps V with
`-ldflags "<flags>"`, and `v -ownership -ldflags ... dir` reaches this on every
platform, since `v3_ownership_forwarded_args` forwards the raw arguments to the
standalone `v3` executable.

The driver already understood link flags coming from the `LDFLAGS` *environment
variable* (`parse_v3_environment_flags('LDFLAGS')`), so only the CLI option was
missing.

## Changes

- Parse `-ldflags <flags>` like `-cflags` (`cmdexec.split_args`, so
  `-L "/dir with spaces"` survives), with the matching "requires a value" error
  and an entry in `v3_driver_option_consumes_value` so the `doc` pre-scan skips
  the value.
- Append the parsed flags after the ambient `LDFLAGS` — the order V1 uses
  (`env_ldflags` before `ccoptions.ldflags`, `vlib/v/builder/cc.v`) — on every
  link path: the C backend flag plan, FastC, and the direct TinyCC one.
  Object-only builds (`-o x.o`) keep skipping link flags, and
  `-generate-c-project` picks them up through the same flag plan.
- Record them in the `crun` build identity, so a cached binary is not reused
  after the link flags change.

## Tests

New `test_driver_ldflags_are_appended_to_the_link_command` in
`vlib/v3/tests/driver_cli_test.v` covers that the option is accepted, that the
ambient `LDFLAGS` come before the explicit `-ldflags` on the link command, that
the flags really reach the linker (an unknown `-l` library still fails the
build), and that a missing value is reported.

Manually verified on the C, FastC and TinyCC paths, and that `-showcc` shows the
flags at the end of the link command.