### PR TITLE
v3: let C headers own their declarations, like the V1 backend

### DIFF
--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -406,6 +406,7 @@ mut:
 	inlined_c_fns                  map[string]bool
 	inlined_c_declared_fns         map[string]bool
 	files_with_c_includes          map[string]bool
+	files_with_c_postincludes      map[string]bool
 	files_linking_c_sources        map[string]bool
 	mods_with_c_libs               map[string]bool
 	mods_with_c_includes           map[string]bool
@@ -1113,6 +1114,7 @@ pub fn FlatGen.new() FlatGen {
 		inlined_c_fns: map[string]bool{}
 		inlined_c_declared_fns: map[string]bool{}
 		files_with_c_includes: map[string]bool{}
+		files_with_c_postincludes: map[string]bool{}
 		files_linking_c_sources: map[string]bool{}
 		mods_with_c_libs: map[string]bool{}
 		mods_with_c_includes: map[string]bool{}
@@ -2826,6 +2828,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.inlined_c_fns.clear()
 	g.inlined_c_declared_fns.clear()
 	g.files_with_c_includes.clear()
+	g.files_with_c_postincludes.clear()
 	g.files_linking_c_sources.clear()
 	g.mods_with_c_libs.clear()
 	g.mods_with_c_includes.clear()
@@ -4557,6 +4560,15 @@ fn (mut g FlatGen) note_c_include_directive(module_name string, source_file stri
 	}
 }
 
+// note_c_postinclude_directive records a `#postinclude`. Such a header is emitted
+// after every generated declaration and call site, so it cannot declare anything
+// for them: the generated prototype is the only declaration they can get.
+fn (mut g FlatGen) note_c_postinclude_directive(source_file string) {
+	if source_file.len > 0 {
+		g.files_with_c_postincludes[source_file] = true
+	}
+}
+
 // c_flag_links_c_source reports whether a `#flag` adds a C source or object file to
 // the link. Such a file ships no header, so the V declaration is the only prototype
 // the translation unit can get.
@@ -4581,24 +4593,27 @@ fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, sourc
 	if node.kind != .directive {
 		return false
 	}
-	if node.value in ['include', 'preinclude', 'insert'] {
-		g.note_c_include_directive(module_name, source_file)
-	}
 	if node.value in ['preinclude', 'postinclude'] {
 		if node.typ.len == 0 {
 			return true
 		}
 		include_arg := c_include_arg_for_target(node.typ, g.compiler_vroot, source_file, g.target)
+		// A `#include linux <x.h>` contributes nothing when building for another
+		// target, so it must not make the file look header backed there.
 		if include_arg.len == 0 {
 			return true
 		}
 		directive := '#include ${include_arg}'
 		if node.value == 'preinclude' {
+			g.note_c_include_directive(module_name, source_file)
 			if directive !in g.preinclude_directives {
 				g.preinclude_directives << directive
 			}
-		} else if directive !in g.postinclude_directives {
-			g.postinclude_directives << directive
+		} else {
+			g.note_c_postinclude_directive(source_file)
+			if directive !in g.postinclude_directives {
+				g.postinclude_directives << directive
+			}
 		}
 		return true
 	}
@@ -4610,6 +4625,7 @@ fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, sourc
 		if include_arg.len == 0 {
 			return true
 		}
+		g.note_c_include_directive(module_name, source_file)
 		// These helper headers are superseded by the inline compiler helpers emitted in
 		// builtin_abi_decls(); also including them would redefine the helpers.
 		if c_include_arg_is_builtin_abi_helper(include_arg, g.compiler_vroot) {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -405,6 +405,10 @@ mut:
 	inlined_c_typedef_names        map[string]bool
 	inlined_c_fns                  map[string]bool
 	inlined_c_declared_fns         map[string]bool
+	files_with_c_includes          map[string]bool
+	files_linking_c_sources        map[string]bool
+	mods_with_c_libs               map[string]bool
+	mods_with_c_includes           map[string]bool
 	inlined_c_active_macros        map[string]bool
 	inlined_c_static_fns           map[string]bool
 	cache_omitted_c_fns            map[string]bool
@@ -460,6 +464,7 @@ mut:
 	decl_attrs                    map[int][]string
 	decl_attrs_by_source_position map[u64][]string
 	c_decl_abi_names              map[string]string
+	c_extern_forced_decls         map[string]bool
 	export_c_abi_decls            map[string]flat.NodeId
 	main_export_owners            map[string][]string
 	c_extern_global_names         map[string]string
@@ -1107,6 +1112,10 @@ pub fn FlatGen.new() FlatGen {
 		cache_native_c_symbols: map[string]bool{}
 		inlined_c_fns: map[string]bool{}
 		inlined_c_declared_fns: map[string]bool{}
+		files_with_c_includes: map[string]bool{}
+		files_linking_c_sources: map[string]bool{}
+		mods_with_c_libs: map[string]bool{}
+		mods_with_c_includes: map[string]bool{}
 		inlined_c_active_macros: map[string]bool{}
 		inlined_c_static_fns: map[string]bool{}
 		cache_omitted_c_fns: map[string]bool{}
@@ -1144,6 +1153,7 @@ pub fn FlatGen.new() FlatGen {
 		decl_attrs: map[int][]string{}
 		decl_attrs_by_source_position: map[u64][]string{}
 		c_decl_abi_names: map[string]string{}
+		c_extern_forced_decls: map[string]bool{}
 		export_c_abi_decls: map[string]flat.NodeId{}
 		main_export_owners: map[string][]string{}
 		c_extern_global_names: map[string]string{}
@@ -2815,6 +2825,10 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.cache_native_c_symbols.clear()
 	g.inlined_c_fns.clear()
 	g.inlined_c_declared_fns.clear()
+	g.files_with_c_includes.clear()
+	g.files_linking_c_sources.clear()
+	g.mods_with_c_libs.clear()
+	g.mods_with_c_includes.clear()
 	g.inlined_c_active_macros.clear()
 	g.inlined_c_static_fns.clear()
 	g.cache_omitted_c_fns.clear()
@@ -2857,6 +2871,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.decl_attrs.clear()
 	g.decl_attrs_by_source_position.clear()
 	g.c_decl_abi_names.clear()
+	g.c_extern_forced_decls.clear()
 	g.export_c_abi_decls.clear()
 	g.main_export_owners.clear()
 	g.c_extern_global_names.clear()
@@ -4450,6 +4465,9 @@ fn (mut g FlatGen) collect_c_flags_from_directives() {
 		if node.kind != .directive || node.typ.len == 0 {
 			continue
 		}
+		if node.value == 'flag' {
+			g.note_c_flag_directive(cur_module, cur_file, node.typ)
+		}
 		flags := if node.value == 'flag' {
 			c_flag_args_with_values(node.typ, g.compiler_vroot, cur_file, g.target, g.compile_values)
 		} else if node.value == 'pkgconfig' {
@@ -4516,9 +4534,55 @@ pub fn cache_directive_flags(a &flat.FlatAst, vroot string, target pref.Target, 
 	return result
 }
 
+// c_source_file_is_in_vlib reports whether a source file belongs to the compiler's
+// own vlib tree. Module level C library/include flags are only tracked for user
+// modules, so a platform `#flag` inside vlib never forces a prototype.
+fn (g &FlatGen) c_source_file_is_in_vlib(source_file string) bool {
+	root := g.compiler_vroot.replace('\\', '/').trim_right('/')
+	if root.len == 0 {
+		return false
+	}
+	return source_file.replace('\\', '/').starts_with('${root}/vlib/')
+}
+
+// note_c_include_directive records that a file (and, for user code, its module)
+// pulls in a C header. The header is the authoritative declaration of everything it
+// covers, so V3 must not add a second, less precise prototype next to it.
+fn (mut g FlatGen) note_c_include_directive(module_name string, source_file string) {
+	if source_file.len > 0 {
+		g.files_with_c_includes[source_file] = true
+	}
+	if module_name.len > 0 && !g.c_source_file_is_in_vlib(source_file) {
+		g.mods_with_c_includes[module_name] = true
+	}
+}
+
+// c_flag_links_c_source reports whether a `#flag` adds a C source or object file to
+// the link. Such a file ships no header, so the V declaration is the only prototype
+// the translation unit can get.
+fn c_flag_links_c_source(flag string) bool {
+	return flag.contains('.c ') || flag.ends_with('.c') || flag.contains('.cpp')
+		|| flag.contains('.cc') || flag.contains('.o ') || flag.ends_with('.o')
+}
+
+// note_c_flag_directive records the two `#flag` shapes that leave a `fn C.` symbol
+// without a header: a linked C source/object, and a user module that links a C
+// library (`-lfoo`) without including anything.
+fn (mut g FlatGen) note_c_flag_directive(module_name string, source_file string, flag string) {
+	if source_file.len > 0 && c_flag_links_c_source(flag) {
+		g.files_linking_c_sources[source_file] = true
+	}
+	if module_name.len > 0 && flag.contains('-l') && !g.c_source_file_is_in_vlib(source_file) {
+		g.mods_with_c_libs[module_name] = true
+	}
+}
+
 fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, source_file string, before_import bool) bool {
 	if node.kind != .directive {
 		return false
+	}
+	if node.value in ['include', 'preinclude', 'insert'] {
+		g.note_c_include_directive(module_name, source_file)
 	}
 	if node.value in ['preinclude', 'postinclude'] {
 		if node.typ.len == 0 {
@@ -4551,11 +4615,6 @@ fn (mut g FlatGen) collect_c_directive(module_name string, node flat.Node, sourc
 		if c_include_arg_is_builtin_abi_helper(include_arg, g.compiler_vroot) {
 			return true
 		}
-		// Header parsing is intentionally left to the C compiler. Keep the small
-		// amount of ABI ownership information that cannot be inferred from V
-		// declarations themselves, so V3 does not emit a second, incompatible
-		// declaration for APIs whose headers use const or typedef-qualified types.
-		g.collect_known_c_header_metadata(include_arg)
 		include_dirs := c_flag_include_dirs(g.c_flags)
 		// `#insert` is an explicit request to inline the source text. Delay only
 		// ordinary source includes until after generated type declarations.
@@ -4677,85 +4736,6 @@ fn c_include_arg_is_builtin_abi_helper(include_arg string, vroot string) bool {
 	return false
 }
 
-fn (mut g FlatGen) collect_known_c_header_metadata(include_arg string) {
-	path := normalized_c_include_arg_path(include_arg)
-	match path {
-		'pwd.h' {
-			g.collect_preserved_c_fns(['getpwnam', 'getpwuid'])
-			g.collect_preserved_c_structs(['passwd'])
-		}
-		'mbedtls/net_sockets.h' {
-			g.collect_preserved_c_fns([
-				'mbedtls_net_accept',
-				'mbedtls_net_bind',
-				'mbedtls_net_connect',
-				'mbedtls_net_free',
-				'mbedtls_net_init',
-				'mbedtls_net_recv',
-				'mbedtls_net_recv_timeout',
-				'mbedtls_net_send',
-			])
-		}
-		'mbedtls/entropy.h' {
-			g.collect_preserved_c_fns(['mbedtls_entropy_free', 'mbedtls_entropy_func',
-				'mbedtls_entropy_init'])
-		}
-		'mbedtls/ctr_drbg.h' {
-			g.collect_preserved_c_fns(['mbedtls_ctr_drbg_free', 'mbedtls_ctr_drbg_init',
-				'mbedtls_ctr_drbg_random', 'mbedtls_ctr_drbg_seed'])
-		}
-		'mbedtls/error.h' {
-			g.collect_preserved_c_fns(['mbedtls_high_level_strerr'])
-		}
-		'mbedtls/ssl.h' {
-			g.collect_preserved_c_fns([
-				'mbedtls_debug_set_threshold',
-				'mbedtls_pk_free',
-				'mbedtls_pk_init',
-				'mbedtls_pk_parse_key',
-				'mbedtls_pk_parse_keyfile',
-				'mbedtls_pk_sign_ext',
-				'mbedtls_pk_verify',
-				'mbedtls_pk_verify_ext',
-				'mbedtls_ssl_conf_alpn_protocols',
-				'mbedtls_ssl_conf_authmode',
-				'mbedtls_ssl_conf_ca_chain',
-				'mbedtls_ssl_conf_own_cert',
-				'mbedtls_ssl_conf_read_timeout',
-				'mbedtls_ssl_conf_rng',
-				'mbedtls_ssl_conf_sni',
-				'mbedtls_ssl_config_defaults',
-				'mbedtls_ssl_config_free',
-				'mbedtls_ssl_config_init',
-				'mbedtls_ssl_free',
-				'mbedtls_ssl_get_alpn_protocol',
-				'mbedtls_ssl_handshake',
-				'mbedtls_ssl_init',
-				'mbedtls_ssl_read',
-				'mbedtls_ssl_session_reset',
-				'mbedtls_ssl_set_bio',
-				'mbedtls_ssl_set_hostname',
-				'mbedtls_ssl_set_hs_authmode',
-				'mbedtls_ssl_set_hs_ca_chain',
-				'mbedtls_ssl_set_hs_own_cert',
-				'mbedtls_ssl_setup',
-				'mbedtls_ssl_write',
-				'mbedtls_x509_crt_free',
-				'mbedtls_x509_crt_init',
-				'mbedtls_x509_crt_parse',
-				'mbedtls_x509_crt_parse_file',
-				'mbedtls_x509_crt_verify',
-			])
-		}
-		else {
-			if normalized_c_include_path_is_vroot_header(path, g.compiler_vroot, '/vlib/compress/brotli/brotli_dl.h') {
-				g.collect_preserved_c_fns(['v_brotli_open', 'v_brotli_sym', 'v_brotli_close',
-					'v_brotli_msan_unpoison'])
-			}
-		}
-	}
-}
-
 fn normalized_c_include_arg_path(include_arg string) string {
 	clean := trimmed_space(include_arg)
 	is_quoted := clean.len >= 2 && clean[0] == `"` && clean[clean.len - 1] == `"`
@@ -4766,15 +4746,6 @@ fn normalized_c_include_arg_path(include_arg string) string {
 		clean
 	}
 	return path.replace('\\', '/')
-}
-
-fn normalized_c_include_path_is_vroot_header(path string, vroot string, suffix string) bool {
-	root := vroot.replace('\\', '/').trim_right('/')
-	return (root.len > 0 && path == root + suffix) || path == '@VEXEROOT' + suffix
-}
-
-fn c_include_arg_is_vroot_header(include_arg string, vroot string, suffix string) bool {
-	return normalized_c_include_path_is_vroot_header(normalized_c_include_arg_path(include_arg), vroot, suffix)
 }
 
 fn (mut g FlatGen) emit_preinclude_directives() {
@@ -10157,11 +10128,19 @@ fn (mut g FlatGen) index_c_decl_attributes(target_idx int, module_name string, a
 	}
 	target := g.a.nodes[target_idx]
 	if target.kind == .c_fn_decl {
+		raw_name := target.value.trim_string_left('C.')
+		qualified := qualify_name_in_module(module_name, raw_name)
+		names := [raw_name, 'C.${raw_name}', qualified, g.cname(raw_name), g.cname(qualified)]
 		if abi_name := cgen_decl_attr_arg(attrs, 'c') {
-			raw_name := target.value.trim_string_left('C.')
-			qualified := qualify_name_in_module(module_name, raw_name)
-			for name in [raw_name, 'C.${raw_name}', qualified, g.cname(raw_name), g.cname(qualified)] {
+			for name in names {
 				g.c_decl_abi_names[name] = abi_name
+			}
+		}
+		// `@[c_extern]` is the documented way to say "this symbol comes from a linked
+		// library or object, not from a header", so its prototype is always emitted.
+		if cgen_decl_has_attr(attrs, 'c_extern') {
+			for name in names {
+				g.c_extern_forced_decls[name] = true
 			}
 		}
 		return
@@ -16716,7 +16695,35 @@ fn (mut g FlatGen) system_libc_headers() {
 	g.writeln('#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)')
 	g.writeln('#include <sys/event.h>')
 	g.writeln('#endif')
+	g.system_execinfo_declarations()
 	g.writeln('')
+}
+
+// system_execinfo_declarations owns the backtrace API the same way the V1 backend
+// does: include <execinfo.h> where it exists, and fall back to the glibc shaped
+// prototypes where it does not (musl, older toolchains). builtin declares
+// `fn C.backtrace` next to an unrelated `#include`, so nothing else can supply it.
+fn (mut g FlatGen) system_execinfo_declarations() {
+	g.writeln('#if defined(__has_include) && !defined(__TINYC__)')
+	g.writeln('\t#if __has_include(<execinfo.h>) && !defined(_WIN32)')
+	g.writeln('\t\t#define __V_HAVE_EXECINFO_H 1')
+	g.writeln('\t\t#include <execinfo.h>')
+	g.writeln('\t#endif')
+	g.writeln('#elif (defined(__linux__) && (defined(__GLIBC__) || defined(__GNU_LIBRARY__))) || defined(__APPLE__) || defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)')
+	g.writeln('\t#define __V_HAVE_EXECINFO_H 1')
+	g.writeln('\t#include <execinfo.h>')
+	g.writeln('#endif')
+	g.headerless_execinfo_declarations()
+}
+
+// headerless_execinfo_declarations declares the backtrace API without reaching for
+// <execinfo.h>, for units that are generated without system headers.
+fn (mut g FlatGen) headerless_execinfo_declarations() {
+	g.writeln('#if !defined(__V_HAVE_EXECINFO_H) && !defined(_WIN32)')
+	g.writeln('int backtrace(void** __array, int __size);')
+	g.writeln('char** backtrace_symbols(void* const* __array, int __size);')
+	g.writeln('void backtrace_symbols_fd(void* const* __array, int __size, int __fd);')
+	g.writeln('#endif')
 }
 
 fn (mut g FlatGen) system_libc_preamble() {
@@ -16901,6 +16908,7 @@ fn (mut g FlatGen) headerless_libc_preamble() {
 	g.writeln('int setenv(const char* name, const char* value, int overwrite);')
 	g.writeln('int unsetenv(const char* name);')
 	g.writeln('void abort(void);')
+	g.headerless_execinfo_declarations()
 	for name in c_function_like_macro_decl_names() {
 		g.writeln('#ifdef ${name}')
 		g.writeln('#undef ${name}')
@@ -17251,6 +17259,9 @@ fn c_function_like_macro_decl_names() []string {
 }
 
 const c_headerless_libc_declared_fns = [
+	'backtrace',
+	'backtrace_symbols',
+	'backtrace_symbols_fd',
 	'malloc',
 	'calloc',
 	'realloc',

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -17094,7 +17094,9 @@ fn (mut g FlatGen) c_extern_forward_decls() {
 			&& !referenced_c_externs[raw_cfn] && !referenced_c_externs[cfn] {
 			continue
 		}
-		if !g.should_emit_c_extern_decl_from_file(cfn, cur_file) {
+		forced_extern := g.c_extern_forced_decls[raw_name] || g.c_extern_forced_decls[raw_cfn]
+			|| g.c_extern_forced_decls[cfn]
+		if !forced_extern && !g.should_emit_c_extern_decl_from_file(cfn, cur_file, cur_module) {
 			continue
 		}
 		if cfn == 'syscall' {
@@ -17487,7 +17489,26 @@ fn (g &FlatGen) c_extern_decl_is_cached_object_fallback(cfn string) bool {
 		&& cfn !in g.inlined_c_declared_fns && cfn !in g.inlined_c_active_macros
 }
 
-fn (g &FlatGen) should_emit_c_extern_decl_from_file(cfn string, source_file string) bool {
+// c_extern_decl_has_no_header mirrors the V1 backend's rule for deciding whether a
+// `fn C.foo` declaration still needs a generated prototype. V3 does not parse C
+// headers, so a V declaration is only ever an approximation of the real signature:
+// `&char` cannot express `const char*`, and a typedef'd `Window` or `Status` cannot
+// be spelled at all. Emitting one next to the header that already declares the
+// symbol is therefore a `conflicting types` error waiting to happen (sokol, stb,
+// fontstash and Xlib all hit it). A prototype is only needed where no header can
+// supply one: the declaring file links a C source/object directly, or its module
+// links a C library without including anything.
+fn (g &FlatGen) c_extern_decl_has_no_header(source_file string, module_name string) bool {
+	if g.files_with_c_includes[source_file] {
+		return false
+	}
+	if g.files_linking_c_sources[source_file] {
+		return true
+	}
+	return g.mods_with_c_libs[module_name] && module_name !in g.mods_with_c_includes
+}
+
+fn (g &FlatGen) should_emit_c_extern_decl_from_file(cfn string, source_file string, module_name string) bool {
 	// builtin/cfns.c.v declares the static vschannel helper supplied by its C header.
 	// A user C.request declaration is unrelated and still needs an extern prototype.
 	if cfn == 'request' && source_file.replace('\\', '/').ends_with('/builtin/cfns.c.v') {
@@ -17508,7 +17529,10 @@ fn (g &FlatGen) should_emit_c_extern_decl_from_file(cfn string, source_file stri
 			}
 		}
 	}
-	return g.should_emit_c_extern_decl(cfn)
+	if !g.should_emit_c_extern_decl(cfn) {
+		return false
+	}
+	return g.c_extern_decl_has_no_header(source_file, module_name)
 }
 
 // c_system_libc_preamble_declared_fns contains only symbols declared by the fixed

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -17505,6 +17505,12 @@ fn (g &FlatGen) c_extern_decl_has_no_header(source_file string, module_name stri
 	if g.files_linking_c_sources[source_file] {
 		return true
 	}
+	// A `#postinclude` lands after every declaration and call site in the unit, so it
+	// can never be the declaration they use; without a prototype they would compile to
+	// an implicit declaration.
+	if g.files_with_c_postincludes[source_file] {
+		return true
+	}
 	return g.mods_with_c_libs[module_name] && module_name !in g.mods_with_c_includes
 }
 

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -2417,6 +2417,7 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		global_inits: g.global_inits
 		global_init_order: g.global_init_order
 		c_decl_abi_names: g.c_decl_abi_names
+		c_extern_forced_decls: g.c_extern_forced_decls
 		export_c_abi_decls: g.export_c_abi_decls
 		main_export_owners: g.main_export_owners
 		c_extern_global_names: g.c_extern_global_names

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -2315,6 +2315,11 @@ fn (g &FlatGen) configure_c_extern_scan_worker(mut worker FlatGen) {
 	worker.c_directives = g.c_directives
 	worker.inlined_c_fns = g.inlined_c_fns.clone()
 	worker.inlined_c_declared_fns = g.inlined_c_declared_fns.clone()
+	worker.files_with_c_includes = g.files_with_c_includes.clone()
+	worker.files_linking_c_sources = g.files_linking_c_sources.clone()
+	worker.mods_with_c_libs = g.mods_with_c_libs.clone()
+	worker.mods_with_c_includes = g.mods_with_c_includes.clone()
+	worker.c_extern_forced_decls = g.c_extern_forced_decls.clone()
 	worker.inlined_c_active_macros = g.inlined_c_active_macros.clone()
 	worker.inlined_c_static_fns = g.inlined_c_static_fns.clone()
 	worker.cache_omitted_c_fns = g.cache_omitted_c_fns.clone()
@@ -2441,6 +2446,10 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		inlined_c_typedef_names: g.inlined_c_typedef_names
 		inlined_c_fns: g.inlined_c_fns
 		inlined_c_declared_fns: g.inlined_c_declared_fns
+		files_with_c_includes: g.files_with_c_includes
+		files_linking_c_sources: g.files_linking_c_sources
+		mods_with_c_libs: g.mods_with_c_libs
+		mods_with_c_includes: g.mods_with_c_includes
 		inlined_c_active_macros: g.inlined_c_active_macros
 		inlined_c_static_fns: g.inlined_c_static_fns
 		libc_compat_fns: g.libc_compat_fns.clone()

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -2316,6 +2316,7 @@ fn (g &FlatGen) configure_c_extern_scan_worker(mut worker FlatGen) {
 	worker.inlined_c_fns = g.inlined_c_fns.clone()
 	worker.inlined_c_declared_fns = g.inlined_c_declared_fns.clone()
 	worker.files_with_c_includes = g.files_with_c_includes.clone()
+	worker.files_with_c_postincludes = g.files_with_c_postincludes.clone()
 	worker.files_linking_c_sources = g.files_linking_c_sources.clone()
 	worker.mods_with_c_libs = g.mods_with_c_libs.clone()
 	worker.mods_with_c_includes = g.mods_with_c_includes.clone()
@@ -2447,6 +2448,7 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		inlined_c_fns: g.inlined_c_fns
 		inlined_c_declared_fns: g.inlined_c_declared_fns
 		files_with_c_includes: g.files_with_c_includes
+		files_with_c_postincludes: g.files_with_c_postincludes
 		files_linking_c_sources: g.files_linking_c_sources
 		mods_with_c_libs: g.mods_with_c_libs
 		mods_with_c_includes: g.mods_with_c_includes

--- a/vlib/v3/gen/c/names_test.v
+++ b/vlib/v3/gen/c/names_test.v
@@ -406,32 +406,32 @@ fn test_system_libc_preamble_identifies_glibc_before_manual_stdio_declarations()
 	assert features < manual_stdio
 }
 
-fn test_known_c_header_metadata_avoids_conflicting_fallback_declarations() {
-	mut g := FlatGen.new()
-	g.compiler_vroot = '/vroot'
-	g.collect_known_c_header_metadata('<pwd.h>')
-	g.collect_known_c_header_metadata('<mbedtls/net_sockets.h>')
-	g.collect_known_c_header_metadata('<mbedtls/ssl.h>')
-	g.collect_known_c_header_metadata('"/vroot/vlib/compress/brotli/brotli_dl.h"')
-	assert g.inlined_c_structs['passwd']
-	for name in ['getpwnam', 'getpwuid', 'mbedtls_net_bind', 'mbedtls_pk_parse_key',
-		'mbedtls_ssl_write', 'v_brotli_msan_unpoison'] {
-		assert !g.should_emit_c_extern_decl(name)
-	}
-	assert c_include_arg_is_vroot_header('"@VEXEROOT/vlib/compress/brotli/brotli_dl.h"', '', '/vlib/compress/brotli/brotli_dl.h')
+fn test_header_backed_c_declarations_skip_generated_prototypes() {
+	source := '/project/user.v'
+	header_source := '/project/bindings.c.v'
 
-	mut quoted := FlatGen.new()
-	quoted.compiler_vroot = '/vroot'
-	for header in ['"pwd.h"', '"mbedtls/net_sockets.h"', '"mbedtls/entropy.h"', '"mbedtls/ctr_drbg.h"',
-		'"mbedtls/error.h"', '"mbedtls/ssl.h"', '"/vroot/vlib/compress/brotli/brotli_dl.h"'] {
-		quoted.collect_known_c_header_metadata(header)
-	}
-	assert quoted.inlined_c_structs['passwd']
-	for name in ['getpwnam', 'getpwuid', 'mbedtls_net_bind', 'mbedtls_entropy_init',
-		'mbedtls_ctr_drbg_seed', 'mbedtls_high_level_strerr', 'mbedtls_ssl_write',
-		'v_brotli_msan_unpoison'] {
-		assert !quoted.should_emit_c_extern_decl(name)
-	}
+	// A `fn C.` declaration in a file that includes a header is already declared by
+	// that header; a generated prototype would only conflict with it.
+	mut g := FlatGen.new()
+	g.note_c_include_directive('bindings', header_source)
+	assert !g.should_emit_c_extern_decl_from_file('mbedtls_ssl_write', header_source, 'bindings')
+
+	// A file that links a C source or object ships no header, so it keeps its
+	// prototype, and so does a module that only links a C library.
+	mut linked := FlatGen.new()
+	linked.note_c_flag_directive('bindings', header_source, '@VMODROOT/helper.o')
+	assert linked.should_emit_c_extern_decl_from_file('helper_fn', header_source, 'bindings')
+
+	mut lib_only := FlatGen.new()
+	lib_only.note_c_flag_directive('bindings', source, '-lfoo')
+	assert lib_only.should_emit_c_extern_decl_from_file('foo_open', source, 'bindings')
+	lib_only.note_c_include_directive('bindings', '/project/other.c.v')
+	assert !lib_only.should_emit_c_extern_decl_from_file('foo_open', source, 'bindings')
+
+	// Nothing links and nothing includes: the symbol has to come from somewhere else,
+	// so V3 stays out of the way, exactly like the V1 backend.
+	mut bare := FlatGen.new()
+	assert !bare.should_emit_c_extern_decl_from_file('unrelated_api', source, 'main')
 }
 
 fn test_apple_framework_include_does_not_match_x11() {

--- a/vlib/v3/gen/c/parallel_worker_test.v
+++ b/vlib/v3/gen/c/parallel_worker_test.v
@@ -458,3 +458,23 @@ fn test_dynamic_parallel_chunk_capture_keeps_deduplicated_wrapper_attempts() {
 	assert g.parallel_chunk_wrapper_defs[0].spawn == ['spawn-shared;', 'spawn-shared;']
 	assert g.parallel_chunk_wrapper_defs[0].callback == ['callback-shared;', 'callback-shared;']
 }
+
+// c_extern_forward_decls() runs inside a disposable worker in scoped mode, so the
+// worker must inherit the header/linkage state the emission rule reads. Without it
+// every `fn C.` declaration looks header backed and silently loses its prototype.
+fn test_scoped_c_extern_worker_inherits_header_and_linkage_state() {
+	mut g, _ := parallel_worker_test_gen(true)
+	linked_file := '/project/linked.c.v'
+	lib_file := '/project/lib_only.c.v'
+	header_file := '/project/wrapped.c.v'
+	g.note_c_flag_directive('linked', linked_file, '@VMODROOT/helper.o')
+	g.note_c_flag_directive('lib_only', lib_file, '-lfoo')
+	g.note_c_include_directive('wrapped', header_file)
+
+	mut worker := g.new_parallel_worker(8)
+	g.configure_c_extern_scan_worker(mut worker)
+
+	assert worker.should_emit_c_extern_decl_from_file('helper_fn', linked_file, 'linked')
+	assert worker.should_emit_c_extern_decl_from_file('foo_open', lib_file, 'lib_only')
+	assert !worker.should_emit_c_extern_decl_from_file('wrapped_fn', header_file, 'wrapped')
+}

--- a/vlib/v3/gen/c/source_directive_test.v
+++ b/vlib/v3/gen/c/source_directive_test.v
@@ -45,8 +45,8 @@ fn test_header_backed_declarations_do_not_get_a_second_prototype() {
 	os.write_file(header, 'int postinclude_api(void);\n')!
 	os.write_file(source, 'fn main() {}\n')!
 
-	// The header is still handed to the C compiler unparsed; it is simply trusted to
-	// declare what it declares, so no generated prototype is placed beside it.
+	// A postincluded header is emitted after every declaration and call site, so it
+	// cannot be the declaration they use and the prototype has to stay.
 	mut postinclude_g := FlatGen.new()
 	postinclude_g.collect_c_directive('main', flat.Node{
 		kind: .directive
@@ -55,8 +55,9 @@ fn test_header_backed_declarations_do_not_get_a_second_prototype() {
 	}, source, false)
 	assert 'postinclude_api' !in postinclude_g.inlined_c_declared_fns
 	assert '#include "${header}"' in postinclude_g.postinclude_directives
-	assert !postinclude_g.should_emit_c_extern_decl_from_file('postinclude_api', source, 'main')
+	assert postinclude_g.should_emit_c_extern_decl_from_file('postinclude_api', source, 'main')
 
+	// A preincluded header comes first, so it owns what it declares.
 	mut preinclude_g := FlatGen.new()
 	preinclude_g.collect_c_directive('main', flat.Node{
 		kind: .directive
@@ -481,4 +482,45 @@ fn test_preprocessor_scan_tracks_comments_after_source_code() {
 	assert trailing == '#if defined(ENABLED)'
 	not_a_directive, _ := c_preprocessor_directive_scan_line('int other; #define LATE 1', false)
 	assert not_a_directive == ''
+}
+
+// A `#include linux <x.h>` is dropped when building for another target, so it must
+// not make the file look header backed there and swallow the prototype of a
+// declaration that only a linked C source can supply.
+fn test_target_inactive_include_does_not_claim_header_ownership() {
+	root := os.join_path(os.vtmp_dir(), 'v3_inactive_include_ownership_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root)!
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	source := os.join_path(root, 'main.v')
+	os.write_file(source, 'fn main() {}\n')!
+	inactive_target := if os.user_os() == 'windows' { 'linux' } else { 'windows' }
+
+	mut g := FlatGen.new()
+	g.set_target(pref.target_from(os.user_os(), 'amd64') or { panic(err) })
+	g.note_c_flag_directive('main', source, '@VMODROOT/helper.o')
+	for kind in ['include', 'preinclude'] {
+		g.collect_c_directive('main', flat.Node{
+			kind: .directive
+			value: kind
+			typ: '${inactive_target} <ownership_probe.h>'
+		}, source, false)
+	}
+	assert source !in g.files_with_c_includes
+	assert 'main' !in g.mods_with_c_includes
+	assert g.should_emit_c_extern_decl_from_file('helper_fn', source, 'main')
+
+	// The same include for the target being built does claim ownership.
+	mut active_g := FlatGen.new()
+	active_g.set_target(pref.target_from(os.user_os(), 'amd64') or { panic(err) })
+	active_g.note_c_flag_directive('main', source, '@VMODROOT/helper.o')
+	active_g.collect_c_directive('main', flat.Node{
+		kind: .directive
+		value: 'include'
+		typ: '${os.user_os()} <ownership_probe.h>'
+	}, source, false)
+	assert source in active_g.files_with_c_includes
+	assert !active_g.should_emit_c_extern_decl_from_file('helper_fn', source, 'main')
 }

--- a/vlib/v3/gen/c/source_directive_test.v
+++ b/vlib/v3/gen/c/source_directive_test.v
@@ -33,7 +33,7 @@ fn test_multiline_inlined_c_function_definition_is_collected() {
 	assert 'declared_with_anon_param' !in g.inlined_c_fns
 }
 
-fn test_header_directives_do_not_suppress_c_prototypes() {
+fn test_header_backed_declarations_do_not_get_a_second_prototype() {
 	root := os.join_path(os.vtmp_dir(), 'v3_postinclude_prototype_${os.getpid()}')
 	os.rmdir_all(root) or {}
 	os.mkdir_all(root)!
@@ -45,6 +45,8 @@ fn test_header_directives_do_not_suppress_c_prototypes() {
 	os.write_file(header, 'int postinclude_api(void);\n')!
 	os.write_file(source, 'fn main() {}\n')!
 
+	// The header is still handed to the C compiler unparsed; it is simply trusted to
+	// declare what it declares, so no generated prototype is placed beside it.
 	mut postinclude_g := FlatGen.new()
 	postinclude_g.collect_c_directive('main', flat.Node{
 		kind: .directive
@@ -53,7 +55,7 @@ fn test_header_directives_do_not_suppress_c_prototypes() {
 	}, source, false)
 	assert 'postinclude_api' !in postinclude_g.inlined_c_declared_fns
 	assert '#include "${header}"' in postinclude_g.postinclude_directives
-	assert postinclude_g.should_emit_c_extern_decl_from_file('postinclude_api', source)
+	assert !postinclude_g.should_emit_c_extern_decl_from_file('postinclude_api', source, 'main')
 
 	mut preinclude_g := FlatGen.new()
 	preinclude_g.collect_c_directive('main', flat.Node{
@@ -62,7 +64,7 @@ fn test_header_directives_do_not_suppress_c_prototypes() {
 		typ: '"${header}"'
 	}, source, false)
 	assert 'postinclude_api' !in preinclude_g.inlined_c_declared_fns
-	assert preinclude_g.should_emit_c_extern_decl_from_file('postinclude_api', source)
+	assert !preinclude_g.should_emit_c_extern_decl_from_file('postinclude_api', source, 'main')
 	assert '#include "${header}"' in preinclude_g.preinclude_directives
 }
 
@@ -89,8 +91,15 @@ fn test_include_preserves_header_without_scanning_declarations() {
 	assert g.c_directives[0].text == '#include "${header}"'
 	assert 'api_type' !in g.inlined_c_typedef_names
 	assert 'header_api' !in g.inlined_c_declared_fns
-	assert g.should_emit_c_extern_decl_from_file('unrelated_api', source)
-	assert g.should_emit_c_extern_decl_from_file('header_api', source)
+	// The header is not scanned, so V3 cannot tell `header_api` from `unrelated_api`.
+	// It declares neither: whatever the file includes owns both names.
+	assert !g.should_emit_c_extern_decl_from_file('unrelated_api', source, 'main')
+	assert !g.should_emit_c_extern_decl_from_file('header_api', source, 'main')
+
+	// The same declaration in a file that links a C object instead keeps its prototype.
+	mut linked := FlatGen.new()
+	linked.note_c_flag_directive('main', source, '@VMODROOT/api.o')
+	assert linked.should_emit_c_extern_decl_from_file('header_api', source, 'main')
 }
 
 fn test_preinclude_does_not_scan_macro_state() {

--- a/vlib/v3/tests/c_anonymous_param_codegen_test.v
+++ b/vlib/v3/tests/c_anonymous_param_codegen_test.v
@@ -25,16 +25,39 @@ struct C.AnonNative {
 	value int
 }
 
+// No header declares these, so `@[c_extern]` asks for the generated prototypes
+// whose parameter lowering this test checks.
+@[c_extern]
 fn C.take_ptr(&C.AnonNative) int
+
+@[c_extern]
 fn C.take_named(stream &C.AnonNative) int
+
+@[c_extern]
 fn C.take_void(voidptr) int
+
+@[c_extern]
 fn C.take_primitive(int, u64) int
+
+@[c_extern]
 fn C.take_multi(&&C.AnonNative) int
+
+@[c_extern]
 fn C.take_mixed(&C.AnonNative, voidptr, int, &&C.AnonNative) int
+
+@[c_extern]
 fn C.take_fn(fn (&C.AnonNative) int) int
+
+@[c_extern]
 fn C.XLookupString(event &C.AnonNative) int
+
+@[c_extern]
 fn C.SSL_new() voidptr
+
+@[c_extern]
 fn C.load_matrix(m [16]f32) int
+
+@[c_extern]
 fn C.width_runes(r []rune) int
 
 fn callback(n &C.AnonNative) int {

--- a/vlib/v3/tests/c_header_declared_fn_codegen_test.v
+++ b/vlib/v3/tests/c_header_declared_fn_codegen_test.v
@@ -1,0 +1,28 @@
+import os
+
+// A `fn C.` declaration whose file includes a C header must not get a second,
+// generated prototype: the V signature cannot spell `const char*`, so the two
+// declarations conflict. Header only libraries (sokol, stb, fontstash, Xlib) are
+// entirely made of such declarations.
+fn test_header_declared_c_fn_gets_no_generated_prototype() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_header_declared_c_fn_codegen')
+	v3_bin := os.join_path(dir, 'v3')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	v3_dir := os.dir(os.dir(@FILE))
+	vlib_dir := os.dir(v3_dir)
+	build := os.execute('${os.quoted_path(@VEXE)} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${os.quoted_path(v3_bin)} ${os.quoted_path(os.join_path(v3_dir, 'v3.v'))}')
+	assert build.exit_code == 0, build.output
+	os.write_file(os.join_path(dir, 'v.mod'), "Module { name: 'header_declared_c_fn' }\n") or {
+		panic(err)
+	}
+	os.write_file(os.join_path(dir, 'api.h'), '#ifndef V3_TEST_API_H\n#define V3_TEST_API_H\n#include <string.h>\nstatic inline int api_call(const char* name) {\n\treturn (int)strlen(name);\n}\n#endif\n') or { panic(err) }
+	os.write_file(os.join_path(dir, 'main.v'), 'module main\n\n#flag -I@VMODROOT\n#include "api.h"\n\nfn C.api_call(name &char) int\n\nfn main() {\n\tassert C.api_call(c\'abcd\') == 4\n\tprintln(\'ok\')\n}\n') or { panic(err) }
+	program := os.join_path(dir, 'program')
+	result := os.execute('${os.quoted_path(v3_bin)} -b c -o ${os.quoted_path(program)} ${os.quoted_path(os.join_path(dir, 'main.v'))}')
+	assert result.exit_code == 0, result.output
+	run := os.execute(program)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'ok'
+	os.rmdir_all(dir) or {}
+}

--- a/vlib/v3/tests/c_linked_extern_prototype_codegen_test.v
+++ b/vlib/v3/tests/c_linked_extern_prototype_codegen_test.v
@@ -1,18 +1,23 @@
 import os
 
+fn v3_binary_for(dir string) string {
+	v3_bin := os.join_path(dir, 'v3')
+	v3_dir := os.dir(os.dir(@FILE))
+	vlib_dir := os.dir(v3_dir)
+	build := os.execute('${os.quoted_path(@VEXE)} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${os.quoted_path(v3_bin)} ${os.quoted_path(os.join_path(v3_dir, 'v3.v'))}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
 // A `fn C.` declaration that no header can declare keeps its generated prototype:
 // its file links a C source/object directly, or its module links a C library and
 // includes nothing. Both are decided inside the disposable worker that renders the
 // prototypes in scoped mode, which is what ordinary builds use.
 fn test_linked_source_and_library_declarations_keep_their_prototype() {
 	dir := os.join_path(os.vtmp_dir(), 'v3_linked_extern_prototype_codegen')
-	v3_bin := os.join_path(dir, 'v3')
 	os.rmdir_all(dir) or {}
 	os.mkdir_all(os.join_path(dir, 'libonly')) or { panic(err) }
-	v3_dir := os.dir(os.dir(@FILE))
-	vlib_dir := os.dir(v3_dir)
-	build := os.execute('${os.quoted_path(@VEXE)} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${os.quoted_path(v3_bin)} ${os.quoted_path(os.join_path(v3_dir, 'v3.v'))}')
-	assert build.exit_code == 0, build.output
+	v3_bin := v3_binary_for(dir)
 	os.write_file(os.join_path(dir, 'v.mod'), "Module { name: 'linked_extern_prototype' }\n") or {
 		panic(err)
 	}
@@ -38,5 +43,52 @@ fn test_linked_source_and_library_declarations_keep_their_prototype() {
 	c_code := os.read_file(c_path) or { panic(err) }
 	assert c_code.contains('int lib_triple(int x);'), c_code
 
+	os.rmdir_all(dir) or {}
+}
+
+// An include for a target that is not being built contributes no header, so it must
+// not take ownership of the declarations in its file.
+fn test_target_inactive_include_keeps_the_linked_source_prototype() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_inactive_include_prototype_codegen')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	v3_bin := v3_binary_for(dir)
+	inactive_target := if os.user_os() == 'windows' { 'linux' } else { 'windows' }
+	os.write_file(os.join_path(dir, 'v.mod'), "Module { name: 'inactive_include_prototype' }\n") or {
+		panic(err)
+	}
+	os.write_file(os.join_path(dir, 'helper.c'), 'int helper_fn(int x) {\n\treturn x * 2;\n}\n') or { panic(err) }
+	os.write_file(os.join_path(dir, 'main.v'), 'module main\n\n#flag @VMODROOT/helper.c\n#include ${inactive_target} <inactive_probe.h>\n\nfn C.helper_fn(x int) int\n\nfn main() {\n\tprintln(C.helper_fn(21))\n}\n') or {
+		panic(err)
+	}
+	program := os.join_path(dir, 'program')
+	result := os.execute('${os.quoted_path(v3_bin)} -b c -o ${os.quoted_path(program)} ${os.quoted_path(os.join_path(dir, 'main.v'))}')
+	assert result.exit_code == 0, result.output
+	run := os.execute(program)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '42'
+	os.rmdir_all(dir) or {}
+}
+
+// `#postinclude` is emitted after every declaration and call site, so it can never
+// declare anything for them and the prototype has to stay.
+fn test_postinclude_keeps_its_prototype() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_postinclude_prototype_codegen')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(os.join_path(dir, 'postmod')) or { panic(err) }
+	v3_bin := v3_binary_for(dir)
+	os.write_file(os.join_path(dir, 'v.mod'), "Module { name: 'postinclude_prototype' }\n") or {
+		panic(err)
+	}
+	os.write_file(os.join_path(dir, 'post_impl.c'), 'int post_fn(int x) {\n\treturn x + 1;\n}\n') or { panic(err) }
+	os.write_file(os.join_path(dir, 'postmod', 'post_api.h'), 'int post_fn(int x);\n') or { panic(err) }
+	os.write_file(os.join_path(dir, 'postmod', 'postmod.v'), 'module postmod\n\n#postinclude "@VMODROOT/postmod/post_api.h"\n\nfn C.post_fn(x int) int\n\npub fn bump(x int) int {\n\treturn C.post_fn(x)\n}\n') or { panic(err) }
+	os.write_file(os.join_path(dir, 'main.v'), 'module main\n\nimport postmod\n\n#flag @VMODROOT/post_impl.c\n\nfn main() {\n\tprintln(postmod.bump(41))\n}\n') or { panic(err) }
+	program := os.join_path(dir, 'program')
+	result := os.execute('${os.quoted_path(v3_bin)} -b c -o ${os.quoted_path(program)} ${os.quoted_path(os.join_path(dir, 'main.v'))}')
+	assert result.exit_code == 0, result.output
+	run := os.execute(program)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '42'
 	os.rmdir_all(dir) or {}
 }

--- a/vlib/v3/tests/c_linked_extern_prototype_codegen_test.v
+++ b/vlib/v3/tests/c_linked_extern_prototype_codegen_test.v
@@ -1,0 +1,42 @@
+import os
+
+// A `fn C.` declaration that no header can declare keeps its generated prototype:
+// its file links a C source/object directly, or its module links a C library and
+// includes nothing. Both are decided inside the disposable worker that renders the
+// prototypes in scoped mode, which is what ordinary builds use.
+fn test_linked_source_and_library_declarations_keep_their_prototype() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_linked_extern_prototype_codegen')
+	v3_bin := os.join_path(dir, 'v3')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(os.join_path(dir, 'libonly')) or { panic(err) }
+	v3_dir := os.dir(os.dir(@FILE))
+	vlib_dir := os.dir(v3_dir)
+	build := os.execute('${os.quoted_path(@VEXE)} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${os.quoted_path(v3_bin)} ${os.quoted_path(os.join_path(v3_dir, 'v3.v'))}')
+	assert build.exit_code == 0, build.output
+	os.write_file(os.join_path(dir, 'v.mod'), "Module { name: 'linked_extern_prototype' }\n") or {
+		panic(err)
+	}
+
+	// A linked C source is compiled, linked and run, so a missing prototype shows up
+	// as an implicit declaration error rather than a silently guessed signature.
+	os.write_file(os.join_path(dir, 'helper.c'), 'int helper_fn(int x) {\n\treturn x * 2;\n}\n') or { panic(err) }
+	os.write_file(os.join_path(dir, 'main.v'), 'module main\n\n#flag @VMODROOT/helper.c\n\nfn C.helper_fn(x int) int\n\nfn main() {\n\tprintln(C.helper_fn(21))\n}\n') or { panic(err) }
+	program := os.join_path(dir, 'program')
+	result := os.execute('${os.quoted_path(v3_bin)} -b c -o ${os.quoted_path(program)} ${os.quoted_path(os.join_path(dir, 'main.v'))}')
+	assert result.exit_code == 0, result.output
+	run := os.execute(program)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '42'
+
+	// A module that only links a C library. The library itself is not built here, so
+	// only the generated C is inspected for the prototype.
+	os.write_file(os.join_path(dir, 'libonly', 'libonly.v'), 'module libonly\n\n#flag -L@VMODROOT -lmathhelper\n\nfn C.lib_triple(x int) int\n\npub fn triple(x int) int {\n\treturn C.lib_triple(x)\n}\n') or { panic(err) }
+	os.write_file(os.join_path(dir, 'lib_main.v'), 'module main\n\nimport libonly\n\nfn main() {\n\tprintln(libonly.triple(14))\n}\n') or { panic(err) }
+	c_path := os.join_path(dir, 'lib_main.c')
+	lib_result := os.execute('${os.quoted_path(v3_bin)} -b c -o ${os.quoted_path(c_path)} ${os.quoted_path(os.join_path(dir, 'lib_main.v'))}')
+	assert lib_result.exit_code == 0, lib_result.output
+	c_code := os.read_file(c_path) or { panic(err) }
+	assert c_code.contains('int lib_triple(int x);'), c_code
+
+	os.rmdir_all(dir) or {}
+}


### PR DESCRIPTION
V3 emitted a prototype for every `fn C.foo` declaration it could not prove was already declared. A V declaration is only ever an approximation of the real C signature — `&char` cannot express `const char*`, and a typedef'd `Window` or `Status` cannot be spelled at all — so placing one next to the header that already declares the symbol is a `conflicting types` error.

Every gg/sokol program hits this on Linux:

```
src.c:5362:5: error: conflicting types for 'XGetWindowAttributes'; have 'int(Display *, u64,  XWindowAttributes *)'
/usr/include/X11/Xlib.h:2701:15: note: previous declaration of 'XGetWindowAttributes' with type 'int(Display *, Window,  XWindowAttributes *)'
src.c:5365:5: error: conflicting types for 'fonsAddFontMem'; have 'i32(FONScontext *, char *, u8 *, i32,  i32)'
thirdparty/fontstash/fontstash.h:921:5: note: previous definition of 'fonsAddFontMem' with type 'int(FONScontext *, const char *, unsigned char *, int,  int)'
src.c:5383:5: error: conflicting types for 'sapp_run'; have 'i32(const sapp_desc *)'
thirdparty/sokol/sokol_app.h:16821:21: note: previous definition of 'sapp_run' with type 'void(const sapp_desc *)'
```

and so does a plain `#include <iconv.h>` on macOS (`conflicting types for 'iconv_close'`).

## What changed

Adopt the V1 backend's rule (`vlib/v/gen/c/fn.v`): a `fn C.` declaration only needs a generated prototype when no header can supply one — its file links a C source/object directly, or its module links a C library without including anything. `@[c_extern]` still forces a prototype, which is what `vlib/v/builder/cc.v` already tells users to reach for when a symbol has no header.

This replaces the hand-maintained "these headers declare these symbols" table (`pwd.h`, mbedtls, brotli). That table could never keep up with header-only libraries — sokol alone exposes ~240 entry points across `sapp_`, `sg_`, `sgl_` and `sfons_`, and Xlib several hundred more.

`vlib/builtin/builtin_backtraces_nix.c.v` declares `fn C.backtrace` next to an unrelated `#include`, so nothing else would declare it any more. The preamble now owns the backtrace API the way V1's `cheaders.v` does, `<execinfo.h>` when available and the glibc-shaped fallback prototypes (musl, older toolchains) when not.

## Testing

- New `vlib/v3/tests/c_header_declared_fn_codegen_test.v`: a `fn C.` declaration whose file includes a header that defines the function `static inline` with a `const char*` parameter. It fails on master with `error: conflicting types for 'api_call'` and passes here.
- `vlib/v3/tests/c_anonymous_param_codegen_test.v` checks the parameter lowering of emitted prototypes, so its declarations are now marked `@[c_extern]` to keep asking for them.
- `vlib/v3/gen/c/names_test.v` and `source_directive_test.v` cover the new rule directly, replacing the assertions that encoded the old policy.
- `v -silent test vlib/v3/gen/c/`: 19/19 pass.
- 20 C-interop tests from `vlib/v3/tests/`: 11 pass, 9 fail — the same 9 fail on unpatched master (checked with a pristine build of this base commit).
- Built and ran on macOS: `examples/gg/rectangles.v`, `examples/gg/rotating_textured_quad.v`, `examples/2048`, `examples/sokol/particles`, `examples/term.ui/rectangles.v`, `hello_world`, `json`, `regex`, `net_raw_http`, `database/sqlite`, `process/command`, plus programs exercising `net.http` over TLS (mbedtls), `compress.brotli`, `os.executable`/`os.loginname` (libproc, pwd.h) and `#include <iconv.h>`. The gg/sokol and iconv ones do not build on master.
