### PR TITLE
v3: keep disposable-arena memo entries out of the shared cgen caches

### DIFF
--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -16882,11 +16882,6 @@ fn (mut g FlatGen) forward_decls() {
 		output_sb := g.sb
 		master_tc := g.tc
 		master_c_name_cache := g.c_name_cache
-		master_import_alias_cache := g.import_alias_cache
-		master_import_type_cache := g.import_type_cache
-		master_enum_selector_cache := g.enum_selector_cache
-		master_enum_method_cache := g.enum_method_cache
-		master_qualified_enum_method_cache := g.qualified_enum_method_cache
 		mut master_concrete_optional_params := g.cur_concrete_optional_params.move()
 		mut master_needed_optional_types := g.needed_optional_types.move()
 		mut master_fn_ptr_types := g.fn_ptr_types.move()
@@ -16898,13 +16893,10 @@ fn (mut g FlatGen) forward_decls() {
 		g.c_name_cache = &CNameCache{
 			base: master_c_name_cache
 		}
-		// Context-cache entries can own strings allocated by this disposable
-		// batch. Disable them until the master caches are restored.
-		g.import_alias_cache = unsafe { nil }
-		g.import_type_cache = unsafe { nil }
-		g.enum_selector_cache = unsafe { nil }
-		g.enum_method_cache = unsafe { nil }
-		g.qualified_enum_method_cache = unsafe { nil }
+		// Memo-cache entries own strings allocated by this disposable batch, and
+		// so do the maps holding them. Emit against batch-local caches, so that
+		// nothing this arena owns is still reachable once it is freed.
+		saved_lookup_caches := g.begin_scratch_lookup_caches()
 		g.cur_concrete_optional_params = map[string]bool{}
 		g.needed_optional_types = map[string]string{}
 		g.fn_ptr_types = master_fn_ptr_types.clone()
@@ -16916,11 +16908,7 @@ fn (mut g FlatGen) forward_decls() {
 		g.line_start = true
 		g.tc = master_tc
 		g.c_name_cache = master_c_name_cache
-		g.import_alias_cache = master_import_alias_cache
-		g.import_type_cache = master_import_type_cache
-		g.enum_selector_cache = master_enum_selector_cache
-		g.enum_method_cache = master_enum_method_cache
-		g.qualified_enum_method_cache = master_qualified_enum_method_cache
+		g.restore_scratch_lookup_caches(saved_lookup_caches)
 		g.cur_concrete_optional_params = master_concrete_optional_params.move()
 		g.needed_optional_types = master_needed_optional_types.move()
 		g.fn_ptr_types = master_fn_ptr_types.move()

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -254,16 +254,10 @@ $if !windows {
 		defer {
 			w.timing_profile('  [ttime]     cg typedecls   ${f64(tdsw.elapsed().microseconds()) / 1000.0:7.2f} ms (task)')
 		}
-		// This task uses the master generator from a pool thread. Keep caches
-		// disabled because their entries would otherwise borrow that thread's
-		// disposable arena.
-		w.import_alias_cache = unsafe { nil }
-		w.enum_selector_cache = unsafe { nil }
-		w.enum_method_cache = unsafe { nil }
-		w.qualified_enum_method_cache = unsafe { nil }
-		w.import_type_cache = unsafe { nil }
-		w.local_typedef_shadow_facts = unsafe { nil }
-		w.local_global_shadow_facts = unsafe { nil }
+		// This task uses the master generator from a pool thread, so memoize into
+		// private caches: entries written here would otherwise borrow this
+		// thread's arena, and body lanes clone the master's memo maps meanwhile.
+		saved_lookup_caches := w.begin_scratch_lookup_caches()
 		// Self-host declaration output is several MiB. Reserve it once instead of
 		// repeatedly copying a geometrically growing builder.
 		w.sb.ensure_cap(4 * 1024 * 1024)
@@ -326,6 +320,7 @@ $if !windows {
 			tail.sb = strings.new_builder(0)
 		}
 		w.timing_profile('  [ttime]       td init defs  ${f64(tdpsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		w.restore_scratch_lookup_caches(saved_lookup_caches)
 		w.parallel_support_ready = true
 		return unsafe { nil }
 	}

--- a/vlib/v3/gen/c/names.v
+++ b/vlib/v3/gen/c/names.v
@@ -2,6 +2,7 @@ module c
 
 import strings
 import v3.gen.c.naming
+import v3.types
 
 // c_name converts c name data for c.
 fn c_name(name string) string {
@@ -267,6 +268,182 @@ fn (mut g FlatGen) reset_context_lookup_caches() {
 	g.enum_method_cache = &ContextStringLookupCache{}
 	g.qualified_enum_method_cache = &ContextStringLookupCache{}
 	g.import_type_cache = &ImportTypeCache{}
+}
+
+// ScratchLookupCaches holds a generator's memoizing caches while it emits from a
+// disposable arena. Both a cached string and the map node holding it come from
+// whichever arena is current when the entry is written, so a cache a scratch
+// batch populates must not outlive that batch: the next lookup would compare
+// against a freed key. The same swap keeps a task that borrows the master
+// generator on a pool thread out of the memo maps body lanes concurrently clone.
+// See begin_scratch_lookup_caches.
+struct ScratchLookupCaches {
+	interface_receiver_cache        &StringLookupCache
+	normalize_call_cache            &StringLookupCache
+	flattened_generic_name_cache    &StringLookupCache
+	generic_struct_context_ct_cache &StringLookupCache
+	struct_cname_cache              &StringLookupCache
+	unique_struct_ct_cache          &StringLookupCache
+	alias_method_cache              &StringLookupCache
+	import_alias_cache              &ContextStringLookupCache
+	enum_selector_cache             &ContextStringLookupCache
+	enum_method_cache               &ContextStringLookupCache
+	qualified_enum_method_cache     &ContextStringLookupCache
+	import_type_cache               &ImportTypeCache
+	mut_recv_facts                  &FnNameFactCache
+	local_typedef_shadow_facts      &FnNameFactCache
+	local_global_shadow_facts       &ContextNameFactCache
+	generic_app_cache               &GenericAppCache
+	struct_decl_pref_cache          &StructDeclPrefCache
+	sum_variant_actual_cache        &SumVariantActualCache
+	array_method_cache              map[string]string
+	param_types_cache               map[string][]types.Type
+}
+
+// begin_scratch_lookup_caches swaps in batch-local memo caches and returns the
+// generator's own caches. The caller must pass the result to
+// restore_scratch_lookup_caches once the scratch arena is no longer current;
+// everything the batch memoized is then dropped together with that arena.
+fn (mut g FlatGen) begin_scratch_lookup_caches() ScratchLookupCaches {
+	saved := ScratchLookupCaches{
+		interface_receiver_cache: g.interface_receiver_cache
+		normalize_call_cache: g.normalize_call_cache
+		flattened_generic_name_cache: g.flattened_generic_name_cache
+		generic_struct_context_ct_cache: g.generic_struct_context_ct_cache
+		struct_cname_cache: g.struct_cname_cache
+		unique_struct_ct_cache: g.unique_struct_ct_cache
+		alias_method_cache: g.alias_method_cache
+		import_alias_cache: g.import_alias_cache
+		enum_selector_cache: g.enum_selector_cache
+		enum_method_cache: g.enum_method_cache
+		qualified_enum_method_cache: g.qualified_enum_method_cache
+		import_type_cache: g.import_type_cache
+		mut_recv_facts: g.mut_recv_facts
+		local_typedef_shadow_facts: g.local_typedef_shadow_facts
+		local_global_shadow_facts: g.local_global_shadow_facts
+		generic_app_cache: g.generic_app_cache
+		struct_decl_pref_cache: g.struct_decl_pref_cache
+		sum_variant_actual_cache: g.sum_variant_actual_cache
+		array_method_cache: g.array_method_cache
+		param_types_cache: g.param_types_cache
+	}
+	// A cache the generator has disabled stays disabled, so this only changes
+	// where entries are written, never whether they are memoized at all.
+	g.interface_receiver_cache = scratch_string_lookup_cache(saved.interface_receiver_cache)
+	g.normalize_call_cache = scratch_string_lookup_cache(saved.normalize_call_cache)
+	g.flattened_generic_name_cache = scratch_string_lookup_cache(saved.flattened_generic_name_cache)
+	g.generic_struct_context_ct_cache = scratch_string_lookup_cache(saved.generic_struct_context_ct_cache)
+	g.struct_cname_cache = scratch_string_lookup_cache(saved.struct_cname_cache)
+	g.unique_struct_ct_cache = scratch_string_lookup_cache(saved.unique_struct_ct_cache)
+	g.alias_method_cache = scratch_string_lookup_cache(saved.alias_method_cache)
+	g.import_alias_cache = scratch_context_string_lookup_cache(saved.import_alias_cache)
+	g.enum_selector_cache = scratch_context_string_lookup_cache(saved.enum_selector_cache)
+	g.enum_method_cache = scratch_context_string_lookup_cache(saved.enum_method_cache)
+	g.qualified_enum_method_cache = scratch_context_string_lookup_cache(saved.qualified_enum_method_cache)
+	g.import_type_cache = scratch_import_type_cache(saved.import_type_cache)
+	g.mut_recv_facts = scratch_fn_name_fact_cache(saved.mut_recv_facts)
+	g.local_typedef_shadow_facts = scratch_fn_name_fact_cache(saved.local_typedef_shadow_facts)
+	g.local_global_shadow_facts = scratch_context_name_fact_cache(saved.local_global_shadow_facts)
+	g.generic_app_cache = scratch_generic_app_cache(saved.generic_app_cache)
+	g.struct_decl_pref_cache = scratch_struct_decl_pref_cache(saved.struct_decl_pref_cache)
+	g.sum_variant_actual_cache = scratch_sum_variant_actual_cache(saved.sum_variant_actual_cache)
+	g.array_method_cache = map[string]string{}
+	g.param_types_cache = map[string][]types.Type{}
+	return saved
+}
+
+// restore_scratch_lookup_caches puts the generator's own caches back. It must run
+// after the scratch arena stops being the current one and before it is freed.
+fn (mut g FlatGen) restore_scratch_lookup_caches(saved ScratchLookupCaches) {
+	g.interface_receiver_cache = saved.interface_receiver_cache
+	g.normalize_call_cache = saved.normalize_call_cache
+	g.flattened_generic_name_cache = saved.flattened_generic_name_cache
+	g.generic_struct_context_ct_cache = saved.generic_struct_context_ct_cache
+	g.struct_cname_cache = saved.struct_cname_cache
+	g.unique_struct_ct_cache = saved.unique_struct_ct_cache
+	g.alias_method_cache = saved.alias_method_cache
+	g.import_alias_cache = saved.import_alias_cache
+	g.enum_selector_cache = saved.enum_selector_cache
+	g.enum_method_cache = saved.enum_method_cache
+	g.qualified_enum_method_cache = saved.qualified_enum_method_cache
+	g.import_type_cache = saved.import_type_cache
+	g.mut_recv_facts = saved.mut_recv_facts
+	g.local_typedef_shadow_facts = saved.local_typedef_shadow_facts
+	g.local_global_shadow_facts = saved.local_global_shadow_facts
+	g.generic_app_cache = saved.generic_app_cache
+	g.struct_decl_pref_cache = saved.struct_decl_pref_cache
+	g.sum_variant_actual_cache = saved.sum_variant_actual_cache
+	g.array_method_cache = saved.array_method_cache
+	g.param_types_cache = saved.param_types_cache
+}
+
+fn scratch_string_lookup_cache(cache &StringLookupCache) &StringLookupCache {
+	if isnil(cache) {
+		return unsafe { nil }
+	}
+	return &StringLookupCache{}
+}
+
+fn scratch_context_string_lookup_cache(cache &ContextStringLookupCache) &ContextStringLookupCache {
+	if isnil(cache) {
+		return unsafe { nil }
+	}
+	return &ContextStringLookupCache{}
+}
+
+// scratch_import_type_cache also drops the per-file child caches: `for_file`
+// allocates an ImportFileTypeCache on first use, so a batch's entry would keep
+// both the file key and that child alive past the arena that made them.
+fn scratch_import_type_cache(cache &ImportTypeCache) &ImportTypeCache {
+	if isnil(cache) {
+		return unsafe { nil }
+	}
+	return &ImportTypeCache{}
+}
+
+fn scratch_fn_name_fact_cache(cache &FnNameFactCache) &FnNameFactCache {
+	if isnil(cache) {
+		return unsafe { nil }
+	}
+	return &FnNameFactCache{}
+}
+
+fn scratch_context_name_fact_cache(cache &ContextNameFactCache) &ContextNameFactCache {
+	if isnil(cache) {
+		return unsafe { nil }
+	}
+	return &ContextNameFactCache{}
+}
+
+fn scratch_struct_decl_pref_cache(cache &StructDeclPrefCache) &StructDeclPrefCache {
+	if isnil(cache) {
+		return unsafe { nil }
+	}
+	return &StructDeclPrefCache{}
+}
+
+fn scratch_sum_variant_actual_cache(cache &SumVariantActualCache) &SumVariantActualCache {
+	if isnil(cache) {
+		return unsafe { nil }
+	}
+	return &SumVariantActualCache{}
+}
+
+// scratch_generic_app_cache keeps reading the enclosing arena's entries through
+// `base`, and keeps that overlay chain one level deep, exactly like the
+// per-worker caches built by new_parallel_worker_config.
+fn scratch_generic_app_cache(cache &GenericAppCache) &GenericAppCache {
+	if isnil(cache) {
+		return unsafe { nil }
+	}
+	if !isnil(cache.base) {
+		return &GenericAppCache{
+			base: cache.base
+		}
+	}
+	return &GenericAppCache{
+		base: cache
+	}
 }
 
 // cname is the memoizing wrapper for naming.c_name used on FlatGen hot paths.

--- a/vlib/v3/gen/c/names_test.v
+++ b/vlib/v3/gen/c/names_test.v
@@ -604,3 +604,57 @@ fn test_specialized_generic_abi_name_does_not_classify_array_receivers() {
 	assert !g.name_uses_specialized_generic_abi('cli.[]Flag.get_int')
 	assert !g.name_uses_specialized_generic_abi('[]Flag.get_int')
 }
+
+// test_scratch_lookup_caches_keep_batch_entries_out_of_the_generator covers the
+// crash where a `forward_decls` batch memoized a struct C type into the master's
+// cache: both the key and the map node were owned by the batch's scratch arena,
+// so the next batch's lookup compared against freed memory.
+fn test_scratch_lookup_caches_keep_batch_entries_out_of_the_generator() {
+	mut g := FlatGen.new()
+	own_unique_struct_ct_cache := g.unique_struct_ct_cache
+	own_struct_cname_cache := g.struct_cname_cache
+	own_generic_app_cache := g.generic_app_cache
+	own_import_type_cache := g.import_type_cache
+	saved := g.begin_scratch_lookup_caches()
+	assert voidptr(g.unique_struct_ct_cache) != voidptr(own_unique_struct_ct_cache)
+	assert voidptr(g.struct_cname_cache) != voidptr(own_struct_cname_cache)
+	assert voidptr(g.generic_app_cache) != voidptr(own_generic_app_cache)
+	assert voidptr(g.import_type_cache) != voidptr(own_import_type_cache)
+	// The frozen entries stay readable through the overlay's base.
+	assert voidptr(g.generic_app_cache.base) == voidptr(own_generic_app_cache)
+	g.unique_struct_ct_cache.put('Batch', 'main__Batch')
+	g.param_types_cache['batch'] = [types.Type(types.void_)]
+	g.import_type_cache.unqualified_texts['Batch'] = 'main.Batch'
+	mut batch_file := g.import_type_cache.for_file('batch.v')
+	batch_file.texts['Batch'] = 'main.Batch'
+	batch_file.parsed['Batch'] = types.Type(types.void_)
+	g.restore_scratch_lookup_caches(saved)
+	assert voidptr(g.unique_struct_ct_cache) == voidptr(own_unique_struct_ct_cache)
+	assert voidptr(g.struct_cname_cache) == voidptr(own_struct_cname_cache)
+	assert voidptr(g.generic_app_cache) == voidptr(own_generic_app_cache)
+	assert voidptr(g.import_type_cache) == voidptr(own_import_type_cache)
+	assert g.unique_struct_ct_cache.get('Batch') == none
+	assert 'batch' !in g.param_types_cache
+	// The per-file child cache the batch created is dropped with it.
+	assert g.import_type_cache.unqualified_texts.len == 0
+	assert g.import_type_cache.by_file.len == 0
+	assert isnil(g.import_type_cache.last)
+}
+
+// test_scratch_lookup_caches_leave_disabled_caches_disabled keeps the swap about
+// where entries are written, never about whether a generator memoizes at all.
+fn test_scratch_lookup_caches_leave_disabled_caches_disabled() {
+	mut g := FlatGen.new()
+	g.import_type_cache = unsafe { nil }
+	assert isnil(g.local_typedef_shadow_facts)
+	assert isnil(g.struct_decl_pref_cache)
+	saved := g.begin_scratch_lookup_caches()
+	assert isnil(g.local_typedef_shadow_facts)
+	assert isnil(g.struct_decl_pref_cache)
+	assert isnil(g.import_type_cache)
+	assert !isnil(g.mut_recv_facts)
+	g.restore_scratch_lookup_caches(saved)
+	assert isnil(g.local_typedef_shadow_facts)
+	assert isnil(g.struct_decl_pref_cache)
+	assert isnil(g.import_type_cache)
+}


### PR DESCRIPTION
`v install <pkg>` rebuilds `cmd/tools/vpm`, and that compile crashed:

```
v install ui2
cannot compile `/home/yeva/git/v/cmd/tools/vpm`: 255
0x7f98eb975047: at ???: RUNTIME ERROR: invalid memory access
src.c:1171: by string__eq
src.c:44770: by c__StringLookupCache__get
src.c:42817: by c__FlatGen__unique_qualified_struct_c_type
src.c:43306: by c__FlatGen__value_c_type
src.c:27065: by c__FlatGen__optional_payload_c_type
src.c:45904: by c__FlatGen__concrete_optional_type_name
src.c:27257: by c__FlatGen__optional_type_name_for_context
src.c:56066: by c__FlatGen__fn_return_type_name_for_context
src.c:56370: by c__FlatGen__forward_decl_items
src.c:56458: by c__FlatGen__forward_decls
src.c:56285: by c__parallel_type_decls_thread
src.c:27359: by workers__pool_worker
```

## Cause

`forward_decls` emits each 1024-item batch from a disposable prealloc arena, and
`parallel_type_decls_thread` drives the master generator from a pool thread. Both
only detached the four *context* lookup caches. Every other memo cache stayed on
the master: the `StringLookupCache` family (`unique_struct_ct_cache`,
`struct_cname_cache`, `flattened_generic_name_cache`, …), the name-fact caches,
`generic_app_cache`, `struct_decl_pref_cache`, `sum_variant_actual_cache`,
`param_types_cache` and `array_method_cache`.

An entry written while a scratch arena is current has its key, its value *and*
its map node allocated from that arena. When the batch frees the arena the
master's cache is left pointing at unmapped memory, so the next batch's lookup
hashes or compares a freed key — the `string__eq` frame above. The same caches
written from the type-declaration pool task are also the maps the body lanes
clone concurrently.

## Fix

Give both sites a full set of scratch-local caches via
`begin_scratch_lookup_caches` / `restore_scratch_lookup_caches`, so no cache the
generator keeps can hold an entry the arena owns. A cache the generator has
disabled stays disabled — the swap only changes *where* entries are written,
never whether they are memoized.

## Verification (macOS/arm64, 18 cores, `-prealloc` self-host build)

- `cmd/tools/vpm`, cold `VCACHE`/`V3CACHE`: master crashes 4/4 runs, patched
  passes 37/37.
- Generated C for `cmd/v` is byte-identical to master's, and stable across two
  further self-host generations.
- Added two unit tests in `vlib/v3/gen/c/names_test.v` covering the swap and the
  "disabled stays disabled" invariant.