### PR TITLE
v3: restore `.vsh` script mode

### DIFF
--- a/vlib/v3/flat/flat.v
+++ b/vlib/v3/flat/flat.v
@@ -273,6 +273,10 @@ pub mut:
 	// or file_index_incomplete is set (a source file failed to read).
 	file_node_ids         []int
 	file_index_incomplete bool
+	// has_vsh_source records that at least one parsed source file is a `.vsh`
+	// script. V script mode makes the `os` module global inside such files, and
+	// the checker only pays for that lookup when this flag is set.
+	has_vsh_source bool
 	// source_buffers owns the storage behind zero-copy scanner strings retained
 	// by AST nodes. Keeping the buffers on the AST makes the lifetime boundary
 	// explicit and lets parser workers transfer ownership with their nodes.

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -288,6 +288,12 @@ pub fn (mut p Parser) parse_into(path string) {
 	p.comptime_value_undos.clear()
 	p.comptime_value_scopes.clear()
 	p.imported_module_names.clear()
+	if !p.prefs.is_fmt && path.ends_with('.vsh') {
+		// V script mode: `os` is in scope from the first statement on, so the alias
+		// has to be known before the body is parsed, not only once the synthetic
+		// `import os` node below is appended.
+		p.imported_module_names['os'] = true
+	}
 	p.local_binding_counts.clear()
 	p.local_binding_undos.clear()
 	p.local_binding_scopes.clear()
@@ -377,6 +383,12 @@ pub fn (mut p Parser) parse_into(path string) {
 			ids << id
 		}
 	}
+	if !p.prefs.is_fmt && path.ends_with('.vsh') {
+		p.a.has_vsh_source = true
+		if implicit_os_id := p.vsh_implicit_os_import(ids) {
+			ids << implicit_os_id
+		}
+	}
 	start := p.add_children(ids)
 	trailing_id := p.add_node(flat.Node{
 		kind: .file
@@ -392,6 +404,24 @@ pub fn (mut p Parser) parse_into(path string) {
 		p.collect_formatter_comments(file, stable_src)
 	}
 	p.collect_scanner_diagnostics()
+}
+
+// vsh_implicit_os_import gives a `.vsh` script the implicit `import os` of V's
+// script mode. It is only added when the script does not already import `os`
+// itself, so that an explicit import keeps its own alias and selected symbols.
+fn (mut p Parser) vsh_implicit_os_import(ids []flat.NodeId) ?flat.NodeId {
+	for id in ids {
+		node := p.a.nodes[int(id)]
+		if node.kind == .import_decl && node.value == 'os' {
+			return none
+		}
+	}
+	return p.add_node(flat.Node{
+		kind: .import_decl
+		value: 'os'
+		typ: 'os'
+		pos: token.new_span(p.cur_file_id, 0, 0)
+	})
 }
 
 fn (mut p Parser) collect_formatter_comments(file &token.File, source string) {

--- a/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
@@ -1190,6 +1190,7 @@ fn (mut p Parser) merge_parsed_worker_bookkeeping(mut w Parser, mut starts []int
 		w.a.file_node_ids.len = 0
 	}
 	p.a.file_index_incomplete = p.a.file_index_incomplete || w.a.file_index_incomplete
+	p.a.has_vsh_source = p.a.has_vsh_source || w.a.has_vsh_source
 	// The worker validated its exports against its own files only; revalidate
 	// them here against disabled fns accumulated from earlier chunks, exactly
 	// like the serial parse where register_pending_export sees every previously

--- a/vlib/v3/tests/vsh_script_mode_test.v
+++ b/vlib/v3/tests/vsh_script_mode_test.v
@@ -1,0 +1,62 @@
+import os
+
+const vsh_mode_vlib_dir = os.dir(os.dir(os.dir(@FILE)))
+const vsh_mode_v3_src = os.join_path(os.dir(os.dir(@FILE)), 'v3.v')
+
+fn build_vsh_mode_v3(root string) string {
+	bin := os.join_path(root, 'v3_vsh_script_mode')
+	build := os.execute('${@VEXE} -gc none -path "${vsh_mode_vlib_dir}|@vlib|@vmodules" -o ${bin} ${vsh_mode_v3_src}')
+	assert build.exit_code == 0, build.output
+	return bin
+}
+
+fn run_vsh_script(name string, source string) os.Result {
+	root := os.join_path(os.vtmp_dir(), 'v3_vsh_${name}_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	v3_bin := build_vsh_mode_v3(root)
+	script := os.join_path(root, '${name}.vsh')
+	os.write_file(script, source) or { panic(err) }
+	// `-silent` keeps the driver's benchmark report out of the script's output.
+	return os.execute('${v3_bin} -silent ${script}')
+}
+
+// A `.vsh` script gets `import os` implicitly, and every `os` function, generic
+// function and constant is usable without the module prefix.
+fn test_vsh_script_uses_os_symbols_unqualified() {
+	result := run_vsh_script('script', "dir := join_path(temp_dir(), 'v3_vsh_script_mode_data')
+mkdir_all(dir)!
+defer {
+	rmdir_all(dir) or {}
+}
+payload := join_path(dir, 'payload.bin')
+write_file_array(payload, [u8(1), 2, 3])!
+println(read_file_array[u8](payload))
+println(exists(payload))
+println(args.len > 0)
+println(path_separator.len)
+// `getenv` must resolve to the `os` wrapper, not to the `fn C.getenv` declaration
+// whose bare name is also registered while `os` is compiled.
+setenv('V3_VSH_SCRIPT_MODE_VALUE', 'from-env', true)
+println(getenv('V3_VSH_SCRIPT_MODE_VALUE'))
+")
+	assert result.exit_code == 0, result.output
+	assert result.output.split_into_lines() == ['[1, 2, 3]', 'true', 'true', '1', 'from-env'], result.output
+}
+
+// Script mode is a last resort: a declaration in the script itself keeps its
+// meaning even when `os` exports the same name.
+fn test_vsh_script_declaration_shadows_os_symbol() {
+	result := run_vsh_script('shadow', "fn exists(path string) string {
+	return 'local ' + path
+}
+
+println(exists('exists'))
+println(os.exists(temp_dir()))
+")
+	assert result.exit_code == 0, result.output
+	assert result.output.split_into_lines() == ['local exists', 'true'], result.output
+}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -4514,7 +4514,7 @@ fn (tc &TypeChecker) const_key_for_name(name string) ?string {
 	if name in tc.const_types {
 		return name
 	}
-	return none
+	return tc.vsh_os_const_key(name)
 }
 
 fn (tc &TypeChecker) local_name_conflicts_with_current_module_const(name string) bool {
@@ -5963,7 +5963,7 @@ fn (tc &TypeChecker) resolve_selective_import_symbol(name string) ?string {
 		// active. Recover a selected symbol from the source file only when it has one
 		// unambiguous declaration across the registered imports.
 		if !tc.resolution_type_mode {
-			return none
+			return tc.vsh_os_fn_symbol(name)
 		}
 		mut resolved := ''
 		suffix := '\n${name}'
@@ -5984,7 +5984,7 @@ fn (tc &TypeChecker) resolve_selective_import_symbol(name string) ?string {
 		if resolved.len > 0 {
 			return resolved
 		}
-		return none
+		return tc.vsh_os_fn_symbol(name)
 	}
 	for candidate in candidates {
 		if tc.fn_signature_known(candidate) || candidate in tc.fn_ret_types
@@ -5992,7 +5992,7 @@ fn (tc &TypeChecker) resolve_selective_import_symbol(name string) ?string {
 			return candidate
 		}
 	}
-	return none
+	return tc.vsh_os_fn_symbol(name)
 }
 
 // resolve_any_selective_import_fn resolves an unqualified selected function
@@ -6017,7 +6017,7 @@ pub fn (tc &TypeChecker) resolve_any_selective_import_fn(name string) ?string {
 	if resolved.len > 0 {
 		return resolved
 	}
-	return none
+	return tc.vsh_os_fn_key(name)
 }
 
 fn (tc &TypeChecker) resolve_selective_import_type_symbol(name string) ?string {
@@ -6028,6 +6028,59 @@ fn (tc &TypeChecker) resolve_selective_import_type_symbol(name string) ?string {
 		}
 	}
 	return none
+}
+
+// vsh_os_fn_symbol resolves an unqualified call name inside a `.vsh` script to
+// its `os` declaration. V script mode makes the `os` module global, but only as
+// a last resort: a local, builtin or explicitly imported declaration with the
+// same name keeps priority, exactly like in a plain `.v` file.
+fn (tc &TypeChecker) vsh_os_fn_symbol(name string) ?string {
+	if !tc.vsh_script_file() {
+		return none
+	}
+	return tc.vsh_os_fn_key(name)
+}
+
+// vsh_os_fn_key applies the script-mode `os` lookup without requiring the script
+// file itself to be the active one. Monomorphization collects candidate names for
+// a generic call outside any file context, and a compilation only has script-mode
+// symbols at all when it contains a `.vsh` script.
+fn (tc &TypeChecker) vsh_os_fn_key(name string) ?string {
+	if !tc.a.has_vsh_source || name.len == 0 || name.contains('.') {
+		return none
+	}
+	// Only a real V declaration shadows the script's `os` symbol. A bare name is
+	// also registered for every `fn C.name()` declaration, and those must not hide
+	// the V wrapper: `getenv('HOME')` in a script is `os.getenv`, not `C.getenv`.
+	if name in tc.v_fn_semantic_names {
+		return none
+	}
+	key := 'os.${name}'
+	if tc.fn_signature_known(key) || key in tc.fn_ret_types || key in tc.fn_param_types {
+		return key
+	}
+	return none
+}
+
+// vsh_os_const_key resolves an unqualified constant name inside a `.vsh` script
+// to its `os` declaration, under the same last-resort rule as `os` functions.
+fn (tc &TypeChecker) vsh_os_const_key(name string) ?string {
+	if !tc.vsh_script_file() || name.len == 0 || name.contains('.') {
+		return none
+	}
+	key := 'os.${name}'
+	if key in tc.const_types {
+		return key
+	}
+	return none
+}
+
+// vsh_script_file reports whether the file being checked is a V script, whose
+// `os` symbols are visible unqualified. The `.vsh` test is guarded by an
+// AST-wide flag so non-script compilations never pay for it.
+@[inline]
+fn (tc &TypeChecker) vsh_script_file() bool {
+	return tc.a.has_vsh_source && tc.cur_file.ends_with('.vsh')
 }
 
 fn (tc &TypeChecker) selective_import_candidates(name string) ?[]string {

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -7502,6 +7502,12 @@ fn (mut tc TypeChecker) check_ident(id flat.NodeId, node flat.Node) {
 		tc.register_synth_type(id, typ)
 		return
 	}
+	if key := tc.vsh_os_const_key(node.value) {
+		tc.register_synth_type(id, tc.const_type_from_initializer(key, tc.const_types[key] or {
+			Type(void_)
+		}))
+		return
+	}
 	if key := tc.generic_fn_value_key(node.value) {
 		if !tc.ident_is_call_callee_or_generic_base(id) && !tc.expr_is_direct_call_argument(id)
 			&& tc.resolved_fn_value_name(id) == none {


### PR DESCRIPTION
## The problem

`make` is broken on master. Its last step runs `.github/problem-matchers/register_all.vsh`, and that fails to compile:

```
V has been successfully built
V 0.5.2 b4b6d28
.github/problem-matchers/register_all.vsh:8:20: error: unknown function `getenv`
.github/problem-matchers/register_all.vsh:8:20: error: const declarations do not support multiple return values yet
.github/problem-matchers/register_all.vsh:15:16: error: cannot use `string` as argument 1 to `chdir`; expected `&char`
.github/problem-matchers/register_all.vsh:15:17: error: unexpected `!`, the function `chdir` does not return a Result
.github/problem-matchers/register_all.vsh:16:10: error: unknown function `walk_ext`
.github/problem-matchers/register_all.vsh:17:28: error: unknown function `real_path`
make: *** [GNUmakefile:222: all] Error 1
```

`register_all.vsh` is not special — **every** `.vsh` script was broken:

```
$ printf 'println(getenv("HOME"))\n' > /tmp/t.vsh && ./v run /tmp/t.vsh
/tmp/t.vsh:1:9: error: unknown function `getenv`
```

Since #28378 the `v` that `make` produces contains only the V3 frontend, and V3 had no `.vsh` handling at all (`grep -rn is_vsh vlib/v3/` matched nothing). It parsed the script as a plain `.v` file, so V script mode was gone: no implicit `import os`, and no unqualified `os` symbols.

That explains each diagnostic:

- `unknown function getenv` — `os` was never in scope. V3 then synthesizes an empty `MultiReturn` for an unknown call, which is where the unrelated-looking `const declarations do not support multiple return values yet` on the same line comes from.
- `chdir ... expected &char` / `does not return a Result` — `chdir` resolved to `fn C.chdir(path &char) i32` (`vlib/builtin/cfns.c.v:187`), whose bare name V3 also registers, instead of `os.chdir(path string) !`.
- `walk_ext` / `real_path` unknown, then `.sorted()` on a non-value and `for in: cannot index ()` — all downstream.

`vlib/v3/test_all.vsh` writes `import os` and qualifies its calls, which is why the V3 CI stayed green.

## The fix

- **`vlib/v3/parser/parser.v`** — a `.vsh` file gets a synthetic `import os` node, skipped when the script imports `os` itself, with the alias registered before the body is parsed. Not added while `is_fmt`, so `v fmt` output for `.vsh` is unchanged.
- **`vlib/v3/flat/flat.v`** + the parallel-parse merge — an AST-wide `has_vsh_source` flag, so every lookup below is behind one bool and a compilation without a script pays nothing.
- **`vlib/v3/types/checker.v`** — inside a `.vsh` file, an unqualified name that resolves to nothing else falls back to `os.<name>`: functions (including generics) through `resolve_selective_import_symbol`, constants through `const_key_for_name`. Precedence matches V1 — a local or builtin V declaration still shadows `os`, but a bare `fn C.name` declaration no longer does. `resolve_any_selective_import_fn` gets the same fallback so monomorphization instantiates `read_file_array[u8](...)` correctly.
- **`vlib/v3/types/checker_tail_stmt.v`** — the bare-ident path resolves script-mode `os` constants (`args`, `path_separator`, `max_path_len`).
- **`vlib/v3/tests/vsh_script_mode_test.v`** — new. The existing `.vsh` coverage is in `vlib/v/slow_tests/inout`, which the V3 CI does not run, which is how this landed unnoticed.

## Verification

- `make` completes; `register_all.vsh` works in both branches (`GITHUB_JOB` set and unset).
- `vlib/v/slow_tests/inout/vscript_using_constants_in_os.vsh` and `vscript_using_generics_in_os.vsh` now match their `.out` files exactly.
- `examples/v_script.vsh` runs correctly again.
- `v fmt -verify` clean on every touched file.