### PR TITLE
v3: use narrower integer types in the AST and node-indexed tables

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -15583,16 +15583,16 @@ fn synthetic_index_shift(insertions []SyntheticInsertion, idx int) int {
 // care about (.file markers/trailers, module_decl, import_decl) for every file
 // pair at or past region_start, in ascending node order. Falls back to the
 // full id range when the parser file index is unusable.
-fn collect_import_scan_ids(a &flat.FlatAst, region_start int, pair_cursor int) ([]int, int) {
+fn collect_import_scan_ids(a &flat.FlatAst, region_start int, pair_cursor int) ([]i32, int) {
 	if !file_index_usable_for_imports(a) {
-		mut all := []int{cap: a.nodes.len - region_start}
+		mut all := []i32{cap: a.nodes.len - region_start}
 		for i in region_start .. a.nodes.len {
 			all << i
 		}
 		return all, pair_cursor
 	}
 	mut cursor := pair_cursor
-	mut ids := []int{cap: 4096}
+	mut ids := []i32{cap: 4096}
 	mut last_trailing := region_start - 1
 	for cursor + 1 < a.file_node_ids.len {
 		marker := a.file_node_ids[cursor]
@@ -15628,7 +15628,7 @@ fn collect_import_scan_ids(a &flat.FlatAst, region_start int, pair_cursor int) (
 	return ids, cursor
 }
 
-fn collect_import_scan_children(a &flat.FlatAst, node &flat.Node, mut ids []int) {
+fn collect_import_scan_children(a &flat.FlatAst, node &flat.Node, mut ids []i32) {
 	for ci in 0 .. node.children_count {
 		id := int(a.child(node, ci))
 		if id < 0 || id >= a.nodes.len {
@@ -16150,7 +16150,7 @@ fn resolve_imports(mut a flat.FlatAst, mut p parser.Parser, prefs &pref.Preferen
 		scan_ids, next_pair_cursor := collect_import_scan_ids(a, node_idx, pair_cursor)
 		pair_cursor = next_pair_cursor
 		if os.getenv('V3_VERIFY_IMPORT_IDX') != '' {
-			mut full := []int{}
+			mut full := []i32{}
 			for i in node_idx .. a.nodes.len {
 				if a.nodes[i].kind in [.file, .module_decl, .import_decl] {
 					full << i

--- a/vlib/v3/driver/implicit_import_test.v
+++ b/vlib/v3/driver/implicit_import_test.v
@@ -237,7 +237,7 @@ fn test_synthetic_import_insertion_preserves_file_index_and_import_order() {
 		assert marker.value == trailing.value
 	}
 	for region in [0, boundary] {
-		mut expected := []int{}
+		mut expected := []i32{}
 		for i in region .. ast.nodes.len {
 			if ast.nodes[i].kind in [.file, .module_decl, .import_decl] {
 				expected << i

--- a/vlib/v3/flat/flat.v
+++ b/vlib/v3/flat/flat.v
@@ -4,7 +4,9 @@ import v3.token
 import v3.workers
 
 // NodeId aliases node id values used by flat.
-pub type NodeId = int
+// Node ids index `FlatAst.nodes`, so i32 is ample and keeps `children` (one entry
+// per AST edge) and every node-id side table half the size of a 64-bit `int`.
+pub type NodeId = i32
 
 // TextId is the stable identity of one canonical AST text value.
 pub type TextId = u32
@@ -271,7 +273,7 @@ pub mut:
 	// its top-level index without a full node scan. Stages that renumber
 	// nodes clear the list; consumers fall back to scanning when it is empty
 	// or file_index_incomplete is set (a source file failed to read).
-	file_node_ids         []int
+	file_node_ids         []i32
 	file_index_incomplete bool
 	// source_buffers owns the storage behind zero-copy scanner strings retained
 	// by AST nodes. Keeping the buffers on the AST makes the lifetime boundary

--- a/vlib/v3/flat/flat_test.v
+++ b/vlib/v3/flat/flat_test.v
@@ -21,7 +21,10 @@ fn test_node_uses_compact_header_and_uncommon_payload() {
 	assert sizeof(NodeKind) == 1
 	assert sizeof(Op) == 1
 	// The former always-present []string field made Node 96 bytes on 64-bit.
-	assert sizeof(Node) <= 72
+	// `int` is 64-bit now, so the two `string` headers alone are 48 bytes; the
+	// rest of the header (payload pointer, child range, flags and Pos) is 40.
+	assert sizeof(Node) <= 88
+	assert sizeof(NodeId) == 4
 }
 
 fn test_node_owned_clone_preserves_semantic_flags_and_payload() {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -302,7 +302,7 @@ mut:
 	used_fns                       &map[string]bool = unsafe { nil }
 	used_fn_names                  []string
 	fn_gen_items                   []FlatFnGenItem
-	top_level_node_ids             []int
+	top_level_node_ids             []i32
 	ast_string_literals            []string
 	ast_string_literals_ready      bool
 	fn_segs                        []string
@@ -1050,7 +1050,7 @@ pub fn FlatGen.new() FlatGen {
 		lazy_param_abi_merge: os.getenv('V3_NO_LAZY_PARAM_ABI_MERGE') == ''
 		sb: strings.new_builder(4096)
 		fn_gen_items: []FlatFnGenItem{}
-		top_level_node_ids: []int{}
+		top_level_node_ids: []i32{}
 		fn_segs: []string{}
 		fn_seg_chunk_indexes: []int{}
 		parallel_chunk_wrapper_defs: []ParallelChunkWrapperDefs{}
@@ -1227,11 +1227,11 @@ pub fn FlatGen.new() FlatGen {
 
 // top_level_nodes returns the precomputed declaration index in full cgen and
 // preserves standalone generator helpers used by focused tests and tools.
-fn (g &FlatGen) top_level_nodes() []int {
+fn (g &FlatGen) top_level_nodes() []i32 {
 	if g.top_level_node_ids.len > 0 {
 		return g.top_level_node_ids
 	}
-	mut ids := []int{}
+	mut ids := []i32{}
 	for node_idx, node in g.a.nodes {
 		if node.kind in [.file, .module_decl, .fn_decl, .c_fn_decl, .struct_decl, .type_decl,
 			.global_decl, .const_decl, .enum_decl, .interface_decl, .import_decl, .directive] {
@@ -1453,18 +1453,18 @@ pub fn cache_external_input_files_with_resolved_flags(a &flat.FlatAst, vroot str
 }
 
 struct CCachePlacedInclude {
-	file_node      int
-	module_node    int
-	directive_node int
+	file_node      i32
+	module_node    i32
+	directive_node i32
 }
 
 // c_cache_external_input_node_order mirrors cgen placement: preincludes are
 // emitted before the translation-unit prefix and postincludes after its bodies,
 // independent of where their V directives occur.
-fn c_cache_external_input_node_order(a &flat.FlatAst) []int {
+fn c_cache_external_input_node_order(a &flat.FlatAst) []i32 {
 	mut preincludes := []CCachePlacedInclude{}
 	mut postincludes := []CCachePlacedInclude{}
-	mut normal := []int{cap: a.nodes.len}
+	mut normal := []i32{cap: a.nodes.len}
 	mut file_node := -1
 	mut module_node := -1
 	for node_id, node in a.nodes {
@@ -1489,7 +1489,7 @@ fn c_cache_external_input_node_order(a &flat.FlatAst) []int {
 		}
 		normal << node_id
 	}
-	mut ordered := []int{cap: normal.len + (preincludes.len + postincludes.len) * 3}
+	mut ordered := []i32{cap: normal.len + (preincludes.len + postincludes.len) * 3}
 	for placed in preincludes {
 		if placed.file_node >= 0 {
 			ordered << placed.file_node
@@ -2736,7 +2736,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	g.used_fns = &used_fns
 	g.used_fn_names = []string{}
 	g.fn_gen_items = []FlatFnGenItem{}
-	g.top_level_node_ids = []int{}
+	g.top_level_node_ids = []i32{}
 	g.ast_string_literals = []string{}
 	g.ast_string_literals_ready = false
 	g.direct_array_access = false
@@ -4271,7 +4271,7 @@ fn (mut g FlatGen) scan_collect_gen_info_serial() CollectGenInfoScanCounts {
 	mut counts := CollectGenInfoScanCounts{}
 	incremental := g.incremental_fn_names.len > 0
 	g.ast_string_literals = []string{cap: 4096}
-	g.top_level_node_ids = []int{cap: 4096}
+	g.top_level_node_ids = []i32{cap: 4096}
 	for node_idx, node in g.a.nodes {
 		if node.kind == .string_literal {
 			g.ast_string_literals << node.value

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -220,7 +220,7 @@ fn (mut g FlatGen) collect_fn_gen_items() []FlatFnGenItem {
 	return items
 }
 
-fn (mut g FlatGen) collect_fn_gen_candidates_range(nodes []int, start int, end int, first_file string, first_module string, direct_array_access_fns DirectArrayAccessFns, ignore_overflow_fns DirectArrayAccessFns, program_modules map[string]bool) []FlatFnGenCandidate {
+fn (mut g FlatGen) collect_fn_gen_candidates_range(nodes []i32, start int, end int, first_file string, first_module string, direct_array_access_fns DirectArrayAccessFns, ignore_overflow_fns DirectArrayAccessFns, program_modules map[string]bool) []FlatFnGenCandidate {
 	mut candidates := []FlatFnGenCandidate{cap: end - start}
 	mut cur_module := first_module
 	mut cur_file := first_file

--- a/vlib/v3/gen/c/fn_parallel_d_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_d_v3_no_parallel.v
@@ -35,7 +35,7 @@ fn (mut g FlatGen) prepare_shared_sum_and_fixed_array_ret_wrappers(_ bool) bool 
 	return false
 }
 
-fn (mut g FlatGen) collect_gen_info_fn_preps(_ []int, _ bool) []CollectGenFnPrep {
+fn (mut g FlatGen) collect_gen_info_fn_preps(_ []i32, _ bool) []CollectGenFnPrep {
 	return []CollectGenFnPrep{}
 }
 

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -47,7 +47,7 @@ mut:
 
 struct CollectGenInfoFnPrepArgs {
 	g            voidptr // read-only &FlatGen master
-	node_ids_ptr voidptr // &[]int
+	node_ids_ptr voidptr // &[]i32
 	preps_ptr    voidptr // &[]CollectGenFnPrep; shards fill disjoint positions
 	start        int
 	end          int
@@ -104,7 +104,7 @@ $if !windows {
 		a.scope = cgen_worker_scope_begin(true)
 		master := unsafe { &FlatGen(a.g) }
 		mut view := master.new_collect_gen_info_view()
-		nodes := unsafe { &[]int(a.nodes_ptr) }
+		nodes := unsafe { &[]i32(a.nodes_ptr) }
 		a.candidates = view.collect_fn_gen_candidates_range(*nodes, a.start, a.end, a.file, a.module_name, a.direct_array_access_fns, a.ignore_overflow_fns, a.program_modules)
 		cgen_worker_scope_leave(a.scope)
 		return unsafe { nil }
@@ -116,7 +116,7 @@ $if !windows {
 		mut view := master.new_collect_gen_info_view()
 		view.tc.cur_file = a.file
 		view.tc.cur_module = a.module_name
-		node_ids := unsafe { &[]int(a.node_ids_ptr) }
+		node_ids := unsafe { &[]i32(a.node_ids_ptr) }
 		mut preps := unsafe { &[]CollectGenFnPrep(a.preps_ptr) }
 		mut cur_file := a.file
 		mut cur_module := a.module_name
@@ -186,7 +186,7 @@ $if !windows {
 	fn collect_gen_info_scan_fill_thread(arg voidptr) voidptr {
 		mut a := unsafe { &CollectGenInfoScanArgs(arg) }
 		g := unsafe { &FlatGen(a.g) }
-		mut top_levels := unsafe { &[]int(a.top_levels_ptr) }
+		mut top_levels := unsafe { &[]i32(a.top_levels_ptr) }
 		mut literals := unsafe { &[]string(a.strings_ptr) }
 		mut top_level_pos := a.top_level_pos
 		mut string_pos := a.string_pos
@@ -560,7 +560,7 @@ fn (mut g FlatGen) scan_collect_gen_info(no_parallel bool) CollectGenInfoScanCou
 			top_level_count += counted_top_levels
 			string_count += counted_strings
 		}
-		g.top_level_node_ids = []int{len: top_level_count}
+		g.top_level_node_ids = []i32{len: top_level_count}
 		g.ast_string_literals = []string{len: string_count}
 		for mut arg in args {
 			arg.top_levels_ptr = unsafe { voidptr(&g.top_level_node_ids) }
@@ -677,7 +677,7 @@ fn (mut g FlatGen) prepare_shared_sum_and_fixed_array_ret_wrappers(parallel bool
 // collect_gen_info_fn_preps resolves used function signatures on the persistent
 // worker pool. Registration stays serial in collect_gen_info, preserving all
 // source-order and duplicate-declaration semantics.
-fn (mut g FlatGen) collect_gen_info_fn_preps(node_ids []int, no_parallel bool) []CollectGenFnPrep {
+fn (mut g FlatGen) collect_gen_info_fn_preps(node_ids []i32, no_parallel bool) []CollectGenFnPrep {
 	$if windows {
 		return []CollectGenFnPrep{}
 	} $else {

--- a/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
@@ -318,7 +318,7 @@ fn remap_worker_pos(pos token.Pos, first_file_id int, next_file_id int, delta in
 	}
 	return token.Pos{
 		...pos
-		id: pos.id + delta
+		id: i32(pos.id + delta)
 	}
 }
 

--- a/vlib/v3/token/position.v
+++ b/vlib/v3/token/position.v
@@ -3,11 +3,14 @@ module token
 import crypto.sha256
 
 // Pos represents pos data used by token.
+// The byte offsets, span end and file id are stored as i32: a Pos is embedded in
+// every AST node, and no source file or file table comes close to 2 GiB. Reads
+// promote to `int` implicitly, so consumers are unaffected.
 pub struct Pos {
 pub:
-	offset int
-	end    int
-	id     int
+	offset i32
+	end    i32
+	id     i32
 	meta   u16
 }
 
@@ -16,9 +19,9 @@ const type_text_meta_flag = u16(0x8000)
 // new_pos creates a source position from a stable file id and byte offset.
 pub fn new_pos(file_id int, offset int) Pos {
 	return Pos{
-		id:     file_id
-		offset: offset
-		end:    offset
+		id:     i32(file_id)
+		offset: i32(offset)
+		end:    i32(offset)
 	}
 }
 
@@ -26,9 +29,9 @@ pub fn new_pos(file_id int, offset int) Pos {
 // retained as the start for compatibility with existing diagnostic consumers.
 pub fn new_span(file_id int, start int, end int) Pos {
 	return Pos{
-		id:     file_id
-		offset: start
-		end:    if end < start { start } else { end }
+		id:     i32(file_id)
+		offset: i32(start)
+		end:    i32(if end < start { start } else { end })
 	}
 }
 
@@ -107,7 +110,8 @@ pub:
 	name string
 	size int
 mut:
-	line_offsets []int = [0]
+	// One entry per source line, so keep it compact: offsets are file-local.
+	line_offsets []i32 = [i32(0)]
 	// Keep the digest inline: stored files can outlive parser-worker preallocation scopes.
 	source_digest     [sha256.size]u8
 	has_source_digest bool
@@ -147,14 +151,14 @@ pub fn File.unindexed(name string, size int) &File {
 	return &File{
 		name:         name
 		size:         size
-		line_offsets: []int{}
+		line_offsets: []i32{}
 	}
 }
 
 // add_line updates add line state for File.
 @[inline]
 pub fn (mut f File) add_line(offset int) {
-	f.line_offsets << offset
+	f.line_offsets << i32(offset)
 }
 
 // index_lines records every source-line start for logarithmic position lookup
@@ -163,7 +167,7 @@ pub fn (mut f File) index_lines(src string) {
 	f.index_lines_without_digest(src)
 	for i, c in src {
 		if c == `\n` {
-			f.line_offsets << i + 1
+			f.line_offsets << i32(i + 1)
 		}
 	}
 	digest := sha256.sum(src.bytes())
@@ -183,7 +187,7 @@ pub fn (mut f File) index_lines(src string) {
 // parameter keeps the call sites and signature stable.
 pub fn (mut f File) index_lines_without_digest(src string) {
 	_ := src
-	f.line_offsets = [0]
+	f.line_offsets = [i32(0)]
 	f.has_source_digest = false
 }
 

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -59,6 +59,7 @@ fn (mut t Transformer) collect_generic_specs_range_scoped(struct_decls map[strin
 		// `last`; workers only read them while collecting type spellings.
 		w.node_module_map_cache = t.node_module_map_cache
 		w.node_file_map_cache = t.node_file_map_cache
+		w.node_context_texts = t.node_context_texts
 		w.node_module_map_nodes = t.node_module_map_nodes
 		mut batch_struct_specs := map[string]string{}
 		mut batch_sum_specs := map[string]GenericSpecContext{}
@@ -2681,7 +2682,12 @@ fn (mut t Transformer) collect_generic_sum_decls() map[string]GenericSumDecl {
 				if node.generic_params().len == 0 || node.children_count == 0 {
 					continue
 				}
-				module_name := t.node_module_map_cache[i] or { cur_module }
+				module_id := t.node_module_map_cache[i] or { u32(0) }
+				module_name := if module_id != 0 {
+					t.node_context_text(module_id)
+				} else {
+					cur_module
+				}
 				key := generic_type_decl_key(node.value, module_name)
 				decls[key] = GenericSumDecl{
 					id: flat.NodeId(i)
@@ -3415,8 +3421,8 @@ fn (mut t Transformer) ensure_node_module_map() {
 		return
 	}
 	if t.node_module_map_nodes < 0 || t.node_module_map_nodes > t.a.nodes.len {
-		t.node_module_map_cache = []string{len: t.a.nodes.len, cap: t.a.nodes.cap}
-		t.node_file_map_cache = []string{len: t.a.nodes.len, cap: t.a.nodes.cap}
+		t.node_module_map_cache = []u32{len: t.a.nodes.len, cap: t.a.nodes.cap}
+		t.node_file_map_cache = []u32{len: t.a.nodes.len, cap: t.a.nodes.cap}
 		t.node_module_map_nodes = 0
 	} else {
 		t.ensure_node_context_map_capacity()
@@ -3454,19 +3460,46 @@ fn (mut t Transformer) ensure_node_context_map_capacity() {
 	}
 	if t.node_module_map_cache.len < t.a.nodes.len {
 		t.node_module_map_cache.ensure_cap(t.a.nodes.cap)
-		t.node_module_map_cache << []string{len: t.a.nodes.len - t.node_module_map_cache.len}
+		t.node_module_map_cache << []u32{len: t.a.nodes.len - t.node_module_map_cache.len}
 	}
 	if t.node_file_map_cache.len < t.a.nodes.len {
 		t.node_file_map_cache.ensure_cap(t.a.nodes.cap)
-		t.node_file_map_cache << []string{len: t.a.nodes.len - t.node_file_map_cache.len}
+		t.node_file_map_cache << []u32{len: t.a.nodes.len - t.node_file_map_cache.len}
 	}
+}
+
+// node_context_text_id interns a declaration-context spelling for the per-node
+// module/file tables. Id 0 means "unset". Only the owning transformer interns
+// (workers run with node_context_read_only set), so the shared table needs no
+// synchronization.
+fn (mut t Transformer) node_context_text_id(value string) u32 {
+	if value.len == 0 {
+		return 0
+	}
+	if id := t.node_context_text_ids[value] {
+		return id
+	}
+	id := u32(t.node_context_texts.len + 1)
+	t.node_context_texts << value
+	t.node_context_text_ids[value] = id
+	return id
+}
+
+// node_context_text resolves an interned declaration-context spelling.
+@[inline]
+fn (t &Transformer) node_context_text(id u32) string {
+	idx := int(id) - 1
+	if idx < 0 || idx >= t.node_context_texts.len {
+		return ''
+	}
+	return t.node_context_texts[idx]
 }
 
 fn (t &Transformer) node_file_or(idx int, fallback string) string {
 	if idx >= 0 && idx < t.node_file_map_cache.len {
-		file_name := t.node_file_map_cache[idx]
-		if file_name.len > 0 {
-			return file_name
+		file_id := t.node_file_map_cache[idx]
+		if file_id != 0 {
+			return t.node_context_text(file_id)
 		}
 	}
 	return fallback
@@ -3474,12 +3507,12 @@ fn (t &Transformer) node_file_or(idx int, fallback string) string {
 
 fn (t &Transformer) node_module_or(idx int, fallback string) string {
 	if idx >= 0 && idx < t.node_module_map_cache.len {
-		module_name := t.node_module_map_cache[idx]
-		if module_name.len > 0 {
-			return module_name
+		module_id := t.node_module_map_cache[idx]
+		if module_id != 0 {
+			return t.node_context_text(module_id)
 		}
 		if !isnil(t.tc) && idx < t.node_file_map_cache.len {
-			file_name := t.node_file_map_cache[idx]
+			file_name := t.node_context_text(t.node_file_map_cache[idx])
 			if source_module := t.tc.file_modules[file_name] {
 				return source_module
 			}
@@ -3495,6 +3528,8 @@ fn (mut t Transformer) mark_node_context(id flat.NodeId, module_name string, fil
 	if t.node_context_read_only {
 		return
 	}
+	module_id := t.node_context_text_id(module_name)
+	file_id := t.node_context_text_id(file_name)
 	t.node_context_stack.clear()
 	t.node_context_stack << id
 	for t.node_context_stack.len > 0 {
@@ -3504,15 +3539,15 @@ fn (mut t Transformer) mark_node_context(id flat.NodeId, module_name string, fil
 			continue
 		}
 		if idx < t.node_module_map_cache.len && idx < t.node_file_map_cache.len
-			&& t.node_module_map_cache[idx] == module_name
-			&& t.node_file_map_cache[idx] == file_name {
+			&& t.node_module_map_cache[idx] == module_id
+			&& t.node_file_map_cache[idx] == file_id {
 			continue
 		}
 		if idx < t.node_module_map_cache.len {
-			t.node_module_map_cache[idx] = module_name
+			t.node_module_map_cache[idx] = module_id
 		}
 		if idx < t.node_file_map_cache.len {
-			t.node_file_map_cache[idx] = file_name
+			t.node_file_map_cache[idx] = file_id
 		}
 		node := t.a.nodes[idx]
 		start := node.children_start

--- a/vlib/v3/transform/monomorphize_test.v
+++ b/vlib/v3/transform/monomorphize_test.v
@@ -104,8 +104,8 @@ fn test_explicit_generic_fn_value_candidates_resolve_selective_import() {
 	file_name := '/tmp/main.v'
 	tc.file_selective_imports[file_import_key(file_name, 'id')] = ['lib.id']
 	mut t := new_transformer(mut a, &tc, map[string]bool{})
-	t.node_file_map_cache = []string{len: a.nodes.len}
-	t.node_file_map_cache[int(index_id)] = file_name
+	t.node_file_map_cache = []u32{len: a.nodes.len}
+	t.node_file_map_cache[int(index_id)] = t.node_context_text_id(file_name)
 
 	candidates := t.explicit_generic_fn_value_decl_candidates(index_id, base_id, a.nodes[int(base_id)], 'main')
 	assert candidates[0] == 'lib.id'

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -161,7 +161,7 @@ mut:
 	declared_fn_name_counts       map[string]u8
 	variadic_suffix_index         map[string]i8
 	const_suffixes                map[string]string
-	source_parent_ids             []int
+	source_parent_ids             []i32
 	shared_local_decl_names       map[string]bool
 	// const_array_fixed_storage_ready marks the cache below as fully populated
 	// (by the overlapped pre-dispatch scan), making the precompute a no-op.
@@ -406,7 +406,7 @@ mut:
 	parallel_monomorph_scan_nodes      []int
 	parallel_monomorph_scan_start      int
 	parallel_monomorph_scan_end        int
-	fn_scan_costs                      []int
+	fn_scan_costs                      []i32
 	fn_escape_scan_flags               []u8
 	literal_fn_decls                   []int
 	literal_fn_decls_ready             bool
@@ -420,10 +420,16 @@ mut:
 	str_expansion_memo                 map[string]int
 	deferred_expansion_items           []FnWorkItem
 	deferred_expansion_count           int
-	node_module_map_cache              []string
-	node_file_map_cache                []string
-	node_module_map_nodes              int = -1
-	node_context_read_only             bool
+	// node_module_map_cache/node_file_map_cache hold one interned id per node
+	// (0 == unset) into node_context_texts. A whole-AST table of 24-byte string
+	// headers costs hundreds of MiB on a compiler-sized program; the id table is
+	// 4 bytes per node and resolves to the same canonical spelling.
+	node_module_map_cache  []u32
+	node_file_map_cache    []u32
+	node_context_texts     []string
+	node_context_text_ids  map[string]u32
+	node_module_map_nodes  int = -1
+	node_context_read_only bool
 	// used_fns_log records names newly inserted into used_fns while the
 	// late-used-fn-bodies pass runs, so that pass can tell "was this name
 	// already used before the current body's transform" without cloning the
@@ -1209,7 +1215,7 @@ fn reserve_parallel_transform_ast_with_cache_mode(mut a flat.FlatAst, skip_gener
 		_ = copy_thread1.wait()
 		_ = copy_thread2.wait()
 		a.nodes = grown_nodes
-		a.file_node_ids = []int{}
+		a.file_node_ids = []i32{}
 		a.children = grown_children
 		return
 	}
@@ -3520,7 +3526,7 @@ fn (mut t Transformer) transform_serial_then_collect_pure(literal_decls []int) [
 			const_ms += f64(scsw.elapsed().microseconds()) / 1000.0
 		}
 	}
-	t.fn_scan_costs = []int{}
+	t.fn_scan_costs = []i32{}
 	t.fn_escape_scan_flags = []u8{}
 	t.timing_profile('  [ttime]   sc consts ${const_ms:.2f} ms, closures ${lit_ms:.2f} ms, expansion est ${est_ms:.2f} ms')
 	return pure
@@ -3542,7 +3548,7 @@ fn (mut t Transformer) collect_literal_fn_decls(limit int) []int {
 		mut literal_pending := false
 		mut escape_scan_needed := false
 		mut span_cost := 0
-		t.fn_scan_costs = []int{len: limit}
+		t.fn_scan_costs = []i32{len: limit}
 		t.fn_escape_scan_flags = []u8{len: limit}
 		for i in 0 .. flags.len {
 			flag := flags[i]
@@ -3780,10 +3786,11 @@ fn (t &Transformer) fork_worker_config(ast &flat.FlatAst, wtc &types.TypeChecker
 	if t.node_context_read_only {
 		w.node_module_map_cache = t.node_module_map_cache
 		w.node_file_map_cache = t.node_file_map_cache
+		w.node_context_texts = t.node_context_texts
 		w.node_module_map_nodes = t.node_module_map_nodes
 		w.node_context_read_only = true
 	} else {
-		w.node_module_map_cache = []string{}
+		w.node_module_map_cache = []u32{}
 		w.node_module_map_nodes = -1
 	}
 	w.var_types = []VarTypeBinding{}
@@ -3908,7 +3915,7 @@ fn (t &Transformer) fork_scan_worker(wtc &types.TypeChecker) &Transformer {
 	w.generic_fn_decls_ready = false
 	w.generic_call_spec_cache = map[int]GenericCallSpec{}
 	w.generic_call_spec_misses = map[int]bool{}
-	w.node_module_map_cache = []string{}
+	w.node_module_map_cache = []u32{}
 	w.node_module_map_nodes = -1
 	w.var_types = []VarTypeBinding{}
 	w.var_type_indices = map[string]int{}
@@ -6127,7 +6134,7 @@ fn (mut t Transformer) collect_exclusive_closure_return_fns() {
 	mut literal_pending := false
 	mut span_cost := 0
 	t.literal_fn_decls = []int{cap: 64}
-	t.fn_scan_costs = []int{len: t.a.nodes.len}
+	t.fn_scan_costs = []i32{len: t.a.nodes.len}
 	for idx in 0 .. t.a.nodes.len {
 		node := t.a.nodes[idx]
 		span_cost += match node.kind {
@@ -10981,7 +10988,7 @@ fn (mut t Transformer) precompute_const_array_fixed_storage() {
 	if candidate_keys.len == 0 {
 		return
 	}
-	mut ref_candidates := []int{len: t.a.nodes.len}
+	mut ref_candidates := []i32{len: t.a.nodes.len}
 	mut ref_states := []u8{len: t.a.nodes.len}
 	mut unmatched := []int{len: candidate_keys.len}
 	mut fixed_candidates := []bool{len: candidate_keys.len}
@@ -11059,7 +11066,7 @@ fn (t &Transformer) const_array_candidate_for_expr(id flat.NodeId, module_name s
 	return candidates[key] or { return none }
 }
 
-fn (t &Transformer) mark_const_array_ref_safe(mut candidates []int, mut states []u8, mut unmatched []int, id flat.NodeId) {
+fn (t &Transformer) mark_const_array_ref_safe(mut candidates []i32, mut states []u8, mut unmatched []int, id flat.NodeId) {
 	idx := int(id)
 	if idx < 0 || idx >= t.a.nodes.len {
 		return
@@ -15848,7 +15855,7 @@ fn (t &Transformer) local_binding_before(name string, before flat.NodeId) ?bool 
 }
 
 fn (mut t Transformer) build_source_parent_index() {
-	t.source_parent_ids = []int{len: t.a.nodes.len, init: -1}
+	t.source_parent_ids = []i32{len: t.a.nodes.len, init: -1}
 	mut decls := map[string][]int{}
 	mut fn_offsets := map[int][]int{}
 	mut if_exprs := map[int][]int{}

--- a/vlib/v3/transform/transform_parallel_test.v
+++ b/vlib/v3/transform/transform_parallel_test.v
@@ -5107,7 +5107,7 @@ fn test_parallel_escape_precheck_preserves_candidate_across_local_type_decl() {
 			a.close_workers()
 		}
 		mut tc := types.TypeChecker.new(&a)
-		tc.top_level_idx = [0, 2, 3, 5, 6]
+		tc.top_level_idx = [i32(0), 2, 3, 5, 6]
 		tc.top_level_idx_nodes_len = a.nodes.len
 		tc.synthetic_top_level_type_ids = [2]
 		mut t := new_transformer(mut a, &tc, map[string]bool{})

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -860,7 +860,7 @@ pub mut:
 	ct_update_indexed             bool
 	insert_include_dirs_by_file   map[string][]string
 	has_spawn_expr                int = -1
-	inactive_top_level_node_ids   []int
+	inactive_top_level_node_ids   []i32
 	selected_file_called_fns      map[string]bool
 	// Names newly inserted into selected_file_called_fns and not yet chased by
 	// the transitive closure in collect_selected_file_called_fns_transitively.
@@ -878,13 +878,13 @@ pub mut:
 	// `collect`; no later phase of the check step appends declarations. Phases
 	// after the check (transform) may grow the AST: top_level_idx_nodes_len
 	// records the node count the index covers.
-	top_level_idx           []int
+	top_level_idx           []i32
 	top_level_idx_nodes_len int
 	// Anonymous and function-local struct declarations are synthesized below
 	// the file's top-level declaration tree. The direct-parent pass records their
 	// sorted node ids so collect_top_level_idx_fast can merge them without
 	// rescanning every gap between parser-recorded declarations.
-	synthetic_top_level_type_ids  []int
+	synthetic_top_level_type_ids  []i32
 	expected_expr_id              int = -1
 	expected_expr_type            Type = Type(void_)
 	cur_fn_ret_type               Type = Type(void_)
@@ -944,14 +944,14 @@ mut:
 	direct_parent_ids           []flat.NodeId
 	rewritten_parent_ids        []flat.NodeId
 	value_used_nodes            []bool
-	fn_check_costs              []int
+	fn_check_costs              []i32
 	direct_parent_index_trusted bool
 	has_goto_nodes              bool
 	// Immutable declaration indexes shared by checker workers.
 	declaration_attributes       map[int][]string
 	type_declaration_ids         map[string][]int
 	strings_builder_bindings     map[string]bool
-	strings_builder_candidates   []int
+	strings_builder_candidates   []i32
 	static_associated_fn_keys    map[string]bool
 	declaration_param_mutability map[string][]bool
 	strict_map_index_files       map[string]bool
@@ -1704,13 +1704,13 @@ fn (mut tc TypeChecker) init_direct_parent_index(a &flat.FlatAst) {
 	tc.direct_parent_ids = []flat.NodeId{len: a.nodes.len, init: flat.empty_node}
 	tc.rewritten_parent_ids = []flat.NodeId{}
 	tc.value_used_nodes = []bool{len: a.nodes.len}
-	tc.fn_check_costs = if tc.building_v_fast { []int{len: a.nodes.len} } else { []int{} }
+	tc.fn_check_costs = if tc.building_v_fast { []i32{len: a.nodes.len} } else { []i32{} }
 	tc.declaration_attributes = map[int][]string{}
 	tc.insert_include_dirs_by_file = map[string][]string{}
 	tc.translated_files = map[string]bool{}
 	tc.has_globals_files = map[string]bool{}
-	tc.strings_builder_candidates = []int{cap: 1024}
-	tc.synthetic_top_level_type_ids = []int{cap: 2048}
+	tc.strings_builder_candidates = []i32{cap: 1024}
+	tc.synthetic_top_level_type_ids = []i32{cap: 2048}
 	tc.has_goto_nodes = false
 }
 
@@ -1999,7 +1999,7 @@ fn (mut tc TypeChecker) build_fn_declaration_indexes(a &flat.FlatAst) {
 			ancestor = next
 		}
 	}
-	tc.strings_builder_candidates = []int{}
+	tc.strings_builder_candidates = []i32{}
 }
 
 // has_fn_decl_short_name reports whether collection indexed a function
@@ -2869,7 +2869,7 @@ pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 	// whole compile.
 	tc.declared_type_scope_keys = map[string]bool{}
 	tc.concrete_type_scope_keys = map[string]bool{}
-	tc.top_level_idx = []int{cap: 65536}
+	tc.top_level_idx = []i32{cap: 65536}
 	if !parallel_index_prep {
 		tc.prepare_threads_condition()
 	}

--- a/vlib/v3/types/checker_comptime.v
+++ b/vlib/v3/types/checker_comptime.v
@@ -1033,7 +1033,7 @@ fn (tc &TypeChecker) comptime_static_enum_helper_fn(callee_name string, enum_mod
 	short := callee_name.all_after_last('.')
 	mut indexes := tc.top_level_idx.clone()
 	if indexes.len == 0 {
-		indexes = []int{len: tc.a.nodes.len, init: index}
+		indexes = []i32{len: tc.a.nodes.len, init: i32(index)}
 	}
 	for priority in 0 .. 4 {
 		mut cur_mod := ''

--- a/vlib/v3/types/checker_parallel_test.v
+++ b/vlib/v3/types/checker_parallel_test.v
@@ -262,7 +262,7 @@ fn test_enclosing_generic_param_uses_the_owning_top_level_declaration() {
 	})
 
 	mut tc := TypeChecker.new(&a)
-	tc.top_level_idx = [int(generic_fn_id), int(unrelated_fn_id)]
+	tc.top_level_idx = [i32(generic_fn_id), i32(unrelated_fn_id)]
 	tc.build_enclosing_generic_param_index(&a)
 	assert tc.node_has_enclosing_generic_param(generic_child, 'T')
 	assert !tc.node_has_enclosing_generic_param(unrelated_child, 'T')

--- a/vlib/v3/types/checker_tail.v
+++ b/vlib/v3/types/checker_tail.v
@@ -1256,7 +1256,7 @@ fn (tc &TypeChecker) enum_initializer_calls_helper(fn_name string, module_name s
 	target_module := if module_name in ['', 'main'] { '' } else { module_name }
 	mut indexes := tc.top_level_idx.clone()
 	if indexes.len == 0 {
-		indexes = []int{len: tc.a.nodes.len, init: index}
+		indexes = []i32{len: tc.a.nodes.len, init: i32(index)}
 	}
 	mut cur_module := ''
 	for idx in indexes {

--- a/vlib/v3/types/scope.v
+++ b/vlib/v3/types/scope.v
@@ -22,7 +22,7 @@ pub mut:
 	fast_name_lens   [32]u16
 	fast_indexes     [32]u32
 	fast_generations [32]u32
-	generations      []int
+	generations      []i32
 	storage_keys     []string
 	next_generation  int
 	lifetime         int


### PR DESCRIPTION
`int` is 64-bit on 64-bit targets now, so every AST field and side table declared `int` silently doubled in size. Nothing in these tables needs more than 32 bits: node ids index `FlatAst.nodes`, and positions are file-local byte offsets.

### What changed

- `token.Pos.offset/end/id` become `i32`, so the `Pos` embedded in every node is **16 bytes instead of 32**, and `flat.Node` drops from **104 to 88 bytes**.
- `flat.NodeId` becomes `i32` (8 → 4 bytes), halving `FlatAst.children` (one entry per AST edge) and every node-id side table, including the checker's direct/rewritten parent indexes.
- `token.File.line_offsets`, `FlatAst.file_node_ids`, the checker's top-level/synthetic/inactive declaration indexes, `fn_check_costs`, `strings_builder_candidates`, `Scope.generations`, the transformer's `source_parent_ids`/`fn_scan_costs`, cgen's `top_level_node_ids` and the driver's import-scan id lists become `[]i32`.
- The transformer's per-node module/file context tables kept a 24-byte string header per node for a handful of distinct spellings; they now keep a `u32` id into a small interned table.

Reads promote to `int` implicitly, so consumers are unchanged. Constructors (`token.new_pos`, `new_span`, `File.add_line`) keep their `int` parameters and narrow internally.

### Effect

Self-hosting `cmd/v` on macOS/arm64 in the `v self` configuration (`-cc tcc -gc none -prealloc`), RSS after each stage:

| stage | before | after |
|---|---|---|
| parse | 531 MB | 495 MB |
| check | 1858 MB | 1823 MB |
| markused | 2914 MB | 2870 MB |
| transform | 3470 MB | 3366 MB |
| cgen | 3009 MB | 2912 MB |
| **peak** | **5335 MB** | **5200 MB** |

Process peak footprint drops from 5.58 GB to 5.44 GB. A plain `-gc none` build (no prealloc) shows the same shape: peak 5387 → 5186 MB. Compile time is unchanged.

### Validation

- **`v self x5` succeeds**, and the last two generations are byte-identical binaries that emit byte-identical C for `cmd/v` — the self-host is a fixpoint, not a drifting chain. (This is also the `-prealloc` configuration, so the disposable transform arenas are exercised.)
- Generated C for a non-v3 program (`cmd/tools/vpm`) matches the pre-change compiler after path normalization; the only residual difference is string-literal numbering, which is already nondeterministic on `master` for that target.
- v3 module unit tests pass. The failures seen (`eval_test`, `gen/arm64/*_test`, `ssa/builder_test`) reproduce identically on `master` with the same cold caches.
- `v fmt -verify` is clean on every touched file (`types/scope.v` was already unformatted before this change).

### Note for reviewers

The v3 checker currently accepts `[]i32` where `[]int` is expected (it rejects `[]f64` and `[]string` in the same position), so an element-width mismatch across such a boundary is silent and only shows up as a garbage index at runtime. That is a pre-existing checker gap, not introduced here, but it made this refactor need a manual audit — every array whose element type changed had its call sites checked by hand, and three real boundaries were found and fixed (`collect_fn_gen_candidates_range`, `collect_gen_info_fn_preps` plus its `&[]int(...)` worker views, and `mark_const_array_ref_safe`).

Follow-up opportunity, not done here: the checker's node-indexed `resolved_call_names`/`resolved_fn_value_names` are `[]string` (24 bytes/node, ~120 MB at self-host scale). Converting them to interned ids needs the parallel-check write path to intern under a lock, so it is left for a separate change.