### PR TITLE
v3: make the self-host ~20% faster (compiler phases 3.6x, peak RSS -67%)

### DIFF
--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -19209,7 +19209,34 @@ fn (mut g FlatGen) builtin_abi_decls() {
 	g.writeln('static const u64 _wyp[4] = {0x2d358dccaa6c78a5ull, 0x8bb84b93962eacc9ull, 0x4b33a62ed433d4a3ull, 0x4d5a2da51de1aa47ull};')
 	g.writeln('static inline u64 _wymix(u64 a, u64 b) { u64 ha = a >> 32, hb = b >> 32, la = (u32)a, lb = (u32)b, hi, lo; u64 rh = ha * hb, rm0 = ha * lb, rm1 = hb * la, rl = la * lb, t = rl + (rm0 << 32), c = t < rl; lo = t + (rm1 << 32); c += lo < t; hi = rh + (rm0 >> 32) + (rm1 >> 32) + c; return lo ^ hi; }')
 	g.writeln('static inline u64 wyhash64(u64 a, u64 b) { a ^= _wyp[0]; b ^= _wyp[1]; a *= 0xa0761d6478bd642full; b *= 0xe7037ed1a0b428dbull; return (a ^ (a >> 32)) ^ (b ^ (b >> 32)); }')
-	g.writeln('static inline u64 wyhash(const void* key, size_t len, u64 seed, const u64* secret) { const unsigned char* p = (const unsigned char*)key; u64 h = seed ^ secret[0] ^ (u64)len; for (size_t i = 0; i < len; i++) h = wyhash64(h ^ (u64)p[i], secret[(i + 1) & 3]); return h; }')
+	// Map keys are hashed on every lookup, so this mixes a 64-bit word per step
+	// instead of a byte. Assembling the word from its bytes is defined for any
+	// alignment and any effective type of the key storage; optimizing compilers
+	// fold it into a single load, and the hash stays identical across byte
+	// orders. The macro keeps the loads inline for compilers that do not honour
+	// `static inline`, such as TinyCC. This matches the fastc preamble.
+	g.writeln('#define V_WY_LOAD8(p) ((u64)(p)[0] | ((u64)(p)[1] << 8) | ((u64)(p)[2] << 16) | ((u64)(p)[3] << 24) | ((u64)(p)[4] << 32) | ((u64)(p)[5] << 40) | ((u64)(p)[6] << 48) | ((u64)(p)[7] << 56))')
+	g.writeln('static inline u64 wyhash(const void* key, size_t len, u64 seed, const u64* secret) {')
+	g.writeln('\tconst unsigned char* p = (const unsigned char*)key;')
+	g.writeln('\tsize_t n = len;')
+	g.writeln('\tu64 h = seed ^ secret[0] ^ ((u64)len * 0x9e3779b97f4a7c15ull);')
+	g.writeln('\twhile (n >= 8) { h = (h ^ V_WY_LOAD8(p)) * 0xa0761d6478bd642full; h ^= h >> 29; p += 8; n -= 8; }')
+	g.writeln('\tif (n > 0) {')
+	g.writeln('\t\tu64 v = 0;')
+	g.writeln('\t\tswitch (n) {')
+	g.writeln('\t\t\tcase 7: v |= (u64)p[6] << 48;')
+	g.writeln('\t\t\tcase 6: v |= (u64)p[5] << 40;')
+	g.writeln('\t\t\tcase 5: v |= (u64)p[4] << 32;')
+	g.writeln('\t\t\tcase 4: v |= (u64)p[3] << 24;')
+	g.writeln('\t\t\tcase 3: v |= (u64)p[2] << 16;')
+	g.writeln('\t\t\tcase 2: v |= (u64)p[1] << 8;')
+	g.writeln('\t\t\tdefault: v |= (u64)p[0];')
+	g.writeln('\t\t}')
+	g.writeln('\t\th = (h ^ v) * 0xe7037ed1a0b428dbull; h ^= h >> 29;')
+	g.writeln('\t}')
+	g.writeln('\th *= 0x8ebc6af09c88c6e3ull; h ^= h >> 32; h *= 0x589965cc75374cc3ull; h ^= h >> 29;')
+	g.writeln('\treturn h;')
+	g.writeln('}')
 	g.writeln('#define v_signal_with_handler_cast(sig, handler) signal((sig), ((void (*)(int))(handler)))')
 	g.writeln('string string__clone(string a);')
 	g.writeln('void string__free(string* s);')

--- a/vlib/v3/transform/array.v
+++ b/vlib/v3/transform/array.v
@@ -6058,26 +6058,103 @@ fn (mut t Transformer) make_array_default_sort_stmt(base flat.NodeId, elem_type 
 			return t.make_expr_stmt(t.make_call_typed(helper, [base_addr], 'void'))
 		}
 	}
+	return t.make_array_merge_sort_stmt(base, elem_type, src, cmp_id, false)
+}
+
+// make_array_merge_sort_stmt lowers `arr.sort(...)` / `arr.sort_with_compare(...)`
+// to an in-place bottom-up merge sort through a scratch buffer, which keeps the
+// stable order the V1 backend produces with its `v_stable_sort` helper. The
+// previous lowering was a plain insertion sort: quadratic, so a single 24k
+// element `sort` call (the compiler's own parallel check work list) cost about
+// 300 ms of the self-host.
+fn (mut t Transformer) make_array_merge_sort_stmt(base flat.NodeId, elem_type string, src flat.Node, cmp flat.NodeId, use_compare bool) flat.NodeId {
+	array_type := '[]${elem_type}'
+	n_name := t.new_temp('sort_n')
+	buf_name := t.new_temp('sort_buf')
+	w_name := t.new_temp('sort_w')
+	lo_name := t.new_temp('sort_lo')
+	mid_name := t.new_temp('sort_mid')
+	hi_name := t.new_temp('sort_hi')
 	i_name := t.new_temp('sort_i')
 	j_name := t.new_temp('sort_j')
-	tmp_name := t.new_temp('sort_tmp')
-	t.set_var_type(i_name, 'int')
-	t.set_var_type(j_name, 'int')
-	t.set_var_type(tmp_name, elem_type)
-	init := t.make_decl_assign_typed(i_name, t.make_int_literal(1), 'int')
-	cond := t.make_infix(.lt, t.make_ident(i_name), t.make_selector(base, 'len', 'int'))
-	post := t.make_expr_stmt(t.make_postfix(t.make_ident(i_name), .inc))
-	j_decl := t.make_decl_assign_typed(j_name, t.make_ident(i_name), 'int')
-	inner_cond := t.make_infix(.logical_and, t.make_infix(.gt, t.make_ident(j_name), t.make_int_literal(0)), t.array_sort_less_expr(base, elem_type, j_name, cmp_id))
-	tmp_decl := t.make_decl_assign_typed(tmp_name, t.make_index(base, t.make_ident(j_name), elem_type), elem_type)
-	prev_idx := t.make_infix(.minus, t.make_ident(j_name), t.make_int_literal(1))
-	assign_cur := t.make_index_assign(t.make_index(base, t.make_ident(j_name), elem_type), t.make_index(base, prev_idx, elem_type))
-	prev_idx2 := t.make_infix(.minus, t.make_ident(j_name), t.make_int_literal(1))
-	assign_prev := t.make_index_assign(t.make_index(base, prev_idx2, elem_type), t.make_ident(tmp_name))
-	dec_j := t.make_expr_stmt(t.make_postfix(t.make_ident(j_name), .dec))
-	inner_body := [tmp_decl, assign_cur, assign_prev, dec_j]
-	inner_for := t.make_for_stmt(t.make_empty(), inner_cond, t.make_empty(), inner_body, src)
-	return t.make_for_stmt(init, cond, post, [j_decl, inner_for], src)
+	k_name := t.new_temp('sort_k')
+	c_name := t.new_temp('sort_c')
+	t.set_var_type(n_name, 'int')
+	t.set_var_type(buf_name, array_type)
+	for name in [w_name, lo_name, mid_name, hi_name, i_name, j_name, k_name, c_name] {
+		t.set_var_type(name, 'int')
+	}
+	// One pass over the merged range picks from the left run whenever the right
+	// run is exhausted or does not compare strictly smaller, so equal elements
+	// keep their original order and the sort stays stable.
+	right := t.make_index(base, t.make_ident(j_name), elem_type)
+	left := t.make_index(base, t.make_ident(i_name), elem_type)
+	less := if use_compare {
+		t.array_sort_compare_less_expr(right, left, elem_type, cmp)
+	} else {
+		t.array_sort_less_expr(right, left, elem_type, cmp)
+	}
+	take_left_cond := t.make_infix(.logical_or, t.make_infix(.ge, t.make_ident(j_name), t.make_ident(hi_name)), t.make_infix(.logical_and, t.make_infix(.lt, t.make_ident(i_name), t.make_ident(mid_name)), t.make_prefix(.not, t.make_paren(less))))
+	take_left := t.make_block([
+		t.copy_sorted_element(t.make_ident(buf_name), k_name, base, i_name, elem_type),
+		t.increment_sort_index(i_name),
+	])
+	take_right := t.make_block([
+		t.copy_sorted_element(t.make_ident(buf_name), k_name, base, j_name, elem_type),
+		t.increment_sort_index(j_name),
+	])
+	merge_for := t.make_for_stmt(t.make_decl_assign_typed(k_name, t.make_ident(lo_name), 'int'), t.make_infix(.lt, t.make_ident(k_name), t.make_ident(hi_name)), t.make_expr_stmt(t.make_postfix(t.make_ident(k_name), .inc)), [
+		t.make_if_with_skip_ownership_drops(take_left_cond, take_left, take_right),
+	], src)
+	// Both halves are clamped to the array length, so a trailing run shorter than
+	// the current width is simply copied through, and `lo = hi` still advances.
+	run_body := [
+		t.make_decl_assign_typed(mid_name, t.make_infix(.plus, t.make_ident(lo_name), t.make_ident(w_name)), 'int'),
+		t.clamp_sort_index(mid_name, n_name),
+		t.make_decl_assign_typed(hi_name, t.make_infix(.plus, t.make_ident(mid_name), t.make_ident(w_name)), 'int'),
+		t.clamp_sort_index(hi_name, n_name),
+		t.make_decl_assign_typed(i_name, t.make_ident(lo_name), 'int'),
+		t.make_decl_assign_typed(j_name, t.make_ident(mid_name), 'int'),
+		merge_for,
+		t.make_assign(t.make_ident(lo_name), t.make_ident(hi_name)),
+	]
+	run_for := t.make_for_stmt(t.make_decl_assign_typed(lo_name, t.make_int_literal(0), 'int'), t.make_infix(.lt, t.make_ident(lo_name), t.make_ident(n_name)), t.make_empty(), run_body, src)
+	copy_back := t.make_for_stmt(t.make_decl_assign_typed(c_name, t.make_int_literal(0), 'int'), t.make_infix(.lt, t.make_ident(c_name), t.make_ident(n_name)), t.make_expr_stmt(t.make_postfix(t.make_ident(c_name), .inc)), [
+		t.copy_sorted_element(base, c_name, t.make_ident(buf_name), c_name, elem_type),
+	], src)
+	width_for := t.make_for_stmt(t.make_decl_assign_typed(w_name, t.make_int_literal(1), 'int'), t.make_infix(.lt, t.make_ident(w_name), t.make_ident(n_name)), t.make_assign(t.make_ident(w_name), t.make_infix(.left_shift, t.make_ident(w_name), t.make_int_literal(1))), [
+		run_for,
+		copy_back,
+	], src)
+	// The scratch buffer only holds shallow copies of elements the array still
+	// owns, so releasing its storage never touches the elements themselves.
+	free_buf := t.make_expr_stmt(t.make_call_typed('array__free', [
+		t.make_prefix(.amp, t.make_ident(buf_name)),
+	], 'void'))
+	return t.make_block([
+		t.make_decl_assign_typed(n_name, t.make_selector(base, 'len', 'int'), 'int'),
+		t.make_decl_assign_typed(buf_name, t.make_array_new_call(elem_type, t.make_ident(n_name), t.make_ident(n_name)), array_type),
+		width_for,
+		free_buf,
+	])
+}
+
+// copy_sorted_element builds `dst[dst_idx] = src[src_idx]` for the merge passes.
+fn (mut t Transformer) copy_sorted_element(dst flat.NodeId, dst_idx string, source flat.NodeId, src_idx string, elem_type string) flat.NodeId {
+	return t.make_index_assign(t.make_index(dst, t.make_ident(dst_idx), elem_type), t.make_index(source, t.make_ident(src_idx), elem_type))
+}
+
+// increment_sort_index builds `name = name + 1`.
+fn (mut t Transformer) increment_sort_index(name string) flat.NodeId {
+	return t.make_assign(t.make_ident(name), t.make_infix(.plus, t.make_ident(name), t.make_int_literal(1)))
+}
+
+// clamp_sort_index builds `if name > limit { name = limit }`.
+fn (mut t Transformer) clamp_sort_index(name string, limit string) flat.NodeId {
+	assign := t.make_block([
+		t.make_assign(t.make_ident(name), t.make_ident(limit)),
+	])
+	return t.make_if_with_skip_ownership_drops(t.make_infix(.gt, t.make_ident(name), t.make_ident(limit)), assign, flat.empty_node)
 }
 
 fn (t &Transformer) array_default_sort_runtime_helper(elem_type string) ?string {
@@ -6091,32 +6168,11 @@ fn (t &Transformer) array_default_sort_runtime_helper(elem_type string) ?string 
 
 // make_array_compare_sort_stmt builds make array compare sort stmt data for transform.
 fn (mut t Transformer) make_array_compare_sort_stmt(base flat.NodeId, elem_type string, src flat.Node, cmp flat.NodeId) flat.NodeId {
-	i_name := t.new_temp('sort_i')
-	j_name := t.new_temp('sort_j')
-	tmp_name := t.new_temp('sort_tmp')
-	t.set_var_type(i_name, 'int')
-	t.set_var_type(j_name, 'int')
-	t.set_var_type(tmp_name, elem_type)
-	init := t.make_decl_assign_typed(i_name, t.make_int_literal(1), 'int')
-	cond := t.make_infix(.lt, t.make_ident(i_name), t.make_selector(base, 'len', 'int'))
-	post := t.make_expr_stmt(t.make_postfix(t.make_ident(i_name), .inc))
-	j_decl := t.make_decl_assign_typed(j_name, t.make_ident(i_name), 'int')
-	inner_cond := t.make_infix(.logical_and, t.make_infix(.gt, t.make_ident(j_name), t.make_int_literal(0)), t.array_sort_compare_less_expr(base, elem_type, j_name, cmp))
-	tmp_decl := t.make_decl_assign_typed(tmp_name, t.make_index(base, t.make_ident(j_name), elem_type), elem_type)
-	prev_idx := t.make_infix(.minus, t.make_ident(j_name), t.make_int_literal(1))
-	assign_cur := t.make_index_assign(t.make_index(base, t.make_ident(j_name), elem_type), t.make_index(base, prev_idx, elem_type))
-	prev_idx2 := t.make_infix(.minus, t.make_ident(j_name), t.make_int_literal(1))
-	assign_prev := t.make_index_assign(t.make_index(base, prev_idx2, elem_type), t.make_ident(tmp_name))
-	dec_j := t.make_expr_stmt(t.make_postfix(t.make_ident(j_name), .dec))
-	inner_body := [tmp_decl, assign_cur, assign_prev, dec_j]
-	inner_for := t.make_for_stmt(t.make_empty(), inner_cond, t.make_empty(), inner_body, src)
-	return t.make_for_stmt(init, cond, post, [j_decl, inner_for], src)
+	return t.make_array_merge_sort_stmt(base, elem_type, src, cmp, true)
 }
 
 // array_sort_less_expr supports array sort less expr handling for Transformer.
-fn (mut t Transformer) array_sort_less_expr(base flat.NodeId, elem_type string, idx_name string, cmp_id flat.NodeId) flat.NodeId {
-	cur := t.make_index(base, t.make_ident(idx_name), elem_type)
-	prev := t.make_index(base, t.make_infix(.minus, t.make_ident(idx_name), t.make_int_literal(1)), elem_type)
+fn (mut t Transformer) array_sort_less_expr(cur flat.NodeId, prev flat.NodeId, elem_type string, cmp_id flat.NodeId) flat.NodeId {
 	if int(cmp_id) >= 0 {
 		cmp_node := t.a.nodes[int(cmp_id)]
 		if cmp_node.kind == .lambda_expr && cmp_node.children_count >= 3 {
@@ -6201,9 +6257,7 @@ fn (mut t Transformer) array_sort_simple_operator_expr(node flat.Node, cur flat.
 }
 
 // array_sort_compare_less_expr supports array sort compare less expr handling for Transformer.
-fn (mut t Transformer) array_sort_compare_less_expr(base flat.NodeId, elem_type string, idx_name string, cmp flat.NodeId) flat.NodeId {
-	cur := t.make_index(base, t.make_ident(idx_name), elem_type)
-	prev := t.make_index(base, t.make_infix(.minus, t.make_ident(idx_name), t.make_int_literal(1)), elem_type)
+fn (mut t Transformer) array_sort_compare_less_expr(cur flat.NodeId, prev flat.NodeId, elem_type string, cmp flat.NodeId) flat.NodeId {
 	cmp_cur_type, cmp_prev_type := t.array_sort_compare_arg_types(cmp, elem_type)
 	cur_arg := if cmp_cur_type == elem_type { cur } else { t.make_prefix(.amp, cur) }
 	prev_arg := if cmp_prev_type == elem_type { prev } else { t.make_prefix(.amp, prev) }

--- a/vlib/v3/transform/map.v
+++ b/vlib/v3/transform/map.v
@@ -1799,6 +1799,20 @@ fn (t &Transformer) const_expr_for_ident(id flat.NodeId) ?flat.NodeId {
 	return none
 }
 
+// const_map_source_for_ident picks the container a `const` map identifier should
+// lower to. Constants are emitted once into a module-scope C global, so an
+// ordinary reference to the identifier reuses that map; substituting the
+// initializer instead would rebuild the whole literal (a `new_map` plus one
+// `map__set`, hash and key clone per entry) at every lookup. Inside a constant's
+// own initializer the global is not assigned yet, so the initializer expression
+// is still the only valid source there.
+fn (t &Transformer) const_map_source_for_ident(id flat.NodeId) flat.NodeId {
+	if t.in_const_init {
+		return t.const_expr_for_ident(id) or { id }
+	}
+	return id
+}
+
 // lower_map_membership_expr builds lower map membership expr data for transform.
 fn (mut t Transformer) lower_map_membership_expr(map_id flat.NodeId, key_id flat.NodeId, map_type string) ?flat.NodeId {
 	clean_type := t.clean_map_type(map_type)
@@ -1818,7 +1832,7 @@ fn (mut t Transformer) lower_map_membership_expr(map_id flat.NodeId, key_id flat
 	if key_type.len == 0 {
 		return none
 	}
-	map_source_id := t.const_expr_for_ident(map_id) or { map_id }
+	map_source_id := t.const_map_source_for_ident(map_id)
 	// Spill the typed key before materializing the container so a side-effecting key
 	// evaluates before a value-branch map's hoisted propagation prelude, preserving
 	// source order, e.g. `tr.key() in (match node { First { tr.map_first(node)! } ... })`.
@@ -1862,7 +1876,7 @@ fn (mut t Transformer) try_lower_map_index_expr(id flat.NodeId, node flat.Node) 
 	if key_type.len == 0 || value_type.len == 0 {
 		return none
 	}
-	map_source_id := t.const_expr_for_ident(base_id) or { base_id }
+	map_source_id := t.const_map_source_for_ident(base_id)
 	source_is_owned_temporary := !isnil(t.tc)
 		&& t.tc.ownership_type_requires_destruction(t.tc.parse_type(map_type))
 		&& !base_type.starts_with('&') && !t.expr_can_take_address(map_source_id)


### PR DESCRIPTION
Three lowering/codegen fixes found by sampling the self-host build
`cd vlib/v3 && ../../v -gc none -prealloc -prod -o v3 v3.v && ./v3 -nocache -building-v -o v4 v3.v`
(338k lines).

### `arr.sort(...)` was lowered to an insertion sort

`make_array_default_sort_stmt` emitted a plain insertion sort for every element type
except primitives with a default comparator (those already call `v3_array_sort_*` =
`qsort`). So every other sort was quadratic. The parallel checker sorts its own 24k
element work list twice per run in `types.split_check_items`: **604 ms of the 2241 ms**
the compiler spent outside `cc`, all serial on the main thread.

It now lowers to a bottom-up merge sort through a scratch buffer. That keeps the
**stable** order the V1 backend produces with `v_stable_sort` (`vlib/v/gen/c/cheaders.v`),
so element order for equal keys is unchanged. Sorting 24k structs: 530 ms -> 3 ms.

### `const` maps were re-materialized at every use site

`x in m` and `m[k]` called `const_expr_for_ident()` and lowered the constant's
*initializer*, so each lookup rebuilt the whole literal: a `new_map` plus one
`map__set` (hash + key clone) per entry. `naming.c_name()` alone was rebuilding a
46-entry and a 56-entry map for **every emitted identifier**.

Constants are already emitted once into a module-scope C global (`naming__reserved_words`
existed in the output and nothing referenced it), so the identifier now lowers to that
global. Inside a constant's own initializer the global is not assigned yet, so the
initializer is still substituted there (`t.in_const_init`). This is also where most of
the peak RSS went.

### The C preamble's `wyhash` mixed one byte per iteration

`builtin_abi_decls` emitted a `wyhash` doing two multiplications *per byte* of the key.
`gen/fastc/fastc.v` already carried a version that mixes a 64-bit word per step; this
ports it to the C backend, so both preambles now agree. V maps keep insertion order
independently of the hash, so program output is unaffected.

## Numbers

Interleaved medians, five runs per binary, 18-core M5 Max, `./v3 -nocache -building-v -o v4 v3.v`:

| | master | this PR | |
|---|---|---|---|
| compiler phases (excl. `cc`) | 2241 ms | **620 ms** | −72% (3.6x) |
| non-cc throughput | 151k lines/s | **546k lines/s** | |
| peak RSS | 5949 MiB | **1977 MiB** | −67% |
| total wall (incl. `cc`) | 8286 ms | **6653 ms** | −19.7% |

Per stage: check 957 -> 132 ms, transform 618 -> 238 ms, cgen 416 -> 152 ms,
markused 123 -> 40 ms. `cc` is unchanged (6051 -> 6028 ms) and is now ~90% of the
command's wall time.

## Checks

- `v3` and the `v4` it builds emit **byte-identical C** (fixed point).
- Sort order and stability verified against a master-built compiler for structs,
  strings, ints, `sort_with_compare`, `sorted`, descending comparators, and empty /
  single-element arrays; also under `-cc tcc`.
- Const-map edge cases give identical output to master: const derived from another
  const map, `__global` initialized from a const map, cross-module const maps, nested
  const maps, const map passed as a `map[string]int` argument, `for k, v in`.
- 20 vlib tests (incl. `builtin/array_test.v`, `builtin/map_test.v`) and 40
  `examples/*.v`: identical pass/fail sets to master.
- `-d v3_no_parallel` builds.
- `v fmt -verify` clean.

Partial run of `vlib/v3/**/*_test.v` against both a master-built and a patched
compiler agreed on every file covered (identical pass/fail set); the full sweep is
left to CI. Note `vlib/v3/test_all.vsh` currently cannot run on master at all — it
invokes the host `v` with `-old-compiler`, which a V3-only executable rejects.