### PR TITLE
v3: fix `make` bootstrap, and `[]int` stores into `[]i32` AST fields

### DIFF
--- a/vlib/v3/gen/c/names.v
+++ b/vlib/v3/gen/c/names.v
@@ -373,8 +373,15 @@ fn (mut g FlatGen) restore_scratch_lookup_caches(saved ScratchLookupCaches) {
 	g.generic_app_cache = saved.generic_app_cache
 	g.struct_decl_pref_cache = saved.struct_decl_pref_cache
 	g.sum_variant_actual_cache = saved.sum_variant_actual_cache
-	g.array_method_cache = saved.array_method_cache
-	g.param_types_cache = saved.param_types_cache
+	// These two are plain maps rather than pointers, so putting the generator's
+	// own map back is an aliasing copy the checker rejects outside `unsafe`.
+	// Cloning would deep-copy a cache we are only restoring, and `saved` is a
+	// by-value parameter that dies with this call, so nothing else can observe
+	// the alias.
+	unsafe {
+		g.array_method_cache = saved.array_method_cache
+		g.param_types_cache = saved.param_types_cache
+	}
 }
 
 fn scratch_string_lookup_cache(cache &StringLookupCache) &StringLookupCache {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -1222,7 +1222,7 @@ fn reserve_parallel_transform_ast_with_cache_mode(mut a flat.FlatAst, skip_gener
 	if grow_nodes {
 		old_nodes := a.nodes
 		a.nodes = []flat.Node{cap: nodes_cap}
-		a.file_node_ids = []int{}
+		a.file_node_ids = []i32{}
 		a.nodes << old_nodes
 	}
 	if grow_children {
@@ -3389,15 +3389,15 @@ fn (mut t Transformer) transform_serial_then_collect_pure(literal_decls []int) [
 	// ((previous top-level decl of ANY kind, fn_idx]); the shared-base parallel
 	// transform relies on those ranges being disjoint per item.
 	use_checker_tl := t.tc.top_level_idx.len > 0 && t.tc.top_level_idx_nodes_len == t.a.nodes.len
-	mut rebuilt_tl := []int{}
+	mut rebuilt_tl := []i32{}
 	if !use_checker_tl {
 		// Hand-built test ASTs and transforms after declaration synthesis do not
 		// have a current checker index. Rebuild only in that uncommon case.
-		rebuilt_tl = []int{cap: 1024}
+		rebuilt_tl = []i32{cap: 1024}
 		for i, node in t.a.nodes {
 			if node.kind in [.file, .module_decl, .struct_decl, .type_decl, .interface_decl,
 				.enum_decl, .import_decl, .const_decl, .global_decl, .fn_decl, .c_fn_decl] {
-				rebuilt_tl << i
+				rebuilt_tl << i32(i)
 			}
 		}
 	}
@@ -5007,7 +5007,7 @@ fn (mut t Transformer) transform_late_used_fn_bodies(names &[]string, names_star
 	late_scan_ids := if t.building_v && t.tc.top_level_idx.len > 0 {
 		t.tc.top_level_idx
 	} else {
-		[]int{}
+		[]i32{}
 	}
 	scan_count := if late_scan_ids.len > 0 { late_scan_ids.len } else { limit }
 	for scan_pos in 0 .. scan_count {

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -1320,7 +1320,7 @@ fn (mut t Transformer) run_parallel_monomorphize_specs(specs []PendingGenericFnS
 				t.a.nodes.flags.set(.nofree)
 			}
 			t.a.nodes = nodes
-			t.a.file_node_ids = []int{}
+			t.a.file_node_ids = []i32{}
 		}
 		if !merge_in_place && t.a.children.data == original_children_data {
 			children := clone_monomorph_child_region(t.a.children, base_children, base_children, merged_children_cap)
@@ -1667,7 +1667,7 @@ fn (mut t Transformer) detach_monomorph_worker_region(base_nodes int, base_child
 		t.a.children.flags.set(.nofree)
 	}
 	t.a.nodes = nodes
-	t.a.file_node_ids = []int{}
+	t.a.file_node_ids = []i32{}
 	t.a.children = children
 }
 
@@ -1906,7 +1906,7 @@ fn (mut t Transformer) promote_scoped_ast_storage(scope voidptr) {
 		mut nodes := []flat.Node{cap: t.a.nodes.len + t.a.nodes.len / 4 + 1024}
 		nodes << t.a.nodes
 		t.a.nodes = nodes
-		t.a.file_node_ids = []int{}
+		t.a.file_node_ids = []i32{}
 	}
 	if owns_children {
 		mut children := []flat.NodeId{cap: t.a.children.len + t.a.children.len / 4 + 1024}


### PR DESCRIPTION
## The failure

A clean `make` on current master fails:

```
vlib/v3/gen/c/names.v:377:30: error: cannot copy map: call `move` or `clone` method (or use a reference)
  375 |     g.sum_variant_actual_cache = saved.sum_variant_actual_cache
  376 |     g.array_method_cache = saved.array_method_cache
  377 |     g.param_types_cache = saved.param_types_cache
      |                                 ~~~~~~~~~~~~~~~~~
make: *** [GNUmakefile:216: all] Error 1
```

`GNUmakefile:216` is stage 2 of the bootstrap — `./v1 -no-parallel -o v2 -gc none cmd/v` — which builds `cmd/v` with the **V1** compiler compiled from the `vc` snapshot. V1 rejects 8 constructs on master that the V3 checker accepts:

```
vlib/v3/gen/c/names.v:376:31: error: cannot copy map
vlib/v3/gen/c/names.v:377:30: error: cannot copy map
vlib/v3/transform/transform.v:1225:21: error: cannot assign to `a.file_node_ids`: expected `[]i32`, not `[]int`
vlib/v3/transform/transform.v:3404:8:  error: mismatched types `[]i32` and `[]int`
vlib/v3/transform/transform.v:5007:19: error: mismatched types `[]i32` and `[]int`
vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v:1323:24: error: cannot assign to `t.a.file_node_ids`
vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v:1670:22: error: cannot assign to `t.a.file_node_ids`
vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v:1909:23: error: cannot assign to `t.a.file_node_ids`
```

(The report that this was Linux-only was a red herring — the macOS/Windows trees were not at this commit. It reproduces on macOS too.)

## The `[]int` half is a real bug, not just bootstrap pedantry

`flat.FlatAst.file_node_ids` and `TypeChecker.top_level_idx` are `[]i32`. Because v3's `int` emits `i64` on 64-bit targets, `a.file_node_ids = []int{}` installs an array whose `element_size` is **8** into a field that every reader indexes at stride **4**.

Nothing downstream catches it: the V3 checker accepts `[]int` where `[]i32` is expected, and all `Array_*` C typedefs alias the same `array` struct, so the C compiler is blind to it too. The V1 bootstrap is the only gate. `rebuilt_tl` in `transform_serial_then_collect_pure` had the same mismatch — it is selected against the `[]i32` `top_level_idx` in `tl := if use_checker_tl { t.tc.top_level_idx } else { rebuilt_tl }`.

## Fixes

- `transform.v`, `transform_parallel_notd_v3_no_parallel.v`: spell the six `file_node_ids` / `late_scan_ids` resets `[]i32{}`, and retype `rebuilt_tl` to `[]i32` (`<< i32(i)`).
- `names.v`: `restore_scratch_lookup_caches` hands the generator back its *own* `array_method_cache` / `param_types_cache`. The aliasing copy is the intent — `clone` would deep-copy a cache that is only being restored, and `move` would need a `mut` parameter — so the two assignments are wrapped in `unsafe`, with a comment saying why.

Scalar `int`/`i32` mixing is fine under V1, so only the array spellings needed changing.

## Verification

- `make` from a clean tree: succeeds.
- The resulting `./v` self-compiles `cmd/v` through V3.
- `v fmt -verify` clean on all three files.
- 27/28 of `vlib/v3/transform/*_test.v` + `vlib/v3/gen/c/*_test.v` pass.
- The one failure — `transform_parallel_test.v`, 4 assertions at `:919`, `:3652`, `:3860`, `:4279` — reproduces identically on unpatched master (A/B'd by running the same compiler binary against a pristine `origin/master` worktree), so it is pre-existing and unrelated.