### PR TITLE
v3: split the C compile of a large program across cores (self-host 2.4x)

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -1823,8 +1823,26 @@ struct V3CCompilerFlagPlan {
 }
 
 const v3_parallel_cc_unit_marker = '/* V3PARALLEL_CC_UNIT */'
-const v3_parallel_cc_max_jobs = 2
-const v3_parallel_cc_units_per_job = 4
+const v3_parallel_cc_max_jobs = 32
+// One unit per job: every extra unit re-parses the shared declaration header, so
+// splitting finer than the number of concurrent compilers costs more than the
+// better load balancing returns.
+const v3_parallel_cc_units_per_job = 1
+// Used when the free memory of the machine cannot be read; this is the bound the
+// split C build shipped with before it became memory-aware.
+const v3_parallel_cc_fallback_jobs = 2
+// Peak resident size of one C compiler process, measured against the source size
+// of its translation unit (clang needs ~35 bytes per source byte on a generated
+// unit), plus a floor for the fixed per-process cost.
+const v3_parallel_cc_memory_per_source_byte = u64(40)
+const v3_parallel_cc_min_job_memory = u64(192 * 1024 * 1024)
+// Only half of the free memory is spent on C compilers; the rest stays available
+// for the compiler process itself, which still holds its arenas.
+const v3_parallel_cc_memory_share = u64(2)
+// A split unit re-parses the shared declaration header, so a small program would
+// pay for the extra headers instead of saving anything. A program with this many
+// AST nodes takes seconds in a single translation unit.
+const v3_parallel_cc_auto_node_threshold = 400000
 const v3_parallel_cc_monolithic_define = 'v3_parallel_cc_monolithic'
 const v3_parallel_cc_monolithic_exit_code = 125
 const v3_parallel_cc_monolithic_message = 'v3 parallel C source requires monolithic regeneration'
@@ -2098,6 +2116,34 @@ fn split_v3_parallel_c_source(source string, max_units int) !(string, []string) 
 	return split.prefix, merge_v3_parallel_c_units(units, max_units)
 }
 
+// v3_parallel_cc_job_count bounds the concurrent C compiler processes by both the
+// core count and the memory that is actually free. Each unit re-parses the shared
+// declaration prefix and then compiles its own share of the bodies, so its peak
+// resident size follows the unit's source size rather than the whole program's:
+// splitting into more units raises the total memory (every unit pays for the
+// prefix again) while lowering each process's peak.
+fn v3_parallel_cc_job_count(source string) int {
+	cores := int_max(1, int_min(v3_parallel_cc_max_jobs, runtime.nr_jobs()))
+	free := runtime.free_memory() or { return int_min(cores, v3_parallel_cc_fallback_jobs) }
+	budget := u64(free) / v3_parallel_cc_memory_share
+	body_start := source.index('/* V3CACHE_BODY_BEGIN */') or { 0 }
+	prefix_bytes := u64(body_start)
+	body_bytes := u64(source.len) - prefix_bytes
+	mut jobs := cores
+	for jobs > 1 {
+		unit_bytes := prefix_bytes + body_bytes / u64(jobs)
+		mut per_job := unit_bytes * v3_parallel_cc_memory_per_source_byte
+		if per_job < v3_parallel_cc_min_job_memory {
+			per_job = v3_parallel_cc_min_job_memory
+		}
+		if per_job * u64(jobs) <= budget {
+			break
+		}
+		jobs--
+	}
+	return jobs
+}
+
 fn compile_v3_parallel_c(source_path string, c_compiler string, c_flag_plan &V3CCompilerFlagPlan, native_support_inputs []string, cached_objects []string, cached_dev_dylib string, objective_c bool, build_dir string, show_command bool) os.Result {
 	source := os.read_file(source_path) or {
 		return os.Result{
@@ -2105,7 +2151,7 @@ fn compile_v3_parallel_c(source_path string, c_compiler string, c_flag_plan &V3C
 			output: 'failed to read generated C source ${source_path}: ${err.msg()}'
 		}
 	}
-	job_count := int_max(1, int_min(v3_parallel_cc_max_jobs, runtime.nr_jobs()))
+	job_count := v3_parallel_cc_job_count(source)
 	prefix, bodies := split_v3_parallel_c_source(source, job_count * v3_parallel_cc_units_per_job) or {
 		return os.Result{
 			exit_code: 1
@@ -9289,9 +9335,10 @@ pub fn run(args []string) {
 	minimal_literal_output := !is_prof
 		&& input_uses_minimal_literal_output_builtin(input_file, prefs, is_test_command, is_checker_fixture)
 	host_target := pref.host_target()
-	use_parallel_c_compilation := parallel_cc && backend == 'c' && !c_only && !explicit_tcc
-		&& !is_o && target.os != 'windows' && coverage_dir.len == 0 && profile_file.len == 0
+	parallel_c_compilation_supported := backend == 'c' && !c_only && !explicit_tcc && !is_o
+		&& target.os != 'windows' && coverage_dir.len == 0 && profile_file.len == 0
 		&& v3_parallel_cc_monolithic_define !in user_defines
+	mut use_parallel_c_compilation := parallel_cc && parallel_c_compilation_supported
 	// `-keepc` and explicit `-b c` promise a complete generated C translation unit.
 	// The module cache splits imported implementations into separate objects, so its main source
 	// alone cannot reproduce the build. Literal output uses a deliberately reduced
@@ -9301,6 +9348,14 @@ pub fn run(args []string) {
 		&& !keep_c && !backend_explicit && !c_compiler_explicit && !minimal_literal_output
 		&& c_compiler == 'cc' && target.os == host_target.os && target.arch == host_target.arch
 		&& !input_owns_builtin_bundle_module(input_file, prefs.vroot)
+	// A whole program in one C translation unit is a single-threaded C compiler
+	// run, which for a large program costs several times what all of V's own
+	// phases do. When the object cache is not the one feeding the C compiler
+	// there is nothing to reuse, so that work is split across cores instead.
+	// `-prod` keeps its monolithic unit because `-flto` needs to see the whole
+	// program at once. `-d v3_parallel_cc_monolithic` opts out.
+	auto_parallel_c_candidate := !parallel_cc && parallel_c_compilation_supported && !is_prod
+		&& !prefs.is_shared && !cache_candidate_enabled
 	cc_identity := if cache_candidate_enabled { default_cc_identity() } else { '' }
 	compiler_signature := if cache_candidate_enabled {
 		v3_cache_compiler_signature(prefs.vroot)
@@ -9650,6 +9705,15 @@ pub fn run(args []string) {
 	b.metric_items('parsed .v files', p.parsed_v_files, 'files', '.v files', p.parsed_v_file_paths)
 	if !silent {
 		println('    ${'parsed .v lines':-28s} ${source_file_line_count(p.parsed_v_file_paths, a.source_files)} lines')
+	}
+	// A test binary keeps the harness counters (`__v3_test_failures` and the
+	// setjmp buffer) as `static` definitions inside the program body, so a unit
+	// that only references them would not see a definition. Test builds stay in
+	// one translation unit.
+	if test_files.len > 0 {
+		use_parallel_c_compilation = false
+	} else if auto_parallel_c_candidate && a.nodes.len >= v3_parallel_cc_auto_node_threshold {
+		use_parallel_c_compilation = true
 	}
 	b.metric('AST nodes after parse', a.nodes.len, 'nodes')
 	b.metric('AST children after parse', a.children.len, 'edges')
@@ -11087,6 +11151,7 @@ pub fn run(args []string) {
 			g.set_compile_values(prefs.compile_values)
 			g.set_track_heap('track_heap' in prefs.user_defines)
 			g.set_cache_split(cache_state.manager.enabled || use_parallel_c_compilation)
+			g.set_cache_stable_symbols(cache_state.manager.enabled)
 			g.set_parallel_cc(use_parallel_c_compilation)
 			g.set_cache_native_input_paths(cache_scoped_native_input_paths(cache_state))
 			g.set_program_body_only(generic_cache_hit)
@@ -11142,6 +11207,7 @@ pub fn run(args []string) {
 			g.set_compile_values(prefs.compile_values)
 			g.set_track_heap('track_heap' in prefs.user_defines)
 			g.set_cache_split(cache_state.manager.enabled || use_parallel_c_compilation)
+			g.set_cache_stable_symbols(cache_state.manager.enabled)
 			g.set_parallel_cc(use_parallel_c_compilation)
 			g.set_cache_native_input_paths(cache_scoped_native_input_paths(cache_state))
 			g.set_program_body_only(generic_cache_hit)

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -626,6 +626,7 @@ mut:
 	qualified_struct_c_types_ready     bool
 	unused_param_seen                  &UnusedParamSeen = unsafe { nil }
 	cache_split                        bool
+	cache_stable_symbols               bool
 	parallel_cc                        bool
 	cache_native_input_paths           map[string]bool
 	program_body_only                  bool
@@ -1334,6 +1335,15 @@ pub fn (mut g FlatGen) set_track_heap(enabled bool) {
 // module objects without changing regular `-o file.c` output.
 pub fn (mut g FlatGen) set_cache_split(enabled bool) {
 	g.cache_split = enabled
+}
+
+// set_cache_stable_symbols turns on the content-addressed renaming of generated
+// string-literal symbols. Only the module cache needs it, so that separately
+// compiled generations agree on a symbol's name. A split C build shares one
+// generated prefix with its own units, so it keeps the plain `_str_N` numbering
+// and skips a rewrite pass over the whole translation unit.
+pub fn (mut g FlatGen) set_cache_stable_symbols(enabled bool) {
+	g.cache_stable_symbols = enabled
 }
 
 // set_parallel_cc marks safe top-level function batches for split C compilation.
@@ -2662,12 +2672,19 @@ fn (mut g FlatGen) write_scoped_function_output(path string, fn_code string) boo
 	return true
 }
 
-fn (mut g FlatGen) append_function_output(path string, fn_code string) bool {
+fn (mut g FlatGen) append_function_output(path string, fn_code string, separator string) bool {
 	mut file := os.open_append(path) or {
 		g.output_error = err.msg()
 		return false
 	}
 	for segment in g.fn_segs {
+		if separator.len > 0 {
+			file.write_string(separator) or {
+				g.output_error = err.msg()
+				file.close()
+				return false
+			}
+		}
 		file.write_string(segment) or {
 			g.output_error = err.msg()
 			file.close()
@@ -3198,19 +3215,33 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 			unsafe { fn_code.free() }
 		}
 		g.writeln('/* V3CACHE_BODY_END */')
-		source := g.sb.str()
-		result := g.rewrite_cache_string_symbols(source)
-		unsafe {
-			source.free()
-			g.sb.free()
+		if g.cache_stable_symbols {
+			source := g.sb.str()
+			result := g.rewrite_cache_string_symbols(source)
+			unsafe {
+				source.free()
+				g.sb.free()
+			}
+			if g.output_path.len > 0 {
+				os.write_file(g.output_path, result) or { g.output_error = err.msg() }
+				unsafe { result.free() }
+				g.sb = strings.new_builder(4096)
+				return ''
+			}
+			return result
 		}
+		// A split C build keeps the plain `_str_N` numbering, so nothing rewrites
+		// the finished unit and it never needs a second copy of it.
 		if g.output_path.len > 0 {
-			os.write_file(g.output_path, result) or { g.output_error = err.msg() }
-			unsafe { result.free() }
+			mut output := unsafe { g.sb.reuse_as_plain_u8_array() }
+			os.write_file_array(g.output_path, output) or { g.output_error = err.msg() }
+			unsafe { output.free() }
 			g.sb = strings.new_builder(4096)
 			return ''
 		}
-		return result
+		plain := g.sb.str()
+		unsafe { g.sb.free() }
+		return plain
 	}
 	mut known_output_len := g.sb.len + fn_code.len + const_code.len + g.parallel_type_decls.len + g.parallel_global_decls.len + g.parallel_support_decls.len + g.parallel_enum_str_defs.len + g.parallel_interface_stubs.len + g.parallel_init_defs.len
 	for segment in g.fn_segs {
@@ -3325,11 +3356,22 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	}
 	g.timing_profile('  [ttime] cg postamble       ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms (sb: ${g.sb.len})')
 	cgsw.restart()
-	if !g.cache_split && !g.object_file_mode && g.output_path.len > 0 && g.postinclude_directives.len == 0 && (g.fn_segs.len > 0 || fn_code.len > 0) {
+	// A split C build still streams: it needs the unit markers between the function
+	// segments and the body terminator after them, but nothing rewrites the
+	// finished unit, so the segments never have to be copied through the builder.
+	stream_unit_markers := g.cache_split && g.parallel_cc && !g.cache_stable_symbols
+	if (!g.cache_split || stream_unit_markers) && !g.object_file_mode && g.output_path.len > 0
+		&& g.postinclude_directives.len == 0 && (g.fn_segs.len > 0 || fn_code.len > 0) {
+		separator := if stream_unit_markers { '${parallel_cc_unit_marker}\n' } else { '' }
+		tail := if stream_unit_markers {
+			'${separator}${fn_code}/* V3CACHE_BODY_END */\n'
+		} else {
+			fn_code
+		}
 		mut prefix := unsafe { g.sb.reuse_as_plain_u8_array() }
 		$if !windows {
 			if os.getenv('V3_NO_MMAP_CGEN_OUTPUT') == '' {
-				write_c_output_mapped(g.output_path, prefix, g.fn_segs, fn_code) or {
+				write_c_output_mapped(g.output_path, prefix, g.fn_segs, tail, separator) or {
 					g.output_error = err.msg()
 				}
 				unsafe { prefix.free() }
@@ -3349,7 +3391,7 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 		unsafe { prefix.free() }
 		g.sb = strings.new_builder(4096)
 		if g.output_error.len == 0 {
-			g.append_function_output(g.output_path, fn_code)
+			g.append_function_output(g.output_path, tail, separator)
 		}
 		g.timing_profile('  [ttime] cg write out       ${f64(cgsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		return ''
@@ -3377,19 +3419,23 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	}
 	if g.cache_split {
 		g.writeln('/* V3CACHE_BODY_END */')
-		source := g.sb.str()
-		result := g.rewrite_cache_string_symbols(source)
-		unsafe {
-			source.free()
-			g.sb.free()
+		// Only the module cache renames the string-literal symbols; a split C
+		// build keeps the plain numbering and skips the pass over the whole unit.
+		if g.cache_stable_symbols {
+			source := g.sb.str()
+			result := g.rewrite_cache_string_symbols(source)
+			unsafe {
+				source.free()
+				g.sb.free()
+			}
+			if g.output_path.len > 0 {
+				os.write_file(g.output_path, result) or { g.output_error = err.msg() }
+				unsafe { result.free() }
+				g.sb = strings.new_builder(4096)
+				return ''
+			}
+			return result
 		}
-		if g.output_path.len > 0 {
-			os.write_file(g.output_path, result) or { g.output_error = err.msg() }
-			unsafe { result.free() }
-			g.sb = strings.new_builder(4096)
-			return ''
-		}
-		return result
 	}
 	if g.output_path.len > 0 {
 		mut output := unsafe { g.sb.reuse_as_plain_u8_array() }
@@ -3404,9 +3450,11 @@ pub fn (mut g FlatGen) gen_with_used_options(a &flat.FlatAst, used_fns map[strin
 	return result
 }
 
+const parallel_cc_unit_marker = '/* V3PARALLEL_CC_UNIT */'
+
 fn (mut g FlatGen) write_parallel_cc_unit_marker() {
 	if g.parallel_cc {
-		g.writeln('/* V3PARALLEL_CC_UNIT */')
+		g.writeln(parallel_cc_unit_marker)
 	}
 }
 

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -1076,7 +1076,7 @@ fn (mut g FlatGen) write_scoped_cgen_batch_output(batch &FlatGen) bool {
 		g.output_error = err.msg()
 		return false
 	}
-	if batch.cache_split {
+	if batch.cache_stable_symbols {
 		mut b := unsafe { batch }
 		source := b.sb.str()
 		stable_source := b.rewrite_cache_string_symbols(source)
@@ -1154,7 +1154,7 @@ fn (mut g FlatGen) absorb_scoped_cgen_batch(batch &FlatGen, output_streamed bool
 		}
 	}
 	for def in batch.spawn_wrapper_defs {
-		if batch.cache_split {
+		if batch.cache_stable_symbols {
 			stable_def := b.rewrite_cache_string_symbols(def)
 			g.add_spawn_wrapper_def(stable_def)
 		} else {
@@ -1167,7 +1167,7 @@ fn (mut g FlatGen) absorb_scoped_cgen_batch(batch &FlatGen, output_streamed bool
 		}
 	}
 	for def in batch.callback_wrapper_defs {
-		if batch.cache_split {
+		if batch.cache_stable_symbols {
 			stable_def := b.rewrite_cache_string_symbols(def)
 			g.add_callback_wrapper_def(stable_def)
 		} else {
@@ -2461,6 +2461,7 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		}
 		has_builtins: g.has_builtins
 		cache_split: g.cache_split
+		cache_stable_symbols: g.cache_stable_symbols
 		compile_values: g.compile_values
 		trace_calls: g.trace_calls
 		skip_generics: g.skip_generics
@@ -2858,7 +2859,7 @@ fn (mut g FlatGen) merge_parallel_worker_into(w &FlatGen, mut ordered []string, 
 	}
 	string_id_remap := g.publish_worker_string_literals(w)
 	borrow_worker_segments := os.getenv('V3_RETAIN_CGEN_RESULT_SCOPES') != ''
-		&& w.worker_scope != unsafe { nil } && !g.cache_split && string_id_remap.len == 0
+		&& w.worker_scope != unsafe { nil } && !g.cache_stable_symbols && string_id_remap.len == 0
 	user_c_symbols := if string_id_remap.len > 0 {
 		g.cache_user_c_string_symbols()
 	} else {
@@ -2866,7 +2867,7 @@ fn (mut g FlatGen) merge_parallel_worker_into(w &FlatGen, mut ordered []string, 
 	}
 	worker_output := ww.sb.str()
 	if worker_output.len > 0 {
-		if g.cache_split {
+		if g.cache_stable_symbols {
 			stable_output := ww.rewrite_cache_string_symbols(worker_output)
 			g.fn_segs << stable_output
 			unsafe { worker_output.free() }
@@ -2882,7 +2883,7 @@ fn (mut g FlatGen) merge_parallel_worker_into(w &FlatGen, mut ordered []string, 
 	// The ordered segment owns the copied output; release the worker builder.
 	unsafe { ww.sb.free() }
 	for segment_idx, segment in w.fn_segs {
-		normalized := if g.cache_split {
+		normalized := if g.cache_stable_symbols {
 			ww.rewrite_cache_string_symbols(segment)
 		} else if string_id_remap.len > 0 {
 			remap_scoped_worker_string_symbols(segment, string_id_remap, user_c_symbols)
@@ -2945,7 +2946,7 @@ fn (mut g FlatGen) merge_parallel_worker_into(w &FlatGen, mut ordered []string, 
 				continue
 			}
 			for def in wrappers.spawn {
-				normalized := if g.cache_split {
+				normalized := if g.cache_stable_symbols {
 					ww.rewrite_cache_string_symbols(def)
 				} else if string_id_remap.len > 0 {
 					remap_scoped_worker_string_symbols(def, string_id_remap, user_c_symbols)
@@ -2957,7 +2958,7 @@ fn (mut g FlatGen) merge_parallel_worker_into(w &FlatGen, mut ordered []string, 
 		}
 	} else {
 		for def in w.spawn_wrapper_defs {
-			if g.cache_split {
+			if g.cache_stable_symbols {
 				g.add_spawn_wrapper_def(ww.rewrite_cache_string_symbols(def))
 			} else if string_id_remap.len > 0 {
 				g.add_spawn_wrapper_def(remap_scoped_worker_string_symbols(def, string_id_remap, user_c_symbols))
@@ -2977,7 +2978,7 @@ fn (mut g FlatGen) merge_parallel_worker_into(w &FlatGen, mut ordered []string, 
 				continue
 			}
 			for def in wrappers.callback {
-				normalized := if g.cache_split {
+				normalized := if g.cache_stable_symbols {
 					ww.rewrite_cache_string_symbols(def)
 				} else if string_id_remap.len > 0 {
 					remap_scoped_worker_string_symbols(def, string_id_remap, user_c_symbols)
@@ -2989,7 +2990,7 @@ fn (mut g FlatGen) merge_parallel_worker_into(w &FlatGen, mut ordered []string, 
 		}
 	} else {
 		for def in w.callback_wrapper_defs {
-			if g.cache_split {
+			if g.cache_stable_symbols {
 				g.add_callback_wrapper_def(ww.rewrite_cache_string_symbols(def))
 			} else if string_id_remap.len > 0 {
 				g.add_callback_wrapper_def(remap_scoped_worker_string_symbols(def, string_id_remap, user_c_symbols))

--- a/vlib/v3/gen/c/output_nix.c.v
+++ b/vlib/v3/gen/c/output_nix.c.v
@@ -5,12 +5,15 @@ import os
 #include <sys/mman.h>
 #include <unistd.h>
 
-fn write_c_output_sequential(mut file os.File, prefix []u8, segments []string, tail string) ! {
+fn write_c_output_sequential(mut file os.File, prefix []u8, segments []string, tail string, separator string) ! {
 	if prefix.len > 0 {
 		unsafe { file.write_full_buffer(prefix.data, usize(prefix.len))! }
 	}
 	for segment in segments {
 		if segment.len > 0 {
+			if separator.len > 0 {
+				file.write_string(separator)!
+			}
 			file.write_string(segment)!
 		}
 	}
@@ -19,14 +22,18 @@ fn write_c_output_sequential(mut file os.File, prefix []u8, segments []string, t
 	}
 }
 
-fn write_c_output_mapped(path string, prefix []u8, segments []string, tail string) ! {
+// separator is written ahead of every non-empty segment, which is how a split C
+// build marks the boundaries its units are cut at.
+fn write_c_output_mapped(path string, prefix []u8, segments []string, tail string, separator string) ! {
 	mut total := prefix.len + tail.len
 	for segment in segments {
-		total += segment.len
+		if segment.len > 0 {
+			total += segment.len + separator.len
+		}
 	}
 	mut file := os.open_file(path, 'w+b') or {
 		mut sequential_file := os.open_file(path, 'wb')!
-		write_c_output_sequential(mut sequential_file, prefix, segments, tail) or {
+		write_c_output_sequential(mut sequential_file, prefix, segments, tail, separator) or {
 			sequential_file.close()
 			return err
 		}
@@ -38,7 +45,7 @@ fn write_c_output_mapped(path string, prefix []u8, segments []string, tail strin
 		return
 	}
 	if C.ftruncate(file.fd, u64(total)) != 0 {
-		write_c_output_sequential(mut file, prefix, segments, tail) or {
+		write_c_output_sequential(mut file, prefix, segments, tail, separator) or {
 			file.close()
 			return err
 		}
@@ -49,7 +56,7 @@ fn write_c_output_mapped(path string, prefix []u8, segments []string, tail strin
 		C.mmap(nil, usize(total), C.PROT_READ | C.PROT_WRITE, C.MAP_SHARED, file.fd, 0)
 	}
 	if mapped == voidptr(-1) {
-		write_c_output_sequential(mut file, prefix, segments, tail) or {
+		write_c_output_sequential(mut file, prefix, segments, tail, separator) or {
 			file.close()
 			return err
 		}
@@ -64,6 +71,10 @@ fn write_c_output_mapped(path string, prefix []u8, segments []string, tail strin
 		}
 		for segment in segments {
 			if segment.len > 0 {
+				if separator.len > 0 {
+					vmemcpy(&u8(mapped) + offset, separator.str, separator.len)
+					offset += separator.len
+				}
 				vmemcpy(&u8(mapped) + offset, segment.str, segment.len)
 				offset += segment.len
 			}


### PR DESCRIPTION
After #28407 the self-host spends **670 ms** in all of V's own phases and
**6.1 s** in one `cc` process. 90% of
`./v3 -nocache -building-v -o v4 v3.v` is a single-threaded C compiler working
through one 22 MB translation unit, so that is where the remaining time is.

The split C build already existed behind `-parallel-cc` (#28389). This turns it
on for the builds where it is a pure win and removes the things that were making
it cost almost as much as it saved.

### Auto-enable it, without touching the cached path

A split build is enabled when the object cache is *not* the one feeding the C
compiler — so there is nothing to reuse and the whole program is about to be
compiled from scratch anyway — and the program is big enough to be worth
splitting (400k AST nodes; hello world stays in one unit and is unchanged at
62 ms). `-prod` keeps its monolithic unit because `-flto` has to see the whole
program. `-d v3_parallel_cc_monolithic` still opts out.

### Bound the C compilers by memory, not by a constant

`v3_parallel_cc_max_jobs` was 2, which is what made the flag only worth ~25%.
A unit is the shared declaration prefix plus its share of the bodies, and clang
needs ~35 bytes of resident memory per source byte of a generated unit, so the
job count now follows `runtime.free_memory()` and the unit size. On this machine
that is 18 jobs and a measured 2.2 GiB of concurrent C compilers, against
840 MiB for the single monolithic one. On a machine with less free memory it
scales down, and it falls back to the old bound of 2 if free memory cannot be
read.

Also one unit per job instead of four: every extra unit re-parses the 2.3 MB
declaration header (0.09 s each), which costs more than the finer load balancing
returns.

### Stop paying for cache machinery a split build does not use

`-parallel-cc` had to turn on `cache_split`, which also turns on the
content-addressed renaming of `_str_N` symbols. That renaming is what lets
separately compiled *module cache* generations agree on a symbol's name; a split
build shares one generated prefix with its own units and does not need it. It
was a byte-by-byte pass over all 22 MB, on the main thread, once per worker
segment — **720 ms** of the cgen stage. It is now behind its own
`cache_stable_symbols` flag, set only when the module cache is on.

With that gone, a split build can also stream the unit markers straight into the
mapped output file instead of copying every function body through the builder
first (another ~60 ms).

### Test binaries stay monolithic

`gen_test_failure_global()` emits `static int __v3_test_failures` and the setjmp
buffer into the program *body*, so a unit that only referenced them would not
compile. Test builds keep one translation unit. (This also fixes the explicit
`-parallel-cc` flag for test files, which produced unbuildable C before.)

## Numbers

Interleaved medians, five runs per binary, 18-core M5 Max,
`./v3 -nocache -building-v -o v4 v3.v`:

| | master | this PR | |
|---|---|---|---|
| `cc` | 6127 ms | **2213 ms** | −64% |
| V's own phases | 668 ms | 674 ms | unchanged |
| **total** | **6798 ms** | **2895 ms** | **−57%** (2.35x) |

Peak resident memory of the `v3` process is unchanged (1.96 GiB); the C
compilers add 2.2 GiB concurrently at the peak instead of 840 MiB, which is what
the memory-aware job count bounds.

## Checks

- `v3` and the `v4` it builds emit byte-identical C (fixed point), and a
  compiler built through the split path emits the same C as one built with
  `-d v3_parallel_cc_monolithic`.
- Cached builds are unchanged: the C stored in the module cache is byte-identical
  to master's, content-addressed symbol names included, and cold+warm builds
  reuse it.
- `hello_world` stays in one translation unit; `-cc tcc`, `-d v3_no_parallel`,
  and explicit `-parallel-cc` all still work.
- `vlib/v3/driver/parallel_cc_test.v`, `modulecache_test.v`,
  `gen/c/source_directive_test.v`, `gen/c/types_test.v` pass.
- 20 vlib tests and 40 `examples/*.v`: identical pass/fail sets to master.
- `v fmt -verify` clean.
- A file-by-file A/B of the `vlib/v3/**/*_test.v` unit tests (each with its own
  V3CACHE) against a master-built compiler agrees on every file so far; the three
  failures seen (`eval_test.v`, `gen/arm64/gen_test.v`, `gen/arm64/linker_test.v`)
  fail identically on master.