### PR TITLE
v3: give the self-host transform one lane per core (9% off `v self`)

### DIFF
--- a/vlib/v3/transform/ast_snapshot_darwin.c.v
+++ b/vlib/v3/transform/ast_snapshot_darwin.c.v
@@ -14,6 +14,12 @@ fn C.mach_vm_remap(target C.task_t, address &u64, size u64, mask u64, flags int,
 
 fn C.getpagesize() int
 
+// ast_snapshots_supported reports that a base-AST lane can be handed out as a
+// copy-on-write mapping instead of a byte copy.
+fn ast_snapshots_supported() bool {
+	return true
+}
+
 fn snapshot_ast_buffer(data voidptr, len u64, capacity u64) ?AstBufferSnapshot {
 	if len == 0 || capacity < len || data == unsafe { nil } {
 		return none

--- a/vlib/v3/transform/ast_snapshot_default.c.v
+++ b/vlib/v3/transform/ast_snapshot_default.c.v
@@ -1,5 +1,11 @@
 module transform
 
+// ast_snapshots_supported reports that every base-AST lane must be copied byte
+// for byte here, so each lane costs a full clone.
+fn ast_snapshots_supported() bool {
+	return false
+}
+
 fn snapshot_ast_buffer(data voidptr, len u64, capacity u64) ?AstBufferSnapshot {
 	return none
 }

--- a/vlib/v3/transform/fn_test.v
+++ b/vlib/v3/transform/fn_test.v
@@ -958,7 +958,13 @@ fn test_unchanged_node_text_still_invalidates_semantic_memos() {
 }
 
 fn test_selfhost_transform_lane_count_is_memory_bounded() {
-	assert transform_job_count(18, 10_000, true) == 7
+	// A self-host lane is a copy-on-write mapping of the base AST where the
+	// target supports one, so the count follows the cores; where the base has to
+	// be copied, every lane costs a clone and the old bound applies.
+	selfhost_lanes := if ast_snapshots_supported() { 18 } else { 7 }
+	assert transform_job_count(18, 10_000, true) == selfhost_lanes
 	assert transform_job_count(18, 10_000, false) == 7
 	assert transform_job_count(4, 10_000, true) == 4
+	// Fewer items than lanes still gives one lane per item.
+	assert transform_job_count(18, 3, true) == 3
 }

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -2883,7 +2883,18 @@ fn transform_job_count(n_runtime_jobs int, n_items int, scoped_selfhost bool) in
 	}
 	mut n := n_runtime_jobs
 	limit := if scoped_selfhost {
-		max_selfhost_transform_jobs
+		if ast_snapshots_supported() {
+			// A copy-on-write lane shares the base AST's pages until it rewrites
+			// them, so it costs the pages it touches rather than a whole clone and
+			// the count can follow the core count. Going from 7 lanes to one per
+			// core took the transform phase of the self-host from 235 ms to 148 ms
+			// for 23 MiB of extra peak RSS. clamp_transform_jobs_to_clone_budget
+			// still bounds it by the size of the base AST, which also covers a
+			// snapshot that fails at runtime and falls back to a real copy.
+			n_runtime_jobs
+		} else {
+			max_selfhost_transform_jobs
+		}
 	} else {
 		max_parallel_transform_jobs
 	}


### PR DESCRIPTION
Correcting the target of the last round: `v self` builds with **tcc** on Apple
Silicon — `cmd/tools/vself.v` passes `-cc tcc` — so the self-host is ~925 ms, of
which tcc is only 287 ms. Almost all of it is V's own phases, and the largest of
those was **transform at 228 ms**.

## Transform was the only phase not using the cores

| phase | lanes |
|---|---|
| check | 17 |
| markused | 17 |
| parse | 18 |
| cgen | 18 |
| monomorph | 18 |
| **transform** | **7** |

The cap is a memory decision, and a fair one as written: each self-host lane owns
a clone of the base AST, and the comment says seven lanes "keep the production
compiler build below 4 GB".

But on targets that have `snapshot_ast_buffer`, a lane does *not* own a clone.
`mach_vm_remap` with `copy=1` hands it a copy-on-write mapping of the base
buffers, so a lane only ever pays for the pages it rewrites. Measured, going from
7 lanes to one per core costs **23 MiB** of peak RSS (1983 → 2006 MiB).

So the limit now asks whether the lane is a mapping or a copy:

- `ast_snapshots_supported()` — true where `snapshot_ast_buffer` returns a
  mapping (darwin), false where the base has to be copied byte for byte, which
  keeps the old bound of 7 there.
- `clamp_transform_jobs_to_clone_budget` is unchanged and still bounds the count
  by the size of the base AST, so a larger program keeps its memory ceiling —
  and that also covers a snapshot that fails at runtime and falls back to a real
  copy.

Scaling of the phase before the change (VJOBS sweep, serial → 18 cores): cgen
7.3x, check 3.9x, transform 4.6x. Transform was the outlier because it was
capped, not because the work does not divide.

## Numbers

Interleaved medians, five runs each, 18-core M5 Max,
`./v3 -cc tcc -nocache -building-v -o v4 v3.v`:

| | master | this PR | |
|---|---|---|---|
| transform | 227.66 ms | **142.79 ms** | −37% |
| tcc | 286.52 ms | 286.77 ms | — |
| **total** | **925.25 ms** | **841.19 ms** | **−9.1%** |

Peak RSS 1983 → 2006 MiB.

## Checks

- The generated C is **byte-identical** to master's, modulo the compiler path
  baked into it, and the compiler this builds reproduces its own C (fixed point).
- `-d v3_no_parallel` builds.
- 20 vlib tests and 40 `examples/*.v`: identical pass/fail sets to master.
- `transform/ast_snapshot_test.v` passes;
  `transform/transform_parallel_test.v` has the same three pre-existing failures
  with a master-built compiler.
- `transform/fn_test.v` asserted the old cap; updated to assert the lane count
  against `ast_snapshots_supported()` so both paths stay covered.
- `v fmt -verify` clean.