### PR TITLE
v3: fix the `c_name` shadow and unused stub params reported by `make`

### DIFF
--- a/vlib/v3/transform/array.v
+++ b/vlib/v3/transform/array.v
@@ -6078,10 +6078,10 @@ fn (mut t Transformer) make_array_merge_sort_stmt(base flat.NodeId, elem_type st
 	i_name := t.new_temp('sort_i')
 	j_name := t.new_temp('sort_j')
 	k_name := t.new_temp('sort_k')
-	c_name := t.new_temp('sort_c')
+	copy_name := t.new_temp('sort_c')
 	t.set_var_type(n_name, 'int')
 	t.set_var_type(buf_name, array_type)
-	for name in [w_name, lo_name, mid_name, hi_name, i_name, j_name, k_name, c_name] {
+	for name in [w_name, lo_name, mid_name, hi_name, i_name, j_name, k_name, copy_name] {
 		t.set_var_type(name, 'int')
 	}
 	// One pass over the merged range picks from the left run whenever the right
@@ -6119,8 +6119,8 @@ fn (mut t Transformer) make_array_merge_sort_stmt(base flat.NodeId, elem_type st
 		t.make_assign(t.make_ident(lo_name), t.make_ident(hi_name)),
 	]
 	run_for := t.make_for_stmt(t.make_decl_assign_typed(lo_name, t.make_int_literal(0), 'int'), t.make_infix(.lt, t.make_ident(lo_name), t.make_ident(n_name)), t.make_empty(), run_body, src)
-	copy_back := t.make_for_stmt(t.make_decl_assign_typed(c_name, t.make_int_literal(0), 'int'), t.make_infix(.lt, t.make_ident(c_name), t.make_ident(n_name)), t.make_expr_stmt(t.make_postfix(t.make_ident(c_name), .inc)), [
-		t.copy_sorted_element(base, c_name, t.make_ident(buf_name), c_name, elem_type),
+	copy_back := t.make_for_stmt(t.make_decl_assign_typed(copy_name, t.make_int_literal(0), 'int'), t.make_infix(.lt, t.make_ident(copy_name), t.make_ident(n_name)), t.make_expr_stmt(t.make_postfix(t.make_ident(copy_name), .inc)), [
+		t.copy_sorted_element(base, copy_name, t.make_ident(buf_name), copy_name, elem_type),
 	], src)
 	width_for := t.make_for_stmt(t.make_decl_assign_typed(w_name, t.make_int_literal(1), 'int'), t.make_infix(.lt, t.make_ident(w_name), t.make_ident(n_name)), t.make_assign(t.make_ident(w_name), t.make_infix(.left_shift, t.make_ident(w_name), t.make_int_literal(1))), [
 		run_for,

--- a/vlib/v3/transform/ast_snapshot_default.c.v
+++ b/vlib/v3/transform/ast_snapshot_default.c.v
@@ -6,9 +6,9 @@ fn ast_snapshots_supported() bool {
 	return false
 }
 
-fn snapshot_ast_buffer(data voidptr, len u64, capacity u64) ?AstBufferSnapshot {
+fn snapshot_ast_buffer(_data voidptr, _len u64, _capacity u64) ?AstBufferSnapshot {
 	return none
 }
 
-fn release_ast_buffer_snapshot(snapshot AstBufferSnapshot) {
+fn release_ast_buffer_snapshot(_snapshot AstBufferSnapshot) {
 }


### PR DESCRIPTION
A `make` bootstrap prints four checker notices from `vlib/v3/transform`. Both are real, not false positives.

### `array.v:6081` — shadowed function

The merge-sort lowering declared a local `c_name`, which shadows `fn c_name(name string) string` in `expr.v` — the same `transform` module:

```
vlib/v3/transform/array.v:6081:2: notice: variable `c_name` shadows a function declaration
```

Renamed the local to `copy_name` (4 occurrences, all inside `make_array_merge_sort_stmt`). The generated temp string is still `'sort_c'`, so the emitted C is byte-identical.

### `ast_snapshot_default.c.v` — unused stub params

This is the non-darwin fallback, whose functions are deliberate no-ops, so the parameters genuinely are unused:

```
vlib/v3/transform/ast_snapshot_default.c.v:9:24: notice: unused parameter: `data`
vlib/v3/transform/ast_snapshot_default.c.v:9:38: notice: unused parameter: `len`
vlib/v3/transform/ast_snapshot_default.c.v:9:47: notice: unused parameter: `capacity`
vlib/v3/transform/ast_snapshot_default.c.v:13:32: notice: unused parameter: `snapshot`
```

Prefixed them with `_`, which is what both checkers skip on — V1 at `vlib/v/checker/checker.v:643` (`obj.name[0] != '_'`) and V3 at `vlib/v3/types/checker_parallel.v:2372`. The names are kept rather than replaced by bare `_` so the signatures still document the darwin implementation they stand in for.

These notices only fire off darwin: a macOS build skips `ast_snapshot_default.c.v` in favour of `ast_snapshot_darwin.c.v`, per the `_default.c.v` fallback in `vlib/v/pref/should_compile.v:109`.

## Verification

- Full `make` bootstrap: exit 0, zero notices.
- Since the unused-param notices are Linux-only on macOS, the V1 stage was reproduced cross-target with a `v1` rebuilt from the `vc` snapshot: `./v1 -os linux ... cmd/v` **without** the fix reproduces all four notices; **with** the fix it is clean.
- Sort smoke test through the renamed lowering — `.sort()`, `.sort(a > b)`, strings, `sort_with_compare` stability, and a 3000-element array: passes.
- `v fmt -verify` clean on both files.