### PR TITLE
v3: keep test binaries in one translation unit under `-parallel-cc`

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -9289,7 +9289,7 @@ pub fn run(args []string) {
 	minimal_literal_output := !is_prof
 		&& input_uses_minimal_literal_output_builtin(input_file, prefs, is_test_command, is_checker_fixture)
 	host_target := pref.host_target()
-	use_parallel_c_compilation := parallel_cc && backend == 'c' && !c_only && !explicit_tcc
+	mut use_parallel_c_compilation := parallel_cc && backend == 'c' && !c_only && !explicit_tcc
 		&& !is_o && target.os != 'windows' && coverage_dir.len == 0 && profile_file.len == 0
 		&& v3_parallel_cc_monolithic_define !in user_defines
 	// `-keepc` and explicit `-b c` promise a complete generated C translation unit.
@@ -9496,6 +9496,14 @@ pub fn run(args []string) {
 		exit(1)
 	}
 	test_files := test_input_files(user_files, backend, prefs.target)
+	// A test binary keeps the harness counters (`__v3_test_failures` and the
+	// setjmp buffer that `assert` longjmps out of) as `static` definitions inside
+	// the program body, so they live in whichever split unit the body lands in
+	// and a unit that only references them does not compile. Test builds stay in
+	// one translation unit.
+	if test_files.len > 0 {
+		use_parallel_c_compilation = false
+	}
 
 	if !no_builtin {
 		seed_implicit_imports(mut a, minimal_literal_output)

--- a/vlib/v3/driver/parallel_cc_test.v
+++ b/vlib/v3/driver/parallel_cc_test.v
@@ -46,6 +46,29 @@ fn test_v3_parallel_cc_compiles_and_runs_multiple_c_units() {
 	}
 }
 
+fn test_v3_parallel_cc_keeps_test_binaries_in_one_unit() {
+	$if macos || linux {
+		root := os.join_path(os.vtmp_dir(), 'v3_parallel_cc_test_harness_${os.getpid()}')
+		os.rmdir_all(root) or {}
+		os.mkdir_all(root)!
+		defer {
+			os.rmdir_all(root) or {}
+		}
+		source := os.join_path_single(root, 'harness_test.v')
+		output := os.join_path_single(root, 'harness')
+		os.write_file(source, 'fn twice(value int) int { return value * 2 }\n\nfn test_twice() { assert twice(21) == 42 }\n')!
+		// The harness counters `assert` writes are `static` definitions inside the
+		// program body, so a split unit that only references them would not
+		// compile. The build has to stay in one translation unit.
+		build := cmdexec.run(@VEXE, ['-parallel-cc', '-nocache', '-showcc', '-o', output,
+			source])
+		assert build.exit_code == 0, build.output
+		assert !build.output.contains('unit_1.c'), build.output
+		run_result := cmdexec.run(output, [])
+		assert run_result.exit_code == 0, run_result.output
+	}
+}
+
 fn test_v3_parallel_cc_does_not_shadow_user_parallel_header() {
 	$if macos || linux {
 		root := os.join_path(os.vtmp_dir(), 'v3_parallel_cc_header_${os.getpid()}')


### PR DESCRIPTION
`-parallel-cc` on any `_test.v` file produces C that does not compile:

```
unit_8.c:30306:36: error: use of undeclared identifier '__v3_test_failures'
unit_8.c:30307:2: error: use of undeclared identifier '__v3_test_jump_active'
unit_8.c:30308:13: error: use of undeclared identifier '__v3_test_jump_buffer'
```

Reproduce on master with any test file, e.g.

```
v -parallel-cc -nocache -enable-globals -o /tmp/t vlib/v3/gen/c/types_test.v
```

`gen_test_failure_global()` (`vlib/v3/gen/c/fn.v`) emits the harness counters and
the setjmp buffer that `assert` longjmps out of as `static` definitions inside
the *program body*:

```v
g.writeln('static int __v3_test_failures = 0;')
g.writeln('static jmp_buf __v3_test_jump_buffer;')
g.writeln('static int __v3_test_jump_active = 0;')
```

The body is what gets cut into units, so those three land in one of them while
every other unit that contains an `assert` only references them. `static` also
rules out the obvious fix of declaring them `extern` in the shared header.

So test builds stay in one translation unit. Whether to split is decided after
the input files have been classified, which makes the check just
`test_files.len > 0`.

This is a no-op for every build that does not pass `-parallel-cc`, since the
flag is opt-in.

## Test

`test_v3_parallel_cc_keeps_test_binaries_in_one_unit` builds a `_test.v` file
with `-parallel-cc -showcc` and asserts both that it compiles and that no
`unit_1.c` was emitted. It fails against a compiler built from master:

```
vlib/v3/driver/parallel_cc_test.v:65: fn test_v3_parallel_cc_keeps_test_binaries_in_one_unit
> assert build.exit_code == 0, build.output
   left value: build.exit_code = 1
```

and passes with the change. The rest of `parallel_cc_test.v` still passes, a
non-test `-parallel-cc` build still splits into units, and plain `cc` and
`-cc tcc` builds are unaffected.