### PR TITLE
v3: fix calling fn values stored in array and map containers

### DIFF
--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -2314,10 +2314,21 @@ fn (g &FlatGen) concrete_generic_method_name_from_call_receiver(node flat.Node, 
 	return none
 }
 
+// cgen_type_is_indexable_container reports whether `typ` is a container value that
+// `x[i]` indexes into. A selector of such a type cannot be a generic method name.
+fn cgen_type_is_indexable_container(typ types.Type) bool {
+	mut cur := types.unalias_type(typ)
+	for cur is types.Pointer {
+		cur = types.unalias_type(cur.base_type)
+	}
+	return cur is types.Array || cur is types.ArrayFixed || cur is types.Map
+}
+
 fn (g &FlatGen) is_explicit_generic_method_call_selector(fn_node &flat.Node, resolved_target_name string, target_name string) bool {
 	if fn_node.kind != .index || fn_node.children_count < 2 {
 		return false
 	}
+	selector_id := g.a.child(fn_node, 0)
 	selector := g.a.child_node(fn_node, 0)
 	if selector.kind != .selector || selector.children_count == 0 {
 		return false
@@ -2330,6 +2341,11 @@ fn (g &FlatGen) is_explicit_generic_method_call_selector(fn_node &flat.Node, res
 		if arg.kind == .index && arg.value != 'range' {
 			continue
 		}
+		return false
+	}
+	if cgen_type_is_indexable_container(g.usable_expr_type(selector_id)) {
+		// `recv.field[i]()` calls the function value stored at `i` in an array or
+		// map field, so the brackets are an index and not explicit type arguments.
 		return false
 	}
 	if resolved_target_name.contains('.') || target_name.contains('.') {
@@ -15844,7 +15860,12 @@ fn (mut g FlatGen) gen_generated_storage_pointer_arg(arg_idx int, arg_id flat.No
 	if inner.kind != .ident || !generated_storage_pointer_arg_name(inner.value) {
 		return false
 	}
-	g.gen_expr(arg_id)
+	// The container copies `elem_size` bytes from this pointer, so the address of the
+	// temporary is always required. Emitting the `&` here keeps a function-valued
+	// element from collapsing to the bare function pointer, which would make the
+	// container read its element bytes out of the function's own code.
+	g.write('&')
+	g.gen_expr(inner_id)
 	return true
 }
 

--- a/vlib/v3/tests/fn_value_container_index_call_codegen_test.v
+++ b/vlib/v3/tests/fn_value_container_index_call_codegen_test.v
@@ -1,0 +1,153 @@
+import os
+
+const fn_index_vexe = @VEXE
+const fn_index_tests_dir = os.dir(@FILE)
+const fn_index_v3_dir = os.dir(fn_index_tests_dir)
+const fn_index_vlib_dir = os.dir(fn_index_v3_dir)
+const fn_index_v3_src = os.join_path(fn_index_v3_dir, 'v3.v')
+
+fn fn_index_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_fn_index_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${fn_index_vexe} -gc none -path "${fn_index_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${fn_index_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn fn_index_write_source(name string, source string) string {
+	path := os.join_path(os.temp_dir(), 'v3_fn_index_${name}_${os.getpid()}.v')
+	os.write_file(path, source) or { panic(err) }
+	return path
+}
+
+// A `recv.field[i]()` call invokes the function value stored at index `i`. The
+// brackets used to be read as explicit generic type arguments, so the checker
+// rejected the index variable as an unknown type and the C backend emitted a call
+// to a nonexistent `Recv__field` method.
+fn test_fn_value_stored_in_container_field_is_called_through_the_index() {
+	v3_bin := fn_index_build_v3()
+	source := fn_index_write_source('container_field', 'module main
+
+struct Registry {
+mut:
+	fns      []fn (int) int
+	named    map[string]fn (int) int
+	void_fns []fn ()
+}
+
+fn double(x int) int {
+	return x * 2
+}
+
+fn triple(x int) int {
+	return x * 3
+}
+
+fn hello() {
+	println("hello")
+}
+
+fn main() {
+	mut r := Registry{}
+	r.fns << double
+	r.fns << triple
+	r.named["d"] = double
+	r.void_fns << hello
+
+	mut total := 0
+	for i := 0; i < r.fns.len; i++ {
+		total += r.fns[i](i + 1)
+	}
+	key := "d"
+	total += r.named[key](10)
+	idx := 0
+	r.void_fns[idx]()
+	println(total)
+}
+')
+	out := os.join_path(os.temp_dir(), 'v3_fn_index_container_field_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${source} -b c -o ${out}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(out)
+	assert run.exit_code == 0, run.output
+	assert run.output.split_into_lines() == ['hello', '28']
+	generated := os.read_file(out + '.c') or { panic(err) }
+	assert !generated.contains('Registry__fns'), generated
+	assert !generated.contains('Registry__void_fns'), generated
+	assert !generated.contains('Registry__named'), generated
+	assert generated.contains('array_get(r.fns,'), generated
+}
+
+// `arr << fn_value` stores the function pointer by address into the array buffer.
+// Collapsing `&tmp` to the bare function value made `array_push` copy the element
+// bytes out of the function's own code, so the later call crashed.
+fn test_fn_value_pushed_into_a_local_container_is_callable() {
+	v3_bin := fn_index_build_v3()
+	source := fn_index_write_source('local_container', 'module main
+
+fn shout() {
+	println("called")
+}
+
+fn main() {
+	mut fns := []fn (){}
+	mut m := map[string]fn (){}
+	for _ in 0 .. 3 {
+		fns << shout
+	}
+	m["k"] = shout
+	for slot := 0; slot < fns.len; slot++ {
+		fns[slot]()
+	}
+	key := "k"
+	m[key]()
+}
+')
+	out := os.join_path(os.temp_dir(), 'v3_fn_index_local_container_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${source} -b c -o ${out}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(out)
+	assert run.exit_code == 0, run.output
+	assert run.output.split_into_lines() == ['called', 'called', 'called', 'called']
+	generated := os.read_file(out + '.c') or { panic(err) }
+	assert generated.contains('array_push(&fns, &__arr_val_'), generated
+}
+
+// The container guards above must not swallow a real `recv.method[T]()` call.
+fn test_explicit_generic_method_call_still_resolves() {
+	v3_bin := fn_index_build_v3()
+	source := fn_index_write_source('explicit_generic', 'module main
+
+struct Box[T] {
+mut:
+	items []T
+}
+
+fn (b Box[T]) pick[U](d U) U {
+	return d
+}
+
+fn apply[T](f fn (T) T, v T) T {
+	return f(v)
+}
+
+fn double(x int) int {
+	return x * 2
+}
+
+fn main() {
+	b := Box[int]{
+		items: [1, 2, 3]
+	}
+	println(b.pick[string]("generic-ok"))
+	println(apply[int](double, 21))
+}
+')
+	out := os.join_path(os.temp_dir(), 'v3_fn_index_explicit_generic_${os.getpid()}')
+	compile := os.execute('${v3_bin} ${source} -b c -o ${out}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(out)
+	assert run.exit_code == 0, run.output
+	assert run.output.split_into_lines() == ['generic-ok', '42']
+}

--- a/vlib/v3/types/checker_tail.v
+++ b/vlib/v3/types/checker_tail.v
@@ -3286,6 +3286,23 @@ fn (mut tc TypeChecker) check_valid_call_preamble(id flat.NodeId, node flat.Node
 	return false
 }
 
+// call_callee_indexes_container reports whether a call's `x[i]` callee indexes an
+// array or map value. Such a call invokes the function stored at `i`, so the
+// brackets are an index and not explicit generic type arguments.
+fn (mut tc TypeChecker) call_callee_indexes_container(callee &flat.Node) bool {
+	if callee.children_count == 0 || callee.value == 'range' {
+		return false
+	}
+	base_id := tc.a.child(callee, 0)
+	base := tc.a.node(base_id)
+	if base.kind == .ident && !tc.ident_resolves_to_value(base.value) {
+		// A bare generic function name such as `apply` in `apply[int](v)`.
+		return false
+	}
+	base_type := unalias_and_unwrap_pointer_type(tc.resolve_type(base_id))
+	return base_type is Array || base_type is ArrayFixed || base_type is Map
+}
+
 // check_call validates check call state for types.
 @[direct_array_access]
 fn (mut tc TypeChecker) check_call(id flat.NodeId, node flat.Node) {
@@ -3444,7 +3461,8 @@ fn (mut tc TypeChecker) check_call(id flat.NodeId, node flat.Node) {
 		if callee.kind == .call {
 			tc.check_node(callee_id)
 		}
-		if callee.kind == .index && callee.children_count > 1 {
+		if callee.kind == .index && callee.children_count > 1
+			&& !tc.call_callee_indexes_container(callee) {
 			mut has_unbound_generic_type_arg := false
 			for i in 1 .. callee.children_count {
 				type_arg_id := tc.a.child(callee, i)


### PR DESCRIPTION
## Problem

This program fails to build with V3:

```v
module main

struct StructThatHaveFnArray {
mut:
	fns []fn ()
}

fn returnnothing() {
	println('called')
}

const example_repeat_count = 16

fn main() {
	mut functions := []fn ()
	for i in 0 .. example_repeat_count {
		functions << returnnothing
	}
	strct := StructThatHaveFnArray{
		fns: functions
	}
	for i := 0; i < strct.fns.len; i++ {
		strct.fns[i]()
	}
}
```

```
src.c:3394:4: error: call to undeclared function 'StructThatHaveFnArray__fns'
 3394 |    StructThatHaveFnArray__fns(strct);
```

(The driver's silent V1 fallback masks this behind an unrelated
`expression evaluated but not used`; `-new-compiler` shows the real error.)

## Cause

`recv.field[i]()` calls the function value stored at index `i`, but the brackets
parse into the same `.index` node as an explicit generic instantiation
`name[T]()`, and both the checker and the C backend assumed the generic reading.

Three distinct defects fall out of that:

1. `check_call` validated every index argument of an `.index` callee as a generic
   *type* argument, so `r.handlers[idx]()` failed with ``unknown type `idx` ``.
   Single-letter index names slipped through only because of the
   `type_name.len > 1` filter — which is why the report above reaches codegen at
   all.
2. `is_explicit_generic_method_call_selector` dropped the index and emitted a
   method call, producing the `Recv__field` C error above.
3. Independently: `arr << fn_value` lowers to `array_push(&arr, &tmp)`, but the
   `&`-of-a-function-value collapse rule in `gen_expr` stripped the address, so
   `array_push` copied the element bytes out of the function's own code. Even the
   form that parsed correctly (`functions[i]()` on a local) compiled cleanly and
   then died with SIGBUS at runtime.

## Fix

- `vlib/v3/types/checker_tail.v`: new `call_callee_indexes_container()`;
  `check_call` skips generic type-argument validation when the indexed expression
  is an array, fixed array or map value. A bare ident that does not resolve to a
  value (`apply[int](v)`) still takes the generic path.
- `vlib/v3/gen/c/fn.v`: `is_explicit_generic_method_call_selector()` returns
  false for a selector of container type, so the index is no longer dropped.
- `vlib/v3/gen/c/fn.v`: `gen_generated_storage_pointer_arg()` writes the `&`
  itself rather than delegating to `gen_expr`, which collapses `&fn_value`.

## Tests

New `vlib/v3/tests/fn_value_container_index_call_codegen_test.v` covers the
container-field call, the local push-then-call (including a multi-character index
name), and an explicit generic method call to guard against the new checks
matching too broadly.