### PR TITLE
v3: stop expanding an `it` interpolation encoded in a string literal

### DIFF
--- a/vlib/v3/tests/nested_escaped_map_it_interp_test.v
+++ b/vlib/v3/tests/nested_escaped_map_it_interp_test.v
@@ -1,0 +1,48 @@
+import os
+
+const vexe = @VEXE
+const tests_dir = os.dir(@FILE)
+const v3_dir = os.dir(tests_dir)
+const vlib_dir = os.dir(v3_dir)
+const v3_src = os.join_path(v3_dir, 'v3.v')
+
+// Written as a raw string so the escapes reach the compiler under test as typed.
+const nested_it_program = r"fn main() {
+	b := 'B'
+	tags := ['a', 'b']
+	println('1:' + 'p ${tags.map('--\${it}').join(',')}')
+	println('2:' + 'p ${tags.map('--${it}').join(',')}')
+	println('3:' + 'p ${tags.map('--' + it).join(',')}')
+	println('4:' + 'p ${tags.filter(it != 'b').map('<\${it}>').join(',')}')
+	println('5:' + 'L ${'a ${b}'}')
+}
+"
+
+// A `${it}` that reaches the transform still encoded in a string literal's text has
+// no binding to rename: `it` belongs to the enclosing `map`/`filter`, whose lowering
+// renames it while walking the parsed body. Expanding it anyway synthesized an `it`
+// that no declaration reached, and the generated C failed to build with
+// `use of undeclared identifier 'it'`, which made V fall back to the stable compiler.
+fn test_escaped_it_interpolation_in_map_body_compiles() {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_nested_escaped_map_it_interp_test')
+	build := os.execute('${vexe} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+
+	source_file := os.join_path(os.temp_dir(), 'v3_nested_escaped_map_it_interp_input.v')
+	os.write_file(source_file, nested_it_program) or { panic(err) }
+	bin := os.join_path(os.temp_dir(), 'v3_nested_escaped_map_it_interp_input')
+	compile := os.execute('${v3_bin} -nocache ${source_file} -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	lines := run.output.trim_space().split_into_lines()
+	assert lines.len == 5, run.output
+	// the escaped form keeps the dollar the source asked to print
+	assert lines[0] == r'1:p --${it},--${it}', run.output
+	// an unescaped nested interpolation still resolves the `map` binding
+	assert lines[1] == '2:p --a,--b', run.output
+	assert lines[2] == '3:p --a,--b', run.output
+	assert lines[3] == r'4:p <${it}>', run.output
+	// deeper nesting keeps expanding
+	assert lines[4] == '5:L a B', run.output
+}

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -9683,6 +9683,14 @@ fn (mut t Transformer) simple_nested_string_interpolation(value string) ?flat.No
 		if inner.len == 0 || string_has_interp_start_bytes(inner) || string_has_newline_byte(inner) {
 			return none
 		}
+		if nested_interp_text_reads_it(inner) {
+			// `it` is owned by an enclosing `map`/`filter`, which renames it while
+			// lowering its body. A real nested interpolation of `it` reaches this
+			// transform as a parsed part rather than as literal text, so an `it`
+			// still encoded in the text here has no binding to rename and expanding
+			// it would emit an undeclared identifier.
+			return none
+		}
 		expr, typ := t.simple_nested_interp_expr(inner) or { return none }
 		parts << t.wrap_string_conversion(expr, typ)
 		i = end + 1
@@ -9952,6 +9960,46 @@ fn nested_interp_closing_brace(value string, start int) ?int {
 		}
 	}
 	return none
+}
+
+// nested_interp_text_reads_it reports whether an interpolation encoded in literal
+// text reads the implicit `it` binding, ignoring `it` used as a field name or
+// inside a quoted string.
+fn nested_interp_text_reads_it(inner string) bool {
+	mut quote := u8(0)
+	mut i := 0
+	for i < inner.len {
+		c := inner[i]
+		if quote != 0 {
+			if c == `\\` && i + 1 < inner.len {
+				i += 2
+				continue
+			}
+			if c == quote {
+				quote = 0
+			}
+			i++
+			continue
+		}
+		if c == `'` || c == `"` || c == `\`` {
+			quote = c
+			i++
+			continue
+		}
+		if c.is_letter() || c == `_` {
+			mut j := i
+			for j < inner.len && (inner[j].is_alnum() || inner[j] == `_`) {
+				j++
+			}
+			if inner[i..j] == 'it' && (i == 0 || inner[i - 1] != `.`) {
+				return true
+			}
+			i = j
+			continue
+		}
+		i++
+	}
+	return false
 }
 
 fn nested_interp_literal_inner(value string) ?string {


### PR DESCRIPTION
### Reproducer

```v
fn main() {
	tags := ['a', 'b']
	println('p ${tags.map('--\${it}').join(',')}')
}
```

On `master` this makes V3 give up and hand the program to the stable compiler:

```
main.c:3201:66: error: use of undeclared identifier 'it'
 3201 |   string __map_val_3 = string__plus(_v3_lit_2_9afb1200c5c4a565, it);
note: V3 could not build this program, so V used the stable compiler instead.
```

The fallback is silent, so a program hits it with no indication of why beyond the
one-line note. I found it because a 400k-line project stopped building with V3
after an unrelated change; bisecting was misleading because whether V3 declines
looks non-monotonic from the outside — restoring one file flips it to success and
restoring two more flips it back — since it only depends on whether the affected
function survives dead-code elimination.

### Cause

The parser resolves the `\$` escape before building the AST, so the `map` body
arrives at the transform as a `.string_literal` whose text is `--${it}` rather
than as parsed interpolation parts:

```
MAPDBG source kind=string_literal value=`--${it}` children=0
```

`simple_nested_string_interpolation` then expands that text into `'--' + it`. But
`it` is owned by the enclosing `map`, and `lower_array_map_call` has already
renamed the `it` of the *parsed* body to the loop temporary via
`substitute_ident`. The `it` synthesized out of the literal text never passed
through that rename, so nothing declares it.

A genuine nested interpolation of `it` (`'--${it}'`, no backslash) reaches the
transform as parsed parts and already works, so an `it` still encoded in literal
text at this point can never have a binding to rename.

### Fix

Leave those spans unexpanded. This also matches what the stable compiler prints
for the escaped form:

| | stable | V3 before | V3 after |
| --- | --- | --- | --- |
| `'p ${tags.map('--\${it}').join(',')}'` | `p --${it},--${it}` | *build fails* | `p --${it},--${it}` |
| `'p ${tags.map('--${it}').join(',')}'` | `p --a,--b` | `p --a,--b` | `p --a,--b` |
| `'p ${tags.map('--' + it).join(',')}'` | `p --a,--b` | `p --a,--b` | `p --a,--b` |
| `'L ${'a ${b}'}'` | `L a B` | `L a B` | `L a B` |

### Not fixed here

V3 still interpolates `'\${x}'` nested inside an interpolation where the stable
compiler prints it literally — same root cause (the escape is resolved before the
AST exists), but for a name that *is* in scope it silently produces a different
string instead of failing to build:

```v
x := 'X'
println('p ${['a'].map('--\${x}').join(',')}')  // stable: p --${x}   V3: p --X
```

I tried fixing that root cause by preserving the escape through the parser and
resolving it at materialization. It fixes all the cases, but it corrupts string
constants while V3 compiles V3 — the resulting compiler mis-handles `'p\\q'` — so
I have left it out rather than ship a self-host regression. It wants its own
change.

### Testing

- `vlib/v3/tests/nested_escaped_map_it_interp_test.v` added; it fails on `master`
  with `use of undeclared identifier 'it'` and passes with this change.
- V3 self-host (`v3.v`) and `cmd/v` both still build with the patched compiler,
  and a standalone V3 built by it still compiles `'bs ${'p\\q'}'` correctly.
- `generic_struct_str_string_interp_codegen_test`,
  `generic_sum_str_string_interp_codegen_test` and `string_interp_char_format_test`
  pass. `string_interpolation_stringify_codegen_test` fails identically before and
  after this change.