### PR TITLE
v3: preserve C callback prototypes

### DIFF
--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -15501,12 +15501,16 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 			// differ from V's (notably C `int` vs V's i64 for platform `int`) needs an
 			// ABI thunk, not a bare function-pointer cast: casting the pointer does not
 			// convert the arguments the C library passes. Emit the adapter when one is
-			// required; otherwise fall through to the plain C-ABI cast below.
+			// required; otherwise fall through to the plain C-ABI cast below. Direct C
+			// functions already have their exact ABI in the included header, including
+			// qualifiers that cannot be expressed by their `fn C.` declarations.
 			if arg_idx >= 0 && arg_idx < typed_param_count {
 				if cb_fn := fn_type_from(param_types[arg_idx]) {
-					if thunk := g.c_call_callback_abi_thunk(arg_id, cb_fn) {
-						g.write(thunk)
-						continue
+					if !g.is_c_extern_fn_name_arg(arg_id) {
+						if thunk := g.c_call_callback_abi_thunk(arg_id, cb_fn) {
+							g.write(thunk)
+							continue
+						}
 					}
 				}
 			}

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -17940,6 +17940,18 @@ fn (mut g FlatGen) c_call_arg_cabi_cast(arg_idx int, typed_param_count int, para
 		if ct == 'int' {
 			return none
 		}
+		// A `C.` function passed by name into a C callback slot must stay uncast: the
+		// C compiler already has that function's real prototype from the header, and
+		// that prototype is exactly what the callee's parameter type was written
+		// against. A `fn C.` declaration cannot spell C qualifiers, so casting to the
+		// V-declared signature is what *creates* an incompatible-pointer-type error
+		// (e.g. `fn C.mbedtls_net_send(voidptr, &u8, usize) i32` drops the `const` in
+		// mbedtls_net_send's real `const unsigned char *` buffer parameter).
+		if _ := fn_type_from(param_types[arg_idx]) {
+			if g.is_c_extern_fn_name_arg(arg_id) {
+				return none
+			}
+		}
 		return ct
 	}
 	if is_variadic {
@@ -17958,6 +17970,15 @@ fn (mut g FlatGen) c_call_arg_cabi_cast(arg_idx int, typed_param_count int, para
 		}
 	}
 	return none
+}
+
+// is_c_extern_fn_name_arg reports whether the argument expression is a plain
+// reference to a `C.` extern function (`C.foo`, no wrapping conversion), i.e. a
+// function the C compiler already has a real prototype for from an included
+// header.
+fn (g &FlatGen) is_c_extern_fn_name_arg(arg_id flat.NodeId) bool {
+	name := g.direct_callback_ident_name(arg_id) or { return false }
+	return name.starts_with('C.')
 }
 
 fn (mut g FlatGen) c_extern_decl_line(node flat.Node, cfn string) string {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -17977,6 +17977,16 @@ fn (mut g FlatGen) c_call_arg_cabi_cast(arg_idx int, typed_param_count int, para
 // function the C compiler already has a real prototype for from an included
 // header.
 fn (g &FlatGen) is_c_extern_fn_name_arg(arg_id flat.NodeId) bool {
+	if int(arg_id) < 0 || int(arg_id) >= g.a.nodes.len {
+		return false
+	}
+	arg_node := g.a.nodes[int(arg_id)]
+	if arg_node.kind == .cast_expr {
+		return false
+	}
+	if arg_node.kind in [.paren, .expr_stmt] && arg_node.children_count > 0 {
+		return g.is_c_extern_fn_name_arg(g.a.child(&arg_node, 0))
+	}
 	name := g.direct_callback_ident_name(arg_id) or { return false }
 	return name.starts_with('C.')
 }

--- a/vlib/v3/tests/c_extern_fn_callback_arg_codegen_test.v
+++ b/vlib/v3/tests/c_extern_fn_callback_arg_codegen_test.v
@@ -25,6 +25,8 @@ fn extern_cb_write_source() string {
 
 fn C.native_send(voidptr, &u8, usize) i32
 fn C.native_register(fn (voidptr, &u8, usize) i32) i32
+fn C.native_send_int(voidptr, &u8, int) i32
+fn C.native_register_int(fn (voidptr, &u8, int) i32) i32
 
 fn v_send(ctx voidptr, buf &u8, len usize) i32 {
 	return i32(len) + i32(unsafe { buf[0] }) + i32(ctx != unsafe { nil })
@@ -35,6 +37,8 @@ fn main() {
 	println(C.native_register((C.native_send)))
 	println(C.native_register(voidptr(C.native_send)))
 	println(C.native_register(v_send))
+	println(C.native_register_int(C.native_send_int))
+	println(C.native_register_int((C.native_send_int)))
 }
 ') or { panic(err) }
 	return src
@@ -66,4 +70,9 @@ fn test_c_extern_fn_callback_arg_is_not_cast() {
 	// A V function still needs the C-ABI cast: C has no declaration of its own for
 	// it, so the fn-pointer typedef is what gives the argument a type.
 	assert compact.count('native_register((_fn_ptr_') == 2, c_code
+	// A C function with platform `int` in its callback ABI must not be routed
+	// through a V adapter; its header declaration remains the source of truth.
+	assert compact.contains('native_register_int(native_send_int)'), c_code
+	assert compact.contains('native_register_int((native_send_int))'), c_code
+	assert !compact.contains('__v3_callback_wrap_native_send_int'), c_code
 }

--- a/vlib/v3/tests/c_extern_fn_callback_arg_codegen_test.v
+++ b/vlib/v3/tests/c_extern_fn_callback_arg_codegen_test.v
@@ -32,6 +32,8 @@ fn v_send(ctx voidptr, buf &u8, len usize) i32 {
 
 fn main() {
 	println(C.native_register(C.native_send))
+	println(C.native_register((C.native_send)))
+	println(C.native_register(voidptr(C.native_send)))
 	println(C.native_register(v_send))
 }
 ') or { panic(err) }
@@ -56,8 +58,12 @@ fn test_c_extern_fn_callback_arg_is_not_cast() {
 	// prototype, and a cast to the V-declared signature would drop the parameter's
 	// `const` and trip -Wincompatible-pointer-types at the call.
 	assert compact.contains('native_register(native_send)'), c_code
-	assert !compact.contains(')(native_send)'), c_code
+	assert compact.contains('native_register((native_send))'), c_code
+	// An explicit conversion is not a bare C function reference. Preserve it as
+	// the inner expression and cast that result to the callback parameter type.
+	assert !compact.contains('native_register((void*)(native_send))'), c_code
+	assert compact.contains(')((void*)(native_send)))'), c_code
 	// A V function still needs the C-ABI cast: C has no declaration of its own for
 	// it, so the fn-pointer typedef is what gives the argument a type.
-	assert compact.contains('native_register((_fn_ptr_'), c_code
+	assert compact.count('native_register((_fn_ptr_') == 2, c_code
 }

--- a/vlib/v3/tests/c_extern_fn_callback_arg_codegen_test.v
+++ b/vlib/v3/tests/c_extern_fn_callback_arg_codegen_test.v
@@ -1,0 +1,63 @@
+import os
+
+const extern_cb_vexe = @VEXE
+const extern_cb_tests_dir = os.dir(@FILE)
+const extern_cb_v3_dir = os.dir(extern_cb_tests_dir)
+const extern_cb_vlib_dir = os.dir(extern_cb_v3_dir)
+const extern_cb_v3_src = os.join_path(extern_cb_v3_dir, 'v3.v')
+
+fn extern_cb_build_v3() string {
+	v3_bin := os.join_path(os.temp_dir(), 'v3_extern_callback_arg_test_${os.getpid()}')
+	os.rm(v3_bin) or {}
+	build :=
+		os.execute('${extern_cb_vexe} -gc none -path "${extern_cb_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${extern_cb_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+// extern_cb_write_source mirrors the mbedtls shape that broke: `mbedtls_net_send`
+// is handed to `mbedtls_ssl_set_bio`, whose callback slot takes a
+// `const unsigned char *` buffer. A `fn C.` line cannot spell that `const`, so
+// casting the argument to the V-declared signature is what breaks the call.
+fn extern_cb_write_source() string {
+	src := os.join_path(os.temp_dir(), 'v3_extern_callback_arg_${os.getpid()}.v')
+	os.write_file(src, 'module main
+
+fn C.native_send(voidptr, &u8, usize) i32
+fn C.native_register(fn (voidptr, &u8, usize) i32) i32
+
+fn v_send(ctx voidptr, buf &u8, len usize) i32 {
+	return i32(len) + i32(unsafe { buf[0] }) + i32(ctx != unsafe { nil })
+}
+
+fn main() {
+	println(C.native_register(C.native_send))
+	println(C.native_register(v_send))
+}
+') or { panic(err) }
+	return src
+}
+
+fn test_c_extern_fn_callback_arg_is_not_cast() {
+	v3_bin := extern_cb_build_v3()
+	src := extern_cb_write_source()
+	c_path := src + '.c'
+	defer {
+		os.rm(v3_bin) or {}
+		os.rm(src) or {}
+		os.rm(c_path) or {}
+	}
+	compile := os.execute('${v3_bin} ${src} -b c -o ${c_path}')
+	assert compile.exit_code == 0, compile.output
+
+	c_code := os.read_file(c_path) or { panic(err) }
+	compact := c_code.replace('\t', '').replace(' ', '').replace('\n', '')
+	// A `C.` function goes into the callback slot by name: C already has its real
+	// prototype, and a cast to the V-declared signature would drop the parameter's
+	// `const` and trip -Wincompatible-pointer-types at the call.
+	assert compact.contains('native_register(native_send)'), c_code
+	assert !compact.contains(')(native_send)'), c_code
+	// A V function still needs the C-ABI cast: C has no declaration of its own for
+	// it, so the fn-pointer typedef is what gives the argument a type.
+	assert compact.contains('native_register((_fn_ptr_'), c_code
+}


### PR DESCRIPTION
Summary

- leave direct C extern function names uncast when passed to C callback parameters
- keep C ABI casts for V callbacks
- add a regression test for const-qualified native callback prototypes

Tests

- ./vnew -silent test vlib/v3/tests/c_extern_fn_callback_arg_codegen_test.v
- ./vnew -silent test vlib/v3/gen/c/ (19 passed)

Fixes #28412