### PR TITLE
cgen: keep Boehm array scope pins constant-time

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -8952,9 +8952,10 @@ fn (mut g Gen) boehm_collect_keep_alive_helper_name(typ ast.Type) string {
 			sb.writeln('\treturn idx;')
 		}
 		.array {
-			info := sym.info as ast.Array
-			elem_styp := g.styp(info.elem_type)
-			elem_helper := g.boehm_collect_keep_alive_helper_name(info.elem_type)
+			// Arrays whose elements contain pointers use Boehm-scanned backing storage:
+			// check_noscan only selects atomic storage for pointer-free element types.
+			// Keeping that one backing block reachable therefore keeps every nested
+			// allocation reachable too, without walking all elements at every call site.
 			sb.writeln('\tif (it->data == 0) {')
 			sb.writeln('\t\treturn idx;')
 			sb.writeln('\t}')
@@ -8964,11 +8965,6 @@ fn (mut g Gen) boehm_collect_keep_alive_helper_name(typ ast.Type) string {
 			sb.writeln('\t}')
 			sb.writeln('\tif (out != 0) { out[idx] = _v_keep_root; }')
 			sb.writeln('\tidx++;')
-			if elem_helper != '' {
-				sb.writeln('\tfor (int _v_keep_i = 0; _v_keep_i < it->len; ++_v_keep_i) {')
-				sb.writeln('\t\tidx = ${elem_helper}(&(((${elem_styp}*)it->data)[_v_keep_i]), out, idx);')
-				sb.writeln('\t}')
-			}
 			sb.writeln('\treturn idx;')
 		}
 		.struct {

--- a/vlib/v/gen/c/coutput_test.v
+++ b/vlib/v/gen/c/coutput_test.v
@@ -1023,7 +1023,7 @@ fn test_boehm_scope_pin_does_not_walk_array_elements() {
 	defer {
 		os.rm(test_source) or {}
 	}
-	cmd := '${os.quoted_path(vexe)} -prod -gc boehm_full_opt -o - ${os.quoted_path(test_source)}'
+	cmd := '${os.quoted_path(vexe)} -old-compiler -prod -gc boehm_full_opt -o - ${os.quoted_path(test_source)}'
 	compilation := os.execute(cmd)
 	ensure_compilation_succeeded(compilation, cmd)
 	assert !generated_c_uses_v3_codegen(compilation.output)

--- a/vlib/v/gen/c/coutput_test.v
+++ b/vlib/v/gen/c/coutput_test.v
@@ -1008,6 +1008,32 @@ fn test_auxiliary_c_symbols_use_stable_type_hashes() {
 	assert keepalive_a == keepalive_b
 }
 
+fn test_boehm_scope_pin_does_not_walk_array_elements() {
+	$if windows {
+		$if tinyc {
+			eprintln('> skipping ${@FN} on windows-tcc, since deep GC scope pins are not emitted there')
+			return
+		}
+	}
+	os.chdir(vroot) or {}
+	test_source := os.join_path(os.vtmp_dir(), 'coutput_boehm_constant_time_array_pin.v')
+	os.write_file(test_source,
+		['module main', '', 'struct Item {', '\tname string', '\tdata []u8', '}', '', 'fn sink(_ int) {}', '', 'fn hot(items []Item) {', '\tsink(items.len)', '}', '', 'fn main() {', '\thot([])', '}'].join('\n') +
+		'\n')!
+	defer {
+		os.rm(test_source) or {}
+	}
+	cmd := '${os.quoted_path(vexe)} -prod -gc boehm_full_opt -o - ${os.quoted_path(test_source)}'
+	compilation := os.execute(cmd)
+	ensure_compilation_succeeded(compilation, cmd)
+	assert !generated_c_uses_v3_codegen(compilation.output)
+	helper_signature := '_Array_main__Item(Array_main__Item* it, voidptr* out, int idx) {'
+	assert compilation.output.contains(helper_signature)
+	helper_body := compilation.output.all_after(helper_signature).all_before('\n}')
+	assert helper_body.contains('voidptr _v_keep_root = it->data;')
+	assert !helper_body.contains('_v_keep_i')
+}
+
 fn test_veb_implicit_ctx_alias_uses_user_context_name() {
 	os.chdir(vroot) or {}
 	test_source := os.join_path(os.vtmp_dir(), 'coutput_veb_implicit_ctx_alias.vv')


### PR DESCRIPTION
Summary

- root a pointerful array through its Boehm-scanned backing allocation
- stop recursively walking every element before and after every call
- retain recursive rooting for pointerful structs and add a codegen regression

Performance

The issue reproducer at 1,000,000 elements drops from about 2,000,000 ns per empty call to about 1 ns per call on macOS.

Tests

- ./vnew -silent test -run-only test_boehm_scope_pin_does_not_walk_array_elements vlib/v/gen/c/coutput_test.v
- nested_aggregate_boehm_prod_keep_alive_nix output fixture
- boehm_scope_pin_heap_snapshot_nix C-output fixture

The full coutput and compiler-errors runs were also attempted, but current V3 master fails existing unrelated fixtures such as assign_fn_addr.vv and parser diagnostic expectations.

Fixes #28418