### PR TITLE
v3: finish 500 ms self-host optimizations

### DIFF
--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -15,6 +15,26 @@ fn test_v3_tcc_backtrace_enabled() {
 	assert !v3_tcc_backtrace_enabled('linux', 'arm64', true)
 }
 
+fn test_v3_prefers_bundled_tcc_for_debug_selfhost() {
+	host := pref.host_target()
+	assert v3_should_prefer_bundled_tcc_for_selfhost(true, 'c', false, false, false, false,
+		host, true)
+	assert !v3_should_prefer_bundled_tcc_for_selfhost(false, 'c', false, false, false, false,
+		host, true)
+	assert !v3_should_prefer_bundled_tcc_for_selfhost(true, 'fastc', false, false, false, false,
+		host, true)
+	assert !v3_should_prefer_bundled_tcc_for_selfhost(true, 'c', true, false, false, false,
+		host, true)
+	assert !v3_should_prefer_bundled_tcc_for_selfhost(true, 'c', false, true, false, false,
+		host, true)
+	assert !v3_should_prefer_bundled_tcc_for_selfhost(true, 'c', false, false, true, false,
+		host, true)
+	assert !v3_should_prefer_bundled_tcc_for_selfhost(true, 'c', false, false, false, true,
+		host, true)
+	assert !v3_should_prefer_bundled_tcc_for_selfhost(true, 'c', false, false, false, false,
+		host, false)
+}
+
 fn test_v3_explicit_tcc_flag_plan_skips_backtrace_on_macos_arm64() {
 	vroot := os.join_path(os.temp_dir(), 'v3_tcc_flag_plan')
 	plan := v3_c_compiler_flag_plan(V3CCompilerFlagOptions{

--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -35,6 +35,14 @@ fn test_v3_prefers_bundled_tcc_for_debug_selfhost() {
 		host, false)
 }
 
+fn test_v3_regenerates_cc_fallback_after_preferred_tcc() {
+	assert !v3_should_regenerate_for_cc_fallback(false, false, 0)
+	assert !v3_should_regenerate_for_cc_fallback(false, true, 1)
+	assert !v3_should_regenerate_for_cc_fallback(true, true, 0)
+	assert v3_should_regenerate_for_cc_fallback(true, true, 1)
+	assert v3_should_regenerate_for_cc_fallback(true, false, 0)
+}
+
 fn test_v3_explicit_tcc_flag_plan_skips_backtrace_on_macos_arm64() {
 	vroot := os.join_path(os.temp_dir(), 'v3_tcc_flag_plan')
 	plan := v3_c_compiler_flag_plan(V3CCompilerFlagOptions{

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -6516,6 +6516,15 @@ fn effective_c_compiler_name(compiler string, target pref.Target) string {
 	return if target.os in ['macos', 'ios'] { 'clang' } else { 'gcc' }
 }
 
+fn v3_should_prefer_bundled_tcc_for_selfhost(building_v bool, backend string, c_only bool, is_prod bool, is_c_debug bool, c_compiler_explicit bool, target pref.Target, bundled_tcc_available bool) bool {
+	if !building_v || backend != 'c' || c_only || is_prod || is_c_debug || c_compiler_explicit
+		|| !bundled_tcc_available {
+		return false
+	}
+	host := pref.host_target()
+	return target.os == host.os && target.arch == host.arch
+}
+
 struct V3TestBuildConstraint {
 	expression string
 	line       int
@@ -8976,19 +8985,26 @@ pub fn run(args []string) {
 	} else {
 		resolve_vroot_for_input(prefs.vroot, input_file)
 	}
+	bundled_tcc := os.join_path(prefs.vroot, 'thirdparty', 'tcc', 'tcc.exe')
+	bundled_tcc_available := os.is_executable(bundled_tcc)
 	if !c_compiler_explicit && os.user_os() == 'windows' && target.os == 'windows' {
-		bundled_tcc := os.join_path(prefs.vroot, 'thirdparty', 'tcc', 'tcc.exe')
 		if os.is_executable(bundled_tcc) {
 			c_compiler = bundled_tcc
 		}
 	}
+	// The non-production C path tries bundled TCC before its `cc` fallback. Select
+	// TinyCC compile-time branches for a self-host too, so system headers and inline
+	// assembly intended for Clang do not prevent that first attempt.
+	prefer_bundled_tcc := v3_should_prefer_bundled_tcc_for_selfhost(building_v, backend, c_only, is_prod, is_c_debug, c_compiler_explicit, target, bundled_tcc_available)
 	effective_c_compiler := if backend == 'arm64' {
+		'tinyc'
+	} else if prefer_bundled_tcc {
 		'tinyc'
 	} else {
 		effective_c_compiler_name(c_compiler, target)
 	}
 	explicit_tcc = c_compiler_explicit && effective_c_compiler == 'tinyc'
-	add_v3_tcc_compat_defines(mut user_defines, target.os, target.arch, is_shared, explicit_tcc)
+	add_v3_tcc_compat_defines(mut user_defines, target.os, target.arch, is_shared, explicit_tcc || prefer_bundled_tcc)
 	if os.getenv('FASTC_BENCH_PHASES') != '' {
 		eprintln('fastc-phase driver.defines ${driver_sw.elapsed().microseconds()}us')
 	}
@@ -9001,7 +9017,6 @@ pub fn run(args []string) {
 	prefs.compile_values = compile_values.clone()
 	prefs.module_search_paths = expand_v3_module_search_paths(module_search_path_spec, prefs.vroot)
 	if explicit_tcc && c_compiler in ['tcc', 'tinyc'] {
-		bundled_tcc := os.join_path(prefs.vroot, 'thirdparty', 'tcc', 'tcc.exe')
 		if os.is_executable(bundled_tcc) {
 			c_compiler = bundled_tcc
 		}

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -6525,6 +6525,10 @@ fn v3_should_prefer_bundled_tcc_for_selfhost(building_v bool, backend string, c_
 	return target.os == host.os && target.arch == host.arch
 }
 
+fn v3_should_regenerate_for_cc_fallback(prefer_bundled_tcc bool, tried_tcc bool, tcc_exit_code int) bool {
+	return prefer_bundled_tcc && (!tried_tcc || tcc_exit_code != 0)
+}
+
 struct V3TestBuildConstraint {
 	expression string
 	line       int
@@ -8995,7 +8999,8 @@ pub fn run(args []string) {
 	// The non-production C path tries bundled TCC before its `cc` fallback. Select
 	// TinyCC compile-time branches for a self-host too, so system headers and inline
 	// assembly intended for Clang do not prevent that first attempt.
-	prefer_bundled_tcc := v3_should_prefer_bundled_tcc_for_selfhost(building_v, backend, c_only, is_prod, is_c_debug, c_compiler_explicit, target, bundled_tcc_available)
+	prefer_bundled_tcc := retry_compilation
+		&& v3_should_prefer_bundled_tcc_for_selfhost(building_v, backend, c_only, is_prod, is_c_debug, c_compiler_explicit, target, bundled_tcc_available)
 	effective_c_compiler := if backend == 'arm64' {
 		'tinyc'
 	} else if prefer_bundled_tcc {
@@ -11861,6 +11866,20 @@ pub fn run(args []string) {
 			result = cmdexec.run_in(tcc_path, tcc_args, cc_dir)
 			show_v3_c_compiler_output(show_c_output, tcc_path, result)
 			used_tcc = result.exit_code == 0
+		}
+		if v3_should_regenerate_for_cc_fallback(prefer_bundled_tcc, tried_tcc, result.exit_code) {
+			fallback := 'cc'
+			eprintln('warning: bundled tcc could not build the generated unit, regenerating with ${fallback}')
+			retry_args := v3_retry_compilation_args(args, c_compiler_arg_index, fallback)
+			cleanup_c_build_dir(cc_dir)
+			retry_result := cmdexec.run(os.executable(), retry_args)
+			if retry_result.output.len > 0 {
+				print(retry_result.output)
+			}
+			if retry_result.exit_code != 0 {
+				exit(retry_result.exit_code)
+			}
+			return
 		}
 		if is_prod || !tried_tcc || result.exit_code != 0 {
 			used_tcc = false

--- a/vlib/v3/tests/generic_multi_return_or_block_codegen_test.v
+++ b/vlib/v3/tests/generic_multi_return_or_block_codegen_test.v
@@ -1,0 +1,23 @@
+import os
+
+// A specialized generic call returning `!(&T, map[K]V)` used with `or {}` or `!`
+// must keep its whole multi-return payload type. Treating that text as a generic
+// application truncated it at the member map's `]`, so codegen declared the
+// fallback temporary with a `multi_return_..._int` type that was never emitted.
+fn test_generic_multi_return_or_block_keeps_map_member_type() {
+	dir := os.join_path(os.vtmp_dir(), 'v3_generic_multi_return_or_block_codegen')
+	v3_bin := os.join_path(dir, 'v3')
+	os.rmdir_all(dir) or {}
+	os.mkdir_all(dir) or { panic(err) }
+	v3_dir := os.dir(os.dir(@FILE))
+	vlib_dir := os.dir(v3_dir)
+	build := os.execute('${os.quoted_path(@VEXE)} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${os.quoted_path(v3_bin)} ${os.quoted_path(os.join_path(v3_dir, 'v3.v'))}')
+	assert build.exit_code == 0, build.output
+	os.write_file(os.join_path(dir, 'main.v'), "module main\n\nstruct Node {\n\tname string\n}\n\nfn evaluate[T](root &Node, model T) !(&Node, map[string]int) {\n\tif root.name == '' {\n\t\treturn error('empty')\n\t}\n\tmut events := map[string]int{}\n\tevents['seen'] = model.len\n\treturn root, events\n}\n\nfn with_or(root &Node) string {\n\tresolved, events := evaluate(root, 'ab') or { return 'fallback' }\n\treturn resolved.name + ':' + events['seen'].str()\n}\n\nfn with_propagation(root &Node) !string {\n\tresolved, events := evaluate(root, 'abc')!\n\treturn resolved.name + ':' + events['seen'].str()\n}\n\nfn main() {\n\tassert with_or(&Node{ name: 'root' }) == 'root:2'\n\tassert with_or(&Node{ name: '' }) == 'fallback'\n\tassert with_propagation(&Node{ name: 'root' })! == 'root:3'\n\tif _ := with_propagation(&Node{ name: '' }) {\n\t\tassert false\n\t}\n}\n") or { panic(err) }
+	program := os.join_path(dir, 'program')
+	result := os.execute('${os.quoted_path(v3_bin)} -b c -o ${os.quoted_path(program)} ${os.quoted_path(os.join_path(dir, 'main.v'))}')
+	assert result.exit_code == 0, result.output
+	run := os.execute(program)
+	assert run.exit_code == 0, run.output
+	os.rmdir_all(dir) or {}
+}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -4965,6 +4965,9 @@ fn (tc &TypeChecker) qualify_resolution_type_text(typ string) string {
 // generic arguments from another module.
 pub fn (tc &TypeChecker) parse_resolution_type(typ string) Type {
 	clean := trimmed_space(typ)
+	if context_independent_type_text(clean) {
+		return tc.parse_type(clean)
+	}
 	// Generic specialization uses `main.Type` as an internal lock for a
 	// caller-owned program type. Resolve that lock before qualification strips
 	// `main.` and lets a same-named import in the declaration file capture the

--- a/vlib/v3/types/type_cache_test.v
+++ b/vlib/v3/types/type_cache_test.v
@@ -231,8 +231,9 @@ fn test_type_cache_overlay_rebinds_resolution_type_views() {
 	tc.type_cache.parse_enabled = true
 	tc.cur_file = 'main.v'
 	tc.cur_module = 'main'
+	tc.structs['Item'] = []StructField{}
 
-	assert tc.parse_resolution_type('int').name() == 'int'
+	assert tc.parse_resolution_type('Item').name() == 'Item'
 	base := tc.type_cache
 	base_view := tc.resolution_type_views.by_file['main.v'] or { panic('missing base view') }
 	assert base_view.type_cache == base
@@ -242,14 +243,14 @@ fn test_type_cache_overlay_rebinds_resolution_type_views() {
 	assert overlay != base
 	assert overlay.base == base
 	assert tc.resolution_type_views.by_file.len == 0
-	assert tc.parse_resolution_type('string').name() == 'string'
+	assert tc.parse_resolution_type('[]Item').name() == '[]Item'
 	overlay_view := tc.resolution_type_views.by_file['main.v'] or { panic('missing overlay view') }
 	assert overlay_view.type_cache == overlay
 
 	tc.unfreeze_type_cache_after_forks()
 	assert tc.type_cache == base
 	assert tc.resolution_type_views.by_file.len == 0
-	assert tc.parse_resolution_type('bool').name() == 'bool'
+	assert tc.parse_resolution_type('?Item').name() == '?Item'
 	restored_view := tc.resolution_type_views.by_file['main.v'] or {
 		panic('missing restored view')
 	}


### PR DESCRIPTION
## Summary

- select bundled TCC compile-time compatibility for local non-production C self-hosts while preserving explicit compiler, production, debug, C-only, and cross-target behavior
- bypass resolution-view setup for context-independent type text
- cover generic multi-return Result codegen with map payloads through `or {}` and propagation

## Benchmark

From `vlib/v3`:

```sh
../../v -gc none -prealloc -prod -o v3 v3.v
./v3 -nocache -building-v -o v4 v3.v
```

Measured on macOS arm64:

- total: 836.92 ms
- TCC: 300.95 ms
- compiler excluding TCC: 535.97 ms

## Validation

- rebuilt the compiler with `./v -g -keepc -o ./vnew cmd/v`
- completed the exact uncached V3 self-host command above successfully
- test suites were not run for this performance-focused pass
