### PR TITLE
v3: keep parallel support in serial self-host builds

### DIFF
--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -492,9 +492,9 @@ invocation. Target compilations receive both `-ownership` and `-d ownership`, so
 
 The table uses the first v3-generated C stage, `./v3 -o v4 v3.v`. The plain
 bootstrap includes thread support. v3 self-hosts parallel-capable successors by
-default; pass `-no-parallel` or `--no-parallel` to disable threaded
-transform/C codegen and omit parallel support from the self-hosted compiler
-output. Debug builds use bundled TCC first, then fall back to `cc` only when
+default; pass `-no-parallel` or `--no-parallel` to disable threaded transform/C
+codegen for the current build. The self-hosted compiler output retains parallel
+support. Debug builds use bundled TCC first, then fall back to `cc` only when
 that compile fails.
 
 Pass `-c99` to the v3 C backend to compile generated C and support objects as

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -8790,10 +8790,9 @@ pub fn run(args []string) {
 	}
 	if building_v || cmd_v_build {
 		if no_parallel {
+			// This controls the current build only. Keep parallel support in the output
+			// compiler so its module graph does not depend on how it was bootstrapped.
 			user_defines = user_defines.filter(it != 'parallel')
-			if 'v3_no_parallel' !in user_defines {
-				user_defines << 'v3_no_parallel'
-			}
 		} else if 'parallel' !in user_defines {
 			user_defines << 'parallel'
 		}

--- a/vlib/v3/tests/parallel_cgen_test.v
+++ b/vlib/v3/tests/parallel_cgen_test.v
@@ -466,7 +466,7 @@ fn test_parallel_transform_generates_v3_c_with_vjobs_4_and_12() {
 	assert os.exists(c_out_12), cgen_12.output
 }
 
-fn test_no_parallel_directory_selfhost_omits_parallel_support() {
+fn test_no_parallel_directory_selfhost_retains_parallel_support() {
 	v3_bin := build_parallel_prod_v3()
 	bin_out := os.join_path(os.temp_dir(), 'v3_no_parallel_dir_selfhost_out_${os.getpid()}')
 	os.rm(bin_out) or {}
@@ -478,12 +478,12 @@ fn test_no_parallel_directory_selfhost_omits_parallel_support() {
 	assert !compile.output.contains('cgen (parallel)'), compile.output
 	assert os.exists(bin_out), compile.output
 	c_code := os.read_file(bin_out + '.c') or { panic(err) }
-	assert !c_code.contains('flat_cgen_chunk_thread'), c_code
-	assert !c_code.contains('flat_cgen_job_count'), c_code
-	assert !c_code.contains('new_parallel_worker'), c_code
-	assert !c_code.contains('merge_parallel_worker'), c_code
-	assert !c_code.contains('transform_chunk_thread'), c_code
-	assert !c_code.contains('transform_job_count'), c_code
+	assert c_code.contains('flat_cgen_chunk_thread'), c_code
+	assert c_code.contains('flat_cgen_job_count'), c_code
+	assert c_code.contains('new_parallel_worker'), c_code
+	assert c_code.contains('merge_parallel_worker'), c_code
+	assert c_code.contains('transform_chunk_thread'), c_code
+	assert c_code.contains('transform_job_count'), c_code
 }
 
 fn write_no_parallel_user_define_project(name string) string {


### PR DESCRIPTION
Fixes #28423.

`-no-parallel` previously did two things during a compiler build: it kept the active transform/codegen serial, and it injected the internal `v3_no_parallel` define into the compiler being produced. The latter pruned parser, markused, transform, and cgen helpers, changing the self-host module graph and producing the high-memory compiler from the issue reproduction.

This change keeps the active bootstrap serial but leaves parallel support in the emitted compiler. Explicit `-d v3_no_parallel` builds still prune those helpers.

Memory validation for the exact two-generation, `-gc none -nocache -no-memory-limit` serial self-host workload:

- Linux x86_64: 4,353,212 KB -> 2,441,536 KB peak RSS (44% lower)
- Linux ARM64: ~4.34 GB -> ~2.27 GB peak RSS

The much larger WSL2 peak reported in the issue was not reproducible in the available Debian VMs, but the graph-dependent amplification reproduced on both architectures and is removed.

Tests:

- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -silent test -run-only test_no_parallel_directory_selfhost_retains_parallel_support vlib/v3/tests/parallel_cgen_test.v`
- `./vnew -silent test -run-only test_no_parallel_parser_keeps_parse_serial vlib/v3/tests/parallel_parser_test.v`
- explicit `-d v3_no_parallel` generated-C symbol check
- `./vnew check-md vlib/v3/README.md`

The required broad compiler suites were attempted but are not currently green in this checkout: `compiler_errors_test.v` fails existing parser/checker expectations, and `test vlib/v/` fails early in unrelated builder/debug tests.