### PR TITLE
ci: fix remaining bootstrap targets after v3 routing

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -160,12 +160,10 @@ ifneq ($(BOOTSTRAP_VC_UNSAFE_OPTFLAGS),)
 endif
 endif
 endif
-ifdef V1_FALLBACK_BUILD
-	# Recent vc snapshots use the lean V3 dispatcher on macOS and Linux. Build
-	# the temporary v1 as the full compatibility compiler so it can create v2
-	# before either the embedded V3 driver or v1_fallback exists.
-	BOOTSTRAP_VC_CC_CFLAGS += -DCUSTOM_DEFINE_v1_fallback
-endif
+# A vc snapshot may use the lean V3 dispatcher when its generated C is built
+# on a Unix-like host. Keep the temporary v1 on the full compatibility path so
+# it can create v2 before either the embedded V3 driver or v1_fallback exists.
+BOOTSTRAP_VC_CC_CFLAGS += -DCUSTOM_DEFINE_v1_fallback
 BOOTSTRAP_TCC_REQUESTED := $(or $(findstring -cc tcc,$(strip $(VFLAGS))),$(findstring -cc=tcc,$(strip $(VFLAGS))))
 BOOTSTRAP_CCOMPILER_VFLAG :=
 BOOTSTRAP_VC_CCOMPILER_VFLAG :=

--- a/vlib/v3/gen/fastc/array.v
+++ b/vlib/v3/gen/fastc/array.v
@@ -115,16 +115,16 @@ fn (g &Parser) render_higher_order_method_expression(tokens []FastcExpressionTok
 			else {}
 		}
 	}
-	mut closure_type := if closure_or > 0 {
-		vt := g.option_value_type_for_expression(closure_tokens[..closure_or])
-		fastc_normalize_inferred_type(if vt != '' {
-			vt
-		} else {
-			g.infer_expression_type(closure_tokens[..closure_or]) or { '' }
-		})
+	mut inferred_closure_type := ''
+	if closure_or > 0 {
+		inferred_closure_type = g.option_value_type_for_expression(closure_tokens[..closure_or])
+		if inferred_closure_type == '' {
+			inferred_closure_type = g.infer_expression_type(closure_tokens[..closure_or]) or { '' }
+		}
 	} else {
-		fastc_normalize_inferred_type(g.infer_expression_type(closure_tokens) or { '' })
+		inferred_closure_type = g.infer_expression_type(closure_tokens) or { '' }
 	}
+	mut closure_type := fastc_normalize_inferred_type(inferred_closure_type)
 	// A bare function is applied to each element (`items.map(convert)`).
 	if closure_tokens.len == 1 && closure_tokens[0].tok == .name
 		&& closure_tokens[0].lit != it_name {


### PR DESCRIPTION
## Summary

- Build the temporary vc compiler through the full V1 compatibility path on every host, including Termux/Android environments that are detected as Linux by the vc snapshot.
- Keep FastC higher-order closure type inference compilable by the immutable vc snapshot used by the TCC contract job.

This follows #28430 and addresses the remaining distinct failures found while auditing the cascading failures on #28426.

## Validation

- Complete bootstrap from the TCC contract pinned vc snapshot using the native host TCC bundle
- ./vnew -old-compiler -silent vlib/v/compiler_errors_test.v (1699 passed, 1 skipped)
- ./vnew -silent test cmd/v/ (4 passed)
- ./vnew -silent test vlib/v3/driver/ (8 passed)
- Affected FastC higher-order array tests through V1
- vfmt and git diff --check