### PR TITLE
make: fix VC bootstrap without an existing V1 fallback

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,6 +7,9 @@ VROOT  ?= .
 VC     ?= ./vc
 VEXE   ?= ./v
 V1_FALLBACK_EXE := $(dir $(VEXE))v1_fallback
+# Portable VC snapshots do not embed V3. Keep their v1 executable on the full
+# compatibility compiler path even when the generated C is built on macOS/Linux.
+VC_BOOTSTRAP_DEFINE := -DCUSTOM_DEFINE_v1_fallback
 VCREPO ?= https://github.com/vlang/vc
 TCCREPO ?= https://github.com/vlang/tccbin
 LEGACYREPO ?= https://github.com/macports/macports-legacy-support
@@ -204,7 +207,7 @@ BOOTSTRAP_VFLAGS := $(BOOTSTRAP_CCOMPILER_VFLAG) $(if $(strip $(BOOTSTRAP_CFLAGS
 
 all: latest_vc latest_tcc latest_legacy
 ifdef WIN32
-	$(CC) $(CPPFLAGS) $(BOOTSTRAP_VC_CC_CFLAGS) -std=c99 -municode -w -o v1$(EXE_EXT) $(VC)/$(VCFILE) $(LDFLAGS) -lws2_32 || cmd/tools/cc_compilation_failed_windows.sh
+	$(CC) $(CPPFLAGS) $(BOOTSTRAP_VC_CC_CFLAGS) $(VC_BOOTSTRAP_DEFINE) -std=c99 -municode -w -o v1$(EXE_EXT) $(VC)/$(VCFILE) $(LDFLAGS) -lws2_32 || cmd/tools/cc_compilation_failed_windows.sh
 	./v1$(EXE_EXT) -no-parallel -o v2$(EXE_EXT) $(BOOTSTRAP_GC_VFLAG) $(VFLAGS) $(BOOTSTRAP_VC_VFLAGS) cmd/v
 	./v2$(EXE_EXT) -o $(VEXE)$(EXE_EXT) $(BOOTSTRAP_GC_VFLAG) $(VFLAGS) $(BOOTSTRAP_VFLAGS) cmd/v
 	$(RM) v1$(EXE_EXT)
@@ -216,7 +219,7 @@ ifdef LEGACY
 	rm -rf $(TMPLEGACY)
 	$(eval override LDFLAGS+=-L$(realpath $(LEGACYLIBS))/lib -lMacportsLegacySupport)
 endif
-	$(CC) $(CPPFLAGS) $(BOOTSTRAP_VC_CC_CFLAGS) -std=c99 -w -o v1$(EXE_EXT) $(VC)/$(VCFILE) -lm -lpthread $(BOOTSTRAP_LDFLAGS) || cmd/tools/cc_compilation_failed_non_windows.sh
+	$(CC) $(CPPFLAGS) $(BOOTSTRAP_VC_CC_CFLAGS) $(VC_BOOTSTRAP_DEFINE) -std=c99 -w -o v1$(EXE_EXT) $(VC)/$(VCFILE) -lm -lpthread $(BOOTSTRAP_LDFLAGS) || cmd/tools/cc_compilation_failed_non_windows.sh
 ifdef NETBSD
 	paxctl +m v1$(EXE_EXT)
 endif

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ VFLAGS ?=
 CFLAGS ?=
 LDFLAGS ?=
 
+# Portable VC snapshots do not embed V3. Keep their v1 executable on the full
+# compatibility compiler path even when the generated C is built on macOS/Linux.
+VC_BOOTSTRAP_DEFINE = -DCUSTOM_DEFINE_v1_fallback
+
 all: download_vc v
 
 .PHONY: all check download_vc install v
@@ -95,7 +99,7 @@ v:
 	case " $(VFLAGS) " in \
 		*" -gc "*|*" -gc="*) bootstrap_gcflags="";; \
 	esac; \
-	$(CC) $$bootstrap_ccflags -std=gnu11 -w -o v1 vc/v.c -lm -lpthread $$ldflags || cmd/tools/cc_compilation_failed_non_windows.sh; \
+	$(CC) $$bootstrap_ccflags $(VC_BOOTSTRAP_DEFINE) -std=gnu11 -w -o v1 vc/v.c -lm -lpthread $$ldflags || cmd/tools/cc_compilation_failed_non_windows.sh; \
 	set -- ./v1 -no-parallel -o v2 $$bootstrap_gcflags $(VFLAGS); \
 	if [ -n "$$bootstrap_ccflags" ]; then \
 		set -- "$$@" -cflags "$$bootstrap_ccflags"; \

--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -618,6 +618,8 @@ fn initial_bootstrap_args(args []string) []string {
 fn bootstrap_c_cmd(cc string, out_binary string, vc_source string) string {
 	mut parts := []string{cap: 8}
 	parts << os.quoted_path(cc)
+	// Portable VC snapshots have the full V1 compiler but no embedded V3 driver.
+	parts << '-DCUSTOM_DEFINE_v1_fallback'
 	if os.user_os() == 'windows' {
 		parts << ['-std=c99', '-municode', '-w', '-o', os.quoted_path(out_binary),
 			os.quoted_path(vc_source), '-lws2_32']

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -84,13 +84,20 @@ fn test_macos_v3_relevant_command_owns_every_direct_c_build() {
 
 fn test_macos_v3_cmd_source_unlinks_v1_on_supported_hosts() {
 	source := os.read_file(os.join_path(macos_v3_test_vroot, 'cmd', 'v', 'v.v'))!
-	assert source.contains('\$if v1_fallback ?|| ( !macos && !linux ) {')
+	assert source.contains('\$if v1_fallback ?|| cross ?|| ( !macos && !linux ) {')
 	assert source.contains('import v.builder')
 	assert source.contains('import v.builder.cbuilder')
-	assert source.contains('\$if v1_fallback ? {\n\t\t\t\tbuilder.compile')
+	assert source.contains('\$if v1_fallback ?|| cross ? {\n\t\t\t\tbuilder.compile')
 	driver := os.read_file(os.join_path(macos_v3_test_vroot, 'cmd', 'v', 'macos_v3_driver_notd_cross.v'))!
 	assert driver.contains('\$if v1_fallback ? {')
 	assert driver.contains('fn macos_v3_driver_is_available() bool')
+}
+
+fn test_vc_bootstrap_builds_a_v1_compatibility_compiler() {
+	for path in ['GNUmakefile', 'Makefile', 'cmd/tools/vself.v'] {
+		source := os.read_file(os.join_path(macos_v3_test_vroot, path))!
+		assert source.contains('-DCUSTOM_DEFINE_v1_fallback'), path
+	}
 }
 
 fn test_macos_v3_old_compiler_uses_external_v1_command() {

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -94,7 +94,12 @@ fn test_macos_v3_cmd_source_unlinks_v1_on_supported_hosts() {
 }
 
 fn test_vc_bootstrap_builds_a_v1_compatibility_compiler() {
-	for path in ['GNUmakefile', 'Makefile', 'cmd/tools/vself.v'] {
+	for path in [
+		'GNUmakefile',
+		'Makefile',
+		'cmd/tools/vself.v',
+		'thirdparty/tccbin_automation/bootstrap/bootstrap.sh',
+	] {
 		source := os.read_file(os.join_path(macos_v3_test_vroot, path))!
 		assert source.contains('-DCUSTOM_DEFINE_v1_fallback'), path
 	}

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -11,10 +11,10 @@ import v.pref
 import v.util
 import v.util.version
 
-$if v1_fallback ?|| ( !macos && !linux ) {
-	// The compatibility compiler and non-V3 targets both need the V1 builder.
-	// Keep this as one import site: a compatibility compiler generating a cross
-	// target can satisfy both parts of the condition.
+$if v1_fallback ?|| cross ?|| ( !macos && !linux ) {
+	// The compatibility compiler, portable cross snapshots, and non-V3 targets
+	// all need the V1 builder. Keep this as one import site: a compatibility
+	// compiler generating a cross target can satisfy multiple parts of the condition.
 	import v.builder
 	import v.builder.cbuilder
 }
@@ -123,9 +123,9 @@ fn main() {
 	mut args_and_flags := util.join_env_vflags_and_os_args()[1..].clone()
 	prefs, command, command_idx := pref.parse_args_for_launcher_with_command_index(external_tools, args_and_flags, true)
 	maybe_delegate_to_vvmrc(command, prefs)
-	$if v1_fallback ? {
-		// This binary is the stable compatibility compiler. Never delegate back to
-		// either embedded V3 or the V3 ownership compiler.
+	$if v1_fallback ?|| cross ? {
+		// This binary is a stable compatibility compiler, including portable VC
+		// snapshots. Never delegate back to embedded V3 or the ownership compiler.
 	} $else {
 		maybe_delegate_to_ownership(command, prefs, args_and_flags)
 		maybe_delegate_to_macos_v3(command, prefs)
@@ -421,7 +421,7 @@ fn cached_v3_ownership_executable_path(vroot string) string {
 fn rebuild(prefs &pref.Preferences) {
 	match prefs.backend {
 		.c {
-			$if v1_fallback ? {
+			$if v1_fallback ?|| cross ? {
 				builder.compile('build', prefs, cbuilder.compile_c)
 			} $else $if macos || linux {
 

--- a/thirdparty/tccbin_automation/bootstrap/bootstrap.sh
+++ b/thirdparty/tccbin_automation/bootstrap/bootstrap.sh
@@ -405,14 +405,16 @@ case "$(uname -s)" in
 		vc_source=$vc_source_win
 		vc_record=$lock_v_win_c
 		exe_suffix='.exe'
-		"$cc_command" -std=c99 -municode -w -o "$private_contract_root/v1.exe" "$vc_source" \
+		"$cc_command" -std=c99 -DCUSTOM_DEFINE_v1_fallback -municode -w \
+			-o "$private_contract_root/v1.exe" "$vc_source" \
 			-ladvapi32 -lws2_32 -Wl,-stack=33554432
 		;;
 	*)
 		vc_source=$vc_source_v
 		vc_record=$lock_v_c
 		exe_suffix=''
-		"$cc_command" -std=c99 -w -o "$private_contract_root/v1" "$vc_source" -lm -lpthread
+		"$cc_command" -std=c99 -DCUSTOM_DEFINE_v1_fallback -w \
+			-o "$private_contract_root/v1" "$vc_source" -lm -lpthread
 		;;
 esac
 cli_path="$work_root/tccbin-automation${exe_suffix}"


### PR DESCRIPTION
## Summary

- compile portable VC snapshots as V1 compatibility bootstrap executables
- make cross-generated compiler shells use the V1 builder directly
- apply the same bootstrap marker to vself and add regression coverage

## Testing

- make
- ./v -g -keepc -o ./vnew cmd/v
- ./vnew -silent cmd/v/macos_v3_test.v
- ./vnew -silent cmd/v/macos_v3_compat_routing_test.v
- ./vnew -silent cmd/v/macos_v3_external_fallback_test.v
- ./vnew -silent cmd/v/vvm_test.v
- ./vnew -silent cmd/tools/vself_test.v
- ./vnew -silent vlib/v/tests/gnu_make_tcc_fallback_test.v
- ./vnew -old-compiler -silent vlib/v/compiler_errors_test.v (1699 passed, 1 skipped)
- portable cross-snapshot smoke test with V1 fallback disabled

## Notes

The default V3-wide compiler suites currently have unrelated diagnostic mismatches and parser hangs. The complete compiler error suite passes through the compatibility compiler.