### PR TITLE
v3: match template directives at a word boundary (fix #28433)

### DIFF
--- a/vlib/v/tests/tmpl/directive_word_boundary_28433.html
+++ b/vlib/v/tests/tmpl/directive_word_boundary_28433.html
@@ -1,0 +1,9 @@
+<form METHOD="@form_method">
+@if show_form
+<p>@end_note</p>
+@endif
+@for entry in entries
+<li>@entry</li>
+@endfor
+<span>@elsewhere</span>
+</form>

--- a/vlib/v/tests/tmpl_issue_28433_test.v
+++ b/vlib/v/tests/tmpl_issue_28433_test.v
@@ -1,0 +1,30 @@
+// A variable whose name merely starts with a directive's is an interpolation,
+// not the directive: `@form_method` was compiled as a `@for` loop header, and
+// `@end_note` and `@elsewhere` as `@end` and `@else`.
+//
+// The same template closes its blocks with `@endif` and `@endfor`, which
+// TEMPLATES.md documents alongside `@end`. A plain word-boundary rule would
+// reject both, so the test that the fix works and the test that it did not
+// break the documented spellings are deliberately the same template.
+fn render_28433() string {
+	form_method := 'POST'
+	end_note := 'note'
+	elsewhere := 'other'
+	show_form := true
+	entries := ['a', 'b']
+	return $tmpl('tmpl/directive_word_boundary_28433.html')
+}
+
+fn test_a_variable_may_start_with_a_directive_name() {
+	out := render_28433()
+	assert out.contains('METHOD="POST"'), out
+	assert out.contains('<p>note</p>'), out
+	assert out.contains('<span>other</span>'), out
+}
+
+fn test_endif_and_endfor_still_close_their_blocks() {
+	out := render_28433()
+	assert out.contains('<li>a</li>'), out
+	assert out.contains('<li>b</li>'), out
+	assert !out.contains('@end'), out
+}

--- a/vlib/v3/parser/tmpl.v
+++ b/vlib/v3/parser/tmpl.v
@@ -83,6 +83,43 @@ fn is_tmpl_ident_part(c u8) bool {
 	return c.is_letter() || c.is_digit() || c == `_`
 }
 
+// The position of `directive` in `line`, where it is spelled as a directive and
+// not merely as the start of a longer `@name` interpolation.
+//
+// `line.contains('@for')` also matches `@form_method`, so a line interpolating a
+// variable whose name begins with a directive's was compiled as that directive's
+// header (issue #28433). `@if `, `@js ` and `@css ` are spelled with a trailing
+// space and never had the problem.
+//
+// `aliases` are the spellings that may follow the directive and still be it:
+// TEMPLATES.md documents `@endif` and `@endfor` as closing a block exactly as
+// `@end` does, so a plain word-boundary rule would reject two documented forms
+// that `examples/veb/todo` uses.
+fn tmpl_directive_pos(line string, directive string, aliases []string) ?int {
+	mut start := 0
+	for {
+		pos := line.index_after(directive, start) or { return none }
+		end := pos + directive.len
+		if end == line.len || !is_tmpl_ident_part(line[end]) {
+			return pos
+		}
+		for alias in aliases {
+			after := end + alias.len
+			if line[end..].starts_with(alias)
+				&& (after == line.len || !is_tmpl_ident_part(line[after])) {
+				return pos
+			}
+		}
+		start = pos + 1
+	}
+	return none
+}
+
+fn has_tmpl_directive(line string, directive string, aliases []string) bool {
+	tmpl_directive_pos(line, directive, aliases) or { return false }
+	return true
+}
+
 fn find_tmpl_balanced_end(line string, start int, open u8, close u8) int {
 	if start >= line.len || line[start] != open {
 		return -1
@@ -518,7 +555,7 @@ struct TemplateControlSourceMap {
 }
 
 fn parse_tmpl_control_line(line string, directive string) TmplControlLine {
-	pos := line.index(directive) or { return TmplControlLine{} }
+	pos := tmpl_directive_pos(line, directive, []) or { return TmplControlLine{} }
 	remainder := line[pos + directive.len..].trim_space()
 	if remainder.len == 0 {
 		return TmplControlLine{
@@ -561,7 +598,7 @@ fn parse_tmpl_control_line(line string, directive string) TmplControlLine {
 }
 
 fn parse_tmpl_else_line(line string) TmplControlLine {
-	pos := line.index('@else') or { return TmplControlLine{} }
+	pos := tmpl_directive_pos(line, '@else', []) or { return TmplControlLine{} }
 	remainder := line[pos + '@else'.len..].trim_space()
 	if remainder.len == 0 {
 		return TmplControlLine{
@@ -627,7 +664,7 @@ fn template_control_source_map(line string) ?TemplateControlSourceMap {
 			has_inline_body:  control.has_inline_body
 		}
 	}
-	if pos := line.index('@for') {
+	if pos := tmpl_directive_pos(line, '@for', []) {
 		control := parse_tmpl_control_line(line, '@for')
 		inline_source := control.prefix + control.inline_body
 		return TemplateControlSourceMap{
@@ -647,7 +684,7 @@ fn template_control_source_map(line string) ?TemplateControlSourceMap {
 			has_inline_body:  control.has_inline_body
 		}
 	}
-	if pos := line.index('@else') {
+	if pos := tmpl_directive_pos(line, '@else', []) {
 		control := parse_tmpl_else_line(line)
 		inline_source := control.prefix + control.inline_body
 		return TemplateControlSourceMap{
@@ -937,7 +974,7 @@ fn (mut p Parser) compile_template_file(template_file string, bname string, esca
 			}
 			continue
 		}
-		if line.contains('@end') {
+		if has_tmpl_directive(line, '@end', ['if', 'for']) {
 			source.writeln(tmpl_str_end)
 			source.writeln('}')
 			source.write_string(tmpl_str_start)
@@ -946,7 +983,7 @@ fn (mut p Parser) compile_template_file(template_file string, bname string, esca
 			}
 			continue
 		}
-		if line.contains('@else') {
+		if has_tmpl_directive(line, '@else', []) {
 			control := parse_tmpl_else_line(line)
 			source.writeln(tmpl_str_end)
 			source.writeln('} ${control.header} {')
@@ -964,7 +1001,7 @@ fn (mut p Parser) compile_template_file(template_file string, bname string, esca
 			}
 			continue
 		}
-		if line.contains('@for') {
+		if has_tmpl_directive(line, '@for', []) {
 			control := parse_tmpl_control_line(line, '@for')
 			source.writeln(tmpl_str_end)
 			source.writeln('for ${control.header} {')


### PR DESCRIPTION
Fixes #28433

`line.contains('@for')` also matches `@form_method`, so a template line interpolating a variable whose name merely *starts* with a directive's was compiled as that directive's header:

```
<form METHOD="@form_method">

form_template.html:1:5: error: only `c`, `r`, `js` are recognized string prefixes,
                               but you tried to use `m_method`
```

### It is three directives, not one

The issue names `@for`. `@end` and `@else` match the same way, so `@end_note` closes a block and `@elsewhere` opens an else arm:

```
<p>@end_note</p>       -> t.html:16:1: error: invalid expression: unexpected token `}`
<span>@elsewhere</span> -> t.html:1:3: error: invalid expression: unexpected keyword `else`
```

`@if `, `@js ` and `@css ` are spelled with a trailing space and never had the problem, which is why the report notes that `if` is unaffected.

### The suggested fix breaks two documented spellings

The issue proposes matching `\s` or `\W` after the directive. That would reject `@endif` and `@endfor`, and **both are documented**: `vlib/v/TEMPLATES.md:10` says a block closes with "`@end`, `@endif`, or `@endfor`", and `examples/veb/todo/templates/index.html` uses `@endif` in four places. They work today *only* because the match is loose, so a plain word-boundary rule would break the example while fixing the bug.

So `tmpl_directive_pos` takes the suffixes that are still the directive, and `@end` passes `if` and `for`. Everything else with an identifier character after it is an interpolation.

**One deliberate narrowing**: `@endsomethingelse` stops closing a block. It was never documented, and it is indistinguishable from interpolating a variable named `endsomethingelse`.

### One more thing the loose match hid

The search scans past a non-directive match instead of stopping at the first one, so `@form_method` earlier on a line no longer hides a real `@for` after it, and `parse_tmpl_control_line` reads its header from the same occurrence the dispatch matched rather than from an earlier false one.

### Verified

The fix is in `vlib/v3/parser/tmpl.v`, which is the live path: I instrumented both `@for` branches and only the v3 one fires for the reported repro on the default compiler.

- The report's own repro now prints `<form METHOD="POST">`.
- New regression test `vlib/v/tests/tmpl_issue_28433_test.v`, red before the change with exactly the reported error. Its template closes with `@endif` and `@endfor` on purpose, so the test that the fix works and the test that it did not break the documented spellings are the same template.
- **14/14** `tmpl*_test.v` in `vlib/v/tests`, **18/18** `tmpl*_test.v` in `vlib/v3/tests`.
- `examples/veb/todo` (the `@endif` user) still builds.
- `v fmt -verify` clean on both changed files; `v vet` reports nothing on the new code.

The template file is named `directive_word_boundary_28433.html` rather than `issue_28433.html` because `.gitignore:167` ignores `issue*`, which is also why `tmpl_issue_27685_test.v` names its template `template_scope_27685.html`.

`vlib/v/parser/tmpl.v` (the `-old-compiler` path) has the same three loose matches at `:838`, `:850`, `:876`, plus `@header`/`@footer` at `:733`/`:748`. I could not get that code to execute here (the debug print never fired under `-old-compiler`), so I have left it alone rather than ship a change I cannot run. Happy to mirror it if that path is still built and you can point me at how to exercise it.
