### PR TITLE
vup: report tool recompilation failures

### DIFF
--- a/cmd/tools/vup.v
+++ b/cmd/tools/vup.v
@@ -70,7 +70,11 @@ fn main() {
 		eprintln('Try running `${get_make_cmd_name()}` .')
 		exit(1)
 	}
-	app.recompile_vup()
+	if !app.recompile_vup() {
+		app.show_current_v_version()
+		eprintln('`v up` failed. Run `cd ${app.vroot} && git pull --rebase && ${get_make_cmd_name()}` to finish updating V.')
+		exit(1)
+	}
 	app.show_current_v_version()
 }
 

--- a/cmd/tools/vup.v
+++ b/cmd/tools/vup.v
@@ -72,7 +72,7 @@ fn main() {
 	}
 	if !app.recompile_vup() {
 		app.show_current_v_version()
-		eprintln('`v up` failed. Run `cd ${app.vroot} && git pull --rebase && ${get_make_cmd_name()}` to finish updating V.')
+		eprintln('`v up` failed. Run `cd ${os.quoted_path(app.vroot)} && ${v_upstream_pull_command()} && ${get_make_cmd_name()}` to finish updating V.')
 		exit(1)
 	}
 	app.show_current_v_version()


### PR DESCRIPTION
Report a failed `vup` rebuild as a failed `v up` operation.

The diagnostic includes a repository-specific recovery command that pulls with rebase and runs the platform-appropriate make command.

Tests:
- `/Users/alex/code/v/vnew -check cmd/tools/vup.v`
- `/Users/alex/code/v/vnew -silent test cmd/tools/diagnostic_tools_no_libgc_test.v`