### PR TITLE
ast, cgen: restore changes lost by arm64 asm update

### DIFF
--- a/vlib/v/ast/ast.v
+++ b/vlib/v/ast/ast.v
@@ -24,7 +24,7 @@ pub const builtins = ['string', 'array', 'DenseArray', 'map', 'Error', 'IError',
 
 pub type TypeDecl = AliasTypeDecl | FnTypeDecl | SumTypeDecl
 
-pub const int_type_name = $if new_int ? && x64 { 'vint_t' } $else { 'int' }
+pub const int_type_name = $if new_int ?&& x64 { 'vint_t' } $else { 'int' }
 
 pub type Expr = NodeError
 	| AnonFn
@@ -356,7 +356,7 @@ pub mut:
 	or_block                 OrExpr
 	gkind_field              GenericKindField // `T.name` => ast.GenericKindField.name, `T.typ` => ast.GenericKindField.typ, or .unknown
 	scope                    &Scope = unsafe { nil }
-	from_embed_types         []Type   // holds the type of the embed that the method is called from
+	from_embed_types         []Type // holds the type of the embed that the method is called from
 	generic_from_embed_types [][]Type // holds the types of the embeds for each generic instance when the same generic method is called.
 	has_hidden_receiver      bool
 	is_field_typ             bool // var.typ for comptime $for var
@@ -389,7 +389,7 @@ pub:
 	attrs      []Attr
 	pos        token.Pos
 	name_pos   token.Pos // `name` in import name
-	is_skipped bool      // module main can be skipped in single file programs
+	is_skipped bool // module main can be skipped in single file programs
 }
 
 pub struct SemicolonStmt {
@@ -448,10 +448,10 @@ pub:
 	is_exported  bool // an explicit `@[export]` tag; the const will NOT be removed by `-skip-unused`, no matter what
 	pos          token.Pos
 	attrs        []Attr // same value as `attrs` of the ConstDecl to which it belongs
-	is_virtual_c bool   // `const C.MY_CONST u8`
+	is_virtual_c bool // `const C.MY_CONST u8`
 pub mut:
-	expr         Expr      // the value expr of field; everything after `=`
-	typ          Type      // the type of the const field, it can be any type in V
+	expr         Expr // the value expr of field; everything after `=`
+	typ          Type // the type of the const field, it can be any type in V
 	comments     []Comment // comments before current const field
 	end_comments []Comment // comments that after const field
 	// the comptime_expr_value field is filled by the checker, when it has enough
@@ -468,8 +468,8 @@ pub:
 	attrs  []Attr // tags like `@[markused]`, valid for all the consts in the list
 pub mut:
 	fields       []ConstField // all the const fields in the `const (...)` block
-	end_comments []Comment    // comments that after last const field
-	is_block     bool         // const() block
+	end_comments []Comment // comments that after last const field
+	is_block     bool // const() block
 }
 
 @[minify]
@@ -549,9 +549,9 @@ pub:
 	has_break_line   bool
 	is_embed         bool
 pub mut:
-	expr          Expr   // `val1`
+	expr          Expr // `val1`
 	name          string // 'field1'
-	typ           Type   // the type of this field
+	typ           Type // the type of this field
 	expected_type Type
 	parent_type   Type
 }
@@ -572,7 +572,7 @@ pub mut:
 	unresolved           bool
 	pre_comments         []Comment
 	typ_str              string // 'Foo'
-	typ                  Type   // the type of this struct
+	typ                  Type // the type of this struct
 	typ_expr             Expr = EmptyExpr{} // `typeof(x).idx` in `typeof(x).idx{}`
 	generic_typ          Type // original generic struct type; reused for later concrete instantiations
 	update_expr          Expr // `a` in `...a`
@@ -620,9 +620,9 @@ pub:
 pub struct AnonFn {
 pub mut:
 	decl           FnDecl
-	inherited_vars []Param         // note: closures have inherited_vars.len > 0
-	has_ct_var     bool            // has $for var as inherited var
-	typ            Type            // the type of anonymous fn. Both .typ and .decl.name are auto generated
+	inherited_vars []Param // note: closures have inherited_vars.len > 0
+	has_ct_var     bool // has $for var as inherited var
+	typ            Type // the type of anonymous fn. Both .typ and .decl.name are auto generated
 	has_gen        map[string]bool // a map of the names of all generic anon functions, generated from it
 }
 
@@ -641,23 +641,23 @@ pub:
 	is_variadic           bool
 	is_anon               bool
 	is_weak               bool
-	is_noreturn           bool        // true, when @[noreturn] is used on a fn
-	is_manualfree         bool        // true, when @[manualfree] is used on a fn
-	is_main               bool        // true for `fn main()`
-	is_test               bool        // true for `fn test_abcde() {}`, false for `fn test_abc(x int) {}`, or for fns that do not start with test_
-	is_conditional        bool        // true for `@[if abc] fn abc(){}`
-	is_exported           bool        // true for `@[export: 'exact_C_name']`
-	is_keep_alive         bool        // passed memory must not be freed (by GC) before function returns
-	is_unsafe             bool        // true, when @[unsafe] is used on a fn
-	is_must_use           bool        // true, when @[must_use] is used on a fn. Calls to such functions, that ignore the return value, will cause warnings.
-	is_markused           bool        // true, when an explicit `@[markused]` tag was put on a fn; `-skip-unused` will not remove that fn
-	is_ignore_overflow    bool        // true, when an explicit `@[ignore_overflow]` tag was put on a fn. `-check-overflow` will not generate checks for arithmetic done in that fn.
-	is_file_translated    bool        // true, when the file it resides in is `@[translated]`
-	is_closure            bool        // true, for actual closures like `fn [inherited] () {}` . It is false for normal anonymous functions, and for named functions/methods too.
+	is_noreturn           bool // true, when @[noreturn] is used on a fn
+	is_manualfree         bool // true, when @[manualfree] is used on a fn
+	is_main               bool // true for `fn main()`
+	is_test               bool // true for `fn test_abcde() {}`, false for `fn test_abc(x int) {}`, or for fns that do not start with test_
+	is_conditional        bool // true for `@[if abc] fn abc(){}`
+	is_exported           bool // true for `@[export: 'exact_C_name']`
+	is_keep_alive         bool // passed memory must not be freed (by GC) before function returns
+	is_unsafe             bool // true, when @[unsafe] is used on a fn
+	is_must_use           bool // true, when @[must_use] is used on a fn. Calls to such functions, that ignore the return value, will cause warnings.
+	is_markused           bool // true, when an explicit `@[markused]` tag was put on a fn; `-skip-unused` will not remove that fn
+	is_ignore_overflow    bool // true, when an explicit `@[ignore_overflow]` tag was put on a fn. `-check-overflow` will not generate checks for arithmetic done in that fn.
+	is_file_translated    bool // true, when the file it resides in is `@[translated]`
+	is_closure            bool // true, for actual closures like `fn [inherited] () {}` . It is false for normal anonymous functions, and for named functions/methods too.
 	receiver              StructField // TODO: this is not a struct field
-	receiver_pos          token.Pos   // `(u User)` in `fn (u User) name()` position
+	receiver_pos          token.Pos // `(u User)` in `fn (u User) name()` position
 	is_method             bool
-	is_static_type_method bool      // true for `fn Foo.bar() {}`
+	is_static_type_method bool // true for `fn Foo.bar() {}`
 	static_type_pos       token.Pos // `Foo` in `fn Foo.bar() {}`
 	method_type_pos       token.Pos // `User` in ` fn (u User)` position
 	method_idx            int
@@ -667,8 +667,8 @@ pub:
 	rec_share             ShareType
 	language              Language // V, C, JS
 	file_mode             Language // whether *the file*, where a function was a '.c.v', '.js.v' etc.
-	no_body               bool     // just a definition `fn C.malloc()`
-	is_builtin            bool     // this function is defined in builtin/strconv
+	no_body               bool // just a definition `fn C.malloc()`
+	is_builtin            bool // this function is defined in builtin/strconv
 	name_pos              token.Pos
 	body_pos              token.Pos // function bodys position
 	file                  string
@@ -686,14 +686,14 @@ pub mut:
 	return_type_pos   token.Pos // `string` in `fn (u User) name() string` position
 	has_return        bool
 	should_be_skipped bool // true, when -skip-unused could not find any usages of that function, starting from main + other known used functions
-	ninstances        int  // 0 for generic functions with no concrete instances
+	ninstances        int // 0 for generic functions with no concrete instances
 	has_await         bool // 'true' if this function uses JS.await
 
 	comments      []Comment // comments *after* the header, but *before* `{`; used for InterfaceDecl
 	end_comments  []Comment // comments *after* header declarations. E.g.: `fn C.C_func(x int) int // Comment`
 	next_comments []Comment // comments that are one line after the decl; used for InterfaceDecl
 
-	source_file &File  = unsafe { nil }
+	source_file &File = unsafe { nil }
 	scope       &Scope = unsafe { nil }
 	label_names []string
 	pos         token.Pos // function declaration position
@@ -768,10 +768,10 @@ pub mut:
 	usages             int
 	generic_names      []string
 	dep_names          []string // globals or consts dependent names
-	attrs              []Attr   // all fn attributes
-	is_conditional     bool     // true for `[if abc]fn(){}`
-	ctdefine_idx       int      // the index of the attribute, containing the compile time define [if mytag]
-	from_embedded_type Type     // for interface only, fn from the embedded interface
+	attrs              []Attr // all fn attributes
+	is_conditional     bool // true for `[if abc]fn(){}`
+	ctdefine_idx       int // the index of the attribute, containing the compile time define [if mytag]
+	from_embedded_type Type // for interface only, fn from the embedded interface
 	//
 	is_expand_simple_interpolation bool // for tagging b.f(s string), which is then called with `b.f('some ${x} ${y}')`,
 	// when that call, should be expanded to `b.f('some '); b.f(x); b.f(' '); b.f(y);`
@@ -962,9 +962,9 @@ pub mut:
 	return_type            Type
 	return_type_generic    Type // the original generic return type from fn def
 	nr_ret_values          int = -1 // amount of return values
-	fn_var_type            Type   // the fn type, when `is_fn_a_const` or `is_fn_var` is true
+	fn_var_type            Type // the fn type, when `is_fn_a_const` or `is_fn_var` is true
 	const_name             string // the fully qualified name of the const, i.e. `main.c`, given `const c = abc`, and callexpr: `c()`
-	should_be_skipped      bool   // true for calls to `[if someflag?]` functions, when there is no `-d someflag`
+	should_be_skipped      bool // true for calls to `[if someflag?]` functions, when there is no `-d someflag`
 	concrete_types         []Type // concrete types, e.g. [int, string]
 	concrete_list_pos      token.Pos
 	raw_concrete_types     []Type
@@ -1017,14 +1017,14 @@ pub mut:
 }
 
 pub enum ComptimeVarKind {
-	no_comptime   // it is not a comptime var
-	key_var       // map key from `for k,v in t.$(field.name)`
-	value_var     // map value from `for k,v in t.$(field.name)`
-	field_var     // comptime field var `a := t.$(field.name)`
+	no_comptime // it is not a comptime var
+	key_var // map key from `for k,v in t.$(field.name)`
+	value_var // map value from `for k,v in t.$(field.name)`
+	field_var // comptime field var `a := t.$(field.name)`
 	generic_param // generic fn parameter
-	generic_var   // generic var
-	smartcast     // smart cast when used in `is v` (when `v` is from $for .variants)
-	aggregate     // aggregate var
+	generic_var // generic var
+	smartcast // smart cast when used in `is v` (when `v` is from $for .variants)
+	aggregate // aggregate var
 }
 
 @[minify]
@@ -1046,18 +1046,18 @@ pub mut:
 	is_index_var            bool // index loop var
 	expr                    Expr
 	typ                     Type
-	generic_typ             Type   // original generic declaration type; reused for later concrete instantiations
-	orig_type               Type   // original sumtype type; 0 if it's not a sumtype
+	generic_typ             Type // original generic declaration type; reused for later concrete instantiations
+	orig_type               Type // original sumtype type; 0 if it's not a sumtype
 	smartcasts              []Type // nested sum types require nested smart casting, for that a list of types is needed
 	// TODO: move this to a real docs site later
 	// 10 <- original type (orig_type)
 	//   [11, 12, 13] <- cast order (smartcasts)
 	//        12 <- the current casted type (typ)
 	pos               token.Pos
-	is_used           bool            // whether the local variable was used in other expressions
-	is_changed        bool            // to detect mutable vars that are never changed
+	is_used           bool // whether the local variable was used in other expressions
+	is_changed        bool // to detect mutable vars that are never changed
 	ct_type_var       ComptimeVarKind // comptime variable type
-	ct_type_unwrapped bool            // true when the comptime variable gets unwrapped
+	ct_type_unwrapped bool // true when the comptime variable gets unwrapped
 	// (for setting the position after the or block for autofree)
 	is_or        bool // `x := foo() or { ... }`
 	is_tmp       bool // for tmp for loop vars, so that autofree can skip them
@@ -1076,7 +1076,7 @@ pub:
 	is_mut      bool
 	pos         token.Pos
 	typ         Type
-	orig_type   Type   // original sumtype type; 0 if it's not a sumtype
+	orig_type   Type // original sumtype type; 0 if it's not a sumtype
 	smartcasts  []Type // nested sum types require nested smart casting, for that a list of types is needed
 	// TODO: move this to a real docs site later
 	// 10 <- original type (orig_type)
@@ -1099,7 +1099,7 @@ pub:
 	is_hidden   bool
 	// The following fields, are relevant for non V globals, for example `__global C.stdout &C.FILE`:
 	language  Language // for C.stdout, it will be .c .
-	is_extern bool     // true, if an explicit `@[c_extern]` tag was used. It is suitable for globals, that are not initialised by V,
+	is_extern bool // true, if an explicit `@[c_extern]` tag was used. It is suitable for globals, that are not initialised by V,
 	// but come from the external linked objects/libs, like C.stdout etc, and that *are not* declared in included .h files .
 	// Without an explicit `@[c_extern]` tag, V will avoid emiting `extern CType CName;` lines.
 	// V will still know, that the type of C.stdout, is not the default `int`, but &C.FILE, and thus will do more checks on it.
@@ -1113,7 +1113,7 @@ pub struct GlobalDecl {
 pub:
 	mod      string
 	pos      token.Pos
-	is_block bool   // __global() block
+	is_block bool // __global() block
 	attrs    []Attr // tags like `@[markused]`, valid for all the globals in the list
 pub mut:
 	fields       []GlobalField
@@ -1137,7 +1137,7 @@ pub mut:
 pub struct TemplateLineInfo {
 pub:
 	tmpl_path string // path to the template file (for @include support)
-	tmpl_line int    // 0-based line number in the template
+	tmpl_line int // 0-based line number in the template
 }
 
 // Each V source file is represented by one File structure.
@@ -1146,9 +1146,9 @@ pub:
 @[heap]
 pub struct File {
 pub:
-	nr_lines      int    // number of source code lines in the file (including newlines and comments)
-	nr_bytes      int    // number of processed source code bytes
-	nr_tokens     int    // number of processed tokens in the source code of the file
+	nr_lines      int // number of source code lines in the file (including newlines and comments)
+	nr_bytes      int // number of processed source code bytes
+	nr_tokens     int // number of processed tokens in the source code of the file
 	mod           Module // the module of the source file (from `module xyz` at the top)
 	global_scope  &Scope = unsafe { nil }
 	is_test       bool // true for _test.v files
@@ -1156,28 +1156,28 @@ pub:
 	is_translated bool // true for `@[translated] module xyz` files; turn off some checks
 	language      Language
 pub mut:
-	idx                   int    // index in an external container; can be used to refer to the file in a more efficient way, just by its integer index
+	idx                   int // index in an external container; can be used to refer to the file in a more efficient way, just by its integer index
 	path                  string // absolute path of the source file - '/projects/v/file.v'
 	path_base             string // file name - 'file.v' (useful for tracing)
 	scope                 &Scope = unsafe { nil }
-	stmts                 []Stmt   // all the statements in the source file
+	stmts                 []Stmt // all the statements in the source file
 	imports               []Import // all the imports
 	auto_imports          []string // imports that were implicitly added
 	used_imports          []string
-	implied_imports       []string                  // ​imports that the user's code uses but omitted to import explicitly, used by `vfmt`
-	embedded_files        []EmbeddedFile            // list of files to embed in the binary
-	imported_symbols      map[string]string         // used for `import {symbol}`, it maps symbol => module.symbol
+	implied_imports       []string // ​imports that the user's code uses but omitted to import explicitly, used by `vfmt`
+	embedded_files        []EmbeddedFile // list of files to embed in the binary
+	imported_symbols      map[string]string // used for `import {symbol}`, it maps symbol => module.symbol
 	imported_symbols_trie token.KeywordsMatcherTrie // constructed from imported_symbols, to accelerate presense checks
 	imported_symbols_used map[string]bool
-	errors                []errors.Error         // all the checker errors in the file
-	warnings              []errors.Warning       // all the checker warnings in the file
-	notices               []errors.Notice        // all the checker notices in the file
+	errors                []errors.Error // all the checker errors in the file
+	warnings              []errors.Warning // all the checker warnings in the file
+	notices               []errors.Notice // all the checker notices in the file
 	call_stack            []errors.CallStackItem // call stack for this file (used for template errors)
 	generic_fns           []&FnDecl
-	global_labels         []string           // from `asm { .globl labelname }`
-	template_paths        []string           // all the .html/.md files that were processed with $tmpl
+	global_labels         []string // from `asm { .globl labelname }`
+	template_paths        []string // all the .html/.md files that were processed with $tmpl
 	template_line_map     []TemplateLineInfo // maps generated line -> original template location
-	unique_prefix         string             // a hash of the `.path` field, used for making anon fn generation unique
+	unique_prefix         string // a hash of the `.path` field, used for making anon fn generation unique
 	//
 	is_parse_text    bool // true for files, produced by parse_text
 	is_template_text bool // true for files, produced by parse_comptime
@@ -1244,7 +1244,7 @@ pub:
 	mut_pos  token.Pos
 	comptime bool
 pub mut:
-	scope          &Scope      = unsafe { nil }
+	scope          &Scope = unsafe { nil }
 	obj            ScopeObject = empty_scope_object
 	mod            string
 	name           string
@@ -1290,16 +1290,26 @@ pub fn (i &Ident) is_stack_obj() bool {
 @[inline]
 pub fn (i &Ident) is_mut() bool {
 	match i.obj {
-		Var { return i.obj.is_mut }
-		ConstField, EmptyScopeObject { return false }
-		AsmRegister { return true }
-		GlobalField { return !i.obj.is_const }
+		Var {
+			return i.obj.is_mut
+		}
+		ConstField, EmptyScopeObject {
+			return false
+		}
+		AsmRegister {
+			return true
+		}
+		GlobalField {
+			return !i.obj.is_const
+		}
 	}
 }
 
 pub fn (i &Ident) var_info() IdentVar {
 	match i.info {
-		IdentVar { return i.info }
+		IdentVar {
+			return i.info
+		}
 		else { panic('Ident.var_info(): info is not IdentVar variant') }
 	}
 }
@@ -1362,7 +1372,7 @@ pub struct IndexExpr {
 pub:
 	pos token.Pos
 pub mut:
-	index             Expr   // [0], RangeExpr [start..end] or map[key]
+	index             Expr // [0], RangeExpr [start..end] or map[key]
 	indices           []Expr // parsed index parts, e.g. [i], [i, j], [1..3, ..]
 	or_expr           OrExpr
 	left              Expr
@@ -1388,7 +1398,7 @@ pub:
 	pos           token.Pos
 	post_comments []Comment
 pub mut:
-	left       Expr       // `a` in `a := if ...`
+	left       Expr // `a` in `a := if ...`
 	branches   []IfBranch // includes all `else if` branches
 	is_expr    bool
 	force_expr bool
@@ -1481,7 +1491,7 @@ pub:
 	post_comments []Comment
 	scope         &Scope
 pub mut:
-	stmt  Stmt   // `a := <-ch` or `ch <- a`
+	stmt  Stmt // `a := <-ch` or `ch <- a`
 	stmts []Stmt // right side
 }
 
@@ -1539,7 +1549,7 @@ pub mut:
 	cond_type  Type
 	high       Expr // `10` in `for i in 0..10 {`
 	high_type  Type
-	kind       Kind   // array/map/string
+	kind       Kind // array/map/string
 	label      string // `label: for {`
 	scope      &Scope = unsafe { nil }
 	stmts      []Stmt
@@ -1629,8 +1639,8 @@ pub:
 	pre_comments     []Comment // comment before Enumfield
 	comments         []Comment // comment after Enumfield in the same line
 	next_comments    []Comment // comments between current EnumField and next EnumField
-	has_expr         bool      // true, when .expr has a value
-	has_prev_newline bool      // empty newline before Enumfield
+	has_expr         bool // true, when .expr has a value
+	has_prev_newline bool // empty newline before Enumfield
 	has_break_line   bool
 	attrs            []Attr
 pub mut:
@@ -1643,12 +1653,12 @@ pub struct EnumDecl {
 pub:
 	name             string
 	is_pub           bool
-	is_flag          bool        // true when the enum has @[flag] tag,for bit field enum
-	is_multi_allowed bool        // true when the enum has [_allow_multiple_values] tag
-	comments         []Comment   // comments before the first EnumField
+	is_flag          bool // true when the enum has @[flag] tag,for bit field enum
+	is_multi_allowed bool // true when the enum has [_allow_multiple_values] tag
+	comments         []Comment // comments before the first EnumField
 	fields           []EnumField // all the enum fields
-	attrs            []Attr      // attributes of enum declaration
-	typ              Type        // the default is `int`; can be changed by `enum Big as u64 { a = 5 }`
+	attrs            []Attr // attributes of enum declaration
+	typ              Type // the default is `int`; can be changed by `enum Big as u64 { a = 5 }`
 	typ_pos          token.Pos
 	pos              token.Pos
 pub mut:
@@ -1765,8 +1775,8 @@ pub:
 @[minify]
 pub struct ArrayInit {
 pub:
-	pos                token.Pos   // `[]` in []Type{} position
-	elem_type_pos      token.Pos   // `Type` in []Type{} position
+	pos                token.Pos // `[]` in []Type{} position
+	elem_type_pos      token.Pos // `Type` in []Type{} position
 	ecmnts             [][]Comment // optional iembed comments after each expr
 	pre_cmnts          []Comment
 	is_fixed           bool
@@ -1780,21 +1790,21 @@ pub:
 	has_index          bool // true if temp variable index is used
 pub mut:
 	exprs                []Expr // `[expr, expr]` or `[expr]Type{}` for fixed array
-	len_expr             Expr   // len: expr
-	cap_expr             Expr   // cap: expr
-	init_expr            Expr   // init: expr
+	len_expr             Expr // len: expr
+	cap_expr             Expr // cap: expr
+	init_expr            Expr // init: expr
 	elem_type_expr       Expr = empty_expr // `typeof(expr).idx` in `[]typeof(expr).idx{}`
 	expr_types           []Type // [Dog, Cat] // also used for interface_types
-	elem_type            Type   // element type
-	generic_elem_type    Type   // original generic element type; reused for later concrete instantiations
-	init_type            Type   // init: value type
-	typ                  Type   // array type
-	literal_typ          Type   // array type as written, preserved for fmt
-	generic_typ          Type   // original generic array type; reused for later concrete instantiations
-	alias_type           Type   // alias type
-	has_callexpr         bool   // has expr which needs tmp var to initialize it
-	has_update_expr      bool   // has `...a` as in `[...a, 3, 4]`
-	update_expr          Expr   // `a` in `...a`
+	elem_type            Type // element type
+	generic_elem_type    Type // original generic element type; reused for later concrete instantiations
+	init_type            Type // init: value type
+	typ                  Type // array type
+	literal_typ          Type // array type as written, preserved for fmt
+	generic_typ          Type // original generic array type; reused for later concrete instantiations
+	alias_type           Type // alias type
+	has_callexpr         bool // has expr which needs tmp var to initialize it
+	has_update_expr      bool // has `...a` as in `[...a, 3, 4]`
+	update_expr          Expr // `a` in `...a`
 	update_expr_pos      token.Pos
 	update_expr_comments []Comment
 }
@@ -1824,7 +1834,7 @@ pub struct MapInit {
 pub:
 	pos       token.Pos
 	comments  [][]Comment // comments after key-value pairs
-	pre_cmnts []Comment   // comments before the first key-value pair
+	pre_cmnts []Comment // comments before the first key-value pair
 pub mut:
 	keys                 []Expr
 	vals                 []Expr
@@ -1855,12 +1865,12 @@ pub mut:
 @[minify]
 pub struct CastExpr {
 pub mut:
-	arg       Expr   // `n` in `string(buf, n)`
-	typ       Type   // `string`
-	expr      Expr   // `buf` in `string(buf, n)` and `&Type(buf)`
+	arg       Expr // `n` in `string(buf, n)`
+	typ       Type // `string`
+	expr      Expr // `buf` in `string(buf, n)` and `&Type(buf)`
 	typname   string // `&Type` in `&Type(buf)`
-	expr_type Type   // `byteptr`, the type of the `buf` expression
-	has_arg   bool   // true for `string(buf, n)`, false for `&Type(buf)`
+	expr_type Type // `byteptr`, the type of the `buf` expression
+	has_arg   bool // true for `string(buf, n)`, false for `&Type(buf)`
 	pos       token.Pos
 }
 
@@ -1943,13 +1953,13 @@ pub mut:
 // addressing modes:
 pub enum AddressingMode {
 	invalid
-	displacement                                  // displacement
-	base                                          // base
-	base_plus_displacement                        // base + displacement
-	index_times_scale_plus_displacement           // (index ∗ scale) + displacement
-	base_plus_index_plus_displacement             // base + (index ∗ scale) + displacement
+	displacement // displacement
+	base // base
+	base_plus_displacement // base + displacement
+	index_times_scale_plus_displacement // (index ∗ scale) + displacement
+	base_plus_index_plus_displacement // base + (index ∗ scale) + displacement
 	base_plus_index_times_scale_plus_displacement // base + index + displacement
-	rip_plus_displacement                         // rip + displacement
+	rip_plus_displacement // rip + displacement
 }
 
 pub struct AsmClobbered {
@@ -1961,8 +1971,8 @@ pub mut:
 // : [alias_a] '=r' (a) // this is a comment
 pub struct AsmIO {
 pub:
-	alias      string    // [alias_a]
-	constraint string    // '=r' TODO: allow all backends to easily use this with a struct
+	alias      string // [alias_a]
+	constraint string // '=r' TODO: allow all backends to easily use this with a struct
 	comments   []Comment // // this is a comment
 	typ        Type
 	pos        token.Pos
@@ -1975,9 +1985,9 @@ pub mut:
 pub const x86_no_number_register_list = {
 	8:  ['al', 'ah', 'bl', 'bh', 'cl', 'ch', 'dl', 'dh', 'bpl', 'sil', 'dil', 'spl']
 	16: ['ax', 'bx', 'cx', 'dx', 'bp', 'si', 'di', 'sp', // segment registers
-	 	'cs', 'ss', 'ds', 'es', 'fs', 'gs', 'flags', 'ip', // task registers
-	 	'gdtr', 'idtr', 'tr', 'ldtr', // CSR register 'msw', /* FP core registers */ 'cw', 'sw', 'tw', 'fp_ip', 'fp_dp', 'fp_cs',
-	 	'fp_ds', 'fp_opc']
+	'cs', 'ss', 'ds', 'es', 'fs', 'gs', 'flags', 'ip', // task registers
+	'gdtr', 'idtr', 'tr', 'ldtr', // CSR register 'msw', /* FP core registers */ 'cw', 'sw', 'tw', 'fp_ip', 'fp_dp', 'fp_cs',
+	'fp_ds', 'fp_opc']
 	32: [
 		'eax',
 		'ebx',
@@ -2032,10 +2042,10 @@ pub const x86_with_number_register_list = {
 
 // TODO: saved priviled registers for arm
 pub const arm_no_number_register_list = ['fp', // aka r11
- 'ip', // not instruction pointer: aka r12
- 'sp', // aka r13
- 'lr', // aka r14
- 'pc', // this is instruction pointer ('program counter'): aka r15
+'ip', // not instruction pointer: aka r12
+'sp', // aka r13
+'lr', // aka r14
+'pc', // this is instruction pointer ('program counter'): aka r15
 ] // 'cpsr' and 'apsr' are special flags registers, but cannot be referred to directly
 
 pub const arm_with_number_register_list = {
@@ -2191,7 +2201,7 @@ pub mut:
 	pos_expr   token.Pos
 	expr       Expr
 	pos_end    token.Pos
-	scope      &Scope  = unsafe { nil }
+	scope      &Scope = unsafe { nil }
 	func       &AnonFn = unsafe { nil }
 	is_checked bool
 	typ        Type
@@ -2262,8 +2272,8 @@ pub mut:
 	left_type  Type
 	field_expr Expr
 	typ        Type
-	is_name    bool   // true if f.$(field.name)
-	is_method  bool   // true if f.$(method)
+	is_name    bool // true if f.$(field.name)
+	is_method  bool // true if f.$(method)
 	typ_key    string // `f.typ` cached key for type resolver
 }
 
@@ -2430,7 +2440,7 @@ pub:
 	is_dynamic   bool
 	scope        &Scope = unsafe { nil }
 pub mut:
-	object_var       string   // `user`
+	object_var       string // `user`
 	updated_columns  []string // for `update set x=y`
 	is_array_insert  bool
 	is_array_update  bool
@@ -2448,9 +2458,9 @@ pub mut:
 
 // JoinKind represents the type of SQL JOIN operation
 pub enum JoinKind {
-	inner      // INNER JOIN - returns only matching rows
-	left       // LEFT JOIN - returns all left rows, NULL for non-matching right
-	right      // RIGHT JOIN - returns all right rows, NULL for non-matching left
+	inner // INNER JOIN - returns only matching rows
+	left // LEFT JOIN - returns all left rows, NULL for non-matching right
+	right // RIGHT JOIN - returns all right rows, NULL for non-matching left
 	full_outer // FULL OUTER JOIN - returns all rows from both tables
 }
 
@@ -2461,7 +2471,7 @@ pub:
 	pos  token.Pos
 pub mut:
 	table_expr TypeNode // The table being joined (e.g., Department in `join Department`)
-	on_expr    Expr     // The ON condition (e.g., `User.dept_id == Department.id`)
+	on_expr    Expr // The ON condition (e.g., `User.dept_id == Department.id`)
 }
 
 pub enum SqlAggregateKind {
@@ -2590,6 +2600,7 @@ pub fn (expr Expr) is_as_cast() bool {
 }
 
 __global nested_expr_pos_calls = i64(0)
+
 // values above 14000 risk stack overflow by default on macos in Expr.pos() calls
 const max_nested_expr_pos_calls = 5000
 
@@ -2616,13 +2627,7 @@ pub fn (expr Expr) pos() token.Pos {
 			// println('compiler bug, unhandled EmptyExpr pos()')
 			token.Pos{}
 		}
-		NodeError, ArrayDecompose, ArrayInit, AsCast, Assoc, AtExpr, BoolLiteral, CallExpr,
-		CastExpr, ChanInit, CharLiteral, ConcatExpr, Comment, ComptimeCall, ComptimeSelector,
-		EnumVal, DumpExpr, FloatLiteral, GoExpr, SpawnExpr, Ident, IfExpr, IntegerLiteral,
-		IsRefType, Likely, LockExpr, MapInit, MatchExpr, None, OffsetOf, OrExpr, ParExpr,
-		PostfixExpr, PrefixExpr, RangeExpr, SelectExpr, SelectorExpr, SizeOf, SqlExpr,
-		SqlQueryDataExpr, StringInterLiteral, StringLiteral, StructInit, TypeNode, TypeOf,
-		UnsafeExpr, ComptimeType, LambdaExpr, Nil {
+		NodeError, ArrayDecompose, ArrayInit, AsCast, Assoc, AtExpr, BoolLiteral, CallExpr, CastExpr, ChanInit, CharLiteral, ConcatExpr, Comment, ComptimeCall, ComptimeSelector, EnumVal, DumpExpr, FloatLiteral, GoExpr, SpawnExpr, Ident, IfExpr, IntegerLiteral, IsRefType, Likely, LockExpr, MapInit, MatchExpr, None, OffsetOf, OrExpr, ParExpr, PostfixExpr, PrefixExpr, RangeExpr, SelectExpr, SelectorExpr, SizeOf, SqlExpr, SqlQueryDataExpr, StringInterLiteral, StringLiteral, StructInit, TypeNode, TypeOf, UnsafeExpr, ComptimeType, LambdaExpr, Nil {
 			expr.pos
 		}
 		IndexExpr {
@@ -2639,17 +2644,17 @@ pub fn (expr Expr) pos() token.Pos {
 			left_pos := expr.left.pos()
 			right_pos := expr.right.pos()
 			token.Pos{
-				line_nr:   expr.pos.line_nr
-				pos:       left_pos.pos
-				len:       right_pos.pos - left_pos.pos + right_pos.len
-				col:       left_pos.col
+				line_nr: expr.pos.line_nr
+				pos: left_pos.pos
+				len: right_pos.pos - left_pos.pos + right_pos.len
+				col: left_pos.col
 				last_line: right_pos.last_line
 			}
 		}
-		// Please, do NOT use else{} here.
-		// This match is exhaustive *on purpose*, to help force
-		// maintaining/implementing proper .pos fields.
 	}
+	// Please, do NOT use else{} here.
+	// This match is exhaustive *on purpose*, to help force
+	// maintaining/implementing proper .pos fields.
 }
 
 pub fn (expr Expr) is_constant() bool {
@@ -2797,8 +2802,8 @@ pub fn (e &Expr) has_fn_call() bool {
 pub struct CTempVar {
 pub:
 	name   string // the name of the C temporary variable; used by g.expr(x)
-	typ    Type   // the type of the original expression
-	is_ptr bool   // whether the type is a pointer
+	typ    Type // the type of the original expression
+	is_ptr bool // whether the type is a pointer
 pub mut:
 	orig         Expr // the original expression, which produced the C temp variable; used by x.str()
 	is_fixed_ret bool // it is an array fixed returned from call
@@ -2860,11 +2865,11 @@ pub fn (node Node) pos() token.Pos {
 				}
 				EmptyScopeObject, AsmRegister {
 					return token.Pos{
-						len:       -1
-						line_nr:   -1
-						pos:       -1
+						len: -1
+						line_nr: -1
+						pos: -1
 						last_line: -1
-						col:       0
+						col: 0
 					}
 				}
 			}
@@ -3090,6 +3095,7 @@ pub fn (node Node) children() []Node {
 				return_stmt := node
 				return return_stmt.exprs.map(Node(it))
 			}
+
 			// Note: these four decl nodes cannot be merged as one branch
 			StructDecl {
 				struct_decl := node
@@ -3187,17 +3193,17 @@ pub fn (node Node) children() []Node {
 // helper for dealing with `m[k1][k2][k3][k3] = value`
 pub fn (mut lx IndexExpr) recursive_mapset_is_setter(val bool) {
 	lx.is_setter = val
-	if mut lx.left is IndexExpr && lx.left.is_map {
+	if lx.left is IndexExpr && lx.left.is_map {
 		lx.left.recursive_mapset_is_setter(val)
 	}
 }
 
 pub fn (mut lx IndexExpr) recursive_arraymap_set_is_setter() {
 	lx.is_setter = true
-	if mut lx.left is IndexExpr {
+	if lx.left is IndexExpr {
 		lx.left.recursive_arraymap_set_is_setter()
-	} else if mut lx.left is SelectorExpr {
-		if mut lx.left.expr is IndexExpr {
+	} else if lx.left is SelectorExpr {
+		if lx.left.expr is IndexExpr {
 			lx.left.expr.recursive_arraymap_set_is_setter()
 		}
 	}
@@ -3215,7 +3221,7 @@ pub fn all_registers(mut t Table, arch pref.Arch) map[string]ScopeObject {
 				for name in array {
 					res[name] = AsmRegister{
 						name: name
-						typ:  t.bitsize_to_type(bit_size)
+						typ: t.bitsize_to_type(bit_size)
 						size: bit_size
 					}
 				}
@@ -3229,7 +3235,7 @@ pub fn all_registers(mut t Table, arch pref.Arch) map[string]ScopeObject {
 						assembled_name := '${name[..hash_index]}${i}${name[hash_index + 1..]}'
 						res[assembled_name] = AsmRegister{
 							name: assembled_name
-							typ:  t.bitsize_to_type(bit_size)
+							typ: t.bitsize_to_type(bit_size)
 							size: bit_size
 						}
 					}
@@ -3237,55 +3243,47 @@ pub fn all_registers(mut t Table, arch pref.Arch) map[string]ScopeObject {
 			}
 		}
 		.arm32 {
-			arm32 := gen_all_registers(mut t, arm_no_number_register_list,
-				arm_with_number_register_list, 32)
+			arm32 := gen_all_registers(mut t, arm_no_number_register_list, arm_with_number_register_list, 32)
 			for k, v in arm32 {
 				res[k] = v
 			}
 		}
 		.arm64 {
-			arm64 := gen_all_registers(mut t, arm64_no_number_register_list,
-				arm64_with_number_register_list, 64)
+			arm64 := gen_all_registers(mut t, arm64_no_number_register_list, arm64_with_number_register_list, 64)
 			for k, v in arm64 {
 				res[k] = v
 			}
-			arm64_32bit := gen_all_registers(mut t, arm64_32bit_no_number_register_list,
-				arm64_32bit_with_number_register_list, 32)
+			arm64_32bit := gen_all_registers(mut t, arm64_32bit_no_number_register_list, arm64_32bit_with_number_register_list, 32)
 			for k, v in arm64_32bit {
 				res[k] = v
 			}
 		}
 		.rv32 {
-			rv32 := gen_all_registers(mut t, riscv_no_number_register_list,
-				riscv_with_number_register_list, 32)
+			rv32 := gen_all_registers(mut t, riscv_no_number_register_list, riscv_with_number_register_list, 32)
 			for k, v in rv32 {
 				res[k] = v
 			}
 		}
 		.rv64 {
-			rv64 := gen_all_registers(mut t, riscv_no_number_register_list,
-				riscv_with_number_register_list, 64)
+			rv64 := gen_all_registers(mut t, riscv_no_number_register_list, riscv_with_number_register_list, 64)
 			for k, v in rv64 {
 				res[k] = v
 			}
 		}
 		.s390x {
-			s390x := gen_all_registers(mut t, s390x_no_number_register_list,
-				s390x_with_number_register_list, 64)
+			s390x := gen_all_registers(mut t, s390x_no_number_register_list, s390x_with_number_register_list, 64)
 			for k, v in s390x {
 				res[k] = v
 			}
 		}
 		.ppc64le {
-			ppc64le := gen_all_registers(mut t, ppc64le_no_number_register_list,
-				ppc64le_with_number_register_list, 64)
+			ppc64le := gen_all_registers(mut t, ppc64le_no_number_register_list, ppc64le_with_number_register_list, 64)
 			for k, v in ppc64le {
 				res[k] = v
 			}
 		}
 		.loongarch64 {
-			loongarch64 := gen_all_registers(mut t, loongarch64_no_number_register_list,
-				loongarch64_with_number_register_list, 64)
+			loongarch64 := gen_all_registers(mut t, loongarch64_no_number_register_list, loongarch64_with_number_register_list, 64)
 			for k, v in loongarch64 {
 				res[k] = v
 			}
@@ -3307,7 +3305,7 @@ fn gen_all_registers(mut t Table, without_numbers []string, with_numbers map[str
 	for name in without_numbers {
 		res[name] = AsmRegister{
 			name: name
-			typ:  t.bitsize_to_type(bit_size)
+			typ: t.bitsize_to_type(bit_size)
 			size: bit_size
 		}
 	}
@@ -3317,7 +3315,7 @@ fn gen_all_registers(mut t Table, without_numbers []string, with_numbers map[str
 			assembled_name := '${name[..hash_index]}${i}${name[hash_index + 1..]}'
 			res[assembled_name] = AsmRegister{
 				name: assembled_name
-				typ:  t.bitsize_to_type(bit_size)
+				typ: t.bitsize_to_type(bit_size)
 				size: bit_size
 			}
 		}
@@ -3368,7 +3366,8 @@ pub fn (expr Expr) is_literal() bool {
 		}
 		CastExpr {
 			!expr.has_arg && expr.expr.is_literal() && (expr.typ.is_any_kind_of_pointer()
-				|| expr.typ in [i8_type, i16_type, i32_type, int_type, i64_type, u8_type, u16_type, u32_type, u64_type, f32_type, f64_type, char_type, bool_type, rune_type])
+				|| expr.typ in [i8_type, i16_type, i32_type, int_type, i64_type, u8_type, u16_type,
+					u32_type, u64_type, f32_type, f64_type, char_type, bool_type, rune_type])
 		}
 		SizeOf, IsRefType {
 			expr.is_type || expr.expr.is_literal()
@@ -3391,6 +3390,7 @@ pub fn type_can_start_with_token(tok &token.Token) bool {
 			(tok.lit.len > 0 && tok.lit[0].is_capital())
 				|| builtin_type_names_matcher.matches(tok.lit)
 		}
+
 		// Note: return type (T1, T2) should be handled elsewhere
 		.amp, .key_fn, .lsbr, .question {
 			true

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -71,30 +71,30 @@ mut:
 	type_default_vars                    strings.Builder // type_default() var declarations
 	cleanup                              strings.Builder
 	cleanups                             map[string]strings.Builder // contents of `void _vcleanup(){}`
-	gowrappers                           strings.Builder            // all go callsite wrappers
-	waiter_fn_definitions                strings.Builder            // waiter fns definitions
-	auto_str_funcs                       strings.Builder            // function bodies of all auto generated _str funcs
-	dump_funcs                           strings.Builder            // function bodies of all auto generated _str funcs
-	pcs_declarations                     strings.Builder            // -prof profile counter declarations for each function
-	cov_declarations                     strings.Builder            // -cov coverage
-	embedded_data                        strings.Builder            // data to embed in the executable/binary
-	interface_index_definitions          strings.Builder            // real interface index symbols for -parallel-cc helpers
-	shared_types                         strings.Builder            // shared/lock types
-	shared_functions                     strings.Builder            // shared constructors
-	out_options_forward                  strings.Builder            // forward `option_xxxx` types
-	out_options                          strings.Builder            // `option_xxxx` types
-	out_results_forward                  strings.Builder            // forward`result_xxxx` types
-	out_results                          strings.Builder            // `result_xxxx` types
-	json_forward_decls                   strings.Builder            // json type forward decls
-	sql_buf                              strings.Builder            // for writing exprs to args via `sqlite3_bind_int()` etc
+	gowrappers                           strings.Builder // all go callsite wrappers
+	waiter_fn_definitions                strings.Builder // waiter fns definitions
+	auto_str_funcs                       strings.Builder // function bodies of all auto generated _str funcs
+	dump_funcs                           strings.Builder // function bodies of all auto generated _str funcs
+	pcs_declarations                     strings.Builder // -prof profile counter declarations for each function
+	cov_declarations                     strings.Builder // -cov coverage
+	embedded_data                        strings.Builder // data to embed in the executable/binary
+	interface_index_definitions          strings.Builder // real interface index symbols for -parallel-cc helpers
+	shared_types                         strings.Builder // shared/lock types
+	shared_functions                     strings.Builder // shared constructors
+	out_options_forward                  strings.Builder // forward `option_xxxx` types
+	out_options                          strings.Builder // `option_xxxx` types
+	out_results_forward                  strings.Builder // forward`result_xxxx` types
+	out_results                          strings.Builder // `result_xxxx` types
+	json_forward_decls                   strings.Builder // json type forward decls
+	sql_buf                              strings.Builder // for writing exprs to args via `sqlite3_bind_int()` etc
 	global_const_defs                    map[string]GlobalConstDef
 	vsafe_arithmetic_ops                 map[string]VSafeArithmeticOp // 'VSAFE_DIV_u8' -> {11, /}, 'VSAFE_MOD_u8' -> {11,%}, 'VSAFE_MOD_i64' -> the same but with 9
 	sorted_global_const_names            []string
-	file                                 &ast.File  = unsafe { nil }
+	file                                 &ast.File = unsafe { nil }
 	table                                &ast.Table = unsafe { nil }
 	styp_cache                           map[ast.Type]string
 	no_eq_method_types                   map[ast.Type]bool // types that does not need to call its auto eq methods for optimization
-	generic_parts_cache                  []i8              // type idx -> 0 unknown, 1 false, 2 true
+	generic_parts_cache                  []i8 // type idx -> 0 unknown, 1 false, 2 true
 	unwrap_generic_cache                 map[u64]ast.Type
 	resolved_scope_var_type_cache        map[u64]ast.Type
 	unique_file_path_hash                u64 // a hash of file.path, used for making auxiliary fn generation unique (like `compare_xyz`)
@@ -103,9 +103,9 @@ mut:
 	tmp_count                            int // counter for unique tmp vars (_tmp1, _tmp2 etc); resets at the start of each fn.
 	user_goto_label_ids                  map[string]int
 	user_goto_label_count                int
-	tmp_count_af                         int  // a separate tmp var counter for autofree fn calls
-	tmp_count_declarations               int  // counter for unique tmp names (_d1, _d2 etc); does NOT reset, used for C declarations
-	global_tmp_count                     int  // like tmp_count but global and not reset in each function
+	tmp_count_af                         int // a separate tmp var counter for autofree fn calls
+	tmp_count_declarations               int // counter for unique tmp names (_d1, _d2 etc); does NOT reset, used for C declarations
+	global_tmp_count                     int // like tmp_count but global and not reset in each function
 	discard_or_result                    bool // do not safe last ExprStmt of `or` block in tmp variable to defer ongoing expr usage
 	is_direct_array_access               bool // inside a `[direct_array_access fn a() {}` function
 	is_assign_lhs                        bool // inside left part of assign expr (for array_set(), etc)
@@ -125,35 +125,35 @@ mut:
 	is_cc_msvc                           bool // g.pref.ccompiler == 'msvc'
 	is_option_auto_heap                  bool
 	is_auto_deref_synthetic              bool
-	vlines_path                          string            // set to the proper path for generating #line directives
-	options_pos_forward                  int               // insertion point to forward
-	options_forward                      []string          // to forward
+	vlines_path                          string // set to the proper path for generating #line directives
+	options_pos_forward                  int // insertion point to forward
+	options_forward                      []string // to forward
 	options                              map[string]string // to avoid duplicates
-	spawn_arg_options                    []string          // option payloads needed by spawn wrappers
-	emitted_extern_sig_typedefs          map[int]bool      // type idx → already-emitted forward typedef (for C extern decls)
-	results_forward                      []string          // to forward
+	spawn_arg_options                    []string // option payloads needed by spawn wrappers
+	emitted_extern_sig_typedefs          map[int]bool // type idx → already-emitted forward typedef (for C extern decls)
+	results_forward                      []string // to forward
 	results                              map[string]string // to avoid duplicates
-	spawn_arg_results                    []string          // result payloads needed by spawn wrappers
-	done_options                         shared []string   // to avoid duplicates
-	done_results                         shared []string   // to avoid duplicates
-	array_typedefs                       []string          // to avoid duplicate array typedefs
+	spawn_arg_results                    []string // result payloads needed by spawn wrappers
+	done_options                         shared []string // to avoid duplicates
+	done_results                         shared []string // to avoid duplicates
+	array_typedefs                       []string // to avoid duplicate array typedefs
 	written_array_typedefs               int
-	done_typedef_phase                   bool              // set after write_typedef_types() completes
-	late_chan_types                      shared []string   // concrete channel cnames discovered during file generation
-	emitted_chan_types                   map[string]bool   // concrete channel typedefs/helpers already emitted
+	done_typedef_phase                   bool // set after write_typedef_types() completes
+	late_chan_types                      shared []string // concrete channel cnames discovered during file generation
+	emitted_chan_types                   map[string]bool // concrete channel typedefs/helpers already emitted
 	chan_pop_options                     map[string]string // types for `x := <-ch or {...}`
 	chan_push_options                    map[string]string // types for `ch <- x or {...}`
-	mtxs                                 string            // array of mutexes if the `lock` has multiple variables
-	tmp_var_ptr                          map[string]bool   // indicates if the tmp var passed to or_block() is a ptr
+	mtxs                                 string // array of mutexes if the `lock` has multiple variables
+	tmp_var_ptr                          map[string]bool // indicates if the tmp var passed to or_block() is a ptr
 	labeled_loops                        map[string]&ast.Stmt
 	contains_ptr_cache                   map[ast.Type]bool
 	boehm_keep_gen                       shared map[string]bool
 	inner_loop                           &ast.Stmt = unsafe { nil }
-	cur_indexexpr                        []int          // list of nested indexexpr which generates array_set/map_set
+	cur_indexexpr                        []int // list of nested indexexpr which generates array_set/map_set
 	shareds                              map[int]string // types with hidden mutex for which decl has been emitted
 	coverage_files                       map[u64]&CoverageInfo
 	inside_smartcast                     bool
-	inside_ternary                       int  // ?: comma separated statements on a single line
+	inside_ternary                       int // ?: comma separated statements on a single line
 	inside_map_postfix                   bool // inside map++/-- postfix expr
 	inside_map_infix                     bool // inside map<</+=/-= infix expr
 	wrote_windows_tcc_atomic_include     bool
@@ -167,6 +167,7 @@ mut:
 	inside_opt_data                      bool
 	inside_if_option                     bool
 	inside_if_result                     bool
+	discarded_index_error_pos            token.Pos // exact guard lookup whose error cannot be observed
 	inside_match_option                  bool
 	inside_match_result                  bool
 	inside_veb_tmpl                      bool
@@ -202,18 +203,18 @@ mut:
 	inside_lambda_autofree_tmp           bool
 	track_lambda_autofree_tmp_arg_vars   bool
 	outer_tmp_var                        string // tmp var from outer context (e.g. from stmts_with_tmp_var) to be used by nested if/match expressions
-	if_match_tmp_is_fn_ret_arr           ?bool  // set by if/match expr gen: authoritatively whether the shared tmp var is a fn-returned fixed array (wrapper struct accessed via `.ret_arr`); `none` means use the per-branch heuristic
+	if_match_tmp_is_fn_ret_arr           ?bool // set by if/match expr gen: authoritatively whether the shared tmp var is a fn-returned fixed array (wrapper struct accessed via `.ret_arr`); `none` means use the per-branch heuristic
 	last_tmp_call_var                    []string
 	last_if_option_type                  ast.Type // stores the expected if type on nested if expr
 	loop_depth                           int
 	unsafe_level                         int
 	ternary_names                        map[string]string
 	ternary_level_names                  map[string][]string
-	arraymap_set_pos                     int              // map or array set value position
-	stmt_path_pos                        []int            // positions of each statement start, for inserting C statements before the current statement
-	skip_stmt_pos                        bool             // for handling if expressions + autofree (since both prepend C statements)
-	left_is_opt                          bool             // left hand side on assignment is an option
-	right_is_opt                         bool             // right hand side on assignment is an option
+	arraymap_set_pos                     int // map or array set value position
+	stmt_path_pos                        []int // positions of each statement start, for inserting C statements before the current statement
+	skip_stmt_pos                        bool // for handling if expressions + autofree (since both prepend C statements)
+	left_is_opt                          bool // left hand side on assignment is an option
+	right_is_opt                         bool // right hand side on assignment is an option
 	assign_ct_type                       map[int]ast.Type // left hand side resolved comptime type
 	expected_rhs_type_by_pos             map[int]ast.Type // expected value type for local RHS expressions
 	closure_frame_arg_tmps               map[int]string
@@ -229,8 +230,8 @@ mut:
 	closure_cleanup_keep_vars            []ClosureCleanupKeep
 	closure_cleanup_ignore_keep          bool
 	closure_cleanup_target_loop_pos      int
-	str_types                            []StrType       // types that need automatic str() generation
-	generated_str_fns                    []StrType       // types that already have a str() function
+	str_types                            []StrType // types that need automatic str() generation
+	generated_str_fns                    []StrType // types that already have a str() function
 	str_fn_names                         shared []string // remove duplicate function names
 	threaded_fns                         shared []string // for generating unique wrapper types and fns for `go xxx()`
 	waiter_fns                           shared []string // functions that wait for `go xxx()` to finish
@@ -248,7 +249,7 @@ mut:
 	array_get_types                      []ast.Type
 	auto_fn_definitions                  []string // auto generated functions definition list
 	sumtype_casting_fns                  []SumtypeCastingFn
-	anon_fn_definitions                  []string        // anon generated functions definition list
+	anon_fn_definitions                  []string // anon generated functions definition list
 	anon_fns                             shared []string // remove duplicate anon generated functions
 	sumtype_definitions                  map[string]bool // `_TypeA_to_sumtype_TypeB()` fns that have been generated
 	trace_fn_definitions                 []string
@@ -291,11 +292,11 @@ mut:
 	// where an aggregate (at least two types) is generated
 	// sum type deref needs to know which index to deref because unions take care of the correct field
 	aggregate_type_idx  int
-	arg_no_auto_deref   bool            // smartcast must not be dereferenced
-	branch_parent_pos   int             // used in BranchStmt (continue/break) for autofree stop position
+	arg_no_auto_deref   bool // smartcast must not be dereferenced
+	branch_parent_pos   int // used in BranchStmt (continue/break) for autofree stop position
 	returned_var_names  map[string]bool // to detect that vars doesn't need to be freed since it's being returned
-	infix_left_var_name string          // a && if expr
-	curr_var_name       []string        // curr var name on assignment
+	infix_left_var_name string // a && if expr
+	curr_var_name       []string // curr var name on assignment
 	called_fn_name      string
 	timers              &util.Timers = util.get_timers()
 	force_main_console  bool // true when @[console] used on fn main()
@@ -306,7 +307,7 @@ mut:
 	referenced_fns      shared map[string]bool // functions that have been referenced
 	nr_closures         int
 	expected_cast_type  ast.Type // for match expr of sumtypes
-	expected_arg_mut    bool     // generating a mutable fn parameter
+	expected_arg_mut    bool // generating a mutable fn parameter
 	or_expr_return_type ast.Type // or { 0, 1 } return type
 	anon_fn             &ast.AnonFn
 	tests_inited        bool
@@ -327,14 +328,14 @@ mut:
 	/////////
 	// out_parallel []strings.Builder
 	// out_idx      int
-	out_fn_start_pos     []int  // for generating multiple .c files, stores locations of all fn positions in `out` string builder
+	out_fn_start_pos     []int // for generating multiple .c files, stores locations of all fn positions in `out` string builder
 	static_modifier      string // for parallel_cc
 	static_non_parallel  string // for non -parallel_cc
-	has_reflection       bool   // v.reflection has been imported
-	has_debugger         bool   // $dbg has been used in the code
+	has_reflection       bool // v.reflection has been imported
+	has_debugger         bool // $dbg has been used in the code
 	reflection_strings   &map[string]int
 	defer_return_tmp_var string
-	veb_filter_fn_name   string   // veb__filter, used by $veb.html() for escaping strings in templates
+	veb_filter_fn_name   string // veb__filter, used by $veb.html() for escaping strings in templates
 	export_funcs         []string // for .dll export function names
 	//
 	type_default_impl_level    int
@@ -348,7 +349,7 @@ mut:
 	do_int_overflow_checks     bool // outside a `@[ignore_overflow] fn abc() {}` or a function in `builtin.overflow`
 	//
 	tid                  string // the thread id of the file processor in the thread pool (log it to debug issues in parallel cgen)
-	fid                  int    // the index of ast.File that is currently processed (log it to debug issues in parallel cgen)
+	fid                  int // the index of ast.File that is currently processed (log it to debug issues in parallel cgen)
 	mods_with_c_libs     map[string]bool
 	mods_with_c_includes map[string]bool
 }
@@ -356,12 +357,12 @@ mut:
 @[heap]
 pub struct GenOutput {
 pub:
-	header           string          // produced output for out.h (-parallel-cc)
+	header           string // produced output for out.h (-parallel-cc)
 	res_builder      strings.Builder // produced output (complete)
-	out_str          string          // produced output from g.out
-	out0_str         string          // helpers output (auto fns, dump fns) for out_0.c (-parallel-cc)
-	extern_str       string          // extern chunk for (-parallel-cc)
-	out_fn_start_pos []int           // fn decl positions
+	out_str          string // produced output from g.out
+	out0_str         string // helpers output (auto fns, dump fns) for out_0.c (-parallel-cc)
+	extern_str       string // extern chunk for (-parallel-cc)
+	out_fn_start_pos []int // fn decl positions
 }
 
 pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) GenOutput {
@@ -384,67 +385,67 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) GenO
 	}
 	mut reflection_strings := map[string]int{}
 	mut global_g := Gen{
-		fid:                           -1
-		tid:                           v_gettid().hex()
-		file:                          unsafe { nil }
-		out:                           strings.new_builder(512000)
-		cheaders:                      strings.new_builder(15000)
-		includes:                      strings.new_builder(100)
-		preincludes:                   strings.new_builder(100)
-		postincludes:                  strings.new_builder(100)
-		typedefs:                      strings.new_builder(100)
-		enum_typedefs:                 strings.new_builder(100)
-		type_definitions:              strings.new_builder(100)
-		sort_fn_definitions:           strings.new_builder(100)
-		alias_definitions:             strings.new_builder(100)
-		hotcode_definitions:           strings.new_builder(100)
-		channel_definitions:           strings.new_builder(100)
-		thread_definitions:            strings.new_builder(100)
-		comptime_definitions:          strings.new_builder(100)
-		definitions:                   strings.new_builder(100)
-		gowrappers:                    strings.new_builder(100)
-		auto_str_funcs:                strings.new_builder(100)
-		dump_funcs:                    strings.new_builder(100)
-		pcs_declarations:              strings.new_builder(100)
-		cov_declarations:              strings.new_builder(100)
-		embedded_data:                 strings.new_builder(1000)
-		interface_index_definitions:   strings.new_builder(100)
-		out_options_forward:           strings.new_builder(100)
-		out_options:                   strings.new_builder(100)
-		out_results_forward:           strings.new_builder(100)
-		out_results:                   strings.new_builder(100)
-		shared_types:                  strings.new_builder(100)
-		shared_functions:              strings.new_builder(100)
-		json_forward_decls:            strings.new_builder(100)
-		sql_buf:                       strings.new_builder(100)
-		table:                         table
-		pref:                          pref_
-		fn_decl:                       unsafe { nil }
-		anon_fn:                       unsafe { nil }
-		is_autofree:                   pref_.autofree
-		indent:                        -1
-		module_built:                  module_built
-		timers_should_print:           timers_should_print
-		timers:                        util.new_timers(
+		fid: -1
+		tid: v_gettid().hex()
+		file: unsafe { nil }
+		out: strings.new_builder(512000)
+		cheaders: strings.new_builder(15000)
+		includes: strings.new_builder(100)
+		preincludes: strings.new_builder(100)
+		postincludes: strings.new_builder(100)
+		typedefs: strings.new_builder(100)
+		enum_typedefs: strings.new_builder(100)
+		type_definitions: strings.new_builder(100)
+		sort_fn_definitions: strings.new_builder(100)
+		alias_definitions: strings.new_builder(100)
+		hotcode_definitions: strings.new_builder(100)
+		channel_definitions: strings.new_builder(100)
+		thread_definitions: strings.new_builder(100)
+		comptime_definitions: strings.new_builder(100)
+		definitions: strings.new_builder(100)
+		gowrappers: strings.new_builder(100)
+		auto_str_funcs: strings.new_builder(100)
+		dump_funcs: strings.new_builder(100)
+		pcs_declarations: strings.new_builder(100)
+		cov_declarations: strings.new_builder(100)
+		embedded_data: strings.new_builder(1000)
+		interface_index_definitions: strings.new_builder(100)
+		out_options_forward: strings.new_builder(100)
+		out_options: strings.new_builder(100)
+		out_results_forward: strings.new_builder(100)
+		out_results: strings.new_builder(100)
+		shared_types: strings.new_builder(100)
+		shared_functions: strings.new_builder(100)
+		json_forward_decls: strings.new_builder(100)
+		sql_buf: strings.new_builder(100)
+		table: table
+		pref: pref_
+		fn_decl: unsafe { nil }
+		anon_fn: unsafe { nil }
+		is_autofree: pref_.autofree
+		indent: -1
+		module_built: module_built
+		timers_should_print: timers_should_print
+		timers: util.new_timers(
 			should_print: timers_should_print
-			label:        'global_cgen'
+			label: 'global_cgen'
 		)
-		inner_loop:                    unsafe { &ast.empty_stmt }
-		field_data_type:               table.find_type('FieldData')
-		enum_data_type:                table.find_type('EnumData')
-		variant_data_type:             table.find_type('VariantData')
-		is_cc_msvc:                    pref_.ccompiler == 'msvc'
-		use_segfault_handler:          pref_.should_use_segfault_handler()
-		static_modifier:               if pref_.parallel_cc || pref_.is_o { 'static ' } else { '' }
-		static_non_parallel:           if !pref_.parallel_cc { 'static ' } else { '' }
-		has_reflection:                'v.reflection' in table.modules
-		has_debugger:                  'v.debug' in table.modules
-		reflection_strings:            &reflection_strings
-		generated_map_key_fns:         map[ast.Type]bool{}
-		boehm_keep_gen:                map[string]bool{}
-		closure_frame_arg_tmps:        map[int]string{}
-		generic_parts_cache:           []i8{len: table.type_symbols.len}
-		unwrap_generic_cache:          map[u64]ast.Type{}
+		inner_loop: unsafe { &ast.empty_stmt }
+		field_data_type: table.find_type('FieldData')
+		enum_data_type: table.find_type('EnumData')
+		variant_data_type: table.find_type('VariantData')
+		is_cc_msvc: pref_.ccompiler == 'msvc'
+		use_segfault_handler: pref_.should_use_segfault_handler()
+		static_modifier: if pref_.parallel_cc || pref_.is_o { 'static ' } else { '' }
+		static_non_parallel: if !pref_.parallel_cc { 'static ' } else { '' }
+		has_reflection: 'v.reflection' in table.modules
+		has_debugger: 'v.debug' in table.modules
+		reflection_strings: &reflection_strings
+		generated_map_key_fns: map[ast.Type]bool{}
+		boehm_keep_gen: map[string]bool{}
+		closure_frame_arg_tmps: map[int]string{}
+		generic_parts_cache: []i8{len: table.type_symbols.len}
+		unwrap_generic_cache: map[u64]ast.Type{}
 		resolved_scope_var_type_cache: map[u64]ast.Type{}
 	}
 
@@ -923,8 +924,7 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) GenO
 		helpers.write_string2('\n// V embedded data:\n', g.embedded_data.str())
 	}
 	if g.interface_index_definitions.len > 0 {
-		helpers.write_string2('\n// V interface index definitions:\n',
-			g.interface_index_definitions.str())
+		helpers.write_string2('\n// V interface index definitions:\n', g.interface_index_definitions.str())
 	}
 	if g.pref.parallel_cc {
 		helpers.writeln('\n// V global/const non-precomputed definitions:')
@@ -949,8 +949,7 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) GenO
 	}
 	if g.waiter_fn_definitions.len > 0 {
 		if g.pref.parallel_cc {
-			g.extern_out.write_string2('\n// V gowrappers waiter fns:\n',
-				g.waiter_fn_definitions.bytestr())
+			g.extern_out.write_string2('\n// V gowrappers waiter fns:\n', g.waiter_fn_definitions.bytestr())
 		}
 		helpers.write_string2('\n// V gowrappers waiter fns:\n', g.waiter_fn_definitions.str())
 	}
@@ -1028,11 +1027,11 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) GenO
 	unsafe { g.free_builders() }
 
 	return GenOutput{
-		header:           header
-		res_builder:      b
-		out_str:          out_str
-		out0_str:         shelpers
-		extern_str:       extern_out_str
+		header: header
+		res_builder: b
+		out_str: out_str
+		out0_str: shelpers
+		extern_str: extern_out_str
 		out_fn_start_pos: out_fn_start_pos
 	}
 }
@@ -1046,83 +1045,83 @@ fn cgen_process_one_file_cb(mut p pool.PoolProcessor, idx int, wid int) voidptr 
 	}
 	mut global_g := unsafe { &Gen(p.get_shared_context()) }
 	mut g := &Gen{
-		fid:                                idx
-		tid:                                v_gettid().hex()
-		file:                               file
-		out:                                strings.new_builder(512000)
-		cheaders:                           strings.new_builder(15000)
-		includes:                           strings.new_builder(100)
-		typedefs:                           strings.new_builder(100)
-		type_definitions:                   strings.new_builder(100)
-		sort_fn_definitions:                strings.new_builder(100)
-		alias_definitions:                  strings.new_builder(100)
-		definitions:                        strings.new_builder(100)
-		gowrappers:                         strings.new_builder(100)
-		waiter_fn_definitions:              strings.new_builder(100)
-		auto_str_funcs:                     strings.new_builder(100)
-		comptime_definitions:               strings.new_builder(100)
-		pcs_declarations:                   strings.new_builder(100)
-		cov_declarations:                   strings.new_builder(100)
-		hotcode_definitions:                strings.new_builder(100)
-		embedded_data:                      strings.new_builder(1000)
-		interface_index_definitions:        strings.new_builder(100)
-		out_options_forward:                strings.new_builder(100)
-		out_options:                        strings.new_builder(100)
-		out_results_forward:                strings.new_builder(100)
-		out_results:                        strings.new_builder(100)
-		shared_types:                       strings.new_builder(100)
-		shared_functions:                   strings.new_builder(100)
-		channel_definitions:                strings.new_builder(100)
-		thread_definitions:                 strings.new_builder(100)
-		json_forward_decls:                 strings.new_builder(100)
-		enum_typedefs:                      strings.new_builder(100)
-		sql_buf:                            strings.new_builder(100)
-		cleanup:                            strings.new_builder(100)
-		table:                              global_g.table
-		pref:                               global_g.pref
-		fn_decl:                            unsafe { nil }
-		anon_fn:                            unsafe { nil }
-		indent:                             -1
-		module_built:                       global_g.module_built
-		static_non_parallel:                global_g.static_non_parallel
-		static_modifier:                    global_g.static_modifier
-		timers:                             util.new_timers(
+		fid: idx
+		tid: v_gettid().hex()
+		file: file
+		out: strings.new_builder(512000)
+		cheaders: strings.new_builder(15000)
+		includes: strings.new_builder(100)
+		typedefs: strings.new_builder(100)
+		type_definitions: strings.new_builder(100)
+		sort_fn_definitions: strings.new_builder(100)
+		alias_definitions: strings.new_builder(100)
+		definitions: strings.new_builder(100)
+		gowrappers: strings.new_builder(100)
+		waiter_fn_definitions: strings.new_builder(100)
+		auto_str_funcs: strings.new_builder(100)
+		comptime_definitions: strings.new_builder(100)
+		pcs_declarations: strings.new_builder(100)
+		cov_declarations: strings.new_builder(100)
+		hotcode_definitions: strings.new_builder(100)
+		embedded_data: strings.new_builder(1000)
+		interface_index_definitions: strings.new_builder(100)
+		out_options_forward: strings.new_builder(100)
+		out_options: strings.new_builder(100)
+		out_results_forward: strings.new_builder(100)
+		out_results: strings.new_builder(100)
+		shared_types: strings.new_builder(100)
+		shared_functions: strings.new_builder(100)
+		channel_definitions: strings.new_builder(100)
+		thread_definitions: strings.new_builder(100)
+		json_forward_decls: strings.new_builder(100)
+		enum_typedefs: strings.new_builder(100)
+		sql_buf: strings.new_builder(100)
+		cleanup: strings.new_builder(100)
+		table: global_g.table
+		pref: global_g.pref
+		fn_decl: unsafe { nil }
+		anon_fn: unsafe { nil }
+		indent: -1
+		module_built: global_g.module_built
+		static_non_parallel: global_g.static_non_parallel
+		static_modifier: global_g.static_modifier
+		timers: util.new_timers(
 			should_print: global_g.timers_should_print
-			label:        'cgen_process_one_file_cb idx: ${idx}, wid: ${wid}'
+			label: 'cgen_process_one_file_cb idx: ${idx}, wid: ${wid}'
 		)
-		inner_loop:                         &ast.empty_stmt
-		field_data_type:                    global_g.table.find_type('FieldData')
-		enum_data_type:                     global_g.table.find_type('EnumData')
-		variant_data_type:                  global_g.table.find_type('VariantData')
-		array_sort_fn:                      global_g.array_sort_fn
-		array_sort_wrappers:                global_g.array_sort_wrappers
+		inner_loop: &ast.empty_stmt
+		field_data_type: global_g.table.find_type('FieldData')
+		enum_data_type: global_g.table.find_type('EnumData')
+		variant_data_type: global_g.table.find_type('VariantData')
+		array_sort_fn: global_g.array_sort_fn
+		array_sort_wrappers: global_g.array_sort_wrappers
 		generated_array_interface_cast_fns: global_g.generated_array_interface_cast_fns
-		waiter_fns:                         global_g.waiter_fns
-		threaded_fns:                       global_g.threaded_fns
-		str_fn_names:                       global_g.str_fn_names
-		anon_fns:                           global_g.anon_fns
-		options_forward:                    global_g.options_forward
-		results_forward:                    global_g.results_forward
-		done_options:                       global_g.done_options
-		done_results:                       global_g.done_results
-		late_chan_types:                    global_g.late_chan_types
-		is_autofree:                        global_g.pref.autofree
-		obf_table:                          global_g.obf_table
-		referenced_fns:                     global_g.referenced_fns
-		is_cc_msvc:                         global_g.is_cc_msvc
-		use_segfault_handler:               global_g.use_segfault_handler
-		done_typedef_phase:                 global_g.done_typedef_phase
-		array_typedefs:                     global_g.array_typedefs.clone()
-		written_array_typedefs:             global_g.written_array_typedefs
-		has_reflection:                     'v.reflection' in global_g.table.modules
-		has_debugger:                       'v.debug' in global_g.table.modules
-		reflection_strings:                 global_g.reflection_strings
-		generated_map_key_fns:              map[ast.Type]bool{}
-		boehm_keep_gen:                     global_g.boehm_keep_gen
-		closure_frame_arg_tmps:             map[int]string{}
-		generic_parts_cache:                []i8{len: global_g.table.type_symbols.len}
-		unwrap_generic_cache:               map[u64]ast.Type{}
-		resolved_scope_var_type_cache:      map[u64]ast.Type{}
+		waiter_fns: global_g.waiter_fns
+		threaded_fns: global_g.threaded_fns
+		str_fn_names: global_g.str_fn_names
+		anon_fns: global_g.anon_fns
+		options_forward: global_g.options_forward
+		results_forward: global_g.results_forward
+		done_options: global_g.done_options
+		done_results: global_g.done_results
+		late_chan_types: global_g.late_chan_types
+		is_autofree: global_g.pref.autofree
+		obf_table: global_g.obf_table
+		referenced_fns: global_g.referenced_fns
+		is_cc_msvc: global_g.is_cc_msvc
+		use_segfault_handler: global_g.use_segfault_handler
+		done_typedef_phase: global_g.done_typedef_phase
+		array_typedefs: global_g.array_typedefs.clone()
+		written_array_typedefs: global_g.written_array_typedefs
+		has_reflection: 'v.reflection' in global_g.table.modules
+		has_debugger: 'v.debug' in global_g.table.modules
+		reflection_strings: global_g.reflection_strings
+		generated_map_key_fns: map[ast.Type]bool{}
+		boehm_keep_gen: global_g.boehm_keep_gen
+		closure_frame_arg_tmps: map[int]string{}
+		generic_parts_cache: []i8{len: global_g.table.type_symbols.len}
+		unwrap_generic_cache: map[u64]ast.Type{}
+		resolved_scope_var_type_cache: map[u64]ast.Type{}
 	}
 	g.type_resolver = type_resolver.TypeResolver.new(global_g.table, g)
 	g.comptime = &g.type_resolver.info
@@ -1266,11 +1265,9 @@ pub fn (mut g Gen) init() {
 				// int64_t etc; allow a fallback to <stdint.h> for toolchains that do not ship <inttypes.h>.
 				g.cheaders.writeln(get_inttypes_or_stdint_include_text('The C compiler can not find <stdint.h>.${install_compiler_msg}'))
 				if g.pref.os == .ios {
-					g.cheaders.writeln(get_guarded_include_text('<stdbool.h>',
-						'The C compiler can not find <stdbool.h>.${install_compiler_msg}')) // bool, true, false
+					g.cheaders.writeln(get_guarded_include_text('<stdbool.h>', 'The C compiler can not find <stdbool.h>.${install_compiler_msg}')) // bool, true, false
 				}
-				g.cheaders.writeln(get_guarded_include_text('<stddef.h>',
-					'The C compiler can not find <stddef.h>.${install_compiler_msg}')) // size_t, ptrdiff_t
+				g.cheaders.writeln(get_guarded_include_text('<stddef.h>', 'The C compiler can not find <stddef.h>.${install_compiler_msg}')) // size_t, ptrdiff_t
 			}
 		}
 		if g.pref.nofloat {
@@ -1326,10 +1323,8 @@ pub fn (mut g Gen) init() {
 	g.definitions.writeln('// end of definitions #endif')
 	if g.pref.compile_defines_all.len > 0 {
 		g.comptime_definitions.writeln('// V compile time defines by -d or -define flags:')
-		g.comptime_definitions.writeln('//     All custom defines      : ' +
-			g.pref.compile_defines_all.join(','))
-		g.comptime_definitions.writeln('//     Turned ON custom defines: ' +
-			g.pref.compile_defines.join(','))
+		g.comptime_definitions.writeln('//     All custom defines      : ' + g.pref.compile_defines_all.join(','))
+		g.comptime_definitions.writeln('//     Turned ON custom defines: ' + g.pref.compile_defines.join(','))
 		for cdefine in g.pref.compile_defines {
 			g.comptime_definitions.writeln('#define CUSTOM_DEFINE_${cdefine}')
 		}
@@ -1558,8 +1553,7 @@ pub fn (mut g Gen) write_typeof_functions() {
 			if g.pref.build_mode != .build_module {
 				interface_idx_static_prefix := if g.pref.is_o { 'static ' } else { '' }
 				g.definitions.writeln('${interface_idx_static_prefix}u32 v_typeof_interface_idx_${sym.cname}(u32 sidx);')
-				g.writeln2('',
-					'${interface_idx_static_prefix}u32 v_typeof_interface_idx_${sym.cname}(u32 sidx) {')
+				g.writeln2('', '${interface_idx_static_prefix}u32 v_typeof_interface_idx_${sym.cname}(u32 sidx) {')
 				if g.pref.parallel_cc && interface_idx_static_prefix == '' {
 					g.extern_out.writeln('extern u32 v_typeof_interface_idx_${sym.cname}(u32 sidx);')
 				}
@@ -1606,9 +1600,7 @@ fn (mut g Gen) base_type(_t ast.Type) string {
 	if g.cur_fn != unsafe { nil } && g.cur_fn.generic_names.len > 0 && g.cur_concrete_types.len > 0 {
 		sym := g.table.sym(t)
 		if sym.name in g.cur_fn.generic_names {
-			if utyp := g.table.convert_generic_type(t.set_flag(.generic), g.cur_fn.generic_names,
-				g.cur_concrete_types)
-			{
+			if utyp := g.table.convert_generic_type(t.set_flag(.generic), g.cur_fn.generic_names, g.cur_concrete_types) {
 				t = utyp
 			}
 		}
@@ -1687,8 +1679,7 @@ fn (mut g Gen) generic_fn_name(types []ast.Type, before string) string {
 				typ_name = anon_cname
 			}
 		}
-		name += '_' + strings.repeat_string('__ptr__', normalized_typ.nr_muls()) +
-			typ_name.replace(' ', '_')
+		name += '_' + strings.repeat_string('__ptr__', normalized_typ.nr_muls()) + typ_name.replace(' ', '_')
 	}
 	return name
 }
@@ -2657,8 +2648,7 @@ fn (mut g Gen) cc_type(typ ast.Type, is_prefix_struct bool) string {
 		if has_alias {
 			// see comment at top of vlib/v/gen/c/utils.v
 			mut muttable := unsafe { &ast.Table(g.table) }
-			idx := muttable.find_or_register_generic_inst(ast.new_type(info.parent_idx),
-				unaliased_cts)
+			idx := muttable.find_or_register_generic_inst(ast.new_type(info.parent_idx), unaliased_cts)
 			if idx > 0 {
 				resolved_typ = ast.new_type(idx).derive_add_muls(resolved_typ)
 			}
@@ -2929,8 +2919,7 @@ pub fn (mut g Gen) write_typedef_types() {
 									if base !in g.done_options {
 										g.done_options << elem_base
 										g.typedefs.writeln('typedef struct ${styp_elem} ${styp_elem};')
-										g.type_definitions.writeln('${g.option_type_text(styp_elem,
-											elem_base)};')
+										g.type_definitions.writeln('${g.option_type_text(styp_elem, elem_base)};')
 									}
 									if styp !in g.done_options {
 										g.type_definitions.writeln('typedef ${fixed} ${styp} [${len}];')
@@ -2988,6 +2977,7 @@ pub fn (mut g Gen) write_typedef_types() {
 		}
 	}
 	g.write_sorted_fn_typesymbol_declaration()
+
 	// Generating interfaces after all the common types have been defined
 	// to prevent generating interface struct before definition of field types
 
@@ -3097,7 +3087,7 @@ pub fn (mut g Gen) write_alias_typesymbol_declaration(sym ast.TypeSymbol) {
 				mut parent_elem_styp := g.styp(sym.info.parent_type)
 				mut out := strings.new_builder(50)
 				for {
-					if mut elem_sym.info is ast.ArrayFixed {
+					if elem_sym.info is ast.ArrayFixed {
 						old := out.str()
 						out.clear()
 						out.writeln('typedef ${elem_sym.cname} ${parent_elem_styp} [${parent_elem_info.size}];')
@@ -3189,8 +3179,7 @@ pub fn (mut g Gen) write_interface_typesymbol_declaration(sym ast.TypeSymbol) {
 		}
 		vcname := vsym.cname
 		if vsym.info is ast.FnType {
-			g.type_definitions.writeln('\t\t${g.fn_ptr_decl_str(vsym.info as ast.FnType,
-				'_${vcname}')};')
+			g.type_definitions.writeln('\t\t${g.fn_ptr_decl_str(vsym.info as ast.FnType, '_${vcname}')};')
 		} else {
 			g.type_definitions.writeln('\t\t${vcname}* _${vcname};')
 		}
@@ -3247,8 +3236,11 @@ pub fn (mut g Gen) write_fn_typesymbol_declaration(sym ast.TypeSymbol) {
 			}
 		}
 		ret_typ :=
-			if !func.return_type.has_flag(.option) && !func.return_type.has_flag(.result) && g.table.sym(func.return_type).kind == .array_fixed { '_v_' } else { '' } +
-			g.styp(func.return_type)
+			if !func.return_type.has_flag(.option) && !func.return_type.has_flag(.result) && g.table.sym(func.return_type).kind == .array_fixed {
+				'_v_'
+			} else {
+				''
+			} + g.styp(func.return_type)
 		g.type_definitions.write_string('typedef ${ret_typ} (${call_conv_attr}*${fn_name})(')
 		for i, param in func.params {
 			const_prefix := if param.typ.is_any_kind_of_pointer() && !param.is_mut
@@ -3259,8 +3251,7 @@ pub fn (mut g Gen) write_fn_typesymbol_declaration(sym ast.TypeSymbol) {
 			}
 			if const_prefix != '' {
 				styp := g.styp(param.typ)
-				g.type_definitions.write_string(const_prefix +
-					g.const_pointer_param_type_name(param.typ, styp))
+				g.type_definitions.write_string(const_prefix + g.const_pointer_param_type_name(param.typ, styp))
 			} else {
 				g.type_definitions.write_string(g.fn_param_type_decl(param.typ, ''))
 			}
@@ -3535,7 +3526,7 @@ fn (mut g Gen) push_local_closure_cleanup_preserve_vars(vars []ast.Var, loop_pos
 		cname := g.var_cname(var)
 		if !g.closure_cleanup_keep_vars.any(it.cname == cname && it.loop_pos == loop_pos) {
 			g.closure_cleanup_keep_vars << ClosureCleanupKeep{
-				cname:    cname
+				cname: cname
 				loop_pos: loop_pos
 			}
 		}
@@ -3695,8 +3686,7 @@ fn local_closure_var_escapes_in_node(node ast.Node, name string) bool {
 								return true
 							}
 						}
-						return local_closure_var_escapes_in_node(ast.Node(ast.Expr(node.or_block)),
-							name)
+						return local_closure_var_escapes_in_node(ast.Node(ast.Expr(node.or_block)), name)
 					}
 				}
 				ast.ArrayInit {
@@ -3868,8 +3858,7 @@ fn (g &Gen) has_local_closure_vars_to_cleanup(pos int, line_nr int, free_parent_
 	if scope == unsafe { nil } || scope.start_pos == 0 {
 		return false
 	}
-	return g.has_local_closure_vars_to_cleanup2(scope, scope.start_pos, scope.end_pos, line_nr,
-		free_parent_scopes, stop_pos, stmts)
+	return g.has_local_closure_vars_to_cleanup2(scope, scope.start_pos, scope.end_pos, line_nr, free_parent_scopes, stop_pos, stmts)
 }
 
 fn (g &Gen) has_local_closure_vars_to_cleanup2(scope &ast.Scope, start_pos int, end_pos int,
@@ -3889,8 +3878,7 @@ fn (g &Gen) has_local_closure_vars_to_cleanup2(scope &ast.Scope, start_pos int, 
 		}
 	}
 	if g.local_closure_cleanup_can_visit_parent(scope, free_parent_scopes, stop_pos) {
-		return g.has_local_closure_vars_to_cleanup2(scope.parent, start_pos, end_pos, line_nr,
-			true, stop_pos, stmts)
+		return g.has_local_closure_vars_to_cleanup2(scope.parent, start_pos, end_pos, line_nr, true, stop_pos, stmts)
 	}
 	return false
 }
@@ -3904,8 +3892,7 @@ fn (mut g Gen) cleanup_local_closure_vars(pos int, line_nr int, free_parent_scop
 	if scope == unsafe { nil } || scope.start_pos == 0 {
 		return
 	}
-	g.cleanup_local_closure_vars2(scope, scope.start_pos, scope.end_pos, line_nr,
-		free_parent_scopes, stop_pos, stmts)
+	g.cleanup_local_closure_vars2(scope, scope.start_pos, scope.end_pos, line_nr, free_parent_scopes, stop_pos, stmts)
 }
 
 fn (mut g Gen) cleanup_local_closure_vars_before_jump(scope &ast.Scope, pos int, line_nr int,
@@ -3918,15 +3905,13 @@ fn (mut g Gen) cleanup_local_closure_vars_before_jump(scope &ast.Scope, pos int,
 		if cleanup_scope == unsafe { nil } || cleanup_scope.start_pos == 0 {
 			return
 		}
-		g.cleanup_local_closure_vars2(cleanup_scope, cleanup_scope.start_pos, pos, line_nr,
-			free_parent_scopes, stop_pos, stmts)
+		g.cleanup_local_closure_vars2(cleanup_scope, cleanup_scope.start_pos, pos, line_nr, free_parent_scopes, stop_pos, stmts)
 		return
 	}
 	if scope.start_pos == 0 || !g.local_closure_cleanup_scope_in_current_fn(scope) {
 		return
 	}
-	g.cleanup_local_closure_vars2(scope, scope.start_pos, pos, line_nr, free_parent_scopes,
-		stop_pos, stmts)
+	g.cleanup_local_closure_vars2(scope, scope.start_pos, pos, line_nr, free_parent_scopes, stop_pos, stmts)
 }
 
 fn (mut g Gen) cleanup_local_closure_vars2(scope &ast.Scope, start_pos int, end_pos int, line_nr int,
@@ -3947,8 +3932,7 @@ fn (mut g Gen) cleanup_local_closure_vars2(scope &ast.Scope, start_pos int, end_
 		}
 	}
 	if g.local_closure_cleanup_can_visit_parent(scope, free_parent_scopes, stop_pos) {
-		g.cleanup_local_closure_vars2(scope.parent, start_pos, end_pos, line_nr, true, stop_pos,
-			stmts)
+		g.cleanup_local_closure_vars2(scope.parent, start_pos, end_pos, line_nr, true, stop_pos, stmts)
 	}
 }
 
@@ -3959,8 +3943,7 @@ fn (g &Gen) return_needs_local_closure_cleanup(node ast.Return) bool {
 	if g.for_c_init_autofree_cleanup_vars.len > 0 {
 		return true
 	}
-	return g.has_local_closure_vars_to_cleanup(node.pos.pos - 1, node.pos.line_nr, true, -1,
-		g.fn_decl.stmts)
+	return g.has_local_closure_vars_to_cleanup(node.pos.pos - 1, node.pos.line_nr, true, -1, g.fn_decl.stmts)
 }
 
 fn (mut g Gen) cleanup_local_closure_vars_on_return(node ast.Return) {
@@ -3981,8 +3964,7 @@ fn (mut g Gen) cleanup_local_closure_vars_before_synthetic_return(scope &ast.Sco
 	}
 	old_closure_cleanup_ignore_keep := g.closure_cleanup_ignore_keep
 	g.closure_cleanup_ignore_keep = true
-	g.cleanup_local_closure_vars_before_jump(scope, pos.pos - 1, pos.line_nr, true, -1,
-		g.fn_decl.stmts)
+	g.cleanup_local_closure_vars_before_jump(scope, pos.pos - 1, pos.line_nr, true, -1, g.fn_decl.stmts)
 	g.closure_cleanup_ignore_keep = old_closure_cleanup_ignore_keep
 }
 
@@ -4000,7 +3982,9 @@ fn labeled_loop_scope(node &ast.Stmt) &ast.Scope {
 		ast.ForCStmt { node.scope }
 		ast.ForInStmt { node.scope }
 		ast.ForStmt { node.scope }
-		else { unsafe { nil } }
+		else {
+			return unsafe { nil }
+		}
 	}
 }
 
@@ -4064,8 +4048,7 @@ fn (mut g Gen) cleanup_scopes_before_labeled_jump(scope &ast.Scope, target_scope
 	for cleanup_scope := unsafe { scope }; cleanup_scope != unsafe { nil }; cleanup_scope = cleanup_scope.parent {
 		g.write_defer_stmts_before_labeled_jump_in_scope(cleanup_scope, pos)
 		if g.needs_scope_cleanup() && !g.is_builtin_mod {
-			g.autofree_scope_vars2_before_labeled_jump(cleanup_scope, cleanup_scope.start_pos,
-				pos.pos - 1, cleanup_scope == target_scope, keep_vars)
+			g.autofree_scope_vars2_before_labeled_jump(cleanup_scope, cleanup_scope.start_pos, pos.pos - 1, cleanup_scope == target_scope, keep_vars)
 		}
 		if cleanup_scope == target_scope || cleanup_scope.detached_from_parent {
 			break
@@ -4093,9 +4076,7 @@ fn (mut g Gen) autofree_scope_vars2_before_labeled_jump(scope &ast.Scope, start_
 			if obj.expr is ast.UnsafeExpr && obj.expr.expr is ast.CallExpr
 				&& (obj.expr.expr as ast.CallExpr).is_method {
 				if left_var := scope.objects[obj.expr.expr.left.str()] {
-					if func := g.table.find_method(g.table.final_sym(left_var.typ),
-						obj.expr.expr.name)
-					{
+					if func := g.table.find_method(g.table.final_sym(left_var.typ), obj.expr.expr.name) {
 						if func.attrs.contains('reused') && left_var is ast.Var
 							&& left_var.expr is ast.CastExpr {
 							if left_var.expr.expr.is_literal() {
@@ -4119,8 +4100,7 @@ fn (mut g Gen) cleanup_local_closure_vars_before_labeled_continue(scope &ast.Sco
 		return
 	}
 	for cleanup_scope := unsafe { scope }; cleanup_scope != unsafe { nil }; cleanup_scope = cleanup_scope.parent {
-		g.cleanup_local_closure_vars2(cleanup_scope, cleanup_scope.start_pos, pos.pos - 1,
-			pos.line_nr, false, -1, stmts)
+		g.cleanup_local_closure_vars2(cleanup_scope, cleanup_scope.start_pos, pos.pos - 1, pos.line_nr, false, -1, stmts)
 		if cleanup_scope.detached_from_parent {
 			break
 		}
@@ -4419,8 +4399,7 @@ fn (mut g Gen) stmts_with_tmp_var(stmts []ast.Stmt, tmp_var string) bool {
 			if stmt_pos.pos != 0 {
 				cleanup_scope := g.local_closure_cleanup_scope_at(stmt_pos.pos - 1)
 				if !g.should_skip_scope_cleanup(cleanup_scope) {
-					g.cleanup_local_closure_vars(stmt_pos.pos - 1, stmt_pos.line_nr, false, -1,
-						stmts)
+					g.cleanup_local_closure_vars(stmt_pos.pos - 1, stmt_pos.line_nr, false, -1, stmts)
 				}
 			}
 		}
@@ -4446,7 +4425,9 @@ fn (mut g Gen) gen_option_payload_ref(expr ast.PrefixExpr, ret_typ ast.Type, tmp
 	right_expr = right_expr.remove_par()
 	match right_expr {
 		ast.Ident, ast.IndexExpr, ast.SelectorExpr {}
-		else { return false }
+		else {
+			return false
+		}
 	}
 
 	opt_ptr_var := g.new_tmp_var()
@@ -4568,9 +4549,9 @@ fn (mut g Gen) expr_with_tmp_var(expr ast.Expr, expr_typ ast.Type, ret_typ ast.T
 			} else {
 				simple_assign =
 					((expr is ast.SelectorExpr || (expr is ast.Ident && !expr.is_auto_heap()))
-					&& ret_typ.is_ptr() && expr_typ.is_ptr() && expr_typ_is_option)
-					|| (expr_typ == ret_typ && !(expr_typ.has_option_or_result()
-					&& (expr_typ.is_ptr() || expr is ast.LambdaExpr)))
+						&& ret_typ.is_ptr() && expr_typ.is_ptr() && expr_typ_is_option)
+						|| (expr_typ == ret_typ && !(expr_typ.has_option_or_result()
+							&& (expr_typ.is_ptr() || expr is ast.LambdaExpr)))
 				// option ptr assignment simplification
 				if simple_assign {
 					g.write('${tmp_var} = ')
@@ -4851,8 +4832,8 @@ fn (mut g Gen) stmt(node ast.Stmt) {
 				g.autofree_variable(ast.Var{
 					name: discarded_ret_tmp_name
 					expr: node.expr
-					typ:  node.typ
-					pos:  node.pos
+					typ: node.typ
+					pos: node.pos
 				})
 				for g.autofree_scope_stmts.len > 0 {
 					g.write(g.autofree_scope_stmts.pop())
@@ -5083,12 +5064,12 @@ fn (mut g Gen) get_sumtype_casting_fn(got_ ast.Type, exp_ ast.Type) string {
 	g.sumtype_definitions[i] = true
 	g.sumtype_casting_fns << SumtypeCastingFn{
 		fn_name: fn_name
-		got:     if same_parent_sumtype_alias {
+		got: if same_parent_sumtype_alias {
 			got_
 		} else {
 			ast.idx_to_type(got_sym.idx).derive(got_)
 		}
-		exp:     if exp_.has_flag(.option) {
+		exp: if exp_.has_flag(.option) {
 			new_exp := exp.set_flag(.option)
 			new_exp
 		} else {
@@ -5369,7 +5350,8 @@ fn (mut g Gen) call_cfn_for_casting_expr(fname string, expr ast.Expr, exp ast.Ty
 			&& (expr.expr is ast.ArrayInit && expr.expr.is_fixed)
 
 		is_primitive_to_interface := is_interface_cast && expr is ast.Ident
-			&& g.table.sym(got).kind in [.i8, .i16, .i32, .int, .i64, .isize, .u8, .u16, .u32, .u64, .usize, .f32, .f64, .bool, .rune, .string]
+			&& g.table.sym(got).kind in [.i8, .i16, .i32, .int, .i64, .isize, .u8, .u16, .u32, .u64,
+				.usize, .f32, .f64, .bool, .rune, .string]
 		preserve_interface_field_aliasing := is_interface_cast
 			&& g.interface_cast_requires_field_aliasing(exp, interface_cast_source_expr)
 
@@ -5392,7 +5374,7 @@ fn (mut g Gen) call_cfn_for_casting_expr(fname string, expr ast.Expr, exp ast.Ty
 
 		if !is_cast_fixed_array_init && (is_comptime_variant || !expr_is_lvalue
 			|| (expr is ast.Ident && (expr.obj.is_simple_define_const()
-			|| (expr.obj is ast.Var && expr.obj.is_index_var)))
+				|| (expr.obj is ast.Var && expr.obj.is_index_var)))
 			|| is_primitive_to_interface || needs_interface_cast_promotion
 			|| needs_interface_value_copy) {
 			// Note: the `_to_sumtype_` family of functions do call memdup internally, making
@@ -5419,8 +5401,7 @@ fn (mut g Gen) call_cfn_for_casting_expr(fname string, expr ast.Expr, exp ast.Ty
 	if got_styp == 'none' && !g.cur_fn.return_type.has_flag(.option) {
 		g.write('(none){E_STRUCT}')
 	} else if is_comptime_variant {
-		ctyp := g.type_resolver.get_ct_type_or_default('${g.comptime.comptime_for_variant_var}.typ',
-			ast.void_type)
+		ctyp := g.type_resolver.get_ct_type_or_default('${g.comptime.comptime_for_variant_var}.typ', ast.void_type)
 		g.write(g.type_default(ctyp))
 	} else {
 		old_inside_sumtype_cast := g.inside_sumtype_cast
@@ -5650,9 +5631,12 @@ fn (mut g Gen) expr_with_fixed_array(expr ast.Expr, got_type_raw ast.Type, expec
 			g.write('memcpy(${prefix}${tmp_var}[${i}], ')
 			needs_addr :=
 				(actual_item_expr is ast.CallExpr && !actual_item_expr.return_type.is_ptr()
-				&& g.table.final_sym(actual_item_expr.return_type).kind !in [.array, .array_fixed])
-				|| (actual_item_expr is ast.InfixExpr && !actual_item_expr.promoted_type.is_ptr())
-				|| actual_item_expr is ast.StructInit
+					&& g.table.final_sym(actual_item_expr.return_type).kind !in [
+						.array,
+						.array_fixed,
+					])
+					|| (actual_item_expr is ast.InfixExpr && !actual_item_expr.promoted_type.is_ptr())
+					|| actual_item_expr is ast.StructInit
 			if needs_addr {
 				g.write('ADDR(${val_styp}, ')
 			}
@@ -5696,8 +5680,7 @@ fn (mut g Gen) gen_interface_to_interface_conversion(expr ast.Expr, expr_type as
 			if right_info.methods.len == 0 && right_info.fields.len == 0 {
 				info.conversions[to_type] = left_variants.clone()
 			} else {
-				info.conversions[to_type] = g.interface_conversion_variants(left_variants,
-					right_variants)
+				info.conversions[to_type] = g.interface_conversion_variants(left_variants, right_variants)
 			}
 		}
 	}
@@ -5759,8 +5742,7 @@ fn (mut g Gen) expr_with_array_element_upcast(expr ast.Expr, got_type ast.Type, 
 		}
 		g.writeln('${expected_elem_styp} ${converted_tmp} = ${fname}(&(((${concrete_got_elem_styp}*)${source_tmp}_orig.data)[${index_tmp}]));')
 	} else {
-		g.write_prepared_var(item_tmp, got_elem_type, got_elem_styp, source_tmp, index_tmp, true,
-			false)
+		g.write_prepared_var(item_tmp, got_elem_type, got_elem_styp, source_tmp, index_tmp, true, false)
 		g.write('${expected_elem_styp} ${converted_tmp} = ')
 		g.expr_with_cast(ast.Ident{
 			name: item_tmp
@@ -5884,8 +5866,7 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 			if exp_sym.info.is_generic {
 				fname = g.generic_fn_name(exp_sym.info.concrete_types, fname)
 			}
-			g.call_cfn_for_casting_expr(fname, expr, expected_type, concrete_got_type,
-				concrete_got_type, exp_styp, true, false, got_styp)
+			g.call_cfn_for_casting_expr(fname, expr, expected_type, concrete_got_type, concrete_got_type, exp_styp, true, false, got_styp)
 			g.inside_cast_in_heap--
 		} else {
 			got_styp := g.cc_type(concrete_got_type, true)
@@ -5925,19 +5906,17 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 			mut suppress_auto_heap_deref := false
 			if !concrete_got_is_ptr && expr is ast.Ident && g.resolved_ident_is_auto_heap(expr)
 				&& (g.expected_arg_mut
-				|| g.interface_cast_requires_field_aliasing(expected_type, expr)) {
+					|| g.interface_cast_requires_field_aliasing(expected_type, expr)) {
 				effective_got_is_ptr = true
 				suppress_auto_heap_deref = true
 			}
 			if suppress_auto_heap_deref {
 				old_inside_assign_fn_var := g.inside_assign_fn_var
 				g.inside_assign_fn_var = true
-				g.call_cfn_for_casting_expr(fname, expr, expected_type, concrete_got_type,
-					concrete_got_type, exp_styp, effective_got_is_ptr, got_is_fn, got_styp)
+				g.call_cfn_for_casting_expr(fname, expr, expected_type, concrete_got_type, concrete_got_type, exp_styp, effective_got_is_ptr, got_is_fn, got_styp)
 				g.inside_assign_fn_var = old_inside_assign_fn_var
 			} else {
-				g.call_cfn_for_casting_expr(fname, expr, expected_type, concrete_got_type,
-					concrete_got_type, exp_styp, effective_got_is_ptr, got_is_fn, got_styp)
+				g.call_cfn_for_casting_expr(fname, expr, expected_type, concrete_got_type, concrete_got_type, exp_styp, effective_got_is_ptr, got_is_fn, got_styp)
 			}
 		}
 		return
@@ -5984,8 +5963,7 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 		mut sumtype_got_styp := got_styp
 		mut sumtype_got_is_fn := got_is_fn
 		mut sumtype_got_is_ptr := got_is_ptr
-		nil_sumtype_variant := g.single_pointer_sumtype_nil_variant(unwrapped_expected_type, expr,
-			got_type)
+		nil_sumtype_variant := g.single_pointer_sumtype_nil_variant(unwrapped_expected_type, expr, got_type)
 		if nil_sumtype_variant != 0 {
 			sumtype_got_type = nil_sumtype_variant
 			sumtype_got_sym = g.table.sym(sumtype_got_type)
@@ -6040,8 +6018,7 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 					sumtype_got_is_ptr = sumtype_got_type.is_ptr()
 				}
 				actual_sumtype_got_type := sumtype_got_type
-				sumtype_got_type = g.find_matching_sumtype_variant(unwrapped_expected_type,
-					sumtype_got_type)
+				sumtype_got_type = g.find_matching_sumtype_variant(unwrapped_expected_type, sumtype_got_type)
 				sumtype_got_sym = g.table.sym(sumtype_got_type)
 				sumtype_got_styp = g.styp(sumtype_got_type)
 				sumtype_got_is_fn = sumtype_got_sym.kind == .function
@@ -6062,21 +6039,20 @@ fn (mut g Gen) expr_with_cast(expr ast.Expr, got_type_raw ast.Type, expected_typ
 					g.expr(expr)
 					g.writeln(';')
 					g.write2(stmt_str, ' ')
-					g.write('${fname}(&${tmp_var}, ${g.can_reuse_sumtype_variant_storage(unwrapped_expected_type,
-						sumtype_cast_got_is_ptr)})')
+					g.write('${fname}(&${tmp_var}, ${g.can_reuse_sumtype_variant_storage(unwrapped_expected_type, sumtype_cast_got_is_ptr)})')
 					return
 				} else {
-					g.call_cfn_for_casting_expr(fname, expr, expected_type, sumtype_got_type,
-						actual_sumtype_got_type, unwrapped_exp_sym.cname, sumtype_cast_got_is_ptr,
-						sumtype_got_is_fn, sumtype_got_styp)
+					g.call_cfn_for_casting_expr(fname, expr, expected_type, sumtype_got_type, actual_sumtype_got_type, unwrapped_exp_sym.cname, sumtype_cast_got_is_ptr, sumtype_got_is_fn, sumtype_got_styp)
 				}
 			}
 			return
 		}
 	}
 	// Generic dereferencing logic
-	neither_void := ast.voidptr_type !in [got_type.idx_type(), expected_type.idx_type()]
-		&& ast.nil_type !in [got_type.idx_type(), expected_type.idx_type()]
+	neither_void := ast.voidptr_type !in [got_type.idx_type(), expected_type.idx_type()] && ast.nil_type !in [
+		got_type.idx_type(),
+		expected_type.idx_type(),
+	]
 	if g.write_alias_to_shared_expr(expr, expected_type, got_type_raw) {
 		return
 	}
@@ -6329,7 +6305,11 @@ fn (mut g Gen) asm_stmt(stmt ast.AsmStmt) {
 		// the reverse order; Intel blocks already have the order expected by the assembler.
 		if template.args.len > 1 && !template.is_directive && !stmt.is_intel
 			&& stmt.arch !in [.arm64, .s390x, .ppc64le, .loongarch64, .rv64, .rv32] {
-			template.args.reverse_in_place()
+			// `template` is a copy, but its `args` still shares the AST's buffer, so this
+			// has to build a new array. Reversing in place would edit the AST itself, and
+			// a generic `asm` block is generated once per concrete type: the second
+			// instantiation would reverse the first one's result back.
+			template.args = template.args.reverse()
 		}
 
 		for i, arg in template.args {
@@ -6438,12 +6418,12 @@ fn (mut g Gen) asm_arg(arg ast.AsmArg, stmt ast.AsmStmt) {
 		ast.AsmRegister {
 			if stmt.is_intel {
 				g.write(arg.name)
-			} else if stmt.arch in [.rv64, .rv32, .arm64, .arm32] {
+			} else if stmt.arch in [.arm64, .arm32, .rv64, .rv32] {
 				// ARM and RISC-V assembly write register names plainly; the `%`
 				// prefix below is x86/AT&T syntax.
 				g.write('${arg.name}')
 			} else if stmt.arch == .loongarch64 {
-				g.write('$${arg.name}')
+				g.write('\$${arg.name}')
 			} else {
 				if !stmt.is_basic {
 					g.write('%') // escape percent with percent in extended assembly
@@ -6721,7 +6701,7 @@ fn (mut g Gen) map_fn_ptrs(key_sym ast.TypeSymbol) (string, string, string, stri
 			clone_fn = 'builtin__map_enum_fn(3,sizeof(${key_sym.cname}))'
 		}
 		.int {
-			$if new_int ? && x64 {
+			$if new_int ?&& x64 {
 				hash_fn = '&builtin__map_hash_int_8'
 				key_eq_fn = '&builtin__map_eq_int_8'
 				clone_fn = '&builtin__map_clone_int_8'
@@ -6830,8 +6810,7 @@ fn (mut g Gen) gen_fixed_array_map_key_fns(key_type ast.Type) {
 	hash_builder.writeln('\t${key_styp}* key = (${key_styp}*)pkey;')
 	hash_builder.writeln('\tu64 hash = 0;')
 	hash_builder.writeln('\tfor (${ast.int_type_name} i = 0; i < ${key_info.size}; ++i) {')
-	hash_builder.writeln('\t\thash = wyhash64(hash, ${g.fixed_array_map_key_hash_expr(key_info.elem_type,
-		'(*key)[i]')});')
+	hash_builder.writeln('\t\thash = wyhash64(hash, ${g.fixed_array_map_key_hash_expr(key_info.elem_type, '(*key)[i]')});')
 	hash_builder.writeln('\t}')
 	hash_builder.writeln('\treturn hash;')
 	hash_builder.writeln('}')
@@ -6848,8 +6827,7 @@ fn (mut g Gen) gen_fixed_array_map_key_fns(key_type ast.Type) {
 	clone_builder.writeln('\t${key_styp}* dest_key = (${key_styp}*)dest;')
 	clone_builder.writeln('\t${key_styp}* src_key = (${key_styp}*)pkey;')
 	clone_builder.writeln('\tfor (${ast.int_type_name} i = 0; i < ${key_info.size}; ++i) {')
-	g.fixed_array_map_key_clone_stmt(mut clone_builder, key_info.elem_type, '(*dest_key)[i]',
-		'(*src_key)[i]')
+	g.fixed_array_map_key_clone_stmt(mut clone_builder, key_info.elem_type, '(*dest_key)[i]', '(*src_key)[i]')
 	clone_builder.writeln('\t}')
 	clone_builder.writeln('}')
 	g.auto_fn_definitions << clone_builder.str()
@@ -7112,8 +7090,7 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 		ast.ChanInit {
 			resolved_elem_type := g.unwrap_generic(g.recheck_concrete_type(node.elem_type))
 			mut muttable := unsafe { &ast.Table(g.table) }
-			chan_type := ast.new_type(muttable.find_or_register_chan(resolved_elem_type,
-				resolved_elem_type.nr_muls() > 0))
+			chan_type := ast.new_type(muttable.find_or_register_chan(resolved_elem_type, resolved_elem_type.nr_muls() > 0))
 			g.note_chan_type_definition(chan_type)
 			elem_typ_str := g.styp(resolved_elem_type)
 			noscan := g.check_noscan(resolved_elem_type)
@@ -7171,9 +7148,9 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 			old_is_arraymap_set := g.is_arraymap_set
 			g.is_arraymap_set = false
 			g.spawn_and_go_expr(ast.SpawnExpr{
-				pos:       node.pos
+				pos: node.pos
 				call_expr: node.call_expr
-				is_expr:   node.is_expr
+				is_expr: node.is_expr
 			}, .go_)
 			g.is_arraymap_set = old_is_arraymap_set
 		}
@@ -7319,14 +7296,13 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 				g.write(')')
 			} else if node.op == .question {
 				mut expr_type := ast.void_type
-				if mut node.expr is ast.ComptimeSelector {
+				if node.expr is ast.ComptimeSelector {
 					if node.expr.field_expr is ast.SelectorExpr
 						&& g.comptime.is_comptime_selector_field_name(node.expr.field_expr, 'name') {
 						expr_type = g.unwrap_generic(g.comptime.comptime_for_field_type)
 					}
-				} else if mut node.expr is ast.Ident && node.expr.ct_expr {
-					expr_type = g.get_comptime_for_var_type(node.expr, g.type_resolver.get_type_or_default(ast.Expr(node.expr),
-						ast.void_type))
+				} else if node.expr is ast.Ident && node.expr.ct_expr {
+					expr_type = g.get_comptime_for_var_type(node.expr, g.type_resolver.get_type_or_default(ast.Expr(node.expr), ast.void_type))
 				}
 				if expr_type != ast.void_type {
 					if !expr_type.has_flag(.option) {
@@ -7337,10 +7313,10 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 				mut expr_str := ''
 				mut is_unwrapped := true
 				mut dot_or_ptr := '.'
-				if mut node.expr is ast.ComptimeSelector && node.expr.left is ast.Ident {
+				if node.expr is ast.ComptimeSelector && node.expr.left is ast.Ident {
 					// val.$(field.name)?
 					expr_str = g.gen_comptime_selector(node.expr)
-				} else if mut node.expr is ast.Ident && node.expr.ct_expr {
+				} else if node.expr is ast.Ident && node.expr.ct_expr {
 					// val?
 					expr_str = node.expr.name
 					is_unwrapped = !g.inside_assign
@@ -7459,7 +7435,7 @@ fn (mut g Gen) expr(node_ ast.Expr) {
 						g.writeln('${typ} ${tmp_var};')
 						mut stmts := []ast.Stmt{cap: 1}
 						stmts << ast.ExprStmt{
-							pos:  node.pos
+							pos: node.pos
 							expr: node.right
 						}
 						// This tmp var is local to this `&(...)`; don't inherit an enclosing
@@ -7853,8 +7829,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 								name_type = g.resolved_typeof_name_type(node.expr, name_type)
 							}
 						} else {
-							name_type = g.type_resolver.typeof_type(node.expr.expr, g.resolve_typeof_expr_type(node.expr.expr,
-								name_type))
+							name_type = g.type_resolver.typeof_type(node.expr.expr, g.resolve_typeof_expr_type(node.expr.expr, name_type))
 							if name_type == ast.void_type_idx {
 								name_type = node.name_type
 							}
@@ -7884,15 +7859,12 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 						if g.cur_fn != unsafe { nil } && g.cur_concrete_types.len > 0 {
 							resolved := g.resolve_typeof_in_generic(node.expr)
 							if resolved != 0 {
-								name_type = g.type_resolver.typeof_field_type(resolved,
-									node.field_name)
+								name_type = g.type_resolver.typeof_field_type(resolved, node.field_name)
 							} else {
-								name_type = g.type_resolver.typeof_field_type(g.type_resolver.typeof_type(node.expr.expr, g.resolve_typeof_expr_type(node.expr.expr,
-									name_type)), node.field_name)
+								name_type = g.type_resolver.typeof_field_type(g.type_resolver.typeof_type(node.expr.expr, g.resolve_typeof_expr_type(node.expr.expr, name_type)), node.field_name)
 							}
 						} else {
-							name_type = g.type_resolver.typeof_field_type(g.type_resolver.typeof_type(node.expr.expr, g.resolve_typeof_expr_type(node.expr.expr,
-								name_type)), node.field_name)
+							name_type = g.type_resolver.typeof_field_type(g.type_resolver.typeof_type(node.expr.expr, g.resolve_typeof_expr_type(node.expr.expr, name_type)), node.field_name)
 						}
 						// For mut params (auto_deref), strip pointer so that
 						// typeof(mut_param).idx == typeof(val_param).idx
@@ -7908,8 +7880,8 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 						g.write(int(g.unwrap_generic(name_type)).str())
 					}
 					return
-				} else if node.field_name in ['key_type', 'value_type', 'element_type',
-					'pointee_type', 'payload_type'] {
+				} else if node.field_name in ['key_type', 'value_type', 'element_type', 'pointee_type',
+					'payload_type'] {
 					// `T.<field_name>`, `typeof(expr).<field_name>`
 					mut name_type := node.name_type
 					if node.expr is ast.TypeOf {
@@ -7924,8 +7896,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 							name_type = g.resolved_typeof_name_type(node.expr, name_type)
 						}
 					} else if name_type == 0 {
-						name_type = g.type_resolver.typeof_type(node.expr, g.resolve_typeof_expr_type(node.expr,
-							name_type))
+						name_type = g.type_resolver.typeof_type(node.expr, g.resolve_typeof_expr_type(node.expr, name_type))
 					}
 					name_type = g.type_resolver.typeof_field_type(name_type, node.field_name)
 					g.write(int(name_type).str())
@@ -7938,12 +7909,10 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 							if resolved != 0 {
 								name_type = resolved
 							} else {
-								name_type = g.type_resolver.typeof_type(node.expr.expr, g.resolve_typeof_expr_type(node.expr.expr,
-									name_type))
+								name_type = g.type_resolver.typeof_type(node.expr.expr, g.resolve_typeof_expr_type(node.expr.expr, name_type))
 							}
 						} else {
-							name_type = g.type_resolver.typeof_type(node.expr.expr, g.resolve_typeof_expr_type(node.expr.expr,
-								name_type))
+							name_type = g.type_resolver.typeof_type(node.expr.expr, g.resolve_typeof_expr_type(node.expr.expr, name_type))
 						}
 					} else {
 						name_type = g.unwrap_generic(name_type)
@@ -7963,12 +7932,10 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 							if resolved != 0 {
 								name_type = resolved
 							} else {
-								name_type = g.type_resolver.typeof_type(node.expr.expr, g.resolve_typeof_expr_type(node.expr.expr,
-									name_type))
+								name_type = g.type_resolver.typeof_type(node.expr.expr, g.resolve_typeof_expr_type(node.expr.expr, name_type))
 							}
 						} else {
-							name_type = g.type_resolver.typeof_type(node.expr.expr, g.resolve_typeof_expr_type(node.expr.expr,
-								name_type))
+							name_type = g.type_resolver.typeof_type(node.expr.expr, g.resolve_typeof_expr_type(node.expr.expr, name_type))
 						}
 					}
 					// `typeof(expr).indirections`
@@ -7996,8 +7963,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 				}
 			}
 		}
-		resolved_expr_type := g.resolved_expr_type(node.expr, g.type_resolver.get_type_or_default(node.expr,
-			ast.void_type))
+		resolved_expr_type := g.resolved_expr_type(node.expr, g.type_resolver.get_type_or_default(node.expr, ast.void_type))
 		if resolved_expr_type == 0 || resolved_expr_type == ast.void_type {
 			g.checker_bug('unexpected SelectorExpr.expr_type = 0', node.pos)
 		}
@@ -8038,8 +8004,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	if selector_expr_expr is ast.Ident {
 		selector_ident := selector_expr_expr as ast.Ident
 		if selector_ident.obj is ast.Var && selector_ident.obj.smartcasts.len > 0 {
-			lhs_expr_type = g.unwrap_generic(g.recheck_concrete_type(g.exposed_smartcast_type(selector_ident.obj.orig_type,
-				selector_ident.obj.smartcasts.last(), selector_ident.obj.is_mut)))
+			lhs_expr_type = g.unwrap_generic(g.recheck_concrete_type(g.exposed_smartcast_type(selector_ident.obj.orig_type, selector_ident.obj.smartcasts.last(), selector_ident.obj.is_mut)))
 		} else {
 			resolved_current_type := g.resolve_current_fn_generic_param_type(selector_ident.name)
 			resolved_scope_type := g.resolved_expr_type(selector_ident, node.expr_type)
@@ -8047,10 +8012,14 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 				lhs_expr_type = resolved_current_type
 			} else if resolved_scope_type != 0 {
 				if node.expr_type.has_option_or_result()
-					|| g.table.sym(g.unwrap_generic(node.expr_type)).kind in [.interface, .sum_type, .any]
+					|| g.table.sym(g.unwrap_generic(node.expr_type)).kind in [
+						.interface,
+						.sum_type,
+						.any,
+					]
 					|| (selector_ident.obj is ast.Var && selector_ident.obj.smartcasts.len > 0)
 					|| (g.cur_fn != unsafe { nil } && g.cur_concrete_types.len > 0
-					&& resolved_scope_type != node.expr_type) {
+						&& resolved_scope_type != node.expr_type) {
 					lhs_expr_type = resolved_scope_type
 				}
 			} else if selector_ident.obj is ast.Var && (selector_ident.obj.typ.has_flag(.generic)
@@ -8216,8 +8185,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 					}
 					if field_sym.kind == .interface && smartcasts.len > 0 {
 						smartcasts = [
-							g.exposed_smartcast_type(field.orig_type, smartcasts.last(),
-								field.is_mut),
+							g.exposed_smartcast_type(field.orig_type, smartcasts.last(), field.is_mut),
 						]
 					}
 					resolved_scope_field_typ := if g.cur_fn != unsafe { nil }
@@ -8394,8 +8362,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	}
 	mut is_interface_smartcast_selector := false
 	if node.expr is ast.SelectorExpr {
-		base_selector_type := g.unwrap_generic(g.resolved_expr_type(node.expr.expr,
-			node.expr.expr_type))
+		base_selector_type := g.unwrap_generic(g.resolved_expr_type(node.expr.expr, node.expr.expr_type))
 		if node.expr.field_name.starts_with('_')
 			&& g.table.final_sym(base_selector_type).kind == .interface {
 			is_interface_smartcast_selector = true
@@ -8535,8 +8502,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 				}
 				if !is_find {
 					has_embed = node.from_embed_types.len > 0
-					last_embed_is_ptr = g.write_selector_expr_embed_name(node,
-						node.from_embed_types)
+					last_embed_is_ptr = g.write_selector_expr_embed_name(node, node.from_embed_types)
 				}
 			} else {
 				has_embed = node.from_embed_types.len > 0
@@ -8559,8 +8525,7 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 		|| is_interface_smartcast_selector
 	is_interface_smartcast_lhs := is_interface_smartcast_expr || is_interface_smartcast_selector
 	exposed_interface_smartcast_type := if is_interface_smartcast_expr {
-		g.exposed_smartcast_type(smartcast_expr_var.orig_type,
-			smartcast_expr_var.smartcasts.last(), smartcast_expr_var.is_mut)
+		g.exposed_smartcast_type(smartcast_expr_var.orig_type, smartcast_expr_var.smartcasts.last(), smartcast_expr_var.is_mut)
 	} else {
 		ast.void_type
 	}
@@ -8590,8 +8555,8 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	// smartcast type, the pointer is NOT exposed (ident adds `*` dereference).
 	interface_smartcast_selector_emits_ptr := is_interface_smartcast_selector
 		|| (is_interface_smartcast_expr
-		&& g.table.final_sym(g.unwrap_generic(smartcast_expr_var.smartcasts.last())).kind != .interface
-		&& exposed_interface_smartcast_type.is_ptr())
+			&& g.table.final_sym(g.unwrap_generic(smartcast_expr_var.smartcasts.last())).kind != .interface
+			&& exposed_interface_smartcast_type.is_ptr())
 	// Interface→interface smartcast: the conversion `I_X_as_I_Y(parent)` returns
 	// a struct value, not a pointer, so field access must use `.`, not `->`.
 	is_option_unwrapped_interface_ptr := is_interface_smartcast_expr
@@ -8609,13 +8574,13 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	} else {
 		field_is_opt || expr_is_auto_heap || interface_smartcast_selector_emits_ptr
 			|| (is_interface_smartcast_lhs && !interface_smartcast_expr_is_dereferenced
-			&& !smartcast_ident_already_dereferenced) || (((!is_dereferenced
+				&& !smartcast_ident_already_dereferenced) || (((!is_dereferenced
 			&& !is_interface_smartcast_lhs && !smartcast_ident_already_dereferenced
 			&& unwrapped_expr_type.is_ptr()) || sym.kind == .chan || alias_to_ptr
 			|| g.type_resolves_to_shared(unwrapped_expr_type)) && node.from_embed_types.len == 0)
 			|| (node.expr.is_as_cast() && g.inside_smartcast)
 			|| (!opt_ptr_already_deref && unwrapped_expr_type.is_ptr()
-			&& !is_interface_smartcast_lhs && !smartcast_ident_already_dereferenced)
+				&& !is_interface_smartcast_lhs && !smartcast_ident_already_dereferenced)
 	}
 	if (!has_embed && left_is_ptr) || (has_embed && last_embed_is_ptr) {
 		g.write('->')
@@ -8712,7 +8677,7 @@ fn (mut g Gen) resolved_typeof_name_type(node ast.TypeOf, default_type ast.Type)
 	if g.type_resolver.info.is_comptime(node.expr)
 		|| (node.expr is ast.SelectorExpr && node.expr.is_field_typ)
 		|| (node.expr is ast.SelectorExpr && node.expr.name_type != 0
-		&& node.expr.field_name in ['key_type', 'value_type', 'element_type'])
+			&& node.expr.field_name in ['key_type', 'value_type', 'element_type'])
 		|| (node.expr is ast.SelectorExpr && node.expr.expr_type != 0) {
 		resolved_type := g.type_resolver.typeof_type(node.expr, default_type)
 		if resolved_type != ast.void_type_idx && resolved_type != 0 {
@@ -8915,9 +8880,17 @@ fn (mut g Gen) boehm_collect_keep_alive_helper_name(typ ast.Type) string {
 	if sym.kind !in [.string, .array, .struct] {
 		return ''
 	}
+	if g.type_has_pointer_bearing_nested_c_aggregate(resolved_typ) {
+		return ''
+	}
 	if sym.kind == .array {
 		info := sym.info as ast.Array
 		if !g.contains_ptr(info.elem_type) {
+			return ''
+		}
+	}
+	if sym.kind == .struct && sym.language != .v {
+		if !g.c_type_has_ptr(resolved_typ) {
 			return ''
 		}
 	}
@@ -8925,8 +8898,7 @@ fn (mut g Gen) boehm_collect_keep_alive_helper_name(typ ast.Type) string {
 	if styp.ends_with('_ptr') {
 		return ''
 	}
-	fn_name := '__v_boehm_collect_keepalive_${g.stable_type_symbol_hash(resolved_typ)}_${styp.replace('*',
-		'_ptr').replace(' ', '_')}'
+	fn_name := '__v_boehm_collect_keepalive_${g.stable_type_symbol_hash(resolved_typ)}_${styp.replace('*', '_ptr').replace(' ', '_')}'
 	mut should_generate := false
 	lock g.boehm_keep_gen {
 		if fn_name !in g.boehm_keep_gen {
@@ -8949,9 +8921,10 @@ fn (mut g Gen) boehm_collect_keep_alive_helper_name(typ ast.Type) string {
 			sb.writeln('\treturn idx;')
 		}
 		.array {
-			info := sym.info as ast.Array
-			elem_styp := g.styp(info.elem_type)
-			elem_helper := g.boehm_collect_keep_alive_helper_name(info.elem_type)
+			// Arrays whose elements contain pointers use Boehm-scanned backing storage:
+			// check_noscan only selects atomic storage for pointer-free element types.
+			// Keeping that one backing block reachable therefore keeps every nested
+			// allocation reachable too, without walking all elements at every call site.
 			sb.writeln('\tif (it->data == 0) {')
 			sb.writeln('\t\treturn idx;')
 			sb.writeln('\t}')
@@ -8961,11 +8934,6 @@ fn (mut g Gen) boehm_collect_keep_alive_helper_name(typ ast.Type) string {
 			sb.writeln('\t}')
 			sb.writeln('\tif (out != 0) { out[idx] = _v_keep_root; }')
 			sb.writeln('\tidx++;')
-			if elem_helper != '' {
-				sb.writeln('\tfor (int _v_keep_i = 0; _v_keep_i < it->len; ++_v_keep_i) {')
-				sb.writeln('\t\tidx = ${elem_helper}(&(((${elem_styp}*)it->data)[_v_keep_i]), out, idx);')
-				sb.writeln('\t}')
-			}
 			sb.writeln('\treturn idx;')
 		}
 		.struct {
@@ -9050,6 +9018,124 @@ fn (mut g Gen) type_needs_deep_scope_gc_pin(typ ast.Type) bool {
 			return false
 		}
 	}
+}
+
+fn (mut g Gen) c_type_has_ptr(typ ast.Type) bool {
+	mut memo := map[ast.Type]bool{}
+	return g.c_type_has_ptr_memo(typ, mut memo)
+}
+
+fn (mut g Gen) c_type_has_ptr_memo(typ ast.Type, mut memo map[ast.Type]bool) bool {
+	if typ == 0 {
+		return false
+	}
+	unaliased_typ := g.table.fully_unaliased_type(g.unwrap_generic(typ))
+	if unaliased_typ.has_option_or_result() || unaliased_typ.is_any_kind_of_pointer()
+		|| unaliased_typ.is_ptr() {
+		return true
+	}
+	if unaliased_typ in memo {
+		return memo[unaliased_typ]
+	}
+	memo[unaliased_typ] = false
+	sym := g.table.final_sym(unaliased_typ)
+	if sym.is_pointer() {
+		memo[unaliased_typ] = true
+		return true
+	}
+	result := match sym.kind {
+		.i8, .i16, .i32, .int, .i64, .isize, .u8, .u16, .u32, .u64, .usize, .f32, .f64, .char, .rune, .bool, .enum {
+			false
+		}
+		.array_fixed {
+			info := sym.info as ast.ArrayFixed
+			g.c_type_has_ptr_memo(info.elem_type, mut memo)
+		}
+		.struct {
+			info := sym.info as ast.Struct
+			mut has_ptr := false
+			for embed in info.embeds {
+				if g.c_type_has_ptr_memo(embed, mut memo) {
+					has_ptr = true
+					break
+				}
+			}
+			if !has_ptr {
+				for field in info.fields {
+					if g.c_type_has_ptr_memo(field.typ, mut memo) {
+						has_ptr = true
+						break
+					}
+				}
+			}
+			has_ptr
+		}
+		else {
+			true
+		}
+	}
+	memo[unaliased_typ] = result
+	return result
+}
+
+fn (mut g Gen) type_has_pointer_bearing_nested_c_aggregate(typ ast.Type) bool {
+	mut memo := map[ast.Type]bool{}
+	mut ptr_memo := map[ast.Type]bool{}
+	return g.type_has_pointer_bearing_nested_c_aggregate_memo(typ, false, mut memo, mut ptr_memo)
+}
+
+fn (mut g Gen) type_has_pointer_bearing_nested_c_aggregate_memo(typ ast.Type, is_nested bool,
+	mut memo map[ast.Type]bool, mut ptr_memo map[ast.Type]bool) bool {
+	if typ == 0 || typ.has_option_or_result() || typ.is_any_kind_of_pointer() || typ.is_ptr() {
+		return false
+	}
+	mut resolved_typ := g.unwrap_generic(g.recheck_concrete_type(typ))
+	if resolved_typ == 0 {
+		resolved_typ = g.unwrap_generic(typ)
+	}
+	resolved_typ = g.table.fully_unaliased_type(resolved_typ)
+	if resolved_typ == 0 || resolved_typ.has_option_or_result()
+		|| resolved_typ.is_any_kind_of_pointer() || resolved_typ.is_ptr() {
+		return false
+	}
+	if resolved_typ in memo {
+		return memo[resolved_typ]
+	}
+	memo[resolved_typ] = false
+	sym := g.table.final_sym(resolved_typ)
+	result := match sym.kind {
+		.array_fixed {
+			info := sym.info as ast.ArrayFixed
+			g.type_has_pointer_bearing_nested_c_aggregate_memo(info.elem_type, true, mut memo, mut ptr_memo)
+		}
+		.struct {
+			info := sym.info as ast.Struct
+			mut has_pointer_bearing_nested_c_aggregate := is_nested && sym.language != .v
+				&& g.c_type_has_ptr_memo(resolved_typ, mut ptr_memo)
+			if !has_pointer_bearing_nested_c_aggregate {
+				for embed in info.embeds {
+					if g.type_has_pointer_bearing_nested_c_aggregate_memo(embed, true, mut memo, mut ptr_memo) {
+						has_pointer_bearing_nested_c_aggregate = true
+						break
+					}
+				}
+			}
+			if !has_pointer_bearing_nested_c_aggregate {
+				for field in info.fields {
+					if g.type_has_pointer_bearing_nested_c_aggregate_memo(field.typ, true, mut memo, mut ptr_memo) {
+						has_pointer_bearing_nested_c_aggregate = true
+						break
+					}
+				}
+			}
+			has_pointer_bearing_nested_c_aggregate
+		}
+		else {
+			false
+		}
+	}
+	memo[resolved_typ] = result
+	return result
 }
 
 fn (mut g Gen) scope_var_needs_deep_gc_pin(obj ast.Var) bool {
@@ -9142,6 +9228,17 @@ fn (mut g Gen) scope_gc_pin_pregen(node_pos int) []ScopeGcPin {
 		cvar_name := g.scope_gc_pin_expr(obj) or { continue }
 		collect_helper_name := g.boehm_collect_keep_alive_helper_name(obj.typ)
 		if collect_helper_name == '' {
+			if !opened_scope {
+				g.writeln('{')
+				opened_scope = true
+			}
+			// Some C aggregates cannot safely be named in a generated helper prototype.
+			// Keep the whole object conservatively reachable without referring to its type.
+			tmp_name := g.new_tmp_var()
+			g.writeln('voidptr ${tmp_name} = &${cvar_name};')
+			pins << ScopeGcPin{
+				post_stmt: 'GC_reachable_here(${tmp_name});'
+			}
 			continue
 		}
 		if !opened_scope {
@@ -9461,8 +9558,7 @@ fn (mut g Gen) debugger_stmt(node ast.DebuggerStmt) {
 
 					dot := if obj.orig_type.is_ptr() || obj.is_auto_heap { '->' } else { '.' }
 					if obj.ct_type_var == .smartcast {
-						cur_variant_sym := g.table.sym(g.unwrap_generic(g.type_resolver.get_ct_type_or_default('${g.comptime.comptime_for_variant_var}.typ',
-							ast.void_type)))
+						cur_variant_sym := g.table.sym(g.unwrap_generic(g.type_resolver.get_ct_type_or_default('${g.comptime.comptime_for_variant_var}.typ', ast.void_type)))
 						param_var.write_string('${cobj_name}${dot}_${cur_variant_sym.cname}')
 					} else {
 						variant_typ := cast_sym.aggregate_variant_type(g.aggregate_type_idx)
@@ -9690,8 +9786,7 @@ fn (mut g Gen) lock_expr(node ast.LockExpr) {
 		g.writeln(');')
 	} else {
 		mtxs = g.new_tmp_var()
-		g.writeln2('uintptr_t _arr_${mtxs}[${node.lockeds.len}];',
-			'bool _isrlck_${mtxs}[${node.lockeds.len}];')
+		g.writeln2('uintptr_t _arr_${mtxs}[${node.lockeds.len}];', 'bool _isrlck_${mtxs}[${node.lockeds.len}];')
 		mut j := 0
 		for i, is_rlock in node.is_rlock {
 			if !is_rlock {
@@ -9721,10 +9816,8 @@ fn (mut g Gen) lock_expr(node ast.LockExpr) {
 		} else {
 			g.writeln('__sort_ptr(_arr_${mtxs}, _isrlck_${mtxs}, ${node.lockeds.len});')
 		}
-		g.writeln2('for (${ast.int_type_name} ${mtxs}=0; ${mtxs}<${node.lockeds.len}; ${mtxs}++) {',
-			'\tif (${mtxs} && _arr_${mtxs}[${mtxs}] == _arr_${mtxs}[${mtxs}-1]) continue;')
-		g.writeln2('\tif (_isrlck_${mtxs}[${mtxs}])',
-			'\t\tsync__RwMutex_rlock((sync__RwMutex*)_arr_${mtxs}[${mtxs}]);')
+		g.writeln2('for (${ast.int_type_name} ${mtxs}=0; ${mtxs}<${node.lockeds.len}; ${mtxs}++) {', '\tif (${mtxs} && _arr_${mtxs}[${mtxs}] == _arr_${mtxs}[${mtxs}-1]) continue;')
+		g.writeln2('\tif (_isrlck_${mtxs}[${mtxs}])', '\t\tsync__RwMutex_rlock((sync__RwMutex*)_arr_${mtxs}[${mtxs}]);')
 		g.writeln2('\telse', '\t\tsync__RwMutex_lock((sync__RwMutex*)_arr_${mtxs}[${mtxs}]);')
 		g.writeln('}')
 	}
@@ -9770,8 +9863,7 @@ fn (mut g Gen) unlock_locks() {
 }
 
 fn (mut g Gen) lock_expr_mtx(expr ast.Expr) {
-	mut expr_typ := g.resolved_expr_type(expr, g.type_resolver.get_type_or_default(expr,
-		ast.void_type))
+	mut expr_typ := g.resolved_expr_type(expr, g.type_resolver.get_type_or_default(expr, ast.void_type))
 	expr_typ = g.unwrap_generic(g.recheck_concrete_type(expr_typ))
 	expr_sym :=
 		g.table.final_sym(g.table.unaliased_type(expr_typ.clear_flags(.shared_f, .atomic_f)))
@@ -9791,8 +9883,7 @@ fn (mut g Gen) lock_expr_mtx(expr ast.Expr) {
 }
 
 fn (mut g Gen) map_init(node ast.MapInit) {
-	unwrap_key_typ, unwrap_val_typ_ := g.resolved_map_key_value_types(node.typ, node.key_type,
-		node.value_type)
+	unwrap_key_typ, unwrap_val_typ_ := g.resolved_map_key_value_types(node.typ, node.key_type, node.value_type)
 	unwrap_val_typ := unwrap_val_typ_.clear_flag(.result)
 	key_typ_str := g.styp(unwrap_key_typ)
 	value_typ_str := g.styp(unwrap_val_typ)
@@ -10065,7 +10156,7 @@ fn (mut g Gen) is_comptime_for_var(node ast.Ident) bool {
 		field_typ := g.comptime.comptime_for_field_type
 		return (obj_typ.has_flag(.option) && field_typ.has_flag(.option))
 			|| (obj_typ.clear_flag(.option).idx() == field_typ.clear_flag(.option).idx()
-			&& obj_typ.has_flag(.option))
+				&& obj_typ.has_flag(.option))
 	}
 	return false
 }
@@ -10157,7 +10248,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 			has_resolved_var = true
 			if g.cur_fn != unsafe { nil } && g.cur_concrete_types.len > 0 && obj_smartcasts.len > 0
 				&& obj_smartcasts.any(it.has_flag(.generic)
-				|| g.type_has_unresolved_generic_parts(it)) {
+					|| g.type_has_unresolved_generic_parts(it)) {
 				resolved_var.smartcasts = obj_smartcasts
 			}
 		}
@@ -10198,7 +10289,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 				}
 				prefer_scope_runtime_type := resolved_scope_type != 0 && (!has_resolved_var
 					|| (!resolved_var.is_unwrapped && resolved_var.smartcasts.len == 0
-					&& resolved_var.orig_type == ast.no_type))
+						&& resolved_var.orig_type == ast.no_type))
 				mut runtime_type := if prefer_scope_runtime_type {
 					resolved_scope_type
 				} else if has_resolved_var && resolved_var.typ != 0 {
@@ -10207,8 +10298,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 					node.obj.typ
 				}
 				if !prefer_scope_runtime_type && node.name in g.type_resolver.type_map {
-					resolved_runtime_type := g.type_resolver.get_ct_type_or_default(node.name,
-						runtime_type)
+					resolved_runtime_type := g.type_resolver.get_ct_type_or_default(node.name, runtime_type)
 					if resolved_runtime_type != 0 && resolved_runtime_type != ast.void_type {
 						runtime_type = resolved_runtime_type
 					}
@@ -10259,8 +10349,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 					} else {
 						comptime_type
 					}
-					g.or_block(var_name, node.or_expr, g.or_type_with_auto_deref(node,
-						or_return_type))
+					g.or_block(var_name, node.or_expr, g.or_type_with_auto_deref(node, or_return_type))
 					g.writeln(stmt_str)
 				}
 				return
@@ -10431,7 +10520,7 @@ fn (mut g Gen) ident(node ast.Ident) {
 			// smartcast unwrap to access the inner struct.
 			skip_smartcasts := g.is_comptime_for_var(node)
 				|| (g.is_assign_lhs && resolved_var.orig_type.has_flag(.option)
-				&& !g.inside_selector_lhs)
+					&& !g.inside_selector_lhs)
 			if has_resolved_var && resolved_var.smartcasts.len > 0 && !skip_smartcasts {
 				mut smartcast_types := resolved_var.smartcasts.clone()
 				if resolved_var.orig_type.has_flag(.option) {
@@ -10448,10 +10537,9 @@ fn (mut g Gen) ident(node ast.Ident) {
 				}
 				interface_source_is_interface :=
 					g.table.final_sym(g.unwrap_generic(resolved_var.typ)).kind == .interface
-					|| (resolved_var.orig_type != 0
-					&& g.table.final_sym(g.unwrap_generic(resolved_var.orig_type)).kind == .interface)
-				current_smartcast_type := g.exposed_smartcast_type(resolved_var.orig_type,
-					smartcast_types.last(), resolved_var.is_mut)
+						|| (resolved_var.orig_type != 0
+							&& g.table.final_sym(g.unwrap_generic(resolved_var.orig_type)).kind == .interface)
+				current_smartcast_type := g.exposed_smartcast_type(resolved_var.orig_type, smartcast_types.last(), resolved_var.is_mut)
 				mut needs_interface_smartcast_deref := g.table.is_interface_smartcast(resolved_var)
 					&& current_smartcast_type != 0 && !current_smartcast_type.is_ptr()
 					&& smartcast_types.last().nr_muls() == current_smartcast_type.nr_muls() + 1
@@ -10505,7 +10593,8 @@ fn (mut g Gen) ident(node ast.Ident) {
 				interface_scalar_smartcast_needs_deref := interface_source_is_interface
 					&& smartcast_types.len > 0 && smartcast_types.last().is_ptr()
 					&& !g.inside_selector_lhs
-					&& raw_smartcast_target_kind !in [.struct, .aggregate, .array, .array_fixed, .map, .interface, .sum_type, .function]
+					&& raw_smartcast_target_kind !in [.struct, .aggregate, .array, .array_fixed,
+						.map, .interface, .sum_type, .function]
 				if !prevent_sum_type_unwrapping_once {
 					// Special-case: sumtype variant is an Option type and we are
 					// past `if x != none` — emit the simple correct expression
@@ -10582,9 +10671,9 @@ fn (mut g Gen) ident(node ast.Ident) {
 							|| needs_interface_smartcast_deref
 							|| interface_scalar_smartcast_needs_deref
 							|| (resolved_var.ct_type_var == .smartcast && !(g.inside_selector_lhs
-							&& g.table.is_interface_smartcast(resolved_var)))
+								&& g.table.is_interface_smartcast(resolved_var)))
 							|| (obj_sym.kind == .interface
-							&& g.table.type_kind(resolved_var.typ) == .any) {
+								&& g.table.type_kind(resolved_var.typ) == .any) {
 							g.write('*')
 						} else if is_option {
 							unwrap_typ := g.get_comptime_for_var_type(node, resolved_var.typ)
@@ -10647,12 +10736,10 @@ fn (mut g Gen) ident(node ast.Ident) {
 									cur_variant_sym := g.table.sym(ctyp)
 									if resolved_var.is_unwrapped {
 										ctyp = ctyp.set_flag(.option)
-										g.write('${dot}_${g.get_sumtype_variant_name(ctyp,
-											cur_variant_sym)}')
+										g.write('${dot}_${g.get_sumtype_variant_name(ctyp, cur_variant_sym)}')
 										g.write(').data')
 									} else {
-										g.write('${dot}_${g.get_sumtype_variant_name(ctyp,
-											cur_variant_sym)}')
+										g.write('${dot}_${g.get_sumtype_variant_name(ctyp, cur_variant_sym)}')
 									}
 								} else if !is_option_unwrap
 									&& obj_sym.kind in [.sum_type, .interface] {
@@ -10823,8 +10910,7 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 		if node_typ_is_option && node.expr is ast.None {
 			g.gen_option_error(node_typ, ast.Expr(node.expr))
 		} else if node.expr is ast.Ident && g.comptime.is_comptime_variant_var(node.expr) {
-			g.expr_with_cast(ast.Expr(node.expr), g.type_resolver.get_ct_type_or_default('${g.comptime.comptime_for_variant_var}.typ',
-				ast.void_type), effective_node_typ)
+			g.expr_with_cast(ast.Expr(node.expr), g.type_resolver.get_ct_type_or_default('${g.comptime.comptime_for_variant_var}.typ', ast.void_type), effective_node_typ)
 		} else if node_typ_is_option
 			&& g.table.unaliased_type(expr_type) == node_typ.clear_option_and_result() {
 			// Wrapping an already-correct sumtype/interface value in an option:
@@ -10837,8 +10923,8 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 		}
 	} else if !node_typ_is_option && !node_typ.is_ptr() && !expr_type.is_ptr()
 		&& ((sym.info is ast.Struct && !sym.info.is_typedef)
-		|| (expr_sym.kind == .alias && final_expr_sym.info is ast.Struct
-		&& !final_expr_sym.info.is_typedef)) {
+			|| (expr_sym.kind == .alias && final_expr_sym.info is ast.Struct
+				&& !final_expr_sym.info.is_typedef)) {
 		// deprecated, replaced by Struct{...exr}
 		styp := g.styp(node_typ)
 		g.write('*((${styp} *)(&')
@@ -10908,8 +10994,7 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 			return
 		}
 		use_dynamic_ptr_payload := node_typ.is_ptr() && expr_type.is_ptr()
-			&& final_expr_sym.kind == .sum_type && final_sym.kind !in [.sum_type, .interface]
-			&& final_sym.language == .c
+			&& final_expr_sym.kind == .sum_type && final_sym.kind !in [.sum_type, .interface] && final_sym.language == .c
 		if (g.pref.translated || g.file.is_translated) && sym.kind == .function {
 			// TODO: handle the type in fn casts, not just exprs
 			/*
@@ -10928,7 +11013,7 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 		// `ast.string_type` is done for MSVC's bug
 		if sym.kind != .alias
 			|| (sym.info is ast.Alias && !sym.info.parent_type.has_flag(.option)
-			&& alias_parent_type !in [expr_type, ast.string_type]) {
+				&& alias_parent_type !in [expr_type, ast.string_type]) {
 			if sym.kind == .string && !node_typ.is_ptr() {
 				cast_label = '*(string*)&'
 			} else if !((g.is_cc_msvc && (g.styp(node_typ) == g.styp(expr_type)
@@ -10958,8 +11043,7 @@ fn (mut g Gen) cast_expr(node ast.CastExpr) {
 			g.write('(${cast_label}')
 			mut expr_typ := ast.mktyp(expr_type)
 			if is_comptime_variant_expr {
-				expr_typ = g.type_resolver.get_ct_type_or_default('${g.comptime.comptime_for_variant_var}.typ',
-					ast.void_type)
+				expr_typ = g.type_resolver.get_ct_type_or_default('${g.comptime.comptime_for_variant_var}.typ', ast.void_type)
 			}
 			alias_to_sumtype := sym.info is ast.Alias
 				&& g.table.unaliased_type(expr_typ).idx() != sym.info.parent_type.idx()
@@ -11190,8 +11274,7 @@ fn (mut g Gen) hash_stmt_guarded_include(node ast.HashStmt) string {
 	}
 	mut missing_message := 'Header file ${node.main}, needed for module `${node.mod}` was not found.'
 	missing_message += ' ${missing_shader_header_message(node)}'
-	mut guarded_include := get_guarded_include_text(include_path_for_generated_c(node),
-		missing_message)
+	mut guarded_include := get_guarded_include_text(include_path_for_generated_c(node), missing_message)
 	if node.main == '<errno.h>' {
 		// fails with musl-gcc and msvc; but an unguarded include works:
 		guarded_include = '#include ${node.main}'
@@ -11271,8 +11354,7 @@ fn (mut g Gen) gen_hash_stmts(mut sb strings.Builder, node &ast.HashStmtNode, se
 					// `g.table.comptime_is_true` are the branch condition results set by `checker`
 					is_true = comptime_is_true
 				} else {
-					g.error('checker error: condition result idx string not found => [${idx_str}]',
-						node.branches[i].cond.pos())
+					g.error('checker error: condition result idx string not found => [${idx_str}]', node.branches[i].cond.pos())
 					return
 				}
 				if !node.has_else || i < node.branches.len - 1 {
@@ -11349,8 +11431,7 @@ fn (mut g Gen) gen_hash_stmts(mut sb strings.Builder, node &ast.HashStmtNode, se
 			has_low_level_cond := node.ct_low_level_cond.len > 0
 			if has_low_level_cond {
 				ifdef := ast.comptime_if_to_ifdef(node.ct_low_level_cond, g.pref) or {
-					g.error('#${node.kind} has invalid condition `${node.ct_low_level_cond}`',
-						node.pos)
+					g.error('#${node.kind} has invalid condition `${node.ct_low_level_cond}`', node.pos)
 					return
 				}
 				sb.writeln('\n#if defined(${ifdef})')
@@ -11379,8 +11460,8 @@ fn (mut g Gen) gen_hash_stmts(mut sb strings.Builder, node &ast.HashStmtNode, se
 				sb.writeln('#endif')
 			}
 		}
-		// TODO: support $match
 	}
+	// TODO: support $match
 }
 
 fn (mut g Gen) gen_hash_stmts_in_top() {
@@ -11405,7 +11486,7 @@ fn (mut g Gen) gen_hash_stmts_in_top() {
 fn (mut g Gen) branch_stmt(node ast.BranchStmt) {
 	if node.label != '' {
 		x := g.labeled_loops[node.label] or {
-			panic('${node.label} doesn\'t exist ${g.file.path}, ${node.pos}')
+			panic("${node.label} doesn't exist ${g.file.path}, ${node.pos}")
 		}
 		match x {
 			ast.ForCStmt {
@@ -11428,26 +11509,22 @@ fn (mut g Gen) branch_stmt(node ast.BranchStmt) {
 
 		stop_pos := labeled_loop_cleanup_stop_pos(x)
 		target_scope := labeled_loop_scope(x)
-		g.cleanup_scopes_before_labeled_jump(node.scope, target_scope, node.pos,
-			labeled_loop_for_c_init_vars(x))
+		g.cleanup_scopes_before_labeled_jump(node.scope, target_scope, node.pos, labeled_loop_for_c_init_vars(x))
 		if g.fn_decl != unsafe { nil } {
 			if node.kind == .key_break {
 				old_closure_cleanup_target_loop_pos := g.closure_cleanup_target_loop_pos
 				g.closure_cleanup_target_loop_pos = if stop_pos > 0 { stop_pos } else { 0 }
-				g.cleanup_local_closure_vars_before_jump(node.scope, node.pos.pos - 1,
-					node.pos.line_nr, true, stop_pos, g.fn_decl.stmts)
+				g.cleanup_local_closure_vars_before_jump(node.scope, node.pos.pos - 1, node.pos.line_nr, true, stop_pos, g.fn_decl.stmts)
 				g.closure_cleanup_target_loop_pos = old_closure_cleanup_target_loop_pos
 			} else {
 				preserve_start := if x is ast.ForCStmt {
-					g.push_local_closure_cleanup_preserve_vars(g.for_c_init_local_closure_vars(x),
-						x.pos.pos)
+					g.push_local_closure_cleanup_preserve_vars(g.for_c_init_local_closure_vars(x), x.pos.pos)
 				} else {
 					g.closure_cleanup_keep_vars.len
 				}
 				old_closure_cleanup_target_loop_pos := g.closure_cleanup_target_loop_pos
 				g.closure_cleanup_target_loop_pos = if stop_pos > 0 { stop_pos } else { 0 }
-				g.cleanup_local_closure_vars_before_labeled_continue(node.scope, target_scope,
-					node.pos, g.fn_decl.stmts)
+				g.cleanup_local_closure_vars_before_labeled_continue(node.scope, target_scope, node.pos, g.fn_decl.stmts)
 				g.closure_cleanup_target_loop_pos = old_closure_cleanup_target_loop_pos
 				g.pop_local_closure_cleanup_preserve_vars(preserve_start)
 			}
@@ -11485,8 +11562,7 @@ fn (mut g Gen) branch_stmt(node ast.BranchStmt) {
 		// continue or break
 		if g.needs_scope_cleanup() && !g.is_builtin_mod {
 			g.trace_autofree('// free before continue/break')
-			g.autofree_scope_vars_stop(node.pos.pos - 1, node.pos.line_nr, true,
-				g.branch_parent_pos)
+			g.autofree_scope_vars_stop(node.pos.pos - 1, node.pos.line_nr, true, g.branch_parent_pos)
 		}
 		if g.fn_decl != unsafe { nil } {
 			old_closure_cleanup_target_loop_pos := g.closure_cleanup_target_loop_pos
@@ -11495,8 +11571,7 @@ fn (mut g Gen) branch_stmt(node ast.BranchStmt) {
 			} else {
 				0
 			}
-			g.cleanup_local_closure_vars_before_jump(node.scope, node.pos.pos - 1,
-				node.pos.line_nr, true, g.branch_parent_pos, g.fn_decl.stmts)
+			g.cleanup_local_closure_vars_before_jump(node.scope, node.pos.pos - 1, node.pos.line_nr, true, g.branch_parent_pos, g.fn_decl.stmts)
 			g.closure_cleanup_target_loop_pos = old_closure_cleanup_target_loop_pos
 		}
 		g.writeln('${node.kind};')
@@ -11525,8 +11600,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 		ast.void_type
 	}
 	if exprs_len > 0 && expr0 is ast.SelectorExpr && type0_default != ast.void_type {
-		scope_field := expr0.scope.find_struct_field(expr0.expr.str(), expr0.expr_type,
-			expr0.field_name)
+		scope_field := expr0.scope.find_struct_field(expr0.expr.str(), expr0.expr_type, expr0.field_name)
 		if scope_field != unsafe { nil } && scope_field.smartcasts.len > 0 {
 			type0 = type0_default
 		}
@@ -11916,8 +11990,7 @@ fn (mut g Gen) return_stmt(node ast.Return) {
 				} else if g.table.sym(mr_info.types[i]).kind in [.sum_type, .interface] {
 					if is_auto_deref {
 						g.is_auto_deref_synthetic = true
-						g.expr_with_cast(ast.PrefixExpr{ op: .mul, right: expr },
-							resolved_ret_type, mr_info.types[i])
+						g.expr_with_cast(ast.PrefixExpr{ op: .mul, right: expr }, resolved_ret_type, mr_info.types[i])
 						g.is_auto_deref_synthetic = false
 					} else {
 						g.expr_with_cast(expr, resolved_ret_type, mr_info.types[i])
@@ -12245,8 +12318,7 @@ fn (mut g Gen) write_debug_calls_typeof_functions() {
 		return
 	}
 
-	g.writeln2('\t// we call these functions in debug mode so that the C compiler',
-		'\t// does not optimize them and we can access them in the debugger.')
+	g.writeln2('\t// we call these functions in debug mode so that the C compiler', '\t// does not optimize them and we can access them in the debugger.')
 	for _, sym in g.table.type_symbols {
 		if sym.kind == .sum_type {
 			sum_info := sym.info as ast.SumType
@@ -12732,9 +12804,7 @@ fn (mut g Gen) write_types(symbols []&ast.TypeSymbol) {
 				for field in parent_info.fields {
 					mut concrete_field := field
 					if generic_names.len == sym.info.concrete_types.len {
-						if resolved := muttable.convert_generic_type(field.typ, generic_names,
-							sym.info.concrete_types)
-						{
+						if resolved := muttable.convert_generic_type(field.typ, generic_names, sym.info.concrete_types) {
 							concrete_field.typ = resolved
 						}
 					}
@@ -12742,9 +12812,7 @@ fn (mut g Gen) write_types(symbols []&ast.TypeSymbol) {
 				}
 				for embed in parent_info.embeds {
 					if generic_names.len == sym.info.concrete_types.len {
-						if resolved := muttable.convert_generic_type(embed, generic_names,
-							sym.info.concrete_types)
-						{
+						if resolved := muttable.convert_generic_type(embed, generic_names, sym.info.concrete_types) {
 							concrete_embeds << resolved
 							continue
 						}
@@ -12838,7 +12906,7 @@ fn (mut g Gen) write_types(symbols []&ast.TypeSymbol) {
 				if (base_elem_sym.kind == .struct || !base_elem_sym.is_builtin())
 					&& !sym.info.elem_type.has_flag(.generic) && !sym.info.is_fn_ret
 					&& (!g.pref.skip_unused || (!sym.info.is_fn_ret
-					&& sym.idx in g.table.used_features.used_syms)) {
+						&& sym.idx in g.table.used_features.used_syms)) {
 					// .array_fixed {
 					styp := sym.cname
 					// array_fixed_char_300 => char x[300]
@@ -12932,9 +13000,7 @@ fn (mut g Gen) write_sorted_fn_typesymbol_declaration() {
 			for sym in pending {
 				deps << sym.name
 			}
-			verror(
-				'cgen.write_sorted_fn_typesymbol_declaration(): the following functions form a dependency cycle:\n' +
-				deps.join(','))
+			verror('cgen.write_sorted_fn_typesymbol_declaration(): the following functions form a dependency cycle:\n' + deps.join(','))
 		}
 		unsafe {
 			// Swap the to-be-processed and the dependent functions.
@@ -13079,10 +13145,7 @@ fn (mut g Gen) sort_structs(typesa []&ast.TypeSymbol) []&ast.TypeSymbol {
 	if !dep_graph_sorted.acyclic {
 		// this should no longer be called since it's in the parser
 		// TODO: should it be removed?
-		verror('cgen.sort_structs(): the following structs form a dependency cycle:\n' +
-			dep_graph_sorted.display_cycles() +
-			'\nyou can solve this by making one or both of the dependent struct fields references, eg: field &MyStruct' +
-			'\nif you feel this is an error, please create a new issue here: https://github.com/vlang/v/issues and tag @joe-conigliaro')
+		verror('cgen.sort_structs(): the following structs form a dependency cycle:\n' + dep_graph_sorted.display_cycles() + '\nyou can solve this by making one or both of the dependent struct fields references, eg: field &MyStruct' + '\nif you feel this is an error, please create a new issue here: https://github.com/vlang/v/issues and tag @joe-conigliaro')
 	}
 	// sort types
 	unsafe {
@@ -13103,8 +13166,7 @@ fn (mut g Gen) gen_or_block_stmts(cvar_name string, cast_typ string, stmts []ast
 			g.set_current_pos_as_last_stmt_pos()
 			mut expr_typ := expr_stmt.typ
 			if expr_typ == ast.void_type || expr_typ == 0 {
-				expr_typ = g.type_resolver.get_type_or_default(expr_stmt.expr,
-					return_type.clear_option_and_result())
+				expr_typ = g.type_resolver.get_type_or_default(expr_stmt.expr, return_type.clear_option_and_result())
 				if expr_typ == ast.void_type || expr_typ == 0 {
 					match expr_stmt.expr {
 						ast.CallExpr {
@@ -13129,11 +13191,11 @@ fn (mut g Gen) gen_or_block_stmts(cvar_name string, cast_typ string, stmts []ast
 					mut err_expr := expr_stmt.expr
 					if is_custom_error {
 						err_expr = ast.CastExpr{
-							expr:      expr_stmt.expr
-							typname:   'IError'
-							typ:       ast.error_type
+							expr: expr_stmt.expr
+							typname: 'IError'
+							typ: ast.error_type
 							expr_type: expr_typ
-							pos:       pos
+							pos: pos
 						}
 					}
 					if g.cur_fn.return_type.has_flag(.result) {
@@ -13189,8 +13251,7 @@ fn (mut g Gen) gen_or_block_stmts(cvar_name string, cast_typ string, stmts []ast
 								g.write('*(${cast_typ}*) ${cvar_name}${tmp_op}data = ')
 							} else if g.inside_opt_or_res && return_is_option && g.inside_assign {
 								g.write('builtin___option_ok(&(${cast_typ}[]) { ')
-								g.expr_with_cast(expr_stmt.expr, expr_typ,
-									return_type.clear_option_and_result())
+								g.expr_with_cast(expr_stmt.expr, expr_typ, return_type.clear_option_and_result())
 								g.writeln(' }, (${option_name}*)&${cvar_name}, sizeof(${cast_typ}));')
 								g.indent--
 								return
@@ -13211,7 +13272,7 @@ fn (mut g Gen) gen_or_block_stmts(cvar_name string, cast_typ string, stmts []ast
 						is_array_init := expr_stmt.expr is ast.ArrayInit
 							|| expr_stmt.expr is ast.StructInit
 							|| (expr_stmt.expr is ast.CastExpr
-							&& (expr_stmt.expr as ast.CastExpr).expr is ast.ArrayInit)
+								&& (expr_stmt.expr as ast.CastExpr).expr is ast.ArrayInit)
 						if is_array_init {
 							g.write('memcpy(${cvar_name}${tmp_op}data, (${cast_typ})')
 						} else {
@@ -13230,8 +13291,7 @@ fn (mut g Gen) gen_or_block_stmts(cvar_name string, cast_typ string, stmts []ast
 					} else {
 						old_inside_opt_data := g.inside_opt_data
 						g.inside_opt_data = true
-						g.expr_with_cast(expr_stmt.expr, expr_typ,
-							return_type.clear_option_and_result())
+						g.expr_with_cast(expr_stmt.expr, expr_typ, return_type.clear_option_and_result())
 						g.inside_opt_data = old_inside_opt_data
 					}
 					if is_array_fixed {
@@ -13339,8 +13399,7 @@ fn (mut g Gen) or_block_on_value(var_name string, or_block ast.OrExpr, return_ty
 		last_expr_produces_value = last_expr_typ != ast.void_type
 	}
 	if last_expr_produces_value {
-		g.gen_or_block_stmts(cvar_name, g.base_type(return_type), stmts, return_type, false,
-			or_block.scope, or_block.pos)
+		g.gen_or_block_stmts(cvar_name, g.base_type(return_type), stmts, return_type, false, or_block.scope, or_block.pos)
 	} else {
 		g.stmts(stmts)
 		if stmts.len > 0 {
@@ -13465,8 +13524,7 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type ast.Ty
 			last_expr_produces_value = last_expr_typ != ast.void_type
 		}
 		if last_expr_produces_value {
-			g.gen_or_block_stmts(cvar_name, mr_styp, stmts, return_type, true, or_block.scope,
-				or_block.pos)
+			g.gen_or_block_stmts(cvar_name, mr_styp, stmts, return_type, true, or_block.scope, or_block.pos)
 		} else {
 			g.stmts(stmts)
 			if stmts.len > 0 {
@@ -13509,9 +13567,7 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type ast.Ty
 				mut fn_return_type := g.fn_decl.return_type
 				if g.cur_fn != unsafe { nil } && g.cur_fn.generic_names.len > 0
 					&& g.cur_concrete_types.len > 0 {
-					if converted_type := g.table.convert_generic_type(g.fn_decl.return_type,
-						g.cur_fn.generic_names, g.cur_concrete_types)
-					{
+					if converted_type := g.table.convert_generic_type(g.fn_decl.return_type, g.cur_fn.generic_names, g.cur_concrete_types) {
 						fn_return_type = converted_type
 					}
 				}
@@ -13555,8 +13611,7 @@ fn (mut g Gen) or_block(var_name string, or_block ast.OrExpr, return_type ast.Ty
 			} else if g.fn_decl.return_type.clear_option_and_result() == return_type.clear_option_and_result() {
 				styp := g.styp(g.fn_decl.return_type).replace('*', '_ptr')
 				err_obj := g.new_tmp_var()
-				g.writeln2('\t${styp} ${err_obj};',
-					'\tmemcpy(&${err_obj}, &${cvar_name}, sizeof(_option));')
+				g.writeln2('\t${styp} ${err_obj};', '\tmemcpy(&${err_obj}, &${cvar_name}, sizeof(_option));')
 				g.cleanup_local_closure_vars_before_synthetic_return(or_block.scope, or_block.pos)
 				g.writeln('\treturn ${err_obj};')
 			} else {
@@ -13764,8 +13819,7 @@ fn (mut g Gen) type_default_impl(typ_ ast.Type, decode_sumtype bool) string {
 			}
 			init_str := 'builtin__new_map${noscan}(sizeof(${g.styp(info.key_type)}), sizeof(${g.styp(info.value_type)}), ${hash_fn}, ${key_eq_fn}, ${clone_fn}, ${free_fn})'
 			if typ.has_flag(.shared_f) {
-				mtyp := '__shared__Map_${key_sym.cname}_${g.styp(info.value_type).replace('*',
-					'_ptr')}'
+				mtyp := '__shared__Map_${key_sym.cname}_${g.styp(info.value_type).replace('*', '_ptr')}'
 				return '(${mtyp}*)__dup_shared_map(&(${mtyp}){.mtx = {0}, .val =${init_str}}, sizeof(${mtyp}))'
 			} else {
 				return init_str
@@ -13801,7 +13855,9 @@ fn (mut g Gen) type_default_impl(typ_ ast.Type, decode_sumtype bool) string {
 					field_sym := g.table.sym(field.typ)
 					is_option := field.typ.has_flag(.option)
 					if is_option || field.has_default_expr
-						|| field_sym.kind in [.enum, .array_fixed, .array, .map, .string, .bool, .alias, .i8, .i16, .i32, .int, .i64, .u8, .u16, .u32, .u64, .f32, .f64, .char, .voidptr, .byteptr, .charptr, .struct, .chan, .sum_type] {
+						|| field_sym.kind in [.enum, .array_fixed, .array, .map, .string, .bool,
+							.alias, .i8, .i16, .i32, .int, .i64, .u8, .u16, .u32, .u64, .f32, .f64,
+							.char, .voidptr, .byteptr, .charptr, .struct, .chan, .sum_type] {
 						if sym.language == .c && !field.has_default_expr && !is_option {
 							continue
 						}
@@ -13816,8 +13872,7 @@ fn (mut g Gen) type_default_impl(typ_ ast.Type, decode_sumtype bool) string {
 								} else {
 									field.default_expr_typ
 								}
-								expr_str = g.expr_string_with_cast(field.default_expr,
-									default_expr_typ, field.typ)
+								expr_str = g.expr_string_with_cast(field.default_expr, default_expr_typ, field.typ)
 							} else if field_sym.is_array_fixed() && g.inside_global_decl {
 								array_info := field_sym.array_fixed_info()
 								match field.default_expr {
@@ -14124,11 +14179,10 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 		}
 		return
 	}
-	if mut expr_type_sym.info is ast.SumType {
+	if expr_type_sym.info is ast.SumType {
 		expr_is_option := unwrapped_expr_type.has_flag(.option)
 		dot := if expr_type_without_option.is_ptr() { '->' } else { '.' }
-		matching_variants := g.matching_sumtype_variant_types(expr_type_without_option,
-			unwrapped_node_typ)
+		matching_variants := g.matching_sumtype_variant_types(expr_type_without_option, unwrapped_node_typ)
 		index_exprs := g.type_idx_exprs_for_types(matching_variants)
 		payload_type := g.as_cast_payload_type(unwrapped_node_typ, matching_variants)
 		payload_sym := g.table.sym(payload_type)
@@ -14192,13 +14246,12 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 				if right_info.methods.len == 0 && right_info.fields.len == 0 {
 					info.conversions[node.typ] = left_variants.clone()
 				} else {
-					info.conversions[node.typ] = g.interface_conversion_variants(left_variants,
-						right_variants)
+					info.conversions[node.typ] = g.interface_conversion_variants(left_variants, right_variants)
 				}
 			}
 		}
 		expr_type_sym.info = info
-	} else if mut expr_type_sym.info is ast.Interface && node.expr_type != node.typ {
+	} else if expr_type_sym.info is ast.Interface && node.expr_type != node.typ {
 		dot := if node.expr_type.is_ptr() { '->' } else { '.' }
 		matching_variants := g.matching_interface_variant_types(expr_type_sym, unwrapped_node_typ)
 		index_exprs := g.type_idx_exprs_for_types(matching_variants)
@@ -14247,14 +14300,11 @@ fn (mut g Gen) as_cast(node ast.AsCast) {
 		} else if node.expr is ast.SelectorExpr {
 			if node.expr.expr is ast.Ident && node.expr.typ.has_flag(.option)
 				&& !unwrapped_node_typ.has_flag(.option) {
-				g.unwrap_option_type(node.expr.typ,
-					'${node.expr.expr.name}.${node.expr.field_name}', node.expr.expr.is_auto_heap())
+				g.unwrap_option_type(node.expr.typ, '${node.expr.expr.name}.${node.expr.field_name}', node.expr.expr.is_auto_heap())
 				is_optional_ident_var = true
 			} else if node.expr.expr is ast.SelectorExpr && node.expr.typ.has_flag(.option) {
 				if node.expr.expr.expr is ast.Ident {
-					g.unwrap_option_type(node.expr.typ,
-						'${node.expr.expr.expr.name}.${node.expr.expr.field_name}.${node.expr.field_name}',
-						node.expr.expr.expr.is_auto_heap())
+					g.unwrap_option_type(node.expr.typ, '${node.expr.expr.expr.name}.${node.expr.expr.field_name}.${node.expr.field_name}', node.expr.expr.expr.is_auto_heap())
 					is_optional_ident_var = true
 				}
 			}
@@ -14374,8 +14424,7 @@ fn (mut g Gen) interface_field_ptr_expr(st ast.Type, cctype string, field ast.St
 			return ptr_expr.str()
 		}
 	}
-	g.checker_bug('interface field `${field.name}` is not reachable in `${resolved_st_sym.name}` during cast generation',
-		field.pos)
+	g.checker_bug('interface field `${field.name}` is not reachable in `${resolved_st_sym.name}` during cast generation', field.pos)
 	return '0'
 }
 
@@ -14525,8 +14574,7 @@ fn (mut g Gen) interface_table() string {
 			if cctype == cctype2 {
 				for field in inter_info.fields {
 					cname := c_name(field.name)
-					cast_struct.writeln('\t\t.${cname} = ${g.interface_field_ptr_expr(st, cctype,
-						field)},')
+					cast_struct.writeln('\t\t.${cname} = ${g.interface_field_ptr_expr(st, cctype, field)},')
 				}
 			}
 			cast_struct.write_string('\t}')
@@ -14920,8 +14968,7 @@ return ${cast_shared_struct_str};
 			pmessage := 'builtin__string__plus(builtin__string__plus(_S("`as_cast`: cannot convert "), builtin__tos3(v_typeof_interface_${interface_name}(x._typ))), _S(" to ${util.strip_main_name(vsym.name)}"))'
 			if g.pref.is_debug {
 				// TODO: actually return a valid position here
-				conversion_functions.write_string2('\tbuiltin__panic_debug(1, builtin__tos3("builtin.v"), builtin__tos3("builtin"), builtin__tos3("__as_cast"), ',
-					pmessage)
+				conversion_functions.write_string2('\tbuiltin__panic_debug(1, builtin__tos3("builtin.v"), builtin__tos3("builtin"), builtin__tos3("__as_cast"), ', pmessage)
 				conversion_functions.writeln(');')
 			} else {
 				conversion_functions.write_string2('\tbuiltin___v_panic(', pmessage)
@@ -15275,7 +15322,7 @@ fn (mut g Gen) vgc_ptrmap(typ ast.Type) (string, string) {
 
 // vint2int rename `_vint_t` to `int`
 fn vint2int(name string) string {
-	$if new_int ? && x64 {
+	$if new_int ?&& x64 {
 		if name == ast.int_type_name {
 			return 'int'
 		}
@@ -15326,7 +15373,7 @@ fn determine_integer_literal_type(node ast.IntegerLiteral) ast.Type {
 fn get_overflow_fn_type(typ ast.Type) ast.Type {
 	return match typ {
 		ast.int_type {
-			$if new_int ? && x64 {
+			$if new_int ?&& x64 {
 				ast.i64_type
 			} $else {
 				ast.i32_type


### PR DESCRIPTION
## Summary

- restore the AST and C generator changes overwritten by #28375, which applied stale whole-file blobs
- fix the V1 fallback bootstrap failure caused by the missing Gen.discarded_index_error_pos field
- retain the intended AArch64 register handling, which was already present before the stale replacement

Deleting vc does not resolve this failure because the inconsistent files are in vlib/v, not the bootstrap repository.

## Testing

- V_C_ERROR_BUG_REPORT_DISABLED=1 make
- ./v1_fallback -nocache -silent vlib/v/compiler_errors_test.v (1699 passed, 1 skipped)
- focused vlib/v/gen/c/coutput_test.v cases for discarded map guards and Boehm keepalive generation
- ./v1_fallback -silent vlib/v/slow_tests/assembly/asm_test.arm64.v
- ./v1_fallback -silent test vlib/math/bits/
- reproduced the original compiler error on FreeBSD 15.1 and verified the failing bootstrap command after restoring the missing generator state
- full fallback vlib/v sweep: 2348 passed, 28 skipped; 7 fallback/PATH harness failures from V3-only fixtures and VLS subprocesses