### PR TITLE
v3: fix large-project C generation regressions

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -6359,7 +6359,7 @@ fn promote_scoped_type_metadata(mut tc types.TypeChecker) {
 	tc.interface_abstract_methods = clone_string_list_map(tc.interface_abstract_methods)
 }
 
-fn promote_scoped_checker_node_caches(mut tc types.TypeChecker, a &flat.FlatAst, scope voidptr, generated_start int) {
+fn promote_scoped_checker_node_caches(mut tc types.TypeChecker, a &flat.FlatAst, scope voidptr, generated_start int, rewritten_base_nodes []int) {
 	// The per-id loops write disjoint slots and only allocate clones, so fan
 	// them out over the worker pool; fall back to the serial walk without one.
 	if !transform.promote_scoped_checker_node_caches_parallel(mut tc, a, scope, generated_start) {
@@ -6379,6 +6379,15 @@ fn promote_scoped_checker_node_caches(mut tc types.TypeChecker, a &flat.FlatAst,
 			if idx >= generated_start && idx < tc.expr_type_set.len && tc.expr_type_set[idx] {
 				tc.expr_type_values[idx] = types.clone_owned_type(tc.expr_type_values[idx])
 			}
+		}
+	}
+	// A transform can attach a newly allocated semantic type to a source node.
+	// The dense cache slot predates generated_start, but its replacement payload
+	// still belongs to the disposable stage scope.
+	for idx in rewritten_base_nodes {
+		if idx >= 0 && idx < tc.expr_type_set.len && tc.expr_type_set[idx]
+			&& idx < tc.expr_type_values.len {
+			tc.expr_type_values[idx] = types.clone_owned_type(tc.expr_type_values[idx])
 		}
 	}
 	// The dense caches are reserved in the parent arena, but an unexpectedly
@@ -10243,6 +10252,9 @@ pub fn run(args []string) {
 		prepare_transform_overlap := building_v && current_parallel_transform
 			&& scope_prealloc_transform && !incremental_cache_hit && !generic_cache_hit
 			&& !cache_state.manager.enabled
+		if prepare_transform_overlap {
+			transform.materialize_inferred_anonymous_structs_before_prepare(mut a, &pre_tc)
+		}
 		prepared_transform_thread := spawn transform.prepare_selfhost_transform(a, &pre_tc, prepare_transform_overlap)
 		// Mark used functions (dead-code elimination). This is done before transform
 		// so the transformer can skip function bodies that the C backend will prune.
@@ -10587,7 +10599,7 @@ pub fn run(args []string) {
 					eprintln('  [ttime] promote ast nodes  ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 					post_sw.restart()
 				}
-				promote_scoped_checker_node_caches(mut pre_tc, a, transform_scope, base_transform_nodes)
+				promote_scoped_checker_node_caches(mut pre_tc, a, transform_scope, base_transform_nodes, scoped_owned_base_nodes)
 				if verbose {
 					eprintln('  [ttime]   pc node caches   ${f64(post_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 					post_sw.restart()
@@ -10847,7 +10859,7 @@ pub fn run(args []string) {
 				a.specialized_fn_modules = clone_int_string_map(a.specialized_fn_modules)
 				a.specialized_fn_files = clone_int_string_map(a.specialized_fn_files)
 			}
-			promote_scoped_checker_node_caches(mut pre_tc, a, monomorph_scope, base_monomorph_nodes)
+			promote_scoped_checker_node_caches(mut pre_tc, a, monomorph_scope, base_monomorph_nodes, []int{})
 			pre_tc.rebuild_scoped_transform_signature_maps()
 			pre_tc.rebuild_fn_param_suffix_index()
 			pre_tc.promote_scoped_transform_interners(0, 0, monomorph_scope)

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -5321,7 +5321,7 @@ fn c_hash_monomorph_node(initial u64, a &flat.FlatAst, id flat.NodeId, cacheable
 	}
 	node := a.nodes[idx]
 	mut hash := c_hash_bytes(initial, [u8(node.kind), u8(node.op), u8(node.is_mut),
-		u8(node.skip_ownership_drops)])
+		u8(node.skip_ownership_drops), u8(node.is_static_type_method)])
 	hash = c_hash_tag(hash, node.children_count)
 	hash = c_hash_bytes(hash, node.typ.bytes())
 	hash = c_hash_bytes(hash, [u8(0)])
@@ -5431,7 +5431,7 @@ fn incremental_qualified_fn_name(module_name string, name string) string {
 
 fn incremental_hash_node_header(initial u64, node &flat.Node, include_value bool) u64 {
 	mut hash := c_hash_bytes(initial, [u8(node.kind), u8(node.op), u8(node.is_mut),
-		u8(node.skip_ownership_drops)])
+		u8(node.skip_ownership_drops), u8(node.is_static_type_method)])
 	hash = c_hash_tag(hash, node.children_count)
 	hash = c_hash_bytes(hash, node.typ.bytes())
 	hash = c_hash_bytes(hash, [u8(0)])
@@ -5448,7 +5448,7 @@ fn incremental_hash_node_header(initial u64, node &flat.Node, include_value bool
 
 fn incremental_hash_fn_declaration(initial u64, node &flat.Node) u64 {
 	mut hash := c_hash_bytes(initial, [u8(node.kind), u8(node.op), u8(node.is_mut),
-		u8(node.skip_ownership_drops)])
+		u8(node.skip_ownership_drops), u8(node.is_static_type_method)])
 	hash = c_hash_bytes(hash, node.typ.bytes())
 	hash = c_hash_bytes(hash, [u8(0)])
 	hash = c_hash_bytes(hash, node.value.bytes())

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -744,11 +744,7 @@ fn (mut e Eval) register_function(module_name string, file_name string, id flat.
 	if module_name != 'main' && module_name != 'builtin' {
 		e.functions[module_name]['${module_name}.${node.value}'] = def
 	}
-	if node.is_static_type_method {
-		if receiver, method := flat.decode_static_type_method_name(node.value) {
-			e.functions[module_name]['${receiver.all_after_last('.')}.${method}'] = def
-		}
-	} else if node.value.contains('.') {
+	if !node.is_static_type_method && node.value.contains('.') {
 		short := node.value.all_after_last('.')
 		receiver := node.value.all_before_last('.').all_after_last('.')
 		e.functions[module_name]['${receiver}.${short}'] = def
@@ -2938,7 +2934,8 @@ fn (mut e Eval) eval_call_flow(id flat.NodeId, node &flat.Node) !FlowSignal {
 			}
 		}
 		if left is TypeValue {
-			static_name := '${left.name.all_after_last('.')}.${callee.value}'
+			static_name := flat.encode_static_type_method_name(left.name.all_after_last('.'),
+				callee.value)
 			static_module := e.type_value_module_name(left)
 			expected_types := if target := e.function_def(static_module, static_name) {
 				e.function_param_type_names(target, 0)

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -744,13 +744,13 @@ fn (mut e Eval) register_function(module_name string, file_name string, id flat.
 	if module_name != 'main' && module_name != 'builtin' {
 		e.functions[module_name]['${module_name}.${node.value}'] = def
 	}
-	if node.value.contains('.') {
-		short := node.value.all_after_last('.')
-		receiver := node.value.all_before_last('.').all_after_last('.')
-		e.functions[module_name]['${receiver}.${short}'] = def
-	} else if node.value.contains('__static__') {
+	if node.is_static_type_method {
 		receiver := node.value.all_before('__static__').all_after_last('.')
 		short := node.value.all_after('__static__')
+		e.functions[module_name]['${receiver}.${short}'] = def
+	} else if node.value.contains('.') {
+		short := node.value.all_after_last('.')
+		receiver := node.value.all_before_last('.').all_after_last('.')
 		e.functions[module_name]['${receiver}.${short}'] = def
 	}
 }

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -2937,6 +2937,11 @@ fn (mut e Eval) eval_call_flow(id flat.NodeId, node &flat.Node) !FlowSignal {
 			static_name := flat.encode_static_type_method_name(left.name.all_after_last('.'),
 				callee.value)
 			static_module := e.type_value_module_name(left)
+			if value := e.disabled_function_zero_value(static_module, static_name, node) {
+				return FlowSignal{
+					values: [value]
+				}
+			}
 			expected_types := if target := e.function_def(static_module, static_name) {
 				e.function_param_type_names(target, 0)
 			} else {

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -748,6 +748,10 @@ fn (mut e Eval) register_function(module_name string, file_name string, id flat.
 		short := node.value.all_after_last('.')
 		receiver := node.value.all_before_last('.').all_after_last('.')
 		e.functions[module_name]['${receiver}.${short}'] = def
+	} else if node.value.contains('__static__') {
+		receiver := node.value.all_before('__static__').all_after_last('.')
+		short := node.value.all_after('__static__')
+		e.functions[module_name]['${receiver}.${short}'] = def
 	}
 }
 

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -745,9 +745,9 @@ fn (mut e Eval) register_function(module_name string, file_name string, id flat.
 		e.functions[module_name]['${module_name}.${node.value}'] = def
 	}
 	if node.is_static_type_method {
-		receiver := node.value.all_before('__static__').all_after_last('.')
-		short := node.value.all_after('__static__')
-		e.functions[module_name]['${receiver}.${short}'] = def
+		if receiver, method := flat.decode_static_type_method_name(node.value) {
+			e.functions[module_name]['${receiver.all_after_last('.')}.${method}'] = def
+		}
 	} else if node.value.contains('.') {
 		short := node.value.all_after_last('.')
 		receiver := node.value.all_before_last('.').all_after_last('.')

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -87,6 +87,33 @@ fn main() {
 	assert e.stdout() == '0\n'
 }
 
+fn test_eval_disabled_static_method_call_skips_arguments() {
+	mut e := create()
+	e.run_text('
+__global hit int
+
+struct Trace {}
+
+@[if trace ?]
+fn Trace.write(x int) int {
+	return x
+}
+
+fn side_effect() int {
+	hit = 99
+	return 1
+}
+
+fn main() {
+	println(int_str(Trace.write(side_effect())))
+	println(int_str(hit))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '0\n0\n'
+}
+
 fn test_eval_labeled_for_in_flow_targets_named_loop() {
 	mut e := create()
 	e.run_text('

--- a/vlib/v3/eval/eval_test.v
+++ b/vlib/v3/eval/eval_test.v
@@ -835,6 +835,45 @@ fn main() {
 	assert e.stdout() == '7\n'
 }
 
+fn test_eval_static_and_instance_methods_with_same_name_do_not_collide() {
+	mut e := create()
+	e.run_text('
+struct StaticFirst {
+	n int
+}
+
+fn StaticFirst.value() int {
+	return 11
+}
+
+fn (s StaticFirst) value() int {
+	return s.n
+}
+
+struct InstanceFirst {
+	n int
+}
+
+fn (i InstanceFirst) value() int {
+	return i.n
+}
+
+fn InstanceFirst.value() int {
+	return 33
+}
+
+fn main() {
+	println(int_str(StaticFirst.value()))
+	println(int_str(StaticFirst{n: 22}.value()))
+	println(int_str(InstanceFirst.value()))
+	println(int_str(InstanceFirst{n: 44}.value()))
+}
+	') or {
+		panic(err)
+	}
+	assert e.stdout() == '11\n22\n33\n44\n'
+}
+
 fn test_eval_overloaded_plus_operator_dispatches_method() {
 	mut e := create()
 	e.run_text('

--- a/vlib/v3/flat/flat.v
+++ b/vlib/v3/flat/flat.v
@@ -15,33 +15,21 @@ pub const empty_node = NodeId(-1)
 pub const method_value_borrow_receiver_marker = '__v3_method_value_borrow_receiver'
 pub const method_value_clone_receiver_marker_prefix = '__v3_method_value_clone_receiver:'
 
-const static_type_method_name_marker = '__static__'
+const static_type_method_name_marker = '@static@'
 
 // encode_static_type_method_name makes a reversible internal name for a static type method.
 pub fn encode_static_type_method_name(receiver string, method string) string {
-	return '${receiver}${static_type_method_name_marker}${method}${static_type_method_name_marker}${method.len}'
+	return '${receiver}${static_type_method_name_marker}${method}'
 }
 
 // decode_static_type_method_name recovers the receiver and method from an internal static name.
 pub fn decode_static_type_method_name(name string) ?(string, string) {
-	length_marker := name.last_index(static_type_method_name_marker) or { return none }
-	length_start := length_marker + static_type_method_name_marker.len
-	if length_start >= name.len {
+	marker := name.index(static_type_method_name_marker) or { return none }
+	method_start := marker + static_type_method_name_marker.len
+	if marker == 0 || method_start >= name.len {
 		return none
 	}
-	for digit in name[length_start..] {
-		if digit < `0` || digit > `9` {
-			return none
-		}
-	}
-	method_len := name[length_start..].int()
-	method_start := length_marker - method_len
-	receiver_end := method_start - static_type_method_name_marker.len
-	if receiver_end < 0 || method_start < 0
-		|| name[receiver_end..method_start] != static_type_method_name_marker {
-		return none
-	}
-	return name[..receiver_end], name[method_start..length_marker]
+	return name[..marker], name[method_start..]
 }
 
 const empty_node_value = Node{}

--- a/vlib/v3/flat/flat.v
+++ b/vlib/v3/flat/flat.v
@@ -15,6 +15,35 @@ pub const empty_node = NodeId(-1)
 pub const method_value_borrow_receiver_marker = '__v3_method_value_borrow_receiver'
 pub const method_value_clone_receiver_marker_prefix = '__v3_method_value_clone_receiver:'
 
+const static_type_method_name_marker = '__static__'
+
+// encode_static_type_method_name makes a reversible internal name for a static type method.
+pub fn encode_static_type_method_name(receiver string, method string) string {
+	return '${receiver}${static_type_method_name_marker}${method}${static_type_method_name_marker}${method.len}'
+}
+
+// decode_static_type_method_name recovers the receiver and method from an internal static name.
+pub fn decode_static_type_method_name(name string) ?(string, string) {
+	length_marker := name.last_index(static_type_method_name_marker) or { return none }
+	length_start := length_marker + static_type_method_name_marker.len
+	if length_start >= name.len {
+		return none
+	}
+	for digit in name[length_start..] {
+		if digit < `0` || digit > `9` {
+			return none
+		}
+	}
+	method_len := name[length_start..].int()
+	method_start := length_marker - method_len
+	receiver_end := method_start - static_type_method_name_marker.len
+	if receiver_end < 0 || method_start < 0
+		|| name[receiver_end..method_start] != static_type_method_name_marker {
+		return none
+	}
+	return name[..receiver_end], name[method_start..length_marker]
+}
+
 const empty_node_value = Node{}
 
 // NodeKind lists node kind values used by flat.

--- a/vlib/v3/flat/flat.v
+++ b/vlib/v3/flat/flat.v
@@ -188,16 +188,17 @@ pub fn node_payload(generic_params []string) &NodePayload {
 // Node represents node data used by flat.
 pub struct Node {
 pub mut:
-	value                string
-	typ                  string
-	payload              &NodePayload = unsafe { nil }
-	children_start       i32
-	is_mut               bool
-	kind                 NodeKind
-	op                   Op
-	skip_ownership_drops bool
-	children_count       i32
-	pos                  token.Pos
+	value                 string
+	typ                   string
+	payload               &NodePayload = unsafe { nil }
+	children_start        i32
+	is_mut                bool
+	kind                  NodeKind
+	op                    Op
+	skip_ownership_drops  bool
+	is_static_type_method bool
+	children_count        i32
+	pos                   token.Pos
 }
 
 // type_text_id returns the compact canonical identity carried in this node's
@@ -739,6 +740,7 @@ pub fn (n Node) with_shifted_children(shift i32) Node {
 		op:                   n.op
 		is_mut:               n.is_mut
 		skip_ownership_drops: n.skip_ownership_drops
+		is_static_type_method: n.is_static_type_method
 	}
 }
 
@@ -755,6 +757,7 @@ pub fn (n Node) with_pos(pos token.Pos) Node {
 		op:                   n.op
 		is_mut:               n.is_mut
 		skip_ownership_drops: n.skip_ownership_drops
+		is_static_type_method: n.is_static_type_method
 	}
 }
 
@@ -775,6 +778,7 @@ pub fn (n Node) clone_owned() Node {
 		op:                   n.op
 		is_mut:               n.is_mut
 		skip_ownership_drops: n.skip_ownership_drops
+		is_static_type_method: n.is_static_type_method
 	}
 }
 

--- a/vlib/v3/flat/flat_test.v
+++ b/vlib/v3/flat/flat_test.v
@@ -38,6 +38,7 @@ fn test_node_owned_clone_preserves_semantic_flags_and_payload() {
 		op:                   .plus
 		is_mut:               true
 		skip_ownership_drops: true
+		is_static_type_method: true
 	}
 	cloned := node.clone_owned()
 	assert cloned.value == node.value
@@ -49,6 +50,7 @@ fn test_node_owned_clone_preserves_semantic_flags_and_payload() {
 	assert cloned.op == node.op
 	assert cloned.is_mut
 	assert cloned.skip_ownership_drops
+	assert cloned.is_static_type_method
 }
 
 fn test_clone_text_table_owned_detaches_scoped_storage() {

--- a/vlib/v3/flat/flat_test.v
+++ b/vlib/v3/flat/flat_test.v
@@ -56,6 +56,7 @@ fn test_node_owned_clone_preserves_semantic_flags_and_payload() {
 fn test_static_type_method_name_round_trip_with_marker_in_both_parts() {
 	encoded := encode_static_type_method_name('models.Cache__static__State',
 		'reset__static__now')
+	assert encode_static_type_method_name('int', 'tag') != 'int__static__tag__static__3'
 	receiver, method := decode_static_type_method_name(encoded) or { panic('invalid encoding') }
 	assert receiver == 'models.Cache__static__State'
 	assert method == 'reset__static__now'

--- a/vlib/v3/flat/flat_test.v
+++ b/vlib/v3/flat/flat_test.v
@@ -53,6 +53,15 @@ fn test_node_owned_clone_preserves_semantic_flags_and_payload() {
 	assert cloned.is_static_type_method
 }
 
+fn test_static_type_method_name_round_trip_with_marker_in_both_parts() {
+	encoded := encode_static_type_method_name('models.Cache__static__State',
+		'reset__static__now')
+	receiver, method := decode_static_type_method_name(encoded) or { panic('invalid encoding') }
+	assert receiver == 'models.Cache__static__State'
+	assert method == 'reset__static__now'
+	assert decode_static_type_method_name('cache__static__reset') == none
+}
+
 fn test_clone_text_table_owned_detaches_scoped_storage() {
 	$if prealloc {
 		mut ast := FlatAst.new()

--- a/vlib/v3/gen/c/names.v
+++ b/vlib/v3/gen/c/names.v
@@ -469,13 +469,15 @@ fn (g &FlatGen) cname(name string) string {
 		cache.last_value = cached
 		return cached
 	}
-	if c_name_is_pre_sanitized(name) {
+	needs_internal_namespace := naming.c_name_needs_internal_namespace(name)
+	if !needs_internal_namespace && c_name_is_pre_sanitized(name) {
 		cache.last_name = name
 		cache.last_value = name
 		cache.remember(name, name)
 		return name
 	}
-	if naming.is_plain_identifier(name) && name != 'malloc' && name != 'int_str' && name != 'exit'
+	if !needs_internal_namespace && naming.is_plain_identifier(name) && name != 'malloc'
+		&& name != 'int_str' && name != 'exit'
 		&& !c_name_is_string_literal_symbol(name) && !naming.is_reserved_word(name)
 		&& !naming.is_libc_collision(name) {
 		cache.last_name = name
@@ -503,7 +505,7 @@ fn (g &FlatGen) cname(name string) string {
 			return cached
 		}
 	}
-	if !name.starts_with('C.') && c_name_is_plain_dotted(name) {
+	if !needs_internal_namespace && !name.starts_with('C.') && c_name_is_plain_dotted(name) {
 		result := naming.sanitize(name)
 		cache.entries[name] = result
 		cache.last_name = name

--- a/vlib/v3/gen/c/names_test.v
+++ b/vlib/v3/gen/c/names_test.v
@@ -33,7 +33,8 @@ fn test_c_name_pre_sanitized_classifier() {
 fn test_cached_cname_fast_paths_match_canonical_naming() {
 	mut g := FlatGen.new()
 	for name in ['run', 'int', 'send', 'malloc', 'int_str', 'exit', '_str_42', '_str_value',
-		'main.run', 'foo.Bar.method', 'C.printf', 'C.SSL_CTX.str', 'Point.<=', 'pkg.Box[int].value'] {
+		'main.run', 'foo.Bar.method', 'C.printf', 'C.SSL_CTX.str', 'Point.<=', 'pkg.Box[int].value',
+		'int@static@tag', '__v3_internal_symbol_source'] {
 		assert g.cname(name) == c_name(name)
 	}
 }

--- a/vlib/v3/gen/c/naming/naming.v
+++ b/vlib/v3/gen/c/naming/naming.v
@@ -2,6 +2,10 @@ module naming
 
 import strings
 
+// Keep this marker synchronized with v3.flat's static type-method name codec.
+const static_type_method_name_marker = '@static@'
+const internal_symbol_c_prefix = '__v3_internal_symbol_'
+
 // reserved_words is a set (not a list) so `name in reserved_words` is an O(1)
 // hash lookup. c_name() runs on every emitted identifier, so a linear scan here
 // is costly.
@@ -115,6 +119,9 @@ const libc_collisions = {
 
 // c_name returns the C identifier used for a V symbol or type name.
 pub fn c_name(name string) string {
+	if name.contains(static_type_method_name_marker) {
+		return static_type_method_c_name(name)
+	}
 	if name.starts_with('C.') {
 		if name[2..].contains('.') {
 			return sanitize(name)
@@ -135,13 +142,39 @@ pub fn c_name(name string) string {
 		return 'v_exit'
 	}
 	n := sanitize(name)
+	mut result := n
 	if n in reserved_words || n in libc_collisions || is_string_literal_symbol(n) {
 		if name.contains('@') {
-			return '_v_${n}'
+			result = '_v_${n}'
+		} else {
+			result = 'v_${n}'
 		}
-		return 'v_${n}'
 	}
-	return n
+	// Keep the C namespace reserved for internal symbols disjoint from every
+	// spelling that a source-level name can sanitize to.
+	if result.starts_with(internal_symbol_c_prefix) {
+		return '${internal_symbol_c_prefix}source_${result}'
+	}
+	return result
+}
+
+// c_name_needs_internal_namespace reports names that cannot use cgen's direct
+// identifier fast paths because c_name applies the internal-symbol partition.
+pub fn c_name_needs_internal_namespace(name string) bool {
+	return name.contains(static_type_method_name_marker)
+		|| name.starts_with(internal_symbol_c_prefix)
+}
+
+fn static_type_method_c_name(name string) string {
+	hex := '0123456789abcdef'
+	mut b := strings.new_builder(internal_symbol_c_prefix.len + 7 + name.len * 2)
+	b.write_string(internal_symbol_c_prefix)
+	b.write_string('static_')
+	for c in name.bytes() {
+		b.write_u8(hex[c >> 4])
+		b.write_u8(hex[c & 15])
+	}
+	return b.str()
 }
 
 fn is_string_literal_symbol(name string) bool {

--- a/vlib/v3/gen/c/naming/naming_test.v
+++ b/vlib/v3/gen/c/naming/naming_test.v
@@ -16,3 +16,11 @@ fn test_sanitize_dotted_name_autofree() {
 	result := sanitize('alpha.beta')
 	assert result == 'alpha__beta'
 }
+
+fn test_static_type_method_c_name_is_disjoint_from_source_names() {
+	static_name := c_name('int@static@tag')
+	assert static_name.starts_with('${internal_symbol_c_prefix}static_')
+	assert static_name != c_name('int_v_static_v_tag')
+	assert static_name != c_name(static_name)
+	assert c_name(static_name).starts_with('${internal_symbol_c_prefix}source_')
+}

--- a/vlib/v3/gen/v/gen.v
+++ b/vlib/v3/gen/v/gen.v
@@ -237,8 +237,7 @@ fn (g &Gen) collect_json_migration_declarations(ids []flat.NodeId, mut declared_
 			for field_id in g.a.children_of(n) {
 				declared_names[g.a.node(field_id).value] = true
 			}
-		} else if n.kind == .fn_decl && !n.value.contains('.')
-			&& !n.value.contains('__static__') {
+		} else if n.kind == .fn_decl && !n.value.contains('.') && !n.is_static_type_method {
 			declared_names[n.value] = true
 		} else if n.kind == .c_fn_decl && n.value.starts_with('V:') && !n.value[2..].contains('.') {
 			declared_names[n.value[2..]] = true
@@ -3027,7 +3026,7 @@ fn (mut g Gen) fn_decl(id flat.NodeId) {
 		} else {
 			g.write('C.${name}')
 		}
-	} else if name.contains('__static__') {
+	} else if n.is_static_type_method {
 		g.write(name.all_before('__static__'))
 		g.write('.')
 		g.write(name.all_after('__static__'))

--- a/vlib/v3/gen/v/gen.v
+++ b/vlib/v3/gen/v/gen.v
@@ -3027,9 +3027,11 @@ fn (mut g Gen) fn_decl(id flat.NodeId) {
 			g.write('C.${name}')
 		}
 	} else if n.is_static_type_method {
-		g.write(name.all_before('__static__'))
-		g.write('.')
-		g.write(name.all_after('__static__'))
+		if receiver, method := flat.decode_static_type_method_name(name) {
+			g.write('${receiver}.${method}')
+		} else {
+			g.write(name)
+		}
 	} else {
 		g.write(name)
 	}

--- a/vlib/v3/gen/v/gen.v
+++ b/vlib/v3/gen/v/gen.v
@@ -237,7 +237,8 @@ fn (g &Gen) collect_json_migration_declarations(ids []flat.NodeId, mut declared_
 			for field_id in g.a.children_of(n) {
 				declared_names[g.a.node(field_id).value] = true
 			}
-		} else if n.kind == .fn_decl && !n.value.contains('.') {
+		} else if n.kind == .fn_decl && !n.value.contains('.')
+			&& !n.value.contains('__static__') {
 			declared_names[n.value] = true
 		} else if n.kind == .c_fn_decl && n.value.starts_with('V:') && !n.value[2..].contains('.') {
 			declared_names[n.value[2..]] = true
@@ -3026,6 +3027,10 @@ fn (mut g Gen) fn_decl(id flat.NodeId) {
 		} else {
 			g.write('C.${name}')
 		}
+	} else if name.contains('__static__') {
+		g.write(name.all_before('__static__'))
+		g.write('.')
+		g.write(name.all_after('__static__'))
 	} else {
 		g.write(name)
 	}

--- a/vlib/v3/gen/v/gen_test.v
+++ b/vlib/v3/gen/v/gen_test.v
@@ -80,6 +80,13 @@ pub fn (mut p Point) inc(dx int) int {
 '
 }
 
+fn test_formatter_preserves_static_associated_function_syntax() {
+	source := 'struct Widget {}\n\nfn Widget.make() Widget {\n\treturn Widget{}\n}\n'
+	out := vfmt('static_associated_function', source)
+	assert out == source, out
+	assert vfmt('static_associated_function_twice', out) == out
+}
+
 fn test_formatter_preserves_blank_lines_between_statements() {
 	source := "fn spaced() {\n\tprintln('a')\n\tprintln('b')\n\n\tprintln('c')\n\n\tif true {\n\t\tprintln('d')\n\t}\n\n\tdump('e')\n}\n"
 	out := vfmt('statement_blank_lines', source)

--- a/vlib/v3/gen/v/gen_test.v
+++ b/vlib/v3/gen/v/gen_test.v
@@ -81,7 +81,7 @@ pub fn (mut p Point) inc(dx int) int {
 }
 
 fn test_formatter_preserves_static_associated_function_syntax() {
-	source := 'struct Widget {}\n\nfn Widget.make() Widget {\n\treturn Widget{}\n}\n'
+	source := 'struct Widget {}\n\nfn Widget.make() Widget {\n\treturn Widget{}\n}\n\nstruct Cache__static__State {}\n\nfn Cache__static__State.reset__static__now() {}\n'
 	out := vfmt('static_associated_function', source)
 	assert out == source, out
 	assert vfmt('static_associated_function_twice', out) == out

--- a/vlib/v3/gen/v/gen_test.v
+++ b/vlib/v3/gen/v/gen_test.v
@@ -87,6 +87,13 @@ fn test_formatter_preserves_static_associated_function_syntax() {
 	assert vfmt('static_associated_function_twice', out) == out
 }
 
+fn test_formatter_preserves_static_marker_in_ordinary_function_name() {
+	source := 'fn cache__static__reset() {}\n'
+	out := vfmt('ordinary_function_with_static_marker', source)
+	assert out == source, out
+	assert vfmt('ordinary_function_with_static_marker_twice', out) == out
+}
+
 fn test_formatter_preserves_blank_lines_between_statements() {
 	source := "fn spaced() {\n\tprintln('a')\n\tprintln('b')\n\n\tprintln('c')\n\n\tif true {\n\t\tprintln('d')\n\t}\n\n\tdump('e')\n}\n"
 	out := vfmt('statement_blank_lines', source)

--- a/vlib/v3/gen/v/gen_test.v
+++ b/vlib/v3/gen/v/gen_test.v
@@ -81,7 +81,7 @@ pub fn (mut p Point) inc(dx int) int {
 }
 
 fn test_formatter_preserves_static_associated_function_syntax() {
-	source := 'struct Widget {}\n\nfn Widget.make() Widget {\n\treturn Widget{}\n}\n\nstruct Cache__static__State {}\n\nfn Cache__static__State.reset__static__now() {}\n'
+	source := 'struct Widget {}\n\nfn Widget.make() Widget {\n\treturn Widget{}\n}\n\nstruct Cache__static__State {}\n\nfn Cache__static__State.reset__static__now() {}\n\nfn int.tag() {}\n\nfn int__static__tag__static__3() {}\n'
 	out := vfmt('static_associated_function', source)
 	assert out == source, out
 	assert vfmt('static_associated_function_twice', out) == out

--- a/vlib/v3/markused/markused.v
+++ b/vlib/v3/markused/markused.v
@@ -8451,6 +8451,9 @@ fn markused_type_name_or_empty(t types.Type, unwrap_optional_result bool) string
 
 // markused_c_name returns the C identifier used for a V symbol or type name.
 fn markused_c_name(name string) string {
+	if naming.c_name_needs_internal_namespace(name) {
+		return naming.c_name(name)
+	}
 	if name.starts_with('C.') {
 		return name[2..]
 	}

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -5996,7 +5996,11 @@ fn fn_text(a &flat.FlatAst, module_name string, node flat.Node, is_c bool, decla
 	}
 	decl_name := node.value
 	name := if node.is_static_type_method {
-		'${decl_name.all_before('__static__')}.${decl_name.all_after('__static__')}'
+		if receiver, method := flat.decode_static_type_method_name(decl_name) {
+			'${receiver}.${method}'
+		} else {
+			decl_name
+		}
 	} else {
 		decl_name
 	}

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -6007,7 +6007,7 @@ fn fn_text(a &flat.FlatAst, module_name string, node flat.Node, is_c bool, decla
 	visibility := if !is_c && (node.op == .arrow || source_is_public) { 'pub ' } else { '' }
 	mut head := if is_c { 'fn C.${name}' } else { '${visibility}fn ${name}' }
 	mut param_start := 0
-	if !is_c && name.contains('.') && params.len > 0 {
+	if !is_c && !node.is_static_type_method && name.contains('.') && params.len > 0 {
 		receiver_type := name.all_before_last('.')
 		first_type := clean_receiver_type(params[0].typ)
 		if first_type == receiver_type

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -5994,7 +5994,12 @@ fn fn_text(a &flat.FlatAst, module_name string, node flat.Node, is_c bool, decla
 			params << child
 		}
 	}
-	mut name := node.value
+	decl_name := node.value
+	name := if node.is_static_type_method {
+		'${decl_name.all_before('__static__')}.${decl_name.all_after('__static__')}'
+	} else {
+		decl_name
+	}
 	visibility := if !is_c && (node.op == .arrow || source_is_public) { 'pub ' } else { '' }
 	mut head := if is_c { 'fn C.${name}' } else { '${visibility}fn ${name}' }
 	mut param_start := 0
@@ -6047,17 +6052,17 @@ fn fn_text(a &flat.FlatAst, module_name string, node flat.Node, is_c bool, decla
 		head += ' ${node.typ}'
 	}
 	mut attr_lines := []string{}
-	if fn_is_disabled(a, module_name, name) {
+	if fn_is_disabled(a, module_name, decl_name) {
 		attr_lines << '@[if false]'
 	}
 	mut attrs := []string{}
 	if !cached_declaration_has_attr(declaration_attrs, 'export') {
-		if export_name := fn_export_name(a, module_name, name) {
+		if export_name := fn_export_name(a, module_name, decl_name) {
 			attrs << "export: '${escape_v_string(export_name)}'"
 		}
 	}
 	if !cached_declaration_has_attr(declaration_attrs, 'noreturn')
-		&& fn_is_noreturn(a, module_name, name) {
+		&& fn_is_noreturn(a, module_name, decl_name) {
 		attrs << 'noreturn'
 	}
 	if attrs.len > 0 {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -1237,7 +1237,7 @@ fn (mut p Parser) fn_decl() flat.NodeId {
 	if is_method && receiver_type.len > 0 {
 		clean_type := method_receiver_type_name(receiver_type)
 		name = if is_static_type_method {
-			'${clean_type}__static__${name}'
+			flat.encode_static_type_method_name(clean_type, name)
 		} else {
 			'${clean_type}.${name}'
 		}

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -1378,6 +1378,7 @@ fn (mut p Parser) fn_operator_overload(receiver_name string, receiver_type strin
 
 fn (mut p Parser) fn_decl_body(name string, receiver_name string, receiver_type string, receiver_is_mut bool, is_method bool, interop_prefix string, name_pos int) flat.NodeId {
 	is_c_decl := interop_prefix.len > 0
+	is_static_type_method := is_method && receiver_name.len == 0 && !is_c_decl
 	is_pub := p.pending_decl_pub
 	p.pending_decl_pub = false
 	// Capture & clear here so it applies only to this function (not nested closures
@@ -1457,6 +1458,7 @@ fn (mut p Parser) fn_decl_body(name string, receiver_name string, receiver_type 
 			payload: flat.node_payload(generic_params)
 			children_start: start
 			children_count: flat.child_count(param_ids.len)
+			is_static_type_method: is_static_type_method
 			// Function nodes do not otherwise use is_mut. On a .vh declaration it
 			// records that the body lives in a cached object and must not be emitted;
 			// on a C declaration it preserves the parser's implicit unsafe/trusted state.
@@ -1551,6 +1553,7 @@ fn (mut p Parser) fn_decl_body(name string, receiver_name string, receiver_type 
 		payload: flat.node_payload(generic_params)
 		children_start: start
 		children_count: flat.child_count(all_ids.len)
+		is_static_type_method: is_static_type_method
 	})
 	if p.prefs.is_fmt && formatter_end > 0 {
 		p.a.formatter_node_ends[int(id)] = formatter_end

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -3866,9 +3866,19 @@ fn (mut p Parser) resolve_comptime_at_values(cond string) string {
 	return p.resolve_comptime_at_values_at(cond, p.tok_pos)
 }
 
+fn (p &Parser) current_source_fn_name() string {
+	if p.cur_method_is_static {
+		_, method := flat.decode_static_type_method_name(p.cur_fn) or {
+			return p.cur_fn.all_after_last('.')
+		}
+		return method
+	}
+	return p.cur_fn.all_after_last('.')
+}
+
 fn (mut p Parser) resolve_comptime_at_values_at(cond string, pseudo_pos int) string {
 	module_name := if p.cur_module.len > 0 { p.cur_module } else { 'main' }
-	fn_name := p.cur_fn.all_after_last('.')
+	fn_name := p.current_source_fn_name()
 	method_name := if p.cur_struct.len > 0 { '${p.cur_struct}.${fn_name}' } else { fn_name }
 	mut out := strings.new_builder(cond.len)
 	mut i := 0
@@ -9499,13 +9509,14 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 				return p.add_val_id(5, p.cur_module)
 			}
 			if name == '@FN' {
-				return p.add_val_id(5, p.cur_fn.all_after_last('.'))
+				return p.add_val_id(5, p.current_source_fn_name())
 			}
 			if name == '@METHOD' {
+				fn_name := p.current_source_fn_name()
 				return p.add_val_id(5, if p.cur_struct.len > 0 {
-					'${p.cur_struct}.${p.cur_fn.all_after_last('.')}'
+					'${p.cur_struct}.${fn_name}'
 				} else {
-					p.cur_fn.all_after_last('.')
+					fn_name
 				})
 			}
 			if name == '@STRUCT' {
@@ -9513,7 +9524,7 @@ fn (mut p Parser) prefix_expr() flat.NodeId {
 			}
 			if name == '@LOCATION' {
 				module_name := if p.cur_module.len > 0 { p.cur_module } else { 'main' }
-				fn_name := p.cur_fn.all_after_last('.')
+				fn_name := p.current_source_fn_name()
 				mut method_name := '${module_name}.${fn_name}'
 				if p.cur_struct.len > 0 {
 					if p.cur_method_is_static {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -1129,6 +1129,7 @@ fn (mut p Parser) fn_decl() flat.NodeId {
 	mut receiver_type := ''
 	mut receiver_is_mut := false
 	mut is_method := false
+	mut is_static_type_method := false
 
 	// method receiver: fn (mut r Type) name()
 	if p.tok == .lpar {
@@ -1228,13 +1229,18 @@ fn (mut p Parser) fn_decl() flat.NodeId {
 				receiver_type = name
 				name = second
 				is_method = true
+				is_static_type_method = true
 			}
 		}
 	}
 
 	if is_method && receiver_type.len > 0 {
 		clean_type := method_receiver_type_name(receiver_type)
-		name = '${clean_type}.${name}'
+		name = if is_static_type_method {
+			'${clean_type}__static__${name}'
+		} else {
+			'${clean_type}.${name}'
+		}
 	}
 
 	return p.fn_decl_body(name, receiver_name, receiver_type, receiver_is_mut, is_method, '', name_pos)

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -113,6 +113,39 @@ fn test_program_support() {
 	assert run_module_cache_binary(output) == ''
 }
 
+fn test_inferred_anonymous_struct_stays_in_its_source_module() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_cached_anonymous_struct_owner_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'cachedanon/cachedanon.v', "module cachedanon
+
+fn produce() string {
+	return 'owned'
+}
+
+pub fn result() string {
+	value := struct { item: produce() }
+	return value.item
+}
+")
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import cachedanon
+
+fn main() {
+	println(cachedanon.result())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	assert run_cached_module_cache_project(v3_bin, cache_dir, main_file) == 'owned'
+	assert run_cached_module_cache_project(v3_bin, cache_dir, main_file) == 'owned'
+}
+
 fn test_print_v_files_includes_warm_cached_module_sources() {
 	v3_bin := build_module_cache_v3()
 	root := os.join_path(os.temp_dir(), 'v3_print_cached_v_files_${os.getpid()}')

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -5096,6 +5096,46 @@ fn main() {
 	assert run_module_cache_binary(second_output) == '0'
 }
 
+fn test_cached_module_preserves_static_declaration_marker_distinction() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_cached_static_marker_distinction_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'factory/factory.v', 'module factory
+
+pub struct Factory {}
+
+pub fn Factory.make() string {
+	return "static"
+}
+
+pub fn cache__static__reset() string {
+	return "ordinary"
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import factory
+
+fn main() {
+	println(factory.Factory.make())
+	println(factory.cache__static__reset())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == 'static\nordinary'
+
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == 'static\nordinary'
+}
+
 fn test_cached_global_with_unsupported_initializer_is_embedded() {
 	v3_bin := build_module_cache_v3()
 	root := os.join_path(os.temp_dir(), 'v3_module_cache_global_index_${os.getpid()}')

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -5176,6 +5176,49 @@ fn main() {
 	assert run_module_cache_binary(second_output) == 'static\nordinary\nreversible'
 }
 
+fn test_cached_static_method_keeps_matching_first_parameter() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_cached_static_matching_param_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'factory/factory.v', 'module factory
+
+pub struct Widget {
+pub:
+	value int
+}
+
+pub fn Widget.clone(value Widget) Widget {
+	return Widget{
+		value: value.value + 1
+	}
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import factory
+
+fn main() {
+	widget := factory.Widget{
+		value: 41
+	}
+	println(factory.Widget.clone(widget).value)
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '42'
+
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == '42'
+}
+
 fn test_cached_global_with_unsupported_initializer_is_embedded() {
 	v3_bin := build_module_cache_v3()
 	root := os.join_path(os.temp_dir(), 'v3_module_cache_global_index_${os.getpid()}')

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -5115,6 +5115,12 @@ pub fn Factory.make() string {
 pub fn cache__static__reset() string {
 	return "ordinary"
 }
+
+pub struct Cache__static__State {}
+
+pub fn Cache__static__State.reset__static__now() string {
+	return "reversible"
+}
 ')
 	main_file := os.join_path(root, 'main.v')
 	write_module_cache_file(root, 'main.v', 'module main
@@ -5124,16 +5130,17 @@ import factory
 fn main() {
 	println(factory.Factory.make())
 	println(factory.cache__static__reset())
+	println(factory.Cache__static__State.reset__static__now())
 }
 ')
 	cache_dir := os.join_path(root, 'cache')
 	first_output := os.join_path(root, 'first')
 	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
-	assert run_module_cache_binary(first_output) == 'static\nordinary'
+	assert run_module_cache_binary(first_output) == 'static\nordinary\nreversible'
 
 	second_output := os.join_path(root, 'second')
 	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
-	assert run_module_cache_binary(second_output) == 'static\nordinary'
+	assert run_module_cache_binary(second_output) == 'static\nordinary\nreversible'
 }
 
 fn test_cached_global_with_unsupported_initializer_is_embedded() {

--- a/vlib/v3/tests/orm_join_sql_attr_test.v
+++ b/vlib/v3/tests/orm_join_sql_attr_test.v
@@ -112,6 +112,68 @@ fn main() {
 	assert out == ''
 }
 
+fn test_v3_orm_update_call_selector_and_cast_semantics() {
+	v3_bin := orm_join_sql_attr_build_v3()
+	out := orm_join_sql_attr_run(v3_bin, 'orm_update_call_selector_and_cast_semantics', "import db.sqlite
+
+struct User {
+	id int @[primary]
+	name string
+}
+
+fn User.decorate(value string) string {
+	return 'static:\${value}'
+}
+
+fn main() {
+	mut db := sqlite.connect(':memory:') or { panic(err) }
+	defer {
+		db.close() or {}
+	}
+
+	sql db {
+		create table User
+	}!
+
+	user := User{
+		id: 1
+		name: '<Ada>'
+	}
+	sql db {
+		insert user into User
+	}!
+
+	sql db {
+		update User set name = user.name.substr(1, 4) where id == user.id
+	}!
+	method_rows := sql db {
+		select from User where id == user.id
+	}!
+	assert method_rows.len == 1
+	assert method_rows[0].name == 'Ada'
+
+	sql db {
+		update User set name = User.decorate(user.name) where id == user.id
+	}!
+	static_rows := sql db {
+		select from User where id == user.id
+	}!
+	assert static_rows.len == 1
+	assert static_rows[0].name == 'static:<Ada>'
+
+	sql db {
+		update User set name = string(user.name) where id == user.id
+	}!
+	cast_rows := sql db {
+		select from User where id == user.id
+	}!
+	assert cast_rows.len == 1
+	assert cast_rows[0].name == '<Ada>'
+}
+")
+	assert out == ''
+}
+
 fn test_v3_static_where_and_join_sql_attribute_regressions() {
 	v3_bin := orm_join_sql_attr_build_v3()
 	limit_out := orm_join_sql_attr_run(v3_bin, 'orm_limit_zero', "import db.sqlite

--- a/vlib/v3/tests/orm_join_sql_attr_test.v
+++ b/vlib/v3/tests/orm_join_sql_attr_test.v
@@ -69,6 +69,49 @@ fn orm_join_sql_attr_run_project(v3_bin string, name string, files map[string]st
 	return run.output.trim_space()
 }
 
+fn test_v3_orm_update_function_call_value() {
+	v3_bin := orm_join_sql_attr_build_v3()
+	out := orm_join_sql_attr_run(v3_bin, 'orm_update_function_call_value', "import db.sqlite
+import encoding.html
+
+// `Table` intentionally collides with orm.Table. The generic specialization
+// must retain this main-module type while lowering the query.
+struct Table {
+	id int @[primary]
+	name string
+}
+
+fn main() {
+	mut db := sqlite.connect(':memory:') or { panic(err) }
+	defer {
+		db.close() or {}
+	}
+
+	sql db {
+		create table Table
+	}!
+
+	user := Table{
+		id: 1
+		name: '<Ada>'
+	}
+	sql db {
+		insert user into Table
+	}!
+
+	sql db {
+		update Table set name = html.escape(user.name) where id == user.id
+	}!
+	rows := sql db {
+		select from Table where id == 1
+	}!
+	assert rows.len == 1
+	assert rows[0].name == '&lt;Ada&gt;'
+}
+")
+	assert out == ''
+}
+
 fn test_v3_static_where_and_join_sql_attribute_regressions() {
 	v3_bin := orm_join_sql_attr_build_v3()
 	limit_out := orm_join_sql_attr_run(v3_bin, 'orm_limit_zero', "import db.sqlite

--- a/vlib/v3/tests/post_merge_review_fixes_test.v
+++ b/vlib/v3/tests/post_merge_review_fixes_test.v
@@ -6092,6 +6092,15 @@ fn test_imported_private_free_function_is_rejected() {
 	}, ['main.v'], 'function `other.hidden` is private')
 }
 
+fn test_imported_private_static_function_uses_source_name_in_diagnostic() {
+	v3_bin := build_v3()
+	run_bad_project(v3_bin, 'review_imported_private_static_function', {
+		'v.mod':     "Module { name: 'review_imported_private_static_function' }\n"
+		'dep/dep.v': 'module dep\n\npub struct Widget {}\n\nfn Widget.make() Widget {\n\treturn Widget{}\n}\n'
+		'main.v':    'module main\n\nimport dep\n\nfn main() {\n\t_ = dep.Widget.make()\n}\n'
+	}, ['main.v'], 'function `dep.Widget.make` is private')
+}
+
 fn test_private_declarations_in_main_module_accept_empty_module_alias() {
 	v3_bin := build_v3()
 	out := run_good_project(v3_bin, 'review_main_module_private_alias', {

--- a/vlib/v3/tests/selfhost_transform_regression_test.v
+++ b/vlib/v3/tests/selfhost_transform_regression_test.v
@@ -140,13 +140,20 @@ fn cache__static__reset() string {
 	return "ordinary"
 }
 
+struct Cache__static__State {}
+
+fn Cache__static__State.reset__static__now() string {
+	return "reversible"
+}
+
 fn main() {
 	println(Post{7}.form_for("edit").value)
 	println(Post.form_for(id: 9, action: "new").value)
 	println(cache__static__reset())
+	println(Cache__static__State.reset__static__now())
 }
 ')
-	assert out.split_into_lines() == ['static:7:edit', 'static:9:new', 'ordinary']
+	assert out.split_into_lines() == ['static:7:edit', 'static:9:new', 'ordinary', 'reversible']
 }
 
 // A static call through a generic type parameter is resolved only after the

--- a/vlib/v3/tests/selfhost_transform_regression_test.v
+++ b/vlib/v3/tests/selfhost_transform_regression_test.v
@@ -149,6 +149,26 @@ fn main() {
 	assert out.split_into_lines() == ['static:7:edit', 'static:9:new', 'ordinary']
 }
 
+// A static call through a generic type parameter is resolved only after the
+// generic body is cloned. Retarget it to the concrete encoded declaration.
+fn test_generic_static_assoc_call_retargets_encoded_declaration() {
+	out := selfhost_regression_run('generic_static_assoc_call', 'struct Parser {}
+
+fn Parser.parse() string {
+	return "parsed"
+}
+
+fn read[T]() string {
+	return T.parse()
+}
+
+fn main() {
+	println(read[Parser]())
+}
+')
+	assert out == 'parsed'
+}
+
 // An unresolved literal field shape may be shared by several declared anonymous
 // structs. Keep the exact type selected from the call parameter context.
 fn test_contextual_anonymous_struct_call_field_keeps_declared_type() {

--- a/vlib/v3/tests/selfhost_transform_regression_test.v
+++ b/vlib/v3/tests/selfhost_transform_regression_test.v
@@ -109,6 +109,61 @@ fn main() {
 	assert out.split_into_lines() == ['true', 'true']
 }
 
+// A static associated function and an instance method may intentionally share
+// their source-level name. Their internal symbols and ABIs must remain distinct.
+fn test_static_and_instance_method_with_same_name() {
+	out := selfhost_regression_run('static_instance_same_name', 'struct Form {
+	value string
+}
+
+struct Post {
+	id int
+}
+
+@[params]
+struct FormOptions {
+	id     int
+	action string
+}
+
+fn Post.form_for(opts FormOptions) Form {
+	return Form{
+		value: "static:\${opts.id}:\${opts.action}"
+	}
+}
+
+fn (post Post) form_for(action string) Form {
+	return Post.form_for(id: post.id, action: action)
+}
+
+fn main() {
+	println(Post{7}.form_for("edit").value)
+	println(Post.form_for(id: 9, action: "new").value)
+}
+')
+	assert out.split_into_lines() == ['static:7:edit', 'static:9:new']
+}
+
+// A non-capturing fn literal passed to an imported generic must remain a cgen root.
+// The large-project failure called this as `__anon_fn_0` without emitting its body.
+fn test_imported_generic_keeps_non_capturing_fn_literal() {
+	out := selfhost_regression_run('generic_fn_literal_root', 'import arrays
+
+struct Table {
+	name string
+}
+
+fn main() {
+	tables := [Table{name: "users"}, Table{name: "posts"}]
+	result := arrays.find_first(tables, fn (table Table) bool {
+		return table.name == "posts"
+	}) or { panic("missing") }
+	println(result.name)
+}
+')
+	assert out == 'posts'
+}
+
 // Only `for k, mut v in m` binds the map value by reference. A container that is merely a map
 // reference (`m &map[string]bool`) still binds a plain value copy, so the binding must not be
 // typed `&V` — that made every use of it emit a dereference of a non-pointer local.

--- a/vlib/v3/tests/selfhost_transform_regression_test.v
+++ b/vlib/v3/tests/selfhost_transform_regression_test.v
@@ -280,6 +280,27 @@ fn main() {
 	assert out == '2'
 }
 
+// A generic call result is still unknown when the template is first
+// transformed. Revisit the literal after monomorphization gives the cloned
+// call a concrete result type.
+fn test_generic_inferred_anonymous_struct_is_materialized_after_specialization() {
+	out := selfhost_regression_run('generic_inferred_anonymous_struct', 'fn produce[T](value T) T {
+	return value
+}
+
+fn wrap[T](value T) T {
+	result := struct { item: produce(value) }
+	return result.item
+}
+
+fn main() {
+	println(wrap(41))
+	println(wrap("ok"))
+}
+')
+	assert out.split_into_lines() == ['41', 'ok']
+}
+
 // A non-capturing fn literal passed to an imported generic must remain a cgen root.
 // The large-project failure called this as `__anon_fn_0` without emitting its body.
 fn test_imported_generic_keeps_non_capturing_fn_literal() {

--- a/vlib/v3/tests/selfhost_transform_regression_test.v
+++ b/vlib/v3/tests/selfhost_transform_regression_test.v
@@ -146,14 +146,24 @@ fn Cache__static__State.reset__static__now() string {
 	return "reversible"
 }
 
+fn int.tag() string {
+	return "static-int"
+}
+
+fn int__static__tag__static__3() string {
+	return "ordinary-int"
+}
+
 fn main() {
 	println(Post{7}.form_for("edit").value)
 	println(Post.form_for(id: 9, action: "new").value)
 	println(cache__static__reset())
 	println(Cache__static__State.reset__static__now())
+	println(int__static__tag__static__3())
 }
 ')
-	assert out.split_into_lines() == ['static:7:edit', 'static:9:new', 'ordinary', 'reversible']
+	assert out.split_into_lines() == ['static:7:edit', 'static:9:new', 'ordinary', 'reversible',
+		'ordinary-int']
 }
 
 // A static call through a generic type parameter is resolved only after the

--- a/vlib/v3/tests/selfhost_transform_regression_test.v
+++ b/vlib/v3/tests/selfhost_transform_regression_test.v
@@ -136,12 +136,43 @@ fn (post Post) form_for(action string) Form {
 	return Post.form_for(id: post.id, action: action)
 }
 
+fn cache__static__reset() string {
+	return "ordinary"
+}
+
 fn main() {
 	println(Post{7}.form_for("edit").value)
 	println(Post.form_for(id: 9, action: "new").value)
+	println(cache__static__reset())
 }
 ')
-	assert out.split_into_lines() == ['static:7:edit', 'static:9:new']
+	assert out.split_into_lines() == ['static:7:edit', 'static:9:new', 'ordinary']
+}
+
+// An unresolved literal field shape may be shared by several declared anonymous
+// structs. Keep the exact type selected from the call parameter context.
+fn test_contextual_anonymous_struct_call_field_keeps_declared_type() {
+	out := selfhost_regression_run('contextual_anonymous_struct_call_field', 'fn produce() string {
+	return "contextual"
+}
+
+fn take_int(value struct {
+	item int
+}) string {
+	return value.item.str()
+}
+
+fn take_string(value struct {
+	item string
+}) string {
+	return value.item
+}
+
+fn main() {
+	println(take_string(struct { item: produce() }))
+}
+')
+	assert out == 'contextual'
 }
 
 // A non-capturing fn literal passed to an imported generic must remain a cgen root.

--- a/vlib/v3/tests/selfhost_transform_regression_test.v
+++ b/vlib/v3/tests/selfhost_transform_regression_test.v
@@ -146,6 +146,7 @@ fn Cache__static__State.reset__static__now() string {
 	return "reversible"
 }
 
+@[markused]
 fn int.tag() string {
 	return "static-int"
 }

--- a/vlib/v3/tests/selfhost_transform_regression_test.v
+++ b/vlib/v3/tests/selfhost_transform_regression_test.v
@@ -187,6 +187,27 @@ fn main() {
 	assert out == 'parsed'
 }
 
+fn test_generic_static_assoc_declaration_uses_encoded_lookup_key() {
+	out := selfhost_regression_run('generic_static_assoc_declaration', 'struct Box[T] {
+	value T
+}
+
+fn Box.new[T](value T) Box[T] {
+	return Box[T]{
+		value: value
+	}
+}
+
+fn main() {
+	explicit := Box.new[int](41)
+	inferred := Box.new("ok")
+	println(explicit.value + 1)
+	println(inferred.value)
+}
+')
+	assert out.split_into_lines() == ['42', 'ok']
+}
+
 fn test_static_method_pseudo_variables_use_source_name() {
 	name := 'static_method_pseudo_vars'
 	src := os.join_path(os.temp_dir(), 'v3_selfhost_regression_${name}.v')

--- a/vlib/v3/tests/selfhost_transform_regression_test.v
+++ b/vlib/v3/tests/selfhost_transform_regression_test.v
@@ -187,6 +187,37 @@ fn main() {
 	assert out == 'parsed'
 }
 
+fn test_static_method_pseudo_variables_use_source_name() {
+	name := 'static_method_pseudo_vars'
+	src := os.join_path(os.temp_dir(), 'v3_selfhost_regression_${name}.v')
+	source_path_literal := src.replace('\\', '\\\\')
+	out := selfhost_regression_run(name, 'struct Cache__static__State {}
+
+fn Cache__static__State.report__static__now() {
+	\$if @FN != \'report__static__now\' {
+		\$compile_error(\'incorrect @FN\')
+	}
+	\$if @METHOD != \'Cache__static__State.report__static__now\' {
+		\$compile_error(\'incorrect @METHOD\')
+	}
+	\$if @LOCATION != \'${source_path_literal}:10, main.Cache__static__State.report__static__now (static)\' {
+		\$compile_error(\'incorrect @LOCATION\')
+	}
+	println(@FN)
+	println(@METHOD)
+	println(@LOCATION)
+}
+
+fn main() {
+	Cache__static__State.report__static__now()
+}
+')
+	lines := out.split_into_lines()
+	assert lines[0] == 'report__static__now'
+	assert lines[1] == 'Cache__static__State.report__static__now'
+	assert lines[2].ends_with(', main.Cache__static__State.report__static__now (static)')
+}
+
 // An unresolved literal field shape may be shared by several declared anonymous
 // structs. Keep the exact type selected from the call parameter context.
 fn test_contextual_anonymous_struct_call_field_keeps_declared_type() {

--- a/vlib/v3/tests/selfhost_transform_regression_test.v
+++ b/vlib/v3/tests/selfhost_transform_regression_test.v
@@ -244,6 +244,21 @@ fn main() {
 	assert out == 'contextual'
 }
 
+// Literals whose call-valued fields resolve to the same semantic shape must
+// share a concrete anonymous type when an enclosing expression unifies them.
+fn test_inferred_anonymous_struct_call_fields_reuse_semantic_shape() {
+	out := selfhost_regression_run('inferred_anonymous_struct_shape_reuse', 'fn produce(n int) int {
+	return n
+}
+
+fn main() {
+	values := [struct { item: produce(1) }, struct { item: produce(2) }]
+	println(int_str(values.len))
+}
+')
+	assert out == '2'
+}
+
 // A non-capturing fn literal passed to an imported generic must remain a cgen root.
 // The large-project failure called this as `__anon_fn_0` without emitting its body.
 fn test_imported_generic_keeps_non_capturing_fn_literal() {

--- a/vlib/v3/tests/veb_implicit_ctx_test.v
+++ b/vlib/v3/tests/veb_implicit_ctx_test.v
@@ -117,6 +117,7 @@ import veb
 
 pub struct Context {
 	veb.Context
+	msgs []string
 }
 
 pub struct App {}
@@ -124,7 +125,13 @@ pub struct App {}
 pub fn (ctx &Context) before_request() {}
 
 pub fn (mut app App) index(mut ctx Context) veb.Result {
-	return ctx.text("ok")
+	info := struct {
+		profile: map[string]string{
+			"slug": "v3"
+		}
+		messages: ctx.msgs
+	}
+	return ctx.json_pretty(info)
 }
 
 fn main() {
@@ -141,4 +148,10 @@ fn main() {
 	c_code := os.read_file(c_out) or { '' }
 	assert c_code.contains('Context__before_request(user_context)'), c_code
 	assert !c_code.contains('Context__before_request(&user_context->veb__Context)'), c_code
+	assert c_code.contains('AnonStruct_v3_inferred_'), c_code
+	assert !c_code.contains('v_struct'), c_code
+	bin_out := os.join_path(os.temp_dir(), 'v3_veb_complete_context_receiver')
+	os.rm(bin_out) or {}
+	native_compile := os.execute('${v3_bin} -no-memory-limit ${src_file} -o ${bin_out}')
+	assert native_compile.exit_code == 0, native_compile.output
 }

--- a/vlib/v3/transform/anonymous_struct.v
+++ b/vlib/v3/transform/anonymous_struct.v
@@ -1,0 +1,110 @@
+module transform
+
+import v3.flat
+import v3.types
+
+// materialize_inferred_anonymous_structs gives a concrete declaration to an
+// inferred `struct { field: expression }` literal whose field expressions were
+// not syntactically typed by the parser. Semantic checking has resolved those
+// expressions by this point. Do this before parallel transform preparation so
+// all workers and cgen see one immutable set of aggregate declarations.
+fn (mut t Transformer) materialize_inferred_anonymous_structs() {
+	if isnil(t.tc) {
+		return
+	}
+	t.tc.ensure_private_transform_structs()
+	original_node_count := t.a.nodes.len
+	mut cur_file := ''
+	mut cur_module := ''
+	for idx in 0 .. original_node_count {
+		node := t.a.nodes[idx]
+		match node.kind {
+			.file {
+				cur_file = node.value
+				cur_module = t.tc.file_modules[cur_file] or { '' }
+			}
+			.module_decl {
+				cur_module = node.value
+			}
+			.struct_init {
+				if node.value != 'struct' || node.children_count == 0 {
+					continue
+				}
+				mut semantic_fields := []types.StructField{cap: int(node.children_count)}
+				mut valid := true
+				for fi in 0 .. node.children_count {
+					field := t.a.child_node(&node, fi)
+					if field.kind != .field_init || field.value.len == 0
+						|| field.children_count != 1 {
+						valid = false
+						break
+					}
+					value_id := t.a.child(field, 0)
+					field_type := t.tc.expr_type(value_id) or { t.tc.resolve_type(value_id) }
+					field_type_name := t.tc.type_name(field_type)
+					if field_type is types.Unknown || field_type is types.Void
+						|| field_type_name in ['', 'unknown', 'void', 'struct'] {
+						valid = false
+						break
+					}
+					semantic_fields << types.StructField{
+						name: field.value
+						typ: field_type
+					}
+				}
+				if !valid {
+					continue
+				}
+				mut field_ids := []flat.NodeId{cap: semantic_fields.len}
+				for fi, semantic_field in semantic_fields {
+					source_field := t.a.child_node(&node, fi)
+					field_ids << t.a.add_node(flat.Node{
+						kind: .field_decl
+						value: semantic_field.name
+						typ: t.tc.type_name(semantic_field.typ)
+						pos: source_field.pos
+					})
+				}
+				name := 'AnonStruct_v3_inferred_${idx}'
+				if cur_file.len > 0 {
+					t.a.add_node(flat.Node{
+						kind: .file
+						value: cur_file
+					})
+				}
+				if cur_module.len > 0 {
+					t.a.add_node(flat.Node{
+						kind: .module_decl
+						value: cur_module
+					})
+				}
+				children_start := t.a.children.len
+				for field_id in field_ids {
+					t.a.children << field_id
+				}
+				t.a.add_node(flat.Node{
+					kind: .struct_decl
+					value: name
+					children_start: children_start
+					children_count: flat.child_count(field_ids.len)
+					pos: node.pos
+				})
+				semantic_name := if cur_module.len > 0 && cur_module !in ['main', 'builtin'] {
+					'${cur_module}.${name}'
+				} else {
+					name
+				}
+				t.tc.structs[semantic_name] = semantic_fields
+				t.tc.struct_modules[semantic_name] = cur_module
+				t.tc.struct_files[semantic_name] = cur_file
+				t.tc.register_short_type_name(semantic_name)
+				t.a.nodes[idx].value = name
+				t.a.nodes[idx].typ = semantic_name
+				t.tc.register_synth_type(flat.NodeId(idx), types.Struct{
+					name: semantic_name
+				})
+			}
+			else {}
+		}
+	}
+}

--- a/vlib/v3/transform/anonymous_struct.v
+++ b/vlib/v3/transform/anonymous_struct.v
@@ -8,11 +8,13 @@ import v3.types
 // not syntactically typed by the parser. Semantic checking has resolved those
 // expressions by this point. Do this before parallel transform preparation so
 // all workers and cgen see one immutable set of aggregate declarations.
-fn (mut t Transformer) materialize_inferred_anonymous_structs() {
+fn (mut t Transformer) materialize_inferred_anonymous_structs() bool {
 	if isnil(t.tc) {
-		return
+		return false
 	}
 	t.tc.ensure_private_transform_structs()
+	mut materialized := false
+	mut inferred_by_shape := map[string]string{}
 	original_node_count := t.a.nodes.len
 	for idx in 0 .. original_node_count {
 		node := t.a.nodes[idx]
@@ -55,6 +57,20 @@ fn (mut t Transformer) materialize_inferred_anonymous_structs() {
 					}
 				}
 				if !valid {
+					continue
+				}
+				mut shape_parts := []string{cap: semantic_fields.len}
+				for semantic_field in semantic_fields {
+					field_type_name := t.tc.type_name(semantic_field.typ)
+					shape_parts << '${semantic_field.name.len}:${semantic_field.name}:${field_type_name.len}:${field_type_name}'
+				}
+				shape := '${cur_module.len}:${cur_module}:${shape_parts.join(',')}'
+				if semantic_name := inferred_by_shape[shape] {
+					t.a.nodes[idx].value = semantic_name.all_after_last('.')
+					t.a.nodes[idx].typ = semantic_name
+					t.tc.register_synth_type(flat.NodeId(idx), types.Struct{
+						name: semantic_name
+					})
 					continue
 				}
 				mut field_ids := []flat.NodeId{cap: semantic_fields.len}
@@ -100,13 +116,16 @@ fn (mut t Transformer) materialize_inferred_anonymous_structs() {
 				t.tc.struct_modules[semantic_name] = cur_module
 				t.tc.struct_files[semantic_name] = cur_file
 				t.tc.register_short_type_name(semantic_name)
+				inferred_by_shape[shape] = semantic_name
 				t.a.nodes[idx].value = name
 				t.a.nodes[idx].typ = semantic_name
 				t.tc.register_synth_type(flat.NodeId(idx), types.Struct{
 					name: semantic_name
 				})
+				materialized = true
 			}
 			else {}
 		}
 	}
+	return materialized
 }

--- a/vlib/v3/transform/anonymous_struct.v
+++ b/vlib/v3/transform/anonymous_struct.v
@@ -19,8 +19,9 @@ pub fn materialize_inferred_anonymous_structs_before_prepare(mut a flat.FlatAst,
 // materialize_inferred_anonymous_structs gives a concrete declaration to an
 // inferred `struct { field: expression }` literal whose field expressions were
 // not syntactically typed by the parser. Semantic checking has resolved those
-// expressions by this point. Do this before parallel transform preparation so
-// all workers and cgen see one immutable set of aggregate declarations.
+// expressions by this point. Run this before parallel transform preparation,
+// then again after generic specialization for literals whose field types only
+// become concrete in a cloned body.
 fn (mut t Transformer) materialize_inferred_anonymous_structs() bool {
 	if isnil(t.tc) {
 		return false

--- a/vlib/v3/transform/anonymous_struct.v
+++ b/vlib/v3/transform/anonymous_struct.v
@@ -14,22 +14,16 @@ fn (mut t Transformer) materialize_inferred_anonymous_structs() {
 	}
 	t.tc.ensure_private_transform_structs()
 	original_node_count := t.a.nodes.len
-	mut cur_file := ''
-	mut cur_module := ''
 	for idx in 0 .. original_node_count {
 		node := t.a.nodes[idx]
 		match node.kind {
-			.file {
-				cur_file = node.value
-				cur_module = t.tc.file_modules[cur_file] or { '' }
-			}
-			.module_decl {
-				cur_module = node.value
-			}
 			.struct_init {
 				if node.value != 'struct' || node.children_count == 0 {
 					continue
 				}
+				source_file := t.a.source_files[node.pos.id] or { continue }
+				cur_file := source_file.name
+				cur_module := t.tc.file_modules[cur_file] or { '' }
 				// Contextual checking may already have selected one of the declared
 				// anonymous structs with this field shape. Keep that nominal identity;
 				// transform_struct_init will apply it when this literal is lowered.

--- a/vlib/v3/transform/anonymous_struct.v
+++ b/vlib/v3/transform/anonymous_struct.v
@@ -8,6 +8,14 @@ fn inferred_anonymous_struct_type_exists(tc &types.TypeChecker, name string) boo
 		|| name in tc.enum_names || name in tc.interface_names
 }
 
+// materialize_inferred_anonymous_structs_before_prepare gives unresolved
+// anonymous struct literals concrete types before reusable transform indexes
+// are built.
+pub fn materialize_inferred_anonymous_structs_before_prepare(mut a flat.FlatAst, tc &types.TypeChecker) bool {
+	mut t := new_transformer(mut a, tc, map[string]bool{})
+	return t.materialize_inferred_anonymous_structs()
+}
+
 // materialize_inferred_anonymous_structs gives a concrete declaration to an
 // inferred `struct { field: expression }` literal whose field expressions were
 // not syntactically typed by the parser. Semantic checking has resolved those
@@ -73,6 +81,7 @@ fn (mut t Transformer) materialize_inferred_anonymous_structs() bool {
 				if semantic_name := inferred_by_shape[shape] {
 					t.a.nodes[idx].value = semantic_name.all_after_last('.')
 					t.a.nodes[idx].typ = semantic_name
+					t.mark_scoped_owned_base_node(idx)
 					t.tc.register_synth_type(flat.NodeId(idx), types.Struct{
 						name: semantic_name
 					})
@@ -133,6 +142,7 @@ fn (mut t Transformer) materialize_inferred_anonymous_structs() bool {
 				inferred_by_shape[shape] = semantic_name
 				t.a.nodes[idx].value = name
 				t.a.nodes[idx].typ = semantic_name
+				t.mark_scoped_owned_base_node(idx)
 				t.tc.register_synth_type(flat.NodeId(idx), types.Struct{
 					name: semantic_name
 				})

--- a/vlib/v3/transform/anonymous_struct.v
+++ b/vlib/v3/transform/anonymous_struct.v
@@ -30,6 +30,14 @@ fn (mut t Transformer) materialize_inferred_anonymous_structs() {
 				if node.value != 'struct' || node.children_count == 0 {
 					continue
 				}
+				// Contextual checking may already have selected one of the declared
+				// anonymous structs with this field shape. Keep that nominal identity;
+				// transform_struct_init will apply it when this literal is lowered.
+				if checked_type := t.tc.expr_type(flat.NodeId(idx)) {
+					if transform_is_anonymous_struct_name(t.tc.type_name(checked_type)) {
+						continue
+					}
+				}
 				mut semantic_fields := []types.StructField{cap: int(node.children_count)}
 				mut valid := true
 				for fi in 0 .. node.children_count {

--- a/vlib/v3/transform/anonymous_struct.v
+++ b/vlib/v3/transform/anonymous_struct.v
@@ -3,6 +3,11 @@ module transform
 import v3.flat
 import v3.types
 
+fn inferred_anonymous_struct_type_exists(tc &types.TypeChecker, name string) bool {
+	return name in tc.structs || name in tc.type_aliases || name in tc.sum_types
+		|| name in tc.enum_names || name in tc.interface_names
+}
+
 // materialize_inferred_anonymous_structs gives a concrete declaration to an
 // inferred `struct { field: expression }` literal whose field expressions were
 // not syntactically typed by the parser. Semantic checking has resolved those
@@ -83,7 +88,21 @@ fn (mut t Transformer) materialize_inferred_anonymous_structs() bool {
 						pos: source_field.pos
 					})
 				}
-				name := 'AnonStruct_v3_inferred_${idx}'
+				base_name := 'AnonStruct_v3_inferred_${idx}'
+				mut name := base_name
+				mut semantic_name := name
+				if cur_module.len > 0 && cur_module !in ['main', 'builtin'] {
+					semantic_name = '${cur_module}.${name}'
+				}
+				mut collision_suffix := 1
+				for inferred_anonymous_struct_type_exists(t.tc, semantic_name) {
+					name = '${base_name}_${collision_suffix}'
+					semantic_name = name
+					if cur_module.len > 0 && cur_module !in ['main', 'builtin'] {
+						semantic_name = '${cur_module}.${name}'
+					}
+					collision_suffix++
+				}
 				if cur_file.len > 0 {
 					t.a.add_node(flat.Node{
 						kind: .file
@@ -107,11 +126,6 @@ fn (mut t Transformer) materialize_inferred_anonymous_structs() bool {
 					children_count: flat.child_count(field_ids.len)
 					pos: node.pos
 				})
-				semantic_name := if cur_module.len > 0 && cur_module !in ['main', 'builtin'] {
-					'${cur_module}.${name}'
-				} else {
-					name
-				}
 				t.tc.structs[semantic_name] = semantic_fields
 				t.tc.struct_modules[semantic_name] = cur_module
 				t.tc.struct_files[semantic_name] = cur_file

--- a/vlib/v3/transform/anonymous_struct_test.v
+++ b/vlib/v3/transform/anonymous_struct_test.v
@@ -100,6 +100,39 @@ fn test_inferred_anonymous_structs_reuse_their_semantic_shape() {
 	assert synthesized_declarations == 1
 }
 
+fn test_inferred_anonymous_struct_name_does_not_replace_user_struct() {
+	mut a := flat.FlatAst.new()
+	main_file := '/tmp/project/main.v'
+	a.source_files[1] = token.File.unindexed(main_file, 1)
+	struct_id, value_id := add_inferred_anonymous_struct(mut a, 1)
+	colliding_name := 'AnonStruct_v3_inferred_${struct_id}'
+	a.add_node(flat.Node{
+		kind: .struct_decl
+		value: colliding_name
+		pos: token.new_pos(1, 0)
+	})
+	a.add_node(flat.Node{
+		kind: .file
+		value: main_file
+	})
+
+	user_fields := [types.StructField{
+		name: 'user_field'
+		typ: types.Type(types.string_)
+	}]
+	mut tc := types.TypeChecker.new(&a)
+	tc.file_modules[main_file] = 'main'
+	tc.structs[colliding_name] = user_fields
+	tc.register_synth_type(value_id, types.Type(types.int_))
+	mut t := new_transformer(mut a, &tc, map[string]bool{})
+	assert t.materialize_inferred_anonymous_structs()
+
+	generated_name := '${colliding_name}_1'
+	assert a.nodes[int(struct_id)].typ == generated_name
+	assert tc.structs[colliding_name] == user_fields
+	assert tc.structs[generated_name][0].name == 'item'
+}
+
 fn test_prepared_selfhost_transform_materializes_before_repreparing() {
 	mut a := flat.FlatAst.new()
 	main_file := '/tmp/project/main.v'

--- a/vlib/v3/transform/anonymous_struct_test.v
+++ b/vlib/v3/transform/anonymous_struct_test.v
@@ -76,6 +76,11 @@ fn test_inferred_anonymous_structs_reuse_their_semantic_shape() {
 	a.source_files[1] = token.File.unindexed(main_file, 1)
 	first_struct_id, first_value_id := add_inferred_anonymous_struct(mut a, 1)
 	second_struct_id, second_value_id := add_inferred_anonymous_struct(mut a, 1)
+	different_struct_id, different_value_id := add_inferred_anonymous_struct(mut a, 1)
+	// Calls are the unresolved syntax that reaches this post-check prepass.
+	a.nodes[int(first_value_id)].kind = .call
+	a.nodes[int(second_value_id)].kind = .call
+	a.nodes[int(different_value_id)].kind = .call
 	a.add_node(flat.Node{
 		kind: .file
 		value: main_file
@@ -85,12 +90,14 @@ fn test_inferred_anonymous_structs_reuse_their_semantic_shape() {
 	tc.file_modules[main_file] = 'main'
 	tc.register_synth_type(first_value_id, types.Type(types.int_))
 	tc.register_synth_type(second_value_id, types.Type(types.int_))
+	tc.register_synth_type(different_value_id, types.Type(types.string_))
 	mut t := new_transformer(mut a, &tc, map[string]bool{})
 	assert t.materialize_inferred_anonymous_structs()
 
 	shared_name := 'AnonStruct_v3_inferred_${first_struct_id}'
 	assert a.nodes[int(first_struct_id)].typ == shared_name
 	assert a.nodes[int(second_struct_id)].typ == shared_name
+	assert a.nodes[int(different_struct_id)].typ != shared_name
 	mut synthesized_declarations := 0
 	for node in a.nodes {
 		if node.kind == .struct_decl && node.value == shared_name {
@@ -133,7 +140,7 @@ fn test_inferred_anonymous_struct_name_does_not_replace_user_struct() {
 	assert tc.structs[generated_name][0].name == 'item'
 }
 
-fn test_prepared_selfhost_transform_materializes_before_repreparing() {
+fn test_prepared_selfhost_transform_materializes_before_preparing() {
 	mut a := flat.FlatAst.new()
 	main_file := '/tmp/project/main.v'
 	a.source_files[1] = token.File.unindexed(main_file, 1)
@@ -146,12 +153,14 @@ fn test_prepared_selfhost_transform_materializes_before_repreparing() {
 	mut tc := types.TypeChecker.new(&a)
 	tc.file_modules[main_file] = 'main'
 	tc.register_synth_type(value_id, types.Type(types.int_))
+	assert materialize_inferred_anonymous_structs_before_prepare(mut a, &tc)
+	name := 'AnonStruct_v3_inferred_${struct_id}'
 	mut prepared := prepare_selfhost_transform(&a, &tc, true)
-	_, _, errors, _, _ := transform_prepared_selfhost_owned(mut prepared, mut a, &tc,
-		map[string]bool{}, unsafe { nil })
+	assert name in prepared.transformer.structs
+	_, _, errors, _, _ := transform_prepared_selfhost_owned(mut prepared, mut a, &tc, map[string]bool{}, unsafe { nil })
+	transform_worker_scope_free(prepared.take_scope())
 
 	assert errors.len == 0
-	name := 'AnonStruct_v3_inferred_${struct_id}'
 	assert a.nodes[int(struct_id)].typ == name
-	assert name in prepared.transformer.structs
+	assert name in tc.structs
 }

--- a/vlib/v3/transform/anonymous_struct_test.v
+++ b/vlib/v3/transform/anonymous_struct_test.v
@@ -1,0 +1,71 @@
+module transform
+
+import v3.flat
+import v3.token
+import v3.types
+
+fn add_inferred_anonymous_struct(mut a flat.FlatAst, file_id int) (flat.NodeId, flat.NodeId) {
+	pos := token.new_pos(file_id, 0)
+	value_id := a.add_node(flat.Node{
+		kind: .int_literal
+		value: '1'
+		pos: pos
+	})
+	field_children_start := a.children.len
+	a.children << value_id
+	field_id := a.add_node(flat.Node{
+		kind: .field_init
+		value: 'item'
+		children_start: field_children_start
+		children_count: 1
+		pos: pos
+	})
+	struct_children_start := a.children.len
+	a.children << field_id
+	struct_id := a.add_node(flat.Node{
+		kind: .struct_init
+		value: 'struct'
+		children_start: struct_children_start
+		children_count: 1
+		pos: pos
+	})
+	return struct_id, value_id
+}
+
+fn test_inferred_anonymous_struct_uses_position_source_file() {
+	mut a := flat.FlatAst.new()
+	dep_file := '/tmp/dep/item.v'
+	main_file := '/tmp/project/main.v'
+	a.source_files[1] = token.File.unindexed(dep_file, 1)
+	a.source_files[2] = token.File.unindexed(main_file, 1)
+
+	// Parser file markers follow all nodes belonging to that file. The ownership
+	// of either literal therefore cannot be inferred from allocation order.
+	dep_struct_id, dep_value_id := add_inferred_anonymous_struct(mut a, 1)
+	a.add_node(flat.Node{
+		kind: .file
+		value: dep_file
+	})
+	main_struct_id, main_value_id := add_inferred_anonymous_struct(mut a, 2)
+	a.add_node(flat.Node{
+		kind: .file
+		value: main_file
+	})
+
+	mut tc := types.TypeChecker.new(&a)
+	tc.file_modules[dep_file] = 'dep'
+	tc.file_modules[main_file] = 'main'
+	tc.register_synth_type(dep_value_id, types.Type(types.int_))
+	tc.register_synth_type(main_value_id, types.Type(types.int_))
+	mut t := new_transformer(mut a, &tc, map[string]bool{})
+	t.materialize_inferred_anonymous_structs()
+
+	dep_name := 'dep.AnonStruct_v3_inferred_${dep_struct_id}'
+	main_name := 'AnonStruct_v3_inferred_${main_struct_id}'
+	assert tc.struct_files[dep_name] == dep_file
+	assert tc.struct_modules[dep_name] == 'dep'
+	assert tc.struct_files[main_name] == main_file
+	assert tc.struct_modules[main_name] == 'main'
+	assert a.nodes[int(dep_struct_id)].typ == dep_name
+	assert a.nodes[int(main_struct_id)].typ == main_name
+}

--- a/vlib/v3/transform/anonymous_struct_test.v
+++ b/vlib/v3/transform/anonymous_struct_test.v
@@ -69,3 +69,56 @@ fn test_inferred_anonymous_struct_uses_position_source_file() {
 	assert a.nodes[int(dep_struct_id)].typ == dep_name
 	assert a.nodes[int(main_struct_id)].typ == main_name
 }
+
+fn test_inferred_anonymous_structs_reuse_their_semantic_shape() {
+	mut a := flat.FlatAst.new()
+	main_file := '/tmp/project/main.v'
+	a.source_files[1] = token.File.unindexed(main_file, 1)
+	first_struct_id, first_value_id := add_inferred_anonymous_struct(mut a, 1)
+	second_struct_id, second_value_id := add_inferred_anonymous_struct(mut a, 1)
+	a.add_node(flat.Node{
+		kind: .file
+		value: main_file
+	})
+
+	mut tc := types.TypeChecker.new(&a)
+	tc.file_modules[main_file] = 'main'
+	tc.register_synth_type(first_value_id, types.Type(types.int_))
+	tc.register_synth_type(second_value_id, types.Type(types.int_))
+	mut t := new_transformer(mut a, &tc, map[string]bool{})
+	assert t.materialize_inferred_anonymous_structs()
+
+	shared_name := 'AnonStruct_v3_inferred_${first_struct_id}'
+	assert a.nodes[int(first_struct_id)].typ == shared_name
+	assert a.nodes[int(second_struct_id)].typ == shared_name
+	mut synthesized_declarations := 0
+	for node in a.nodes {
+		if node.kind == .struct_decl && node.value == shared_name {
+			synthesized_declarations++
+		}
+	}
+	assert synthesized_declarations == 1
+}
+
+fn test_prepared_selfhost_transform_materializes_before_repreparing() {
+	mut a := flat.FlatAst.new()
+	main_file := '/tmp/project/main.v'
+	a.source_files[1] = token.File.unindexed(main_file, 1)
+	struct_id, value_id := add_inferred_anonymous_struct(mut a, 1)
+	a.add_node(flat.Node{
+		kind: .file
+		value: main_file
+	})
+
+	mut tc := types.TypeChecker.new(&a)
+	tc.file_modules[main_file] = 'main'
+	tc.register_synth_type(value_id, types.Type(types.int_))
+	mut prepared := prepare_selfhost_transform(&a, &tc, true)
+	_, _, errors, _, _ := transform_prepared_selfhost_owned(mut prepared, mut a, &tc,
+		map[string]bool{}, unsafe { nil })
+
+	assert errors.len == 0
+	name := 'AnonStruct_v3_inferred_${struct_id}'
+	assert a.nodes[int(struct_id)].typ == name
+	assert name in prepared.transformer.structs
+}

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -2209,7 +2209,7 @@ fn (t &Transformer) static_assoc_fn_name(base_id flat.NodeId, method string) ?st
 			return none
 		}
 		for type_name in t.static_assoc_type_candidates(base.value) {
-			name := '${type_name}.${method}'
+			name := '${type_name}__static__${method}'
 			if t.is_known_fn_name(name) {
 				return name
 			}
@@ -2219,7 +2219,7 @@ fn (t &Transformer) static_assoc_fn_name(base_id flat.NodeId, method string) ?st
 		if inner.kind == .ident {
 			type_ident := '${inner.value}.${base.value}'
 			for type_name in t.static_assoc_type_candidates(type_ident) {
-				name := '${type_name}.${method}'
+				name := '${type_name}__static__${method}'
 				if t.is_known_fn_name(name) {
 					return name
 				}

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -2209,7 +2209,7 @@ fn (t &Transformer) static_assoc_fn_name(base_id flat.NodeId, method string) ?st
 			return none
 		}
 		for type_name in t.static_assoc_type_candidates(base.value) {
-			name := '${type_name}__static__${method}'
+			name := flat.encode_static_type_method_name(type_name, method)
 			if t.is_known_fn_name(name) {
 				return name
 			}
@@ -2219,7 +2219,7 @@ fn (t &Transformer) static_assoc_fn_name(base_id flat.NodeId, method string) ?st
 		if inner.kind == .ident {
 			type_ident := '${inner.value}.${base.value}'
 			for type_name in t.static_assoc_type_candidates(type_ident) {
-				name := '${type_name}__static__${method}'
+				name := flat.encode_static_type_method_name(type_name, method)
 				if t.is_known_fn_name(name) {
 					return name
 				}

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -3714,6 +3714,7 @@ fn (mut t Transformer) emit_generic_fn_specialization(decl GenericFnDecl, args [
 			children_count: cloned_fn.children_count
 			is_mut: cloned_fn.is_mut
 			skip_ownership_drops: true
+			is_static_type_method: cloned_fn.is_static_type_method
 		})
 	}
 	t.a.specialized_fn_nodes[int(clone_id)] = true
@@ -9951,6 +9952,7 @@ fn (mut t Transformer) clone_generic_node_from(node flat.Node, args []string, is
 			typ: cloned_typ
 			value: t.subst_node_value(node, args)
 			is_mut: node.is_mut
+			is_static_type_method: node.is_static_type_method
 		})
 		if node.kind == .ident && t.mut_param_values[node.value] {
 			t.mut_value_ident_nodes[int(clone_id)] = true
@@ -10021,6 +10023,7 @@ fn (mut t Transformer) clone_generic_node_from(node flat.Node, args []string, is
 		typ: final_typ
 		value: cloned_value
 		is_mut: node.is_mut
+		is_static_type_method: node.is_static_type_method
 	})
 	if t.specialization_node_start >= 0 && node.kind == .decl_assign && children.len >= 2 {
 		lhs := t.a.nodes[int(children[0])]

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -576,7 +576,11 @@ fn (t &Transformer) explicit_generic_fn_value_decl_candidates(id flat.NodeId, ba
 }
 
 fn (mut t Transformer) request_generic_fn_specialization(decl GenericFnDecl, args []string) {
-	concrete_args := t.canonical_generic_specialization_args(args)
+	// Callers pass the canonical arguments used to form `clone_value`. Canonicalizing
+	// them again here can run in the imported declaration's module and rebind a bare
+	// caller-owned type to the declaration's same-named type, leaving the function
+	// name and its registered ABI in disagreement (`..._Context` with `veb.Context`).
+	concrete_args := args.clone()
 	key := t.generic_specialization_progress_key(decl, concrete_args)
 	t.record_monomorph_cache_spec(key, decl.key, decl.module, concrete_args)
 	if key in t.generic_fn_spec_nodes || t.generic_fn_specs_in_progress[key]
@@ -3603,7 +3607,9 @@ fn (mut t Transformer) collect_node_subtree_flags(id flat.NodeId, mut nodes []bo
 }
 
 fn (mut t Transformer) emit_generic_fn_specialization(decl GenericFnDecl, args []string) flat.NodeId {
-	concrete_args := t.canonical_generic_specialization_args(args)
+	// Queueing/inference has already canonicalized these arguments in the caller's
+	// module. Preserve that identity while entering the imported declaration.
+	concrete_args := args.clone()
 	spec_key := t.generic_specialization_progress_key(decl, concrete_args)
 	if clone_id := t.generic_fn_spec_nodes[spec_key] {
 		return clone_id
@@ -4310,7 +4316,10 @@ fn (mut t Transformer) register_specialized_fn_signature_value(decl GenericFnDec
 	old_tc_file := if isnil(t.tc) { '' } else { t.tc.cur_file }
 	old_specialization_args := t.active_specialization_args
 	mut old_specialization_main_types := t.active_specialization_main_types.move()
-	concrete_args := t.canonical_generic_specialization_args(args)
+	// The specialization name and queue key were already formed from these canonical
+	// arguments in the caller's context. Re-resolving them here under another active
+	// module can change a bare nominal type without changing `clone_value`.
+	concrete_args := args.clone()
 	t.active_specialization_args = concrete_args
 	mut caller_main_types := t.specialization_main_type_closure(concrete_args)
 	if old_module in ['', 'main'] {

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -6827,7 +6827,8 @@ fn (t &Transformer) generic_static_assoc_call_decl_key(base_id flat.NodeId, meth
 	}
 	for type_name in t.generic_static_assoc_type_candidates(base_id) {
 		for method_spelling in generic_call_name_spellings(method) {
-			key := generic_fn_decl_base_value('${type_name}.${method_spelling}')
+			key := generic_fn_decl_base_value(flat.encode_static_type_method_name(type_name,
+				method_spelling))
 			if key in decls {
 				return key
 			}
@@ -6837,23 +6838,26 @@ fn (t &Transformer) generic_static_assoc_call_decl_key(base_id flat.NodeId, meth
 }
 
 fn (t &Transformer) generic_call_is_static_assoc_selector(node flat.Node, decl GenericFnDecl) bool {
-	if node.children_count == 0 || !decl.node.value.contains('.') {
+	if node.children_count == 0 {
 		return false
 	}
+	decl_value := generic_fn_decl_base_value(decl.node.value)
+	_, method := flat.decode_static_type_method_name(decl_value) or { return false }
 	callee_id := t.a.child(&node, 0)
 	callee := t.a.nodes[int(callee_id)]
 	if callee.kind != .selector || callee.children_count == 0 {
 		return false
 	}
-	method := decl.node.value.all_after_last('.')
 	if callee.value !in generic_call_name_spellings(method) {
 		return false
 	}
 	base_id := t.a.child(callee, 0)
 	for type_name in t.generic_static_assoc_type_candidates(base_id) {
 		for method_spelling in generic_call_name_spellings(method) {
-			key := generic_fn_decl_base_value('${type_name}.${method_spelling}')
-			if key == decl.key || key == generic_fn_decl_base_value(decl.node.value) {
+			key := generic_fn_decl_base_value(flat.encode_static_type_method_name(type_name,
+				method_spelling))
+			if key == decl.key || key == decl_value
+				|| transform_qualified_fn_name(decl.module, key) == decl.key {
 				return true
 			}
 		}
@@ -11219,6 +11223,13 @@ fn generic_fn_receiver_application_is_structured(value string) bool {
 }
 
 fn generic_fn_decl_base_value(value string) string {
+	if receiver, method := flat.decode_static_type_method_name(value) {
+		base, _, ok := generic_app_parts(receiver)
+		if ok {
+			return flat.encode_static_type_method_name(base, method)
+		}
+		return value
+	}
 	if !value.contains('.') {
 		return value
 	}

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -10716,7 +10716,7 @@ fn (mut t Transformer) retarget_cloned_static_assoc_call(node flat.Node, mut chi
 	}
 	owner := t.resolve_substituted_type_text(t.subst_type(args[idx], args))
 	for type_name in t.static_assoc_type_candidates(owner) {
-		static_fn := '${type_name}__static__${callee.value}'
+		static_fn := flat.encode_static_type_method_name(type_name, callee.value)
 		if t.is_known_fn_name(static_fn) {
 			children[0] = t.make_ident(static_fn)
 			return t.receiver_method_return_type(static_fn, t.subst_type(node.typ, args))

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -10716,7 +10716,7 @@ fn (mut t Transformer) retarget_cloned_static_assoc_call(node flat.Node, mut chi
 	}
 	owner := t.resolve_substituted_type_text(t.subst_type(args[idx], args))
 	for type_name in t.static_assoc_type_candidates(owner) {
-		static_fn := '${type_name}.${callee.value}'
+		static_fn := '${type_name}__static__${callee.value}'
 		if t.is_known_fn_name(static_fn) {
 			children[0] = t.make_ident(static_fn)
 			return t.receiver_method_return_type(static_fn, t.subst_type(node.typ, args))

--- a/vlib/v3/transform/orm.v
+++ b/vlib/v3/transform/orm.v
@@ -1467,6 +1467,18 @@ fn (mut t Transformer) sql_expr_from_token_for_type(token string, typ string) fl
 	if index_expr := t.sql_index_expr_from_token_for_type(token, typ) {
 		return index_expr
 	}
+	if fn_name, args := sql_value_call_parts(token) {
+		mut arg_ids := []flat.NodeId{cap: args.len}
+		for arg in args {
+			arg_ids << t.sql_expr_from_token(arg)
+		}
+		t.mark_fn_used_name(fn_name)
+		call := t.make_call_typed(fn_name, arg_ids, if typ.len > 0 { typ } else { '' })
+		// Run the reconstructed call through ordinary lowering so omitted `@[params]`
+		// arguments, aliases, and argument conversions are handled exactly as they
+		// are outside an SQL block.
+		return t.transform_expr(call)
+	}
 	if token in ['none', 'nil'] {
 		return t.make_struct_init('orm.Null')
 	}
@@ -1503,6 +1515,60 @@ fn (mut t Transformer) sql_expr_from_token_for_type(token string, typ string) fl
 		})
 	}
 	return t.sql_value_name_expr(token)
+}
+
+fn sql_value_call_parts(token string) ?(string, []string) {
+	clean := sql_trim_outer_empty(sql_clean_tokens(token.split(' ')))
+	if clean.len < 3 || clean[clean.len - 1] != ')' {
+		return none
+	}
+	mut open_idx := -1
+	for i, part in clean {
+		if part == '(' {
+			open_idx = i
+			break
+		}
+	}
+	if open_idx <= 0 {
+		return none
+	}
+	callee_name := sql_value_token_text(clean[..open_idx]).replace(' ', '')
+	name_parts := callee_name.split('.')
+	if name_parts.len == 0 {
+		return none
+	}
+	for part in name_parts {
+		if !sql_token_is_plain_ident(part) {
+			return none
+		}
+	}
+	close_idx := sql_matching_pair(clean, open_idx, '(', ')') or { return none }
+	if close_idx != clean.len - 1 {
+		return none
+	}
+	mut args := []string{}
+	mut arg_start := open_idx + 1
+	mut depth := 0
+	for i in open_idx + 1 .. close_idx {
+		part := clean[i]
+		if part in ['(', '[', '{'] {
+			depth++
+		} else if part in [')', ']', '}'] {
+			depth--
+		} else if part == ',' && depth == 0 {
+			if i == arg_start {
+				return none
+			}
+			args << sql_value_token_text(clean[arg_start..i])
+			arg_start = i + 1
+		}
+	}
+	if arg_start < close_idx {
+		args << sql_value_token_text(clean[arg_start..close_idx])
+	} else if arg_start > open_idx + 1 {
+		return none
+	}
+	return name_parts.join('.'), args
 }
 
 fn (mut t Transformer) sql_index_expr_from_token_for_type(token string, typ string) ?flat.NodeId {

--- a/vlib/v3/transform/orm.v
+++ b/vlib/v3/transform/orm.v
@@ -1468,16 +1468,7 @@ fn (mut t Transformer) sql_expr_from_token_for_type(token string, typ string) fl
 		return index_expr
 	}
 	if fn_name, args := sql_value_call_parts(token) {
-		mut arg_ids := []flat.NodeId{cap: args.len}
-		for arg in args {
-			arg_ids << t.sql_expr_from_token(arg)
-		}
-		t.mark_fn_used_name(fn_name)
-		call := t.make_call_typed(fn_name, arg_ids, if typ.len > 0 { typ } else { '' })
-		// Run the reconstructed call through ordinary lowering so omitted `@[params]`
-		// arguments, aliases, and argument conversions are handled exactly as they
-		// are outside an SQL block.
-		return t.transform_expr(call)
+		return t.sql_value_call_expr(fn_name, args, typ)
 	}
 	if token in ['none', 'nil'] {
 		return t.make_struct_init('orm.Null')
@@ -1496,8 +1487,7 @@ fn (mut t Transformer) sql_expr_from_token_for_type(token string, typ string) fl
 	}
 	if sql_token_is_no_arg_call(token) {
 		fn_name := token[..token.len - 2]
-		t.mark_fn_used_name(fn_name)
-		return t.make_call_typed(fn_name, []flat.NodeId{}, if typ.len > 0 { typ } else { '' })
+		return t.sql_value_call_expr(fn_name, []string{}, typ)
 	}
 	if token.starts_with('.') && typ.len > 0 {
 		return t.a.add_node(flat.Node{
@@ -1515,6 +1505,45 @@ fn (mut t Transformer) sql_expr_from_token_for_type(token string, typ string) fl
 		})
 	}
 	return t.sql_value_name_expr(token)
+}
+
+fn (mut t Transformer) sql_value_call_expr(callee_name string, args []string, typ string) flat.NodeId {
+	mut arg_ids := []flat.NodeId{cap: args.len}
+	for arg in args {
+		arg_ids << t.sql_expr_from_token(arg)
+	}
+	if args.len == 1
+		&& (is_plain_builtin_alias_type(callee_name) || t.is_known_type_name(callee_name)) {
+		return t.transform_expr(t.make_cast(callee_name, arg_ids[0], callee_name))
+	}
+	callee := t.sql_value_call_callee(callee_name)
+	call := t.make_call_expr_typed(callee, arg_ids, if typ.len > 0 { typ } else { '' })
+	// Preserve the source call shape so ordinary lowering can distinguish module
+	// functions, receiver methods, and static associated functions.
+	return t.transform_expr(call)
+}
+
+fn (mut t Transformer) sql_value_call_callee(callee_name string) flat.NodeId {
+	parts := callee_name.split('.')
+	if parts.len < 2 {
+		return t.make_ident(callee_name)
+	}
+	mut receiver_type := t.sql_root_value_type_name(parts[0])
+	if receiver_type.len == 0 {
+		return t.sql_qualified_selector(callee_name)
+	}
+	mut receiver := t.make_ident(parts[0])
+	t.set_node_typ(int(receiver), receiver_type)
+	for field in parts[1..parts.len - 1] {
+		field_type := t.lookup_struct_field_type(receiver_type, field) or {
+			t.builtin_selector_type(receiver_type, field) or { '' }
+		}
+		receiver = t.make_selector(receiver, field, field_type)
+		if field_type.len > 0 {
+			receiver_type = field_type
+		}
+	}
+	return t.make_selector(receiver, parts.last(), '')
 }
 
 fn sql_value_call_parts(token string) ?(string, []string) {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -977,6 +977,7 @@ pub fn transform_with_used_opt_config_scoped_workers_checked_owned(mut a flat.Fl
 pub fn transform_selected_functions(mut a flat.FlatAst, tc &types.TypeChecker, selected map[string]bool) (map[string]bool, []string, []string) {
 	mut t := new_transformer(mut a, tc, selected)
 	t.skip_generics = true
+	t.materialize_inferred_anonymous_structs()
 	t.prepare()
 	t.collect_exclusive_closure_return_fns()
 	base_node_count := t.a.nodes.len
@@ -1024,6 +1025,7 @@ fn transform_with_used_opt_config_scoped_workers_checked_impl(mut a flat.FlatAst
 	mut impl_sw := time.new_stopwatch()
 	mut t := new_transformer(mut a, tc, used_fns)
 	configure_transformer(mut t, want_parallel, skip_generics, scope_parallel_workers, building_v, retain_worker_results, stage_scope)
+	t.materialize_inferred_anonymous_structs()
 	t.prepare_with_pre_scans()
 	t.timing_profile('  [ttime] new+prepare        ${f64(impl_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	return transform_after_prepare(mut t, mut a, used_fns, want_parallel, skip_generics)

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -1523,6 +1523,10 @@ pub fn monomorphize_with_used_checked_config_scoped_cached(mut a flat.FlatAst, t
 			break
 		}
 	}
+	// Calls that depend on a generic parameter have concrete result types only in
+	// the specialized clones. Give their inferred anonymous literals concrete
+	// declarations before cgen sees the cloned bodies.
+	t.materialize_inferred_anonymous_structs()
 	t.erase_generic_fn_decls(t.cached_generic_fn_decls())
 	t.materialize_generic_structs(true)
 	t.monomorph_profile('mono wrapper structs: ${time.ticks() - debug_started} ms')

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -8848,6 +8848,7 @@ fn (mut t Transformer) transform_fn_body(fn_idx int) {
 			typ: fn_node.typ
 			payload: fn_node.payload
 			skip_ownership_drops: fn_node.skip_ownership_drops
+			is_static_type_method: fn_node.is_static_type_method
 		})
 	}
 	t.smartcast_stack.clear()

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -917,6 +917,12 @@ pub fn transform_prepared_selfhost_owned(mut prepared PreparedSelfhostTransform,
 	t.tc = unsafe { tc }
 	t.used_fns = used_fns.clone()
 	configure_transformer(mut t, true, true, true, true, true, stage_scope)
+	if t.materialize_inferred_anonymous_structs() {
+		// Preparation overlapped markused against the checked AST. Materialization
+		// appends declarations and assigns their concrete types, so rebuild the
+		// indexes before workers consume that changed AST.
+		t.prepare_with_pre_scans()
+	}
 	augmented, was_parallel, errors, owned_base_nodes, retained_regions := transform_after_prepare(mut t, mut a, used_fns, true, true)
 	prepared.ready = false
 	return augmented, was_parallel, errors, owned_base_nodes, retained_regions

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -2204,6 +2204,7 @@ fn (mut t Transformer) clone_deferred_worker_writes_from(start int) {
 						op: write.node.op
 						is_mut: write.node.is_mut
 						skip_ownership_drops: write.node.skip_ownership_drops
+						is_static_type_method: write.node.is_static_type_method
 					}
 				}
 			}

--- a/vlib/v3/transform/type_propagation.v
+++ b/vlib/v3/transform/type_propagation.v
@@ -185,7 +185,7 @@ fn map_value_starts_with_fixed_array(typ string) bool {
 }
 
 fn decl_type_is_usable(typ string) bool {
-	if typ.len == 0 || typ in ['unknown', 'array', 'map'] || typ.contains('unknown') {
+	if typ.len == 0 || typ in ['unknown', 'array', 'map', 'struct'] || typ.contains('unknown') {
 		return false
 	}
 	if types.type_text_contains_typeof(typ) {

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -9237,7 +9237,9 @@ fn (mut tc TypeChecker) check_fn_declaration_name(id flat.NodeId, node flat.Node
 	tc.check_imported_module_prefix(id, node.value, 'fn')
 	mut name := node.value.all_after_last('.')
 	if node.is_static_type_method {
-		name = name.all_after('__static__')
+		if _, method := flat.decode_static_type_method_name(node.value) {
+			name = method
+		}
 	}
 	if !node.value.contains('.') && !node.is_static_type_method
 		&& tc.cur_module in ['', 'main'] && is_builtin_type_name(name) {
@@ -10929,7 +10931,11 @@ fn (mut tc TypeChecker) check_decl_type_strings(node_id flat.NodeId, node flat.N
 	if node.kind == .fn_decl && (node.value.contains('.') || node.is_static_type_method) {
 		is_marked_static := node.is_static_type_method
 		receiver_name := if is_marked_static {
-			node.value.all_before('__static__').all_after_last('.')
+			if receiver, _ := flat.decode_static_type_method_name(node.value) {
+				receiver.all_after_last('.')
+			} else {
+				''
+			}
 		} else {
 			node.value.all_before_last('.').all_after_last('.')
 		}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -1968,9 +1968,9 @@ fn (mut tc TypeChecker) build_fn_declaration_indexes(a &flat.FlatAst) {
 		if qname !in tc.declaration_param_mutability {
 			tc.declaration_param_mutability[qname] = param_mutability
 		}
-		if node.value.contains('.') {
-			is_static := node.children_count == 0 || a.child_node(&node, 0).kind != .param
-				|| a.child_node(&node, 0).op != .dot
+		if node.value.contains('.') || node.value.contains('__static__') {
+			is_static := node.value.contains('__static__') || node.children_count == 0
+				|| a.child_node(&node, 0).kind != .param || a.child_node(&node, 0).op != .dot
 			if node.value !in tc.static_associated_fn_keys {
 				tc.static_associated_fn_keys[node.value] = is_static
 			}
@@ -6752,7 +6752,7 @@ pub fn (mut tc TypeChecker) diagnose_unused_private_declarations(used_fns map[st
 		if node.kind == .fn_decl {
 			if node.op == .arrow || node.value in ['main', 'init', 'cleanup']
 				|| is_v_test_fn_name(node.value) || node.value.starts_with('__anon_fn_')
-				|| node.value.contains('.') {
+				|| node.value.contains('.') || node.value.contains('__static__') {
 				continue
 			}
 			if tc.declaration_contains_error(node) {
@@ -9235,8 +9235,12 @@ fn (mut tc TypeChecker) check_fn_declaration_name(id flat.NodeId, node flat.Node
 	}
 	tc.check_fn_if_attribute_return(id, node)
 	tc.check_imported_module_prefix(id, node.value, 'fn')
-	name := node.value.all_after_last('.')
-	if !node.value.contains('.') && tc.cur_module in ['', 'main'] && is_builtin_type_name(name) {
+	mut name := node.value.all_after_last('.')
+	if name.contains('__static__') {
+		name = name.all_after('__static__')
+	}
+	if !node.value.contains('.') && !node.value.contains('__static__')
+		&& tc.cur_module in ['', 'main'] && is_builtin_type_name(name) {
 		tc.record_error_at(.duplicate_decl, 'top level declaration cannot shadow builtin type', id, tc.fn_declaration_diagnostic_pos(node))
 	}
 	// V1 treats os and strconv like builtin modules. Their long-standing private
@@ -9252,7 +9256,7 @@ fn (mut tc TypeChecker) check_fn_declaration_name(id flat.NodeId, node flat.Node
 	if name.len == 0 || (!name[0].is_letter() && name[0] != `_`) || snake_case_name_is_valid(name) {
 		return
 	}
-	tc.check_snake_case_name(id, name, if node.value.contains('.') {
+	tc.check_snake_case_name(id, name, if node.value.contains('.') || node.value.contains('__static__') {
 		'method name'
 	} else {
 		'function name'
@@ -10922,12 +10926,17 @@ fn (mut tc TypeChecker) check_decl_type_strings(node_id flat.NodeId, node flat.N
 		&& (node.children_count > 0 || split_sum_variant_texts(node.typ).len > 1) {
 		tc.check_sum_type_decl(node_id, node)
 	}
-	if node.kind == .fn_decl && node.value.contains('.') {
-		receiver_name := node.value.all_before_last('.').all_after_last('.')
-		mut is_static := node.children_count == 0
+	if node.kind == .fn_decl && (node.value.contains('.') || node.value.contains('__static__')) {
+		is_marked_static := node.value.contains('__static__')
+		receiver_name := if is_marked_static {
+			node.value.all_before('__static__').all_after_last('.')
+		} else {
+			node.value.all_before_last('.').all_after_last('.')
+		}
+		mut is_static := is_marked_static || node.children_count == 0
 		if node.children_count > 0 {
 			first := tc.a.child_node(&node, 0)
-			is_static = first.kind != .param || first.op != .dot
+			is_static = is_marked_static || first.kind != .param || first.op != .dot
 		}
 		if is_static && !tc.type_name_known(receiver_name) {
 			tc.record_error_at(.unknown_type, 'unknown type `${receiver_name}`', node_id, tc.type_diagnostic_pos(node_id, receiver_name))

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -1968,8 +1968,8 @@ fn (mut tc TypeChecker) build_fn_declaration_indexes(a &flat.FlatAst) {
 		if qname !in tc.declaration_param_mutability {
 			tc.declaration_param_mutability[qname] = param_mutability
 		}
-		if node.value.contains('.') || node.value.contains('__static__') {
-			is_static := node.value.contains('__static__') || node.children_count == 0
+		if node.value.contains('.') || node.is_static_type_method {
+			is_static := node.is_static_type_method || node.children_count == 0
 				|| a.child_node(&node, 0).kind != .param || a.child_node(&node, 0).op != .dot
 			if node.value !in tc.static_associated_fn_keys {
 				tc.static_associated_fn_keys[node.value] = is_static
@@ -6752,7 +6752,7 @@ pub fn (mut tc TypeChecker) diagnose_unused_private_declarations(used_fns map[st
 		if node.kind == .fn_decl {
 			if node.op == .arrow || node.value in ['main', 'init', 'cleanup']
 				|| is_v_test_fn_name(node.value) || node.value.starts_with('__anon_fn_')
-				|| node.value.contains('.') || node.value.contains('__static__') {
+				|| node.value.contains('.') || node.is_static_type_method {
 				continue
 			}
 			if tc.declaration_contains_error(node) {
@@ -9236,10 +9236,10 @@ fn (mut tc TypeChecker) check_fn_declaration_name(id flat.NodeId, node flat.Node
 	tc.check_fn_if_attribute_return(id, node)
 	tc.check_imported_module_prefix(id, node.value, 'fn')
 	mut name := node.value.all_after_last('.')
-	if name.contains('__static__') {
+	if node.is_static_type_method {
 		name = name.all_after('__static__')
 	}
-	if !node.value.contains('.') && !node.value.contains('__static__')
+	if !node.value.contains('.') && !node.is_static_type_method
 		&& tc.cur_module in ['', 'main'] && is_builtin_type_name(name) {
 		tc.record_error_at(.duplicate_decl, 'top level declaration cannot shadow builtin type', id, tc.fn_declaration_diagnostic_pos(node))
 	}
@@ -9256,7 +9256,7 @@ fn (mut tc TypeChecker) check_fn_declaration_name(id flat.NodeId, node flat.Node
 	if name.len == 0 || (!name[0].is_letter() && name[0] != `_`) || snake_case_name_is_valid(name) {
 		return
 	}
-	tc.check_snake_case_name(id, name, if node.value.contains('.') || node.value.contains('__static__') {
+	tc.check_snake_case_name(id, name, if node.value.contains('.') || node.is_static_type_method {
 		'method name'
 	} else {
 		'function name'
@@ -10926,8 +10926,8 @@ fn (mut tc TypeChecker) check_decl_type_strings(node_id flat.NodeId, node flat.N
 		&& (node.children_count > 0 || split_sum_variant_texts(node.typ).len > 1) {
 		tc.check_sum_type_decl(node_id, node)
 	}
-	if node.kind == .fn_decl && (node.value.contains('.') || node.value.contains('__static__')) {
-		is_marked_static := node.value.contains('__static__')
+	if node.kind == .fn_decl && (node.value.contains('.') || node.is_static_type_method) {
+		is_marked_static := node.is_static_type_method
 		receiver_name := if is_marked_static {
 			node.value.all_before('__static__').all_after_last('.')
 		} else {

--- a/vlib/v3/types/checker_comptime.v
+++ b/vlib/v3/types/checker_comptime.v
@@ -8759,7 +8759,7 @@ fn (tc &TypeChecker) or_block_call_display_name(call &flat.Node) string {
 			if base.kind == .ident && base.value.len > 0 && base.value[0].is_capital()
 				&& tc.resolve_enum_name(base.value) == none
 				&& !tc.ident_resolves_to_value(base.value) {
-				return '${base.value}__static__${callee.value}'
+				return flat.encode_static_type_method_name(base.value, callee.value)
 			}
 		}
 	}

--- a/vlib/v3/types/checker_tail.v
+++ b/vlib/v3/types/checker_tail.v
@@ -13354,7 +13354,8 @@ fn (mut tc TypeChecker) check_call_arg_types(id flat.NodeId, node flat.Node, inf
 							base := tc.a.child_node(callee, 0)
 							if base.kind == .ident
 								&& tc.source_declares_type_in_scope(base.value, tc.cur_file, tc.cur_module) {
-								target_name = '${base.value}__static__${callee.value}'
+								target_name = flat.encode_static_type_method_name(base.value,
+									callee.value)
 							}
 							if info.has_receiver {
 								target_name = callee.value

--- a/vlib/v3/types/checker_tail.v
+++ b/vlib/v3/types/checker_tail.v
@@ -4441,7 +4441,12 @@ fn (mut tc TypeChecker) check_call_privacy(id flat.NodeId, node flat.Node, info 
 				name_pos.offset, node.pos.end))
 			return true
 		}
-		tc.record_error_at(.unknown_fn, 'function `${info.name}` is private', id, node.pos)
+		display_name := if receiver, method := flat.decode_static_type_method_name(info.name) {
+			'${receiver}.${method}'
+		} else {
+			info.name
+		}
+		tc.record_error_at(.unknown_fn, 'function `${display_name}` is private', id, node.pos)
 		return true
 	}
 	return false

--- a/vlib/v3/types/checker_tail.v
+++ b/vlib/v3/types/checker_tail.v
@@ -3536,7 +3536,8 @@ fn (mut tc TypeChecker) check_call(id flat.NodeId, node flat.Node) {
 			if callee.children_count > 0 {
 				base := tc.a.child_node(callee, 0)
 				if base.kind == .ident && !tc.has_active_import(base.value)
-					&& !tc.ident_resolves_to_value(base.value) {
+					&& !tc.ident_resolves_to_value(base.value)
+					&& tc.static_assoc_fn_key_for_base(base.value, callee.value) == none {
 					for type_name in [base.value, tc.qualify_name(base.value)] {
 						key := '${type_name}.${callee.value}'
 						if tc.fn_signature_known(key) && !tc.fn_key_is_static_associated(key)
@@ -18111,6 +18112,9 @@ fn (tc &TypeChecker) is_known_call(node flat.Node) bool {
 			if base_node.value == 'C' {
 				return true
 			}
+			if _ := tc.static_assoc_fn_key_for_base(base_node.value, fn_node.value) {
+				return true
+			}
 			if resolved_mod := tc.resolve_import_alias(base_node.value) {
 				mod_name := '${resolved_mod}.${fn_node.value}'
 				if mod_name in tc.fn_ret_types || mod_name in tc.sum_types || mod_name in tc.structs
@@ -18135,6 +18139,11 @@ fn (tc &TypeChecker) is_known_call(node flat.Node) bool {
 			inner := tc.a.child_node(base_node, 0)
 			if inner.kind == .ident {
 				mod_name := tc.resolve_import_alias(inner.value) or { inner.value }
+				if _ := tc.static_assoc_fn_key_for_base('${mod_name}.${base_node.value}',
+					fn_node.value)
+				{
+					return true
+				}
 				if '${mod_name}.${base_node.value}.${fn_node.value}' in tc.fn_ret_types {
 					return true
 				}

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -7971,13 +7971,13 @@ fn (tc &TypeChecker) static_assoc_fn_key_for_base(type_ident string, method stri
 		return none
 	}
 	for type_name in [type_ident, tc.qualify_name(type_ident)] {
-		key := '${type_name}__static__${method}'
+		key := flat.encode_static_type_method_name(type_name, method)
 		if tc.fn_signature_known(key) {
 			return key
 		}
 	}
 	for type_name in tc.static_assoc_type_candidates(type_ident) {
-		key := '${type_name}__static__${method}'
+		key := flat.encode_static_type_method_name(type_name, method)
 		if tc.fn_signature_known(key) || key in tc.fn_ret_types {
 			return key
 		}

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -7971,15 +7971,14 @@ fn (tc &TypeChecker) static_assoc_fn_key_for_base(type_ident string, method stri
 		return none
 	}
 	for type_name in [type_ident, tc.qualify_name(type_ident)] {
-		key := '${type_name}.${method}'
-		if tc.fn_signature_known(key) && tc.fn_key_is_static_associated(key) {
+		key := '${type_name}__static__${method}'
+		if tc.fn_signature_known(key) {
 			return key
 		}
 	}
 	for type_name in tc.static_assoc_type_candidates(type_ident) {
-		key := '${type_name}.${method}'
-		if (tc.fn_signature_known(key) || key in tc.fn_ret_types)
-			&& tc.fn_key_is_static_associated(key) {
+		key := '${type_name}__static__${method}'
+		if tc.fn_signature_known(key) || key in tc.fn_ret_types {
 			return key
 		}
 	}


### PR DESCRIPTION
## Summary

- preserve caller-resolved generic type arguments when specializing imported functions
- materialize inferred anonymous structs before transform and C generation
- keep static associated functions distinct from same-named instance methods
- lower qualified function calls correctly inside ORM update expressions
- add focused regressions for the supplied veb, ORM, closure, and method-collision failures

The supplied compile log groups into these root causes, plus template and closure paths already covered by passing v3 regressions. Only generated C and its compiler log were available, so the original application could not be regenerated end to end; the regression projects reproduce the independent failures from that log.

## Validation

- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -silent test vlib/v3/parser/` (7/7)
- `./vnew -silent test vlib/v3/gen/c/` (19/19)
- focused eval, formatter, veb, ORM, static/instance method, and imported generic closure regressions
- existing cross-module generic, template capture, and unknown-function regression tests
- production builds of the veb context and static/instance method reproductions
- `git diff --check`

Broader existing suite failures were also observed outside these paths: `vlib/v3/types/storage_source_test.v`, `vlib/v3/transform/transform_parallel_test.v`, legacy diagnostic parity in `vlib/v/compiler_errors_test.v`, and a `vlib/v3/tests/type_checker_errors_test.v` fixture that requires `-enable-globals`.