### PR TITLE
v3: compile QML templates to UI2 element builders

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -7173,6 +7173,67 @@ numbers: [1, 2, 3]
 
 See more [details](https://github.com/vlang/v/blob/master/vlib/v/TEMPLATES.md)
 
+#### `$qml` for compiling UI2 interfaces
+
+The V3 compiler can compile a QML file directly into an `ui2.Element` expression with
+`$qml(path)`. The QML is parsed while the application is compiled; the resulting program
+constructs UI2 elements directly and does not parse the QML file at runtime.
+
+```v ignore
+import ui2
+
+struct App {
+pub mut:
+	name string
+}
+
+pub fn (mut app App) save() {}
+
+fn view(app &App) ui2.Element {
+	return $qml('views/profile.qml')
+}
+```
+
+`views/profile.qml`:
+
+```qml
+Screen {
+    id: root
+    background: "#f8fafc"
+    Column {
+        Label { text: "Hello ${app.name}" }
+        Button { text: "Save" on_tap: app.save() }
+    }
+}
+```
+
+The path must be a compile-time string. String literals, constants, compile-time local
+bindings, and `+` concatenations of those forms are supported. Absolute paths are used as
+given. A relative path is searched for in this order:
+
+1. relative to the V source file;
+2. in a `templates` directory next to the V source file;
+3. relative to the nearest parent directory containing `v.mod`;
+4. in that module root's `templates` directory.
+
+The compiled QML subset supports these UI2 elements:
+
+- `Screen`, `View`, `Rectangle`, `Column`, `Row`, and `Scroll` containers;
+- `Label`, `Image`, `Button`, `Checkbox`, `Dropdown`, `TextField`, and `TextArea`;
+- `ProgressBar`, `Slider`, `Switch`, `Spinner`, and `MessageBox`;
+- `Repeater` delegates, `MenuItem` entries, and `Option` entries.
+
+Properties can use literals, arithmetic and boolean expressions, conditional expressions,
+string interpolation, an enclosing `app` value, and geometry or custom properties exposed
+by an `id`. An ID on an earlier node is available to following nodes in the same component.
+Both quoted and unquoted `#RRGGBB` color values are accepted. A `Repeater` requires `model`
+and stable `key` properties and exposes `item` and `index` inside its delegate.
+
+The `bind.text`, `bind.checked`, `bind.active`, and `bind.value` properties create two-way
+bindings to mutable top-level fields on `app`. Event properties `on_tap`, `on_change`,
+`on_active`, `on_text`, and `on_submit` call an `app` method with zero or one argument. These
+methods and their argument types are checked while the generated V code is compiled.
+
 #### `$env`
 
 ```v

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -17047,16 +17047,17 @@ fn module_path_has_v_sources(path string) bool {
 	if path.len == 0 || !os.is_dir(path) {
 		return false
 	}
-	entries := os.ls(path) or { return false }
+	source_root := v3_directory_source_root(path)
+	entries := os.ls(source_root) or { return false }
 	if entries.any(it.ends_with('.v')) {
 		return true
 	}
 	// A v.mod can expose one logical module from source-only subdirectories. The
 	// importer must accept that root before v3_directory_user_files can expand it.
-	module_root := os.real_path(path)
+	module_root := os.real_path(source_root)
 	mut seen_dirs := map[string]bool{}
 	for subdir in vmod_subdirs(path) or { []string{} } {
-		subdir_path := os.join_path_single(path, subdir)
+		subdir_path := os.join_path_single(source_root, subdir)
 		if module_subdir_has_v_sources(module_root, subdir_path, mut seen_dirs) {
 			return true
 		}

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -17053,8 +17053,37 @@ fn module_path_has_v_sources(path string) bool {
 	}
 	// A v.mod can expose one logical module from source-only subdirectories. The
 	// importer must accept that root before v3_directory_user_files can expand it.
+	module_root := os.real_path(path)
+	mut seen_dirs := map[string]bool{}
 	for subdir in vmod_subdirs(path) or { []string{} } {
-		if os.walk_ext(os.join_path_single(path, subdir), '.v').len > 0 {
+		subdir_path := os.join_path_single(path, subdir)
+		if module_subdir_has_v_sources(module_root, subdir_path, mut seen_dirs) {
+			return true
+		}
+	}
+	return false
+}
+
+fn module_subdir_has_v_sources(module_root string, dir string, mut seen_dirs map[string]bool) bool {
+	if !os.is_dir(dir) {
+		return false
+	}
+	real_dir := os.real_path(dir)
+	if seen_dirs[real_dir] {
+		return false
+	}
+	seen_dirs[real_dir] = true
+	if real_dir != module_root && os.is_file(os.join_path_single(real_dir, 'v.mod')) {
+		return false
+	}
+	entries := os.ls(real_dir) or { return false }
+	for entry in entries {
+		entry_path := os.join_path_single(real_dir, entry)
+		if os.is_file(entry_path) && entry.ends_with('.v') {
+			return true
+		}
+		if os.is_dir(entry_path)
+			&& module_subdir_has_v_sources(module_root, entry_path, mut seen_dirs) {
 			return true
 		}
 	}

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -16924,7 +16924,7 @@ fn resolve_project_or_pref_module_path_cached(prefs &pref.Preferences, mod_name 
 
 fn resolve_project_or_pref_module_path(prefs &pref.Preferences, mod_name string, importing_file string, project_root string, mut cache map[string]string) string {
 	mod_path := mod_name.replace('.', os.path_separator)
-	local_path := resolve_local_or_project_module_path(mod_name, mod_path, importing_file, project_root)
+	local_path := resolve_local_or_project_module_path(prefs, mod_name, mod_path, importing_file, project_root)
 	if local_path.len > 0 {
 		return local_path
 	}
@@ -16947,7 +16947,7 @@ fn resolve_project_or_pref_module_path(prefs &pref.Preferences, mod_name string,
 	return prefs.get_module_path(mod_name, importing_file)
 }
 
-fn resolve_local_or_project_module_path(mod_name string, mod_path string, importing_file string, project_root string) string {
+fn resolve_local_or_project_module_path(prefs &pref.Preferences, mod_name string, mod_path string, importing_file string, project_root string) string {
 	top_name := mod_name.all_before('.')
 	if importing_file.len > 0 {
 		importer_dir := os.dir(importing_file)
@@ -16959,7 +16959,7 @@ fn resolve_local_or_project_module_path(mod_name string, mod_path string, import
 			return alias_path
 		}
 		local_modules_path := os.join_path_single(local_modules_root, mod_path)
-		if module_path_has_v_sources(local_modules_path) {
+		if module_path_has_v_sources(local_modules_path, prefs) {
 			return local_modules_path
 		}
 	}
@@ -16968,7 +16968,7 @@ fn resolve_local_or_project_module_path(mod_name string, mod_path string, import
 			return alias_path
 		}
 		project_path := os.join_path_single(project_root, mod_path)
-		if module_path_has_v_sources(project_path) {
+		if module_path_has_v_sources(project_path, prefs) {
 			return project_path
 		}
 	}
@@ -16976,7 +16976,7 @@ fn resolve_local_or_project_module_path(mod_name string, mod_path string, import
 	// project-root modules precede a module beside the importing file.
 	if importing_file.len > 0 {
 		relative_path := os.join_path_single(os.dir(importing_file), mod_path)
-		if module_path_has_v_sources(relative_path) {
+		if module_path_has_v_sources(relative_path, prefs) {
 			return relative_path
 		}
 	}
@@ -17036,20 +17036,19 @@ fn resolve_global_module_path(prefs &pref.Preferences, mod_name string, mod_path
 			return alias_path
 		}
 		module_path := os.join_path_single(root, mod_path)
-		if module_path_has_v_sources(module_path) {
+		if module_path_has_v_sources(module_path, prefs) {
 			return module_path
 		}
 	}
 	return ''
 }
 
-fn module_path_has_v_sources(path string) bool {
+fn module_path_has_v_sources(path string, prefs &pref.Preferences) bool {
 	if path.len == 0 || !os.is_dir(path) {
 		return false
 	}
 	source_root := v3_directory_source_root(path)
-	entries := os.ls(source_root) or { return false }
-	if entries.any(it.ends_with('.v')) {
+	if pref.get_v_files_from_dir_for_target(source_root, prefs.user_defines, prefs.target).len > 0 {
 		return true
 	}
 	// A v.mod can expose one logical module from source-only subdirectories. The
@@ -17058,14 +17057,14 @@ fn module_path_has_v_sources(path string) bool {
 	mut seen_dirs := map[string]bool{}
 	for subdir in vmod_subdirs(path) or { []string{} } {
 		subdir_path := os.join_path_single(source_root, subdir)
-		if module_subdir_has_v_sources(module_root, subdir_path, mut seen_dirs) {
+		if module_subdir_has_v_sources(module_root, subdir_path, prefs, mut seen_dirs) {
 			return true
 		}
 	}
 	return false
 }
 
-fn module_subdir_has_v_sources(module_root string, dir string, mut seen_dirs map[string]bool) bool {
+fn module_subdir_has_v_sources(module_root string, dir string, prefs &pref.Preferences, mut seen_dirs map[string]bool) bool {
 	if !os.is_dir(dir) {
 		return false
 	}
@@ -17077,14 +17076,14 @@ fn module_subdir_has_v_sources(module_root string, dir string, mut seen_dirs map
 	if real_dir != module_root && os.is_file(os.join_path_single(real_dir, 'v.mod')) {
 		return false
 	}
+	if pref.get_v_files_from_dir_for_target(real_dir, prefs.user_defines, prefs.target).len > 0 {
+		return true
+	}
 	entries := os.ls(real_dir) or { return false }
 	for entry in entries {
 		entry_path := os.join_path_single(real_dir, entry)
-		if os.is_file(entry_path) && entry.ends_with('.v') {
-			return true
-		}
 		if os.is_dir(entry_path)
-			&& module_subdir_has_v_sources(module_root, entry_path, mut seen_dirs) {
+			&& module_subdir_has_v_sources(module_root, entry_path, prefs, mut seen_dirs) {
 			return true
 		}
 	}

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -17048,5 +17048,15 @@ fn module_path_has_v_sources(path string) bool {
 		return false
 	}
 	entries := os.ls(path) or { return false }
-	return entries.any(it.ends_with('.v'))
+	if entries.any(it.ends_with('.v')) {
+		return true
+	}
+	// A v.mod can expose one logical module from source-only subdirectories. The
+	// importer must accept that root before v3_directory_user_files can expand it.
+	for subdir in vmod_subdirs(path) or { []string{} } {
+		if os.walk_ext(os.join_path_single(path, subdir), '.v').len > 0 {
+			return true
+		}
+	}
+	return false
 }

--- a/vlib/v3/driver/module_resolution_test.v
+++ b/vlib/v3/driver/module_resolution_test.v
@@ -28,3 +28,22 @@ fn test_manifest_subdir_probe_stops_at_nested_modules() {
 	os.write_file(os.join_path(outer, 'parts', 'outer.v'), 'module outer\n\npub fn value() int { return 2 }\n')!
 	assert module_path_has_v_sources(outer)
 }
+
+fn test_manifest_subdir_probe_uses_configured_source_root() {
+	root := os.join_path(os.vtmp_dir(), 'v3_module_probe_base_url_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	module_root := os.join_path(root, 'sample')
+	source_subdir := os.join_path(module_root, 'src', 'core')
+	os.mkdir_all(source_subdir) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	os.write_file(os.join_path(module_root, 'v.mod'), "Module { name: 'sample', base_url: 'src', subdirs: ['core'] }\n")!
+	os.write_file(os.join_path(source_subdir, 'core.v'), 'module sample\n\npub fn value() int { return 1 }\n')!
+
+	assert module_path_has_v_sources(module_root)
+	prefs := pref.Preferences{
+		module_search_paths: [root]
+	}
+	assert resolve_global_module_path(&prefs, 'sample', 'sample') == module_root
+}

--- a/vlib/v3/driver/module_resolution_test.v
+++ b/vlib/v3/driver/module_resolution_test.v
@@ -20,13 +20,13 @@ fn test_manifest_subdir_probe_stops_at_nested_modules() {
 	os.write_file(os.join_path(outer, 'parts', 'nested', 'nested.v'), 'module nested\n\npub fn value() int { return 1 }\n')!
 	os.write_file(os.join_path(valid, 'sample.v'), 'module sample\n\npub fn value() int { return 2 }\n')!
 
-	assert !module_path_has_v_sources(outer)
 	prefs := pref.Preferences{
 		module_search_paths: [first_search_root, second_search_root]
 	}
+	assert !module_path_has_v_sources(outer, &prefs)
 	assert resolve_global_module_path(&prefs, 'sample', 'sample') == valid
 	os.write_file(os.join_path(outer, 'parts', 'outer.v'), 'module outer\n\npub fn value() int { return 2 }\n')!
-	assert module_path_has_v_sources(outer)
+	assert module_path_has_v_sources(outer, &prefs)
 }
 
 fn test_manifest_subdir_probe_uses_configured_source_root() {
@@ -41,9 +41,38 @@ fn test_manifest_subdir_probe_uses_configured_source_root() {
 	os.write_file(os.join_path(module_root, 'v.mod'), "Module { name: 'sample', base_url: 'src', subdirs: ['core'] }\n")!
 	os.write_file(os.join_path(source_subdir, 'core.v'), 'module sample\n\npub fn value() int { return 1 }\n')!
 
-	assert module_path_has_v_sources(module_root)
 	prefs := pref.Preferences{
 		module_search_paths: [root]
 	}
+	assert module_path_has_v_sources(module_root, &prefs)
 	assert resolve_global_module_path(&prefs, 'sample', 'sample') == module_root
+}
+
+fn test_manifest_subdir_probe_filters_sources_for_target() {
+	root := os.join_path(os.vtmp_dir(), 'v3_module_probe_target_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	first_search_root := os.join_path(root, 'first')
+	second_search_root := os.join_path(root, 'second')
+	incompatible := os.join_path(first_search_root, 'sample')
+	parts := os.join_path(incompatible, 'parts')
+	valid := os.join_path(second_search_root, 'sample')
+	os.mkdir_all(parts) or { panic(err) }
+	os.mkdir_all(valid) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	os.write_file(os.join_path(incompatible, 'v.mod'), "Module { name: 'sample', subdirs: ['parts'] }\n")!
+	os.write_file(os.join_path(parts, 'sample_windows.c.v'), 'module sample\n')!
+	os.write_file(os.join_path(parts, 'sample_d_missing.v'), 'module sample\n')!
+	os.write_file(os.join_path(parts, 'sample_test.v'), 'module sample\n')!
+	os.write_file(os.join_path(parts, 'sample.js.v'), 'module sample\n')!
+	os.write_file(os.join_path(valid, 'sample.v'), 'module sample\n')!
+	linux := pref.target_from('linux', 'amd64') or { panic(err) }
+	prefs := pref.Preferences{
+		target: linux
+		module_search_paths: [first_search_root, second_search_root]
+	}
+
+	assert !module_path_has_v_sources(incompatible, &prefs)
+	assert resolve_global_module_path(&prefs, 'sample', 'sample') == valid
 }

--- a/vlib/v3/driver/module_resolution_test.v
+++ b/vlib/v3/driver/module_resolution_test.v
@@ -1,0 +1,30 @@
+module driver
+
+import os
+import v3.pref
+
+fn test_manifest_subdir_probe_stops_at_nested_modules() {
+	root := os.join_path(os.vtmp_dir(), 'v3_module_probe_nested_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	first_search_root := os.join_path(root, 'first')
+	second_search_root := os.join_path(root, 'second')
+	outer := os.join_path(first_search_root, 'sample')
+	valid := os.join_path(second_search_root, 'sample')
+	os.mkdir_all(os.join_path(outer, 'parts', 'nested')) or { panic(err) }
+	os.mkdir_all(valid) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	os.write_file(os.join_path(outer, 'v.mod'), "Module { name: 'outer', subdirs: ['parts'] }\n")!
+	os.write_file(os.join_path(outer, 'parts', 'nested', 'v.mod'), "Module { name: 'nested' }\n")!
+	os.write_file(os.join_path(outer, 'parts', 'nested', 'nested.v'), 'module nested\n\npub fn value() int { return 1 }\n')!
+	os.write_file(os.join_path(valid, 'sample.v'), 'module sample\n\npub fn value() int { return 2 }\n')!
+
+	assert !module_path_has_v_sources(outer)
+	prefs := pref.Preferences{
+		module_search_paths: [first_search_root, second_search_root]
+	}
+	assert resolve_global_module_path(&prefs, 'sample', 'sample') == valid
+	os.write_file(os.join_path(outer, 'parts', 'outer.v'), 'module outer\n\npub fn value() int { return 2 }\n')!
+	assert module_path_has_v_sources(outer)
+}

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -23,7 +23,7 @@ const c_source_directives_end = '/* V3CACHE_SOURCE_DIRECTIVES_END */'
 const c_late_directives_begin = '/* V3CACHE_LATE_DIRECTIVES_BEGIN */'
 const c_late_directives_end = '/* V3CACHE_LATE_DIRECTIVES_END */'
 const source_body_marker = '// v3cache: source bodies required'
-const source_signature_cache_format = 'v3-source-signature-cache-5'
+const source_signature_cache_format = 'v3-source-signature-cache-6'
 
 // Manager owns persistent v3 module cache paths for one compiler configuration.
 pub struct Manager {
@@ -240,6 +240,7 @@ struct SourceSignatureDetails {
 	signature      string
 	validation     []string
 	source_digests []string
+	cacheable      bool
 }
 
 fn source_signature_details(source_files []string, build_pseudo_values string, version_pseudo_values string) SourceSignatureDetails {
@@ -250,6 +251,7 @@ fn source_signature_details(source_files []string, build_pseudo_values string, v
 	mut pkgconfig_names := map[string]bool{}
 	mut uses_build_pseudo := false
 	mut uses_version_pseudo := false
+	mut cacheable := true
 	mut validation := []string{}
 	mut source_digests := []string{cap: files.len}
 	for file in files {
@@ -262,7 +264,11 @@ fn source_signature_details(source_files []string, build_pseudo_values string, v
 		hash = hash_bytes(hash, content)
 		hash = hash_bytes(hash, [u8(0xff)])
 		source := content.bytestr()
-		for qml_path in compile_time_qml_paths(source, path) {
+		qml_paths, has_unresolved_qml_path := compile_time_qml_paths(source, path)
+		if has_unresolved_qml_path {
+			cacheable = false
+		}
+		for qml_path in qml_paths {
 			qml_content := os.read_bytes(qml_path) or { return SourceSignatureDetails{} }
 			validation << 'qml=${qml_path}\t${file_metadata_signature(qml_path)}'
 			hash = hash_bytes(hash, [u8(0xf8)])
@@ -352,10 +358,18 @@ fn source_signature_details(source_files []string, build_pseudo_values string, v
 		hash = hash_bytes(hash, [u8(if available { 1 } else { 0 })])
 		hash = hash_bytes(hash, [u8(0xff)])
 	}
+	if !cacheable {
+		// Keep repeated queries consistent inside one compiler process, while
+		// ensuring another process cannot reuse an artifact whose QML input path
+		// could not be extracted from source text.
+		hash = hash_bytes(hash, [u8(0xf7)])
+		hash = hash_bytes(hash, os.getpid().str().bytes())
+	}
 	return SourceSignatureDetails{
 		signature: hash.hex()
 		validation: validation
 		source_digests: source_digests
+		cacheable: cacheable
 	}
 }
 
@@ -576,6 +590,14 @@ fn (m &Manager) source_signature(source_files []string) string {
 	return m.source_signature_details(source_files).signature
 }
 
+fn (m &Manager) cacheable_source_signature(source_files []string) ?string {
+	details := m.source_signature_details(source_files)
+	if !details.cacheable {
+		return none
+	}
+	return details.signature
+}
+
 fn (m &Manager) source_signature_details(source_files []string) SourceSignatureDetails {
 	return cached_source_signature_details_with_build_values(m.dir, 'module', source_files, m.build_pseudo_values, m.version_pseudo_values)
 }
@@ -599,7 +621,7 @@ fn cached_source_signature_details_with_build_values(cache_dir string, namespace
 		}
 	}
 	details := source_signature_details(paths, build_pseudo_values, version_pseudo_values)
-	if details.signature.len == 0 {
+	if details.signature.len == 0 || !details.cacheable {
 		return details
 	}
 	fresh_metadata := source_files_metadata_signature(paths)
@@ -748,6 +770,7 @@ fn valid_cached_source_signature(content string, metadata string, build_pseudo_v
 	return SourceSignatureDetails{
 		signature: signature
 		source_digests: source_digests
+		cacheable: true
 	}
 }
 
@@ -930,11 +953,12 @@ fn signature_string_call_arg(source string, start int) (string, int, bool) {
 	return '', source.len, false
 }
 
-fn compile_time_qml_paths(source string, source_file string) []string {
+fn compile_time_qml_paths(source string, source_file string) ([]string, bool) {
 	if !source.contains('\$qml') {
-		return []
+		return []string{}, false
 	}
 	mut paths := map[string]bool{}
+	mut has_unresolved_path := false
 	mut pos := 0
 	for pos < source.len {
 		if source[pos] == `/` && pos + 1 < source.len
@@ -959,12 +983,14 @@ fn compile_time_qml_paths(source string, source_file string) []string {
 		if ok {
 			path := resolve_signature_qml_path(cached_unescape_v_string(raw_path), source_file)
 			paths[os.real_path(path)] = true
+		} else {
+			has_unresolved_path = true
 		}
 		pos = if next_pos > pos { next_pos } else { pos + 4 }
 	}
 	mut result := paths.keys()
 	result.sort()
-	return result
+	return result, has_unresolved_path
 }
 
 fn resolve_signature_qml_path(path string, source_file string) string {
@@ -1079,6 +1105,10 @@ pub fn (m &Manager) valid_entry_with_metadata_cache(module_name string, source_f
 		return none
 	}
 	source_details := m.source_signature_details(source_files)
+	if !source_details.cacheable {
+		cache_trace_module_miss(module_name, 'source has an unresolved compile-time QML path')
+		return none
+	}
 	expected := entry_stamp(m.salt, source_details.signature)
 	source_bodies := header_stamp_source_bodies(stamp, expected) or {
 		cache_trace_module_miss(module_name, 'source signature changed')
@@ -1117,6 +1147,9 @@ pub fn (m &Manager) valid_header(module_name string, source_files []string) ?Ent
 	}
 	stamp := os.read_file(entry.header_stamp) or { return none }
 	source_details := m.source_signature_details(source_files)
+	if !source_details.cacheable {
+		return none
+	}
 	expected := entry_stamp(m.salt, source_details.signature)
 	source_bodies := header_stamp_source_bodies(stamp, expected) or { return none }
 	return Entry{
@@ -1148,7 +1181,8 @@ pub fn (m &Manager) valid_object(cache_name string, source_files []string) ?Entr
 		return none
 	}
 	stamp := os.read_file(entry.object_stamp) or { return none }
-	if !object_stamp_valid(stamp, entry_stamp(m.salt, m.source_signature(source_files))) {
+	source_hash := m.cacheable_source_signature(source_files) or { return none }
+	if !object_stamp_valid(stamp, entry_stamp(m.salt, source_hash)) {
 		cache_trace_module_miss(cache_name, 'object source or dependency changed')
 		return none
 	}
@@ -1185,7 +1219,8 @@ pub fn (m &Manager) valid_object_for_compile_signature(cache_name string, source
 		return none
 	}
 	stamp := os.read_file(entry.object_stamp) or { return none }
-	if !object_stamp_valid(stamp, entry_stamp(m.salt, m.source_signature(source_files))) {
+	source_hash := m.cacheable_source_signature(source_files) or { return none }
+	if !object_stamp_valid(stamp, entry_stamp(m.salt, source_hash)) {
 		return none
 	}
 	expected := 'compile=${hash_text(compile_signature)}'
@@ -1209,7 +1244,8 @@ pub fn (m &Manager) valid_cgen(source_files []string, generation_signature strin
 		return none
 	}
 	stamp := os.read_file(entry.stamp) or { return none }
-	expected := cgen_entry_stamp(m.salt, m.source_signature(source_files), dependency_inputs, generation_signature)
+	source_hash := m.cacheable_source_signature(source_files) or { return none }
+	expected := cgen_entry_stamp(m.salt, source_hash, dependency_inputs, generation_signature)
 	if stamp != expected {
 		return none
 	}
@@ -1238,7 +1274,8 @@ pub fn (m &Manager) cached_cgen_dependency_inputs(source_files []string, generat
 		return none
 	}
 	stamp := os.read_file(entry.stamp) or { return none }
-	expected_head := entry_stamp(m.salt, m.source_signature(source_files)) + 'generation=${hash_text(generation_signature)}\n'
+	source_hash := m.cacheable_source_signature(source_files) or { return none }
+	expected_head := entry_stamp(m.salt, source_hash) + 'generation=${hash_text(generation_signature)}\n'
 	return cached_dependency_inputs_from_stamp(stamp, expected_head, fixed_dependencies, restored_prefixes)
 }
 

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -23,7 +23,7 @@ const c_source_directives_end = '/* V3CACHE_SOURCE_DIRECTIVES_END */'
 const c_late_directives_begin = '/* V3CACHE_LATE_DIRECTIVES_BEGIN */'
 const c_late_directives_end = '/* V3CACHE_LATE_DIRECTIVES_END */'
 const source_body_marker = '// v3cache: source bodies required'
-const source_signature_cache_format = 'v3-source-signature-cache-8'
+const source_signature_cache_format = 'v3-source-signature-cache-9'
 
 // Manager owns persistent v3 module cache paths for one compiler configuration.
 pub struct Manager {
@@ -437,7 +437,7 @@ fn source_uses_pseudo(source string, names []string) bool {
 					|| (name_end < source.len && signature_name_char(source[name_end])) {
 					continue
 				}
-				value, next_pos, ok, _ := signature_string_call_arg(source, name_end)
+				value, next_pos, ok, _ := signature_string_call_arg_prefix(source, name_end)
 				if ok {
 					if quoted_text_mentions_pseudo(value, 0, value.len, names) {
 						return true
@@ -960,6 +960,18 @@ fn compile_time_pkgconfig_names(source string) []string {
 }
 
 fn signature_string_call_arg(source string, start int) (string, int, bool, bool) {
+	value, literal_end, ok, is_raw := signature_string_call_arg_prefix(source, start)
+	if !ok {
+		return '', literal_end, false, false
+	}
+	end := skip_signature_space_and_comments(source, literal_end)
+	if end >= source.len || source[end] != `)` {
+		return '', end, false, false
+	}
+	return value, end + 1, true, is_raw
+}
+
+fn signature_string_call_arg_prefix(source string, start int) (string, int, bool, bool) {
 	mut pos := skip_signature_space_and_comments(source, start)
 	if pos >= source.len || source[pos] != `(` {
 		return '', start, false, false

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -23,7 +23,7 @@ const c_source_directives_end = '/* V3CACHE_SOURCE_DIRECTIVES_END */'
 const c_late_directives_begin = '/* V3CACHE_LATE_DIRECTIVES_BEGIN */'
 const c_late_directives_end = '/* V3CACHE_LATE_DIRECTIVES_END */'
 const source_body_marker = '// v3cache: source bodies required'
-const source_signature_cache_format = 'v3-source-signature-cache-4'
+const source_signature_cache_format = 'v3-source-signature-cache-5'
 
 // Manager owns persistent v3 module cache paths for one compiler configuration.
 pub struct Manager {
@@ -262,6 +262,15 @@ fn source_signature_details(source_files []string, build_pseudo_values string, v
 		hash = hash_bytes(hash, content)
 		hash = hash_bytes(hash, [u8(0xff)])
 		source := content.bytestr()
+		for qml_path in compile_time_qml_paths(source, path) {
+			qml_content := os.read_bytes(qml_path) or { return SourceSignatureDetails{} }
+			validation << 'qml=${qml_path}\t${file_metadata_signature(qml_path)}'
+			hash = hash_bytes(hash, [u8(0xf8)])
+			hash = hash_bytes(hash, qml_path.bytes())
+			hash = hash_bytes(hash, [u8(0)])
+			hash = hash_bytes(hash, qml_content)
+			hash = hash_bytes(hash, [u8(0xff)])
+		}
 		if source_uses_pseudo(source, [
 			'@BUILD_TIMESTAMP',
 			'@BUILD_DATE',
@@ -695,6 +704,14 @@ fn valid_cached_source_signature(content string, metadata string, build_pseudo_v
 			}
 			continue
 		}
+		if line.starts_with('qml=') {
+			parts := line['qml='.len..].split('\t')
+			if parts.len != 2 || parts[0].len == 0
+				|| file_metadata_signature(parts[0]) != parts[1] {
+				return none
+			}
+			continue
+		}
 		if line.starts_with('vmod=') {
 			parts := line['vmod='.len..].split('\t')
 			if parts.len != 4 || parts[0].len == 0 {
@@ -911,6 +928,70 @@ fn signature_string_call_arg(source string, start int) (string, int, bool) {
 		value_end++
 	}
 	return '', source.len, false
+}
+
+fn compile_time_qml_paths(source string, source_file string) []string {
+	if !source.contains('\$qml') {
+		return []
+	}
+	mut paths := map[string]bool{}
+	mut pos := 0
+	for pos < source.len {
+		if source[pos] == `/` && pos + 1 < source.len
+			&& (source[pos + 1] == `/` || source[pos + 1] == `*`) {
+			pos = skip_signature_space_and_comments(source, pos)
+			continue
+		}
+		if source[pos] in [`'`, `"`, `\``] {
+			pos = skip_signature_quoted_text(source, pos, false)
+			continue
+		}
+		if source[pos] == `r` && pos + 1 < source.len && source[pos + 1] in [`'`, `"`] {
+			pos = skip_signature_quoted_text(source, pos + 1, true)
+			continue
+		}
+		if pos + 4 > source.len || source[pos..pos + 4] != '\$qml'
+			|| (pos + 4 < source.len && signature_name_char(source[pos + 4])) {
+			pos++
+			continue
+		}
+		raw_path, next_pos, ok := signature_string_call_arg(source, pos + 4)
+		if ok {
+			path := resolve_signature_qml_path(cached_unescape_v_string(raw_path), source_file)
+			paths[os.real_path(path)] = true
+		}
+		pos = if next_pos > pos { next_pos } else { pos + 4 }
+	}
+	mut result := paths.keys()
+	result.sort()
+	return result
+}
+
+fn resolve_signature_qml_path(path string, source_file string) string {
+	if os.is_abs_path(path) {
+		return path
+	}
+	dir := os.dir(os.real_path(source_file))
+	direct := os.join_path_single(dir, path)
+	if os.exists(direct) {
+		return direct
+	}
+	in_templates := os.join_path(dir, 'templates', path)
+	if os.exists(in_templates) {
+		return in_templates
+	}
+	root, _ := signature_vmod_root(source_file)
+	if root != dir {
+		vmod_direct := os.join_path_single(root, path)
+		if os.exists(vmod_direct) {
+			return vmod_direct
+		}
+		vmod_templates := os.join_path(root, 'templates', path)
+		if os.exists(vmod_templates) {
+			return vmod_templates
+		}
+	}
+	return direct
 }
 
 fn signature_name_char(c u8) bool {

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -23,7 +23,7 @@ const c_source_directives_end = '/* V3CACHE_SOURCE_DIRECTIVES_END */'
 const c_late_directives_begin = '/* V3CACHE_LATE_DIRECTIVES_BEGIN */'
 const c_late_directives_end = '/* V3CACHE_LATE_DIRECTIVES_END */'
 const source_body_marker = '// v3cache: source bodies required'
-const source_signature_cache_format = 'v3-source-signature-cache-6'
+const source_signature_cache_format = 'v3-source-signature-cache-7'
 
 // Manager owns persistent v3 module cache paths for one compiler configuration.
 pub struct Manager {
@@ -264,9 +264,19 @@ fn source_signature_details(source_files []string, build_pseudo_values string, v
 		hash = hash_bytes(hash, content)
 		hash = hash_bytes(hash, [u8(0xff)])
 		source := content.bytestr()
-		qml_paths, has_unresolved_qml_path := compile_time_qml_paths(source, path)
+		qml_paths, qml_lookup_candidates, has_unresolved_qml_path := compile_time_qml_paths(source,
+			path)
 		if has_unresolved_qml_path {
 			cacheable = false
+		}
+		for candidate in qml_lookup_candidates {
+			metadata := optional_file_metadata_signature(candidate)
+			validation << 'qmlcandidate=${candidate}\t${metadata}'
+			hash = hash_bytes(hash, [u8(0xf6)])
+			hash = hash_bytes(hash, candidate.bytes())
+			hash = hash_bytes(hash, [u8(0)])
+			hash = hash_bytes(hash, metadata.bytes())
+			hash = hash_bytes(hash, [u8(0xff)])
 		}
 		for qml_path in qml_paths {
 			qml_content := os.read_bytes(qml_path) or { return SourceSignatureDetails{} }
@@ -734,6 +744,14 @@ fn valid_cached_source_signature(content string, metadata string, build_pseudo_v
 			}
 			continue
 		}
+		if line.starts_with('qmlcandidate=') {
+			parts := line['qmlcandidate='.len..].split('\t')
+			if parts.len != 2 || parts[0].len == 0
+				|| optional_file_metadata_signature(parts[0]) != parts[1] {
+				return none
+			}
+			continue
+		}
 		if line.starts_with('vmod=') {
 			parts := line['vmod='.len..].split('\t')
 			if parts.len != 4 || parts[0].len == 0 {
@@ -953,11 +971,12 @@ fn signature_string_call_arg(source string, start int) (string, int, bool) {
 	return '', source.len, false
 }
 
-fn compile_time_qml_paths(source string, source_file string) ([]string, bool) {
+fn compile_time_qml_paths(source string, source_file string) ([]string, []string, bool) {
 	if !source.contains('\$qml') {
-		return []string{}, false
+		return []string{}, []string{}, false
 	}
 	mut paths := map[string]bool{}
+	mut lookup_candidates := map[string]bool{}
 	mut has_unresolved_path := false
 	mut pos := 0
 	for pos < source.len {
@@ -981,8 +1000,12 @@ fn compile_time_qml_paths(source string, source_file string) ([]string, bool) {
 		}
 		raw_path, next_pos, ok := signature_string_call_arg(source, pos + 4)
 		if ok {
-			path := resolve_signature_qml_path(cached_unescape_v_string(raw_path), source_file)
+			path, candidates := resolve_signature_qml_path(cached_unescape_v_string(raw_path),
+				source_file)
 			paths[os.real_path(path)] = true
+			for candidate in candidates {
+				lookup_candidates[os.real_path(candidate)] = true
+			}
 		} else {
 			has_unresolved_path = true
 		}
@@ -990,34 +1013,44 @@ fn compile_time_qml_paths(source string, source_file string) ([]string, bool) {
 	}
 	mut result := paths.keys()
 	result.sort()
-	return result, has_unresolved_path
+	mut candidates := lookup_candidates.keys()
+	candidates.sort()
+	return result, candidates, has_unresolved_path
 }
 
-fn resolve_signature_qml_path(path string, source_file string) string {
+fn resolve_signature_qml_path(path string, source_file string) (string, []string) {
 	if os.is_abs_path(path) {
-		return path
+		return path, []string{}
 	}
 	dir := os.dir(os.real_path(source_file))
 	direct := os.join_path_single(dir, path)
 	if os.exists(direct) {
-		return direct
+		return direct, []string{}
 	}
+	mut candidates := [direct]
 	in_templates := os.join_path(dir, 'templates', path)
 	if os.exists(in_templates) {
-		return in_templates
+		return in_templates, candidates
 	}
+	candidates << in_templates
 	root, _ := signature_vmod_root(source_file)
 	if root != dir {
 		vmod_direct := os.join_path_single(root, path)
 		if os.exists(vmod_direct) {
-			return vmod_direct
+			return vmod_direct, candidates
 		}
+		candidates << vmod_direct
 		vmod_templates := os.join_path(root, 'templates', path)
 		if os.exists(vmod_templates) {
-			return vmod_templates
+			return vmod_templates, candidates
 		}
 	}
-	return direct
+	return direct, []string{}
+}
+
+fn optional_file_metadata_signature(path string) string {
+	metadata := file_metadata_signature(path)
+	return if metadata.len > 0 { metadata } else { 'missing' }
 }
 
 fn signature_name_char(c u8) bool {

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -23,7 +23,7 @@ const c_source_directives_end = '/* V3CACHE_SOURCE_DIRECTIVES_END */'
 const c_late_directives_begin = '/* V3CACHE_LATE_DIRECTIVES_BEGIN */'
 const c_late_directives_end = '/* V3CACHE_LATE_DIRECTIVES_END */'
 const source_body_marker = '// v3cache: source bodies required'
-const source_signature_cache_format = 'v3-source-signature-cache-7'
+const source_signature_cache_format = 'v3-source-signature-cache-8'
 
 // Manager owns persistent v3 module cache paths for one compiler configuration.
 pub struct Manager {
@@ -264,10 +264,20 @@ fn source_signature_details(source_files []string, build_pseudo_values string, v
 		hash = hash_bytes(hash, content)
 		hash = hash_bytes(hash, [u8(0xff)])
 		source := content.bytestr()
-		qml_paths, qml_lookup_candidates, has_unresolved_qml_path := compile_time_qml_paths(source,
-			path)
+		qml_paths, qml_lookup_paths, qml_lookup_candidates, has_unresolved_qml_path := compile_time_qml_paths(
+			source, path)
 		if has_unresolved_qml_path {
 			cacheable = false
+		}
+		for lookup_path in qml_lookup_paths {
+			resolved := os.real_path(lookup_path)
+			metadata := optional_file_metadata_signature(lookup_path)
+			validation << 'qmllookup=${lookup_path}\t${resolved}\t${metadata}'
+			hash = hash_bytes(hash, [u8(0xf7)])
+			hash = hash_bytes(hash, lookup_path.bytes())
+			hash = hash_bytes(hash, [u8(0)])
+			hash = hash_bytes(hash, resolved.bytes())
+			hash = hash_bytes(hash, [u8(0xff)])
 		}
 		for candidate in qml_lookup_candidates {
 			metadata := optional_file_metadata_signature(candidate)
@@ -427,7 +437,7 @@ fn source_uses_pseudo(source string, names []string) bool {
 					|| (name_end < source.len && signature_name_char(source[name_end])) {
 					continue
 				}
-				value, next_pos, ok := signature_string_call_arg(source, name_end)
+				value, next_pos, ok, _ := signature_string_call_arg(source, name_end)
 				if ok {
 					if quoted_text_mentions_pseudo(value, 0, value.len, names) {
 						return true
@@ -752,6 +762,14 @@ fn valid_cached_source_signature(content string, metadata string, build_pseudo_v
 			}
 			continue
 		}
+		if line.starts_with('qmllookup=') {
+			parts := line['qmllookup='.len..].split('\t')
+			if parts.len != 3 || parts[0].len == 0 || os.real_path(parts[0]) != parts[1]
+				|| optional_file_metadata_signature(parts[0]) != parts[2] {
+				return none
+			}
+			continue
+		}
 		if line.starts_with('vmod=') {
 			parts := line['vmod='.len..].split('\t')
 			if parts.len != 4 || parts[0].len == 0 {
@@ -930,7 +948,7 @@ fn compile_time_pkgconfig_names(source string) []string {
 			pos++
 			continue
 		}
-		name, next_pos, ok := signature_string_call_arg(source, pos + 9)
+		name, next_pos, ok, _ := signature_string_call_arg(source, pos + 9)
 		if ok && signature_pkgconfig_name_is_safe(name) {
 			names[name] = true
 		}
@@ -941,10 +959,10 @@ fn compile_time_pkgconfig_names(source string) []string {
 	return result
 }
 
-fn signature_string_call_arg(source string, start int) (string, int, bool) {
+fn signature_string_call_arg(source string, start int) (string, int, bool, bool) {
 	mut pos := skip_signature_space_and_comments(source, start)
 	if pos >= source.len || source[pos] != `(` {
-		return '', start, false
+		return '', start, false, false
 	}
 	pos = skip_signature_space_and_comments(source, pos + 1)
 	mut is_raw := false
@@ -953,7 +971,7 @@ fn signature_string_call_arg(source string, start int) (string, int, bool) {
 		pos++
 	}
 	if pos >= source.len || source[pos] !in [`'`, `"`] {
-		return '', start, false
+		return '', start, false, false
 	}
 	quote := source[pos]
 	value_start := pos + 1
@@ -964,18 +982,19 @@ fn signature_string_call_arg(source string, start int) (string, int, bool) {
 			continue
 		}
 		if source[value_end] == quote {
-			return source[value_start..value_end], value_end + 1, true
+			return source[value_start..value_end], value_end + 1, true, is_raw
 		}
 		value_end++
 	}
-	return '', source.len, false
+	return '', source.len, false, false
 }
 
-fn compile_time_qml_paths(source string, source_file string) ([]string, []string, bool) {
+fn compile_time_qml_paths(source string, source_file string) ([]string, []string, []string, bool) {
 	if !source.contains('\$qml') {
-		return []string{}, []string{}, false
+		return []string{}, []string{}, []string{}, false
 	}
 	mut paths := map[string]bool{}
+	mut lookup_paths := map[string]bool{}
 	mut lookup_candidates := map[string]bool{}
 	mut has_unresolved_path := false
 	mut pos := 0
@@ -998,11 +1017,12 @@ fn compile_time_qml_paths(source string, source_file string) ([]string, []string
 			pos++
 			continue
 		}
-		raw_path, next_pos, ok := signature_string_call_arg(source, pos + 4)
+		raw_path, next_pos, ok, is_raw := signature_string_call_arg(source, pos + 4)
 		if ok {
-			path, candidates := resolve_signature_qml_path(cached_unescape_v_string(raw_path),
-				source_file)
+			path_value := if is_raw { raw_path } else { cached_unescape_v_string(raw_path) }
+			path, candidates := resolve_signature_qml_path(path_value, source_file)
 			paths[os.real_path(path)] = true
+			lookup_paths[path] = true
 			for candidate in candidates {
 				lookup_candidates[os.real_path(candidate)] = true
 			}
@@ -1013,9 +1033,11 @@ fn compile_time_qml_paths(source string, source_file string) ([]string, []string
 	}
 	mut result := paths.keys()
 	result.sort()
+	mut lookups := lookup_paths.keys()
+	lookups.sort()
 	mut candidates := lookup_candidates.keys()
 	candidates.sort()
-	return result, candidates, has_unresolved_path
+	return result, lookups, candidates, has_unresolved_path
 }
 
 fn resolve_signature_qml_path(path string, source_file string) (string, []string) {

--- a/vlib/v3/modulecache/modulecache_test.v
+++ b/vlib/v3/modulecache/modulecache_test.v
@@ -464,6 +464,17 @@ fn test_cached_source_signature_tracks_qml_inputs() {
 	assert concat_lookups.len == 0
 	assert concat_candidates.len == 0
 	assert concat_unresolved
+	os.write_file(os.join_path(root, 'form'), 'not the selected template')!
+	os.write_file(source, "module main\n\nfn build() { _ = \$qml('form' + '.qml') }\n")!
+	literal_concat := source_signature_details([source], '', '')
+	assert literal_concat.signature.len > 0
+	assert !literal_concat.cacheable
+	literal_paths, literal_lookups, literal_candidates, literal_unresolved := compile_time_qml_paths(
+		os.read_file(source)!, source)
+	assert literal_paths.len == 0
+	assert literal_lookups.len == 0
+	assert literal_candidates.len == 0
+	assert literal_unresolved
 	manager := Manager{
 		dir: os.join_path(root, 'module-cache')
 		enabled: true
@@ -480,8 +491,7 @@ fn test_qml_signature_scanner_preserves_raw_paths() {
 	raw_path, next_pos, ok, is_raw := signature_string_call_arg(call, 4)
 	assert ok
 	assert is_raw
-	assert next_pos == call.len - 1
-	assert call[next_pos] == `)`
+	assert next_pos == call.len
 	assert raw_path == r'C:\views\form.qml'
 
 	target, expected_candidates := resolve_signature_qml_path(raw_path, @FILE)
@@ -600,6 +610,7 @@ fn test_source_uses_pseudo_in_quoted_compile_time_paths() {
 	assert source_uses_pseudo('module m\n\n#include "@VMODROOT/header.h"', roots)
 	assert source_uses_pseudo('module m\n\n#flag -I "@VMODROOT/include"', roots)
 	assert source_uses_pseudo('module m\n\nconst p = \$embed_file(r"@VROOT/x")', roots)
+	assert source_uses_pseudo("module m\n\nconst p = \$tmpl('@VMODROOT' + '/x.html')", roots)
 	// a pseudo after a string containing `//` must still be seen
 	assert source_uses_pseudo("module m\n\nconst u = 'http://x' + \$embed_file('@VMODROOT/y')",
 		roots)

--- a/vlib/v3/modulecache/modulecache_test.v
+++ b/vlib/v3/modulecache/modulecache_test.v
@@ -436,9 +436,10 @@ fn test_cached_source_signature_tracks_qml_inputs() {
 	second := cached_source_signature(cache_dir, 'qml', [source])
 	assert second.len > 0
 	assert second != first
-	ignored_paths, ignored_unresolved := compile_time_qml_paths("// \$qml('ignored.qml')\nconst s = \"\$qml('also_ignored.qml')\"",
-		source)
+	ignored_paths, ignored_candidates, ignored_unresolved := compile_time_qml_paths(
+		"// \$qml('ignored.qml')\nconst s = \"\$qml('also_ignored.qml')\"", source)
 	assert ignored_paths.len == 0
+	assert ignored_candidates.len == 0
 	assert !ignored_unresolved
 
 	os.write_file(source,
@@ -450,12 +451,15 @@ fn test_cached_source_signature_tracks_qml_inputs() {
 	assert dynamic.signature.len > 0
 	assert !dynamic.cacheable
 	assert os.ls(cache_dir)!.len == before_cache_entries
-	dynamic_paths, dynamic_unresolved := compile_time_qml_paths(os.read_file(source)!, source)
+	dynamic_paths, dynamic_candidates, dynamic_unresolved := compile_time_qml_paths(os.read_file(source)!,
+		source)
 	assert dynamic_paths.len == 0
+	assert dynamic_candidates.len == 0
 	assert dynamic_unresolved
-	concat_paths, concat_unresolved := compile_time_qml_paths(
+	concat_paths, concat_candidates, concat_unresolved := compile_time_qml_paths(
 		"fn build() { _ = \$qml(template_dir + '/form.qml') }", source)
 	assert concat_paths.len == 0
+	assert concat_candidates.len == 0
 	assert concat_unresolved
 	manager := Manager{
 		dir: os.join_path(root, 'module-cache')
@@ -466,6 +470,40 @@ fn test_cached_source_signature_tracks_qml_inputs() {
 	if _ := manager.valid_header('dynamic_qml', [source]) {
 		assert false, 'an unresolved compile-time QML path must disable cache reuse'
 	}
+}
+
+fn test_cached_source_signature_tracks_shadowing_qml_paths() {
+	root := os.join_path(os.vtmp_dir(), 'v3_modulecache_qml_shadow_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(os.join_path(root, 'templates')) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	source := os.join_path(root, 'main.v')
+	direct_qml := os.join_path(root, 'form.qml')
+	direct_candidate := os.join_path(os.real_path(root), 'form.qml')
+	template_qml := os.join_path(root, 'templates', 'form.qml')
+	os.write_file(source, "module main\n\nfn build() { _ = \$qml('form.qml') }\n")!
+	os.write_file(template_qml, 'Label { text: "Template" }')!
+	cache_dir := os.join_path(root, 'cache')
+
+	first := cached_source_signature(cache_dir, 'qml-shadow', [source])
+	assert first.len > 0
+	paths, candidates, unresolved := compile_time_qml_paths(os.read_file(source)!, source)
+	assert paths == [os.real_path(template_qml)]
+	assert candidates == [direct_candidate]
+	assert !unresolved
+	details := source_signature_details([source], '', '')
+	assert details.validation.any(it == 'qmlcandidate=${direct_candidate}\tmissing')
+
+	os.write_file(direct_qml, 'Label { text: "Direct" }')!
+	second := cached_source_signature(cache_dir, 'qml-shadow', [source])
+	assert second.len > 0
+	assert second != first
+	shadowing_paths, shadowing_candidates, _ := compile_time_qml_paths(os.read_file(source)!,
+		source)
+	assert shadowing_paths == [os.real_path(direct_qml)]
+	assert shadowing_candidates.len == 0
 }
 
 fn test_version_pseudo_signature_ignores_build_clock() {

--- a/vlib/v3/modulecache/modulecache_test.v
+++ b/vlib/v3/modulecache/modulecache_test.v
@@ -436,9 +436,10 @@ fn test_cached_source_signature_tracks_qml_inputs() {
 	second := cached_source_signature(cache_dir, 'qml', [source])
 	assert second.len > 0
 	assert second != first
-	ignored_paths, ignored_candidates, ignored_unresolved := compile_time_qml_paths(
+	ignored_paths, ignored_lookups, ignored_candidates, ignored_unresolved := compile_time_qml_paths(
 		"// \$qml('ignored.qml')\nconst s = \"\$qml('also_ignored.qml')\"", source)
 	assert ignored_paths.len == 0
+	assert ignored_lookups.len == 0
 	assert ignored_candidates.len == 0
 	assert !ignored_unresolved
 
@@ -451,14 +452,16 @@ fn test_cached_source_signature_tracks_qml_inputs() {
 	assert dynamic.signature.len > 0
 	assert !dynamic.cacheable
 	assert os.ls(cache_dir)!.len == before_cache_entries
-	dynamic_paths, dynamic_candidates, dynamic_unresolved := compile_time_qml_paths(os.read_file(source)!,
-		source)
+	dynamic_paths, dynamic_lookups, dynamic_candidates, dynamic_unresolved := compile_time_qml_paths(
+		os.read_file(source)!, source)
 	assert dynamic_paths.len == 0
+	assert dynamic_lookups.len == 0
 	assert dynamic_candidates.len == 0
 	assert dynamic_unresolved
-	concat_paths, concat_candidates, concat_unresolved := compile_time_qml_paths(
+	concat_paths, concat_lookups, concat_candidates, concat_unresolved := compile_time_qml_paths(
 		"fn build() { _ = \$qml(template_dir + '/form.qml') }", source)
 	assert concat_paths.len == 0
+	assert concat_lookups.len == 0
 	assert concat_candidates.len == 0
 	assert concat_unresolved
 	manager := Manager{
@@ -470,6 +473,41 @@ fn test_cached_source_signature_tracks_qml_inputs() {
 	if _ := manager.valid_header('dynamic_qml', [source]) {
 		assert false, 'an unresolved compile-time QML path must disable cache reuse'
 	}
+}
+
+fn test_qml_signature_scanner_preserves_raw_paths() {
+	call := r'$' + r"qml(r'C:\views\form.qml')"
+	raw_path, next_pos, ok, is_raw := signature_string_call_arg(call, 4)
+	assert ok
+	assert is_raw
+	assert next_pos == call.len - 1
+	assert call[next_pos] == `)`
+	assert raw_path == r'C:\views\form.qml'
+
+	target, expected_candidates := resolve_signature_qml_path(raw_path, @FILE)
+	paths, lookups, candidates, unresolved := compile_time_qml_paths(call, @FILE)
+	assert paths == [os.real_path(target)]
+	assert lookups == [target]
+	assert candidates == expected_candidates.map(os.real_path(it))
+	assert !unresolved
+
+	root := os.join_path(os.vtmp_dir(), 'v3_modulecache_qml_raw_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	source := os.join_path(root, 'main.v')
+	relative_call := r'$' + r"qml(r'views\form.qml')"
+	os.write_file(source, 'module main\n\nfn build() { _ = ' + relative_call + ' }\n')!
+	qml_path, _ := resolve_signature_qml_path(r'views\form.qml', source)
+	os.mkdir_all(os.dir(qml_path))!
+	os.write_file(qml_path, 'Label { text: "Raw" }')!
+	cache_dir := os.join_path(root, 'cache')
+	first := cached_source_signature(cache_dir, 'qml-raw', [source])
+	assert first.len > 0
+	assert source_signature_details([source], '', '').cacheable
+	assert cached_source_signature(cache_dir, 'qml-raw', [source]) == first
 }
 
 fn test_cached_source_signature_tracks_shadowing_qml_paths() {
@@ -489,8 +527,9 @@ fn test_cached_source_signature_tracks_shadowing_qml_paths() {
 
 	first := cached_source_signature(cache_dir, 'qml-shadow', [source])
 	assert first.len > 0
-	paths, candidates, unresolved := compile_time_qml_paths(os.read_file(source)!, source)
+	paths, lookups, candidates, unresolved := compile_time_qml_paths(os.read_file(source)!, source)
 	assert paths == [os.real_path(template_qml)]
+	assert lookups == [os.join_path(os.real_path(root), 'templates', 'form.qml')]
 	assert candidates == [direct_candidate]
 	assert !unresolved
 	details := source_signature_details([source], '', '')
@@ -500,10 +539,40 @@ fn test_cached_source_signature_tracks_shadowing_qml_paths() {
 	second := cached_source_signature(cache_dir, 'qml-shadow', [source])
 	assert second.len > 0
 	assert second != first
-	shadowing_paths, shadowing_candidates, _ := compile_time_qml_paths(os.read_file(source)!,
-		source)
+	shadowing_paths, shadowing_lookups, shadowing_candidates, _ := compile_time_qml_paths(os.read_file(source)!, source)
 	assert shadowing_paths == [os.real_path(direct_qml)]
+	assert shadowing_lookups == [direct_candidate]
 	assert shadowing_candidates.len == 0
+}
+
+fn test_cached_source_signature_tracks_qml_symlink_target() {
+	root := os.join_path(os.vtmp_dir(), 'v3_modulecache_qml_symlink_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	source := os.join_path(root, 'main.v')
+	first_target := os.join_path(root, 'first.qml')
+	second_target := os.join_path(root, 'second.qml')
+	qml_link := os.join_path(root, 'form.qml')
+	os.write_file(source, "module main\n\nfn build() { _ = \$qml('form.qml') }\n")!
+	os.write_file(first_target, 'Label { text: "First" }')!
+	os.write_file(second_target, 'Label { text: "Second" }')!
+	os.symlink(first_target, qml_link) or { return }
+	cache_dir := os.join_path(root, 'cache')
+
+	first := cached_source_signature(cache_dir, 'qml-symlink', [source])
+	assert first.len > 0
+	lookup_path := os.join_path(os.real_path(root), 'form.qml')
+	details := source_signature_details([source], '', '')
+	assert details.validation.any(it.starts_with('qmllookup=${lookup_path}\t${os.real_path(first_target)}\t'))
+
+	os.rm(qml_link)!
+	os.symlink(second_target, qml_link)!
+	second := cached_source_signature(cache_dir, 'qml-symlink', [source])
+	assert second.len > 0
+	assert second != first
 }
 
 fn test_version_pseudo_signature_ignores_build_clock() {

--- a/vlib/v3/modulecache/modulecache_test.v
+++ b/vlib/v3/modulecache/modulecache_test.v
@@ -431,12 +431,41 @@ fn test_cached_source_signature_tracks_qml_inputs() {
 
 	first := cached_source_signature(cache_dir, 'qml', [source])
 	assert first.len > 0
+	assert source_signature_details([source], '', '').cacheable
 	os.write_file(qml, 'Label { text: "Changed" }')!
 	second := cached_source_signature(cache_dir, 'qml', [source])
 	assert second.len > 0
 	assert second != first
-	assert compile_time_qml_paths("// \$qml('ignored.qml')\nconst s = \"\$qml('also_ignored.qml')\"",
-		source).len == 0
+	ignored_paths, ignored_unresolved := compile_time_qml_paths("// \$qml('ignored.qml')\nconst s = \"\$qml('also_ignored.qml')\"",
+		source)
+	assert ignored_paths.len == 0
+	assert !ignored_unresolved
+
+	os.write_file(source,
+		"module main\n\nconst form_path = 'form.qml'\nfn build() { _ = \$qml(form_path) }\n")!
+	before_cache_entries := os.ls(cache_dir)!.len
+	dynamic := cached_source_signature_details_with_build_values(cache_dir, 'dynamic-qml', [
+		source,
+	], '', '')
+	assert dynamic.signature.len > 0
+	assert !dynamic.cacheable
+	assert os.ls(cache_dir)!.len == before_cache_entries
+	dynamic_paths, dynamic_unresolved := compile_time_qml_paths(os.read_file(source)!, source)
+	assert dynamic_paths.len == 0
+	assert dynamic_unresolved
+	concat_paths, concat_unresolved := compile_time_qml_paths(
+		"fn build() { _ = \$qml(template_dir + '/form.qml') }", source)
+	assert concat_paths.len == 0
+	assert concat_unresolved
+	manager := Manager{
+		dir: os.join_path(root, 'module-cache')
+		enabled: true
+		salt: 'dynamic-qml-test'
+	}
+	manager.write_header('dynamic_qml', [source], '// generated header')!
+	if _ := manager.valid_header('dynamic_qml', [source]) {
+		assert false, 'an unresolved compile-time QML path must disable cache reuse'
+	}
 }
 
 fn test_version_pseudo_signature_ignores_build_clock() {

--- a/vlib/v3/modulecache/modulecache_test.v
+++ b/vlib/v3/modulecache/modulecache_test.v
@@ -416,6 +416,29 @@ fn test_cached_source_signature_keeps_per_file_sha256_digests() {
 	assert cached.source_digests == details.source_digests
 }
 
+fn test_cached_source_signature_tracks_qml_inputs() {
+	root := os.join_path(os.vtmp_dir(), 'v3_modulecache_qml_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	source := os.join_path(root, 'main.v')
+	qml := os.join_path(root, 'form.qml')
+	os.write_file(source, "module main\n\nfn build() { _ = \$qml('form.qml') }\n")!
+	os.write_file(qml, 'Label { text: "A" }')!
+	cache_dir := os.join_path(root, 'cache')
+
+	first := cached_source_signature(cache_dir, 'qml', [source])
+	assert first.len > 0
+	os.write_file(qml, 'Label { text: "Changed" }')!
+	second := cached_source_signature(cache_dir, 'qml', [source])
+	assert second.len > 0
+	assert second != first
+	assert compile_time_qml_paths("// \$qml('ignored.qml')\nconst s = \"\$qml('also_ignored.qml')\"",
+		source).len == 0
+}
+
 fn test_version_pseudo_signature_ignores_build_clock() {
 	root := os.join_path(os.vtmp_dir(), 'v3_modulecache_version_pseudo_${os.getpid()}')
 	os.rmdir_all(root) or {}

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -5733,6 +5733,9 @@ fn (mut p Parser) parse_comptime_expr() flat.NodeId {
 	if p.tok == .name && p.lit == 'embed_file' {
 		return p.parse_embed_file_expr()
 	}
+	if p.tok == .name && p.lit == 'qml' {
+		return p.parse_qml_template_expr(dollar_pos)
+	}
 	if p.tok == .name && p.lit in ['zero', 'new'] {
 		name := p.lit
 		p.next()

--- a/vlib/v3/parser/qml.v
+++ b/vlib/v3/parser/qml.v
@@ -70,19 +70,13 @@ fn (mut l QmlLexer) skip_space() {
 }
 
 fn qml_is_name_char(c u8) bool {
-	return c.is_alnum() || c in [`_`, `-`, `.`, `#`]
+	return c.is_alnum() || c in [`_`, `.`, `#`]
 }
 
 fn (mut l QmlLexer) read_name() QmlToken {
 	start := l.pos
 	line := l.line
 	for l.pos < l.source.len && qml_is_name_char(l.source[l.pos]) {
-		if l.source[l.pos] == `-` && l.pos > start {
-			prefix := l.source[start..l.pos]
-			if prefix.contains('.') || prefix == 'index' {
-				break
-			}
-		}
 		l.pos++
 	}
 	return QmlToken{.name, l.source[start..l.pos], line}
@@ -235,13 +229,17 @@ enum QmlExprKind {
 
 struct QmlInterpolationPart {
 	text string
+	// A nil expression marks a literal-text part. V requires `unsafe` only to
+	// declare that sentinel pointer default; interpolation logic checks it before use.
 	expr &QmlExpr = unsafe { nil }
 }
 
 struct QmlExpr {
-	kind   QmlExprKind
-	value  string
-	line   int
+	kind  QmlExprKind
+	value string
+	line  int
+	// The tagged expression tree is recursive. Nil marks child links unused by
+	// the current kind, and V requires `unsafe` only for those pointer defaults.
 	left   &QmlExpr = unsafe { nil }
 	right  &QmlExpr = unsafe { nil }
 	third  &QmlExpr = unsafe { nil }
@@ -491,6 +489,36 @@ fn (mut p QmlSourceParser) parse_primary() !&QmlExpr {
 	}
 }
 
+fn qml_interpolation_end(value string, start int) ?int {
+	mut quoted := false
+	mut escaped := false
+	mut nested_braces := 0
+	for i := start; i < value.len; i++ {
+		ch := value[i]
+		if quoted {
+			if escaped {
+				escaped = false
+			} else if ch == `\\` {
+				escaped = true
+			} else if ch == `"` {
+				quoted = false
+			}
+			continue
+		}
+		if ch == `"` {
+			quoted = true
+		} else if ch == `{` {
+			nested_braces++
+		} else if ch == `}` {
+			if nested_braces == 0 {
+				return i
+			}
+			nested_braces--
+		}
+	}
+	return none
+}
+
 fn parse_qml_interpolation(value string, line int) !&QmlExpr {
 	if !value.contains(r'${') {
 		return &QmlExpr{ kind: .literal, value: value, line: line, quoted: true }
@@ -506,10 +534,9 @@ fn parse_qml_interpolation(value string, line int) !&QmlExpr {
 		if start > cursor {
 			parts << QmlInterpolationPart{ text: value[cursor..start] }
 		}
-		end_relative := value[start + 2..].index('}') or {
+		end := qml_interpolation_end(value, start + 2) or {
 			return error('unterminated interpolation at line ${line}')
 		}
-		end := start + 2 + end_relative
 		tokens := tokenize_qml(value[start + 2..end])!
 		mut parser := QmlSourceParser{ tokens: tokens }
 		parts << QmlInterpolationPart{ expr: parser.parse_expression()! }
@@ -848,13 +875,10 @@ fn (c &QmlCompiler) expr(expr &QmlExpr, scope QmlScope, use QmlExprUse) string {
 				if expr.value.starts_with('#') && expr.value.len == 7 {
 					return 'u32(0x${expr.value[1..]})'
 				}
-				if known && resolved != expr.value {
-					return resolved
-				}
 				if !known {
 					return 'u32(0xffffff)'
 				}
-				return 'ui2.parse_hex_color(${qml_stringify(resolved)})'
+				return qml_color_call(resolved)
 			}
 			if use == .string_ {
 				if !known {
@@ -1103,6 +1127,15 @@ fn (mut c QmlCompiler) write_action_type_checks(node &QmlNode, suffix string, sc
 		// that its argument has the declared type.
 		c.out.writeln('\tif false {')
 		c.out.writeln('\t\tmut ${check_name} := *app')
+		// The runtime dispatcher exposes public methods only. Reflection makes a
+		// same-module private method a compile error before its action is serialized.
+		c.out.writeln('\t\t\$for method in ${check_name}.methods {')
+		c.out.writeln('\t\t\t\$if method.name == ${qml_quote(method_name)} {')
+		c.out.writeln('\t\t\t\t\$if !method.is_pub {')
+		c.out.writeln('\t\t\t\t\t\$compile_error(${qml_quote('QML action method `${method_name}` must be public')})')
+		c.out.writeln('\t\t\t\t}')
+		c.out.writeln('\t\t\t}')
+		c.out.writeln('\t\t}')
 		c.out.writeln('\t\t${check_name}.${method_name}(${arguments})')
 		c.out.writeln('\t}')
 	}

--- a/vlib/v3/parser/qml.v
+++ b/vlib/v3/parser/qml.v
@@ -810,10 +810,12 @@ fn (c &QmlCompiler) resolve_path(path string, scope QmlScope) (string, bool) {
 		return replacement + if parts.len > 1 { '.' + parts[1..].join('.') } else { '' }, true
 	}
 	if named := scope.ids[parts[0]] {
-		if parts.len == 2 {
+		if parts.len >= 2 {
 			if prop := named.props[parts[1]] {
-				return prop, true
+				return prop + if parts.len > 2 { '.' + parts[2..].join('.') } else { '' }, true
 			}
+		}
+		if parts.len == 2 {
 			if parts[1] in ['x', 'y', 'width', 'height'] {
 				return '${named.frame}.${parts[1]}', true
 			}
@@ -1015,8 +1017,11 @@ fn (mut c QmlCompiler) compile_node(node &QmlNode, path string, input string, in
 		}
 		name := 'qml_property_${suffix}_${qml_var(property.name)}'
 		property_use := qml_property_use(property)
-		value := if property.declared_type in ['f32', 'int'] {
+		value := if property.declared_type == 'int' {
 			numeric_value := c.expr(property.expr, scope, .raw)
+			qml_numeric_cast(property.declared_type, numeric_value)
+		} else if property.declared_type == 'f32' {
+			numeric_value := c.expr(property.expr, scope, .number)
 			qml_numeric_cast(property.declared_type, numeric_value)
 		} else {
 			c.expr(property.expr, scope, property_use)

--- a/vlib/v3/parser/qml.v
+++ b/vlib/v3/parser/qml.v
@@ -733,6 +733,13 @@ fn qml_stringify(expression string) string {
 	return "'" + r'$' + '{' + expression + "}'"
 }
 
+fn qml_numeric_cast(type_name string, expression string) string {
+	if expression.starts_with('(') && expression.ends_with(')') {
+		return type_name + expression
+	}
+	return '${type_name}(${expression})'
+}
+
 enum QmlExprUse {
 	raw
 	number
@@ -918,6 +925,40 @@ fn qml_prop(properties map[string]string, name string, default_ string) string {
 	return properties[name] or { default_ }
 }
 
+fn qml_order_declared_properties(properties []QmlProperty, node_id string) []QmlProperty {
+	mut remaining := properties.filter(it.declared_type.len > 0)
+	if node_id.len == 0 || remaining.len < 2 {
+		return remaining
+	}
+	mut ordered := []QmlProperty{cap: remaining.len}
+	for remaining.len > 0 {
+		mut deferred := []QmlProperty{cap: remaining.len}
+		for property in remaining {
+			mut has_pending_dependency := false
+			for candidate in remaining {
+				if candidate.name != property.name
+					&& qml_expr_uses_path(property.expr, '${node_id}.${candidate.name}') {
+					has_pending_dependency = true
+					break
+				}
+			}
+			if has_pending_dependency {
+				deferred << property
+			} else {
+				ordered << property
+			}
+		}
+		if deferred.len == remaining.len {
+			// Preserve source order for a dependency cycle; generated V will report
+			// the invalid forward reference without making this pass loop forever.
+			ordered << deferred
+			break
+		}
+		remaining = deferred.clone()
+	}
+	return ordered
+}
+
 fn (mut c QmlCompiler) compile_node(node &QmlNode, path string, input string, incoming QmlScope, default_key string) QmlScope {
 	suffix := qml_var(path)
 	c.out.writeln('\t_ = ${input}')
@@ -935,7 +976,7 @@ fn (mut c QmlCompiler) compile_node(node &QmlNode, path string, input string, in
 		scope.ids[node.id] = QmlNamedValue{ frame: input, props: named_props.clone() }
 	}
 	mut properties := map[string]string{}
-	mut ordered_properties := node.properties.filter(it.declared_type.len > 0)
+	mut ordered_properties := qml_order_declared_properties(node.properties, node.id)
 	ordered_properties << node.properties.filter(it.declared_type.len == 0)
 	for property in ordered_properties {
 		if property.name == 'id'
@@ -944,7 +985,12 @@ fn (mut c QmlCompiler) compile_node(node &QmlNode, path string, input string, in
 		}
 		name := 'qml_property_${suffix}_${qml_var(property.name)}'
 		property_use := qml_property_use(property)
-		value := c.expr(property.expr, scope, property_use)
+		value := if property.declared_type in ['f32', 'int'] {
+			numeric_value := c.expr(property.expr, scope, .raw)
+			qml_numeric_cast(property.declared_type, numeric_value)
+		} else {
+			c.expr(property.expr, scope, property_use)
+		}
 		if property_use == .color && property.expr.kind in [.literal, .path]
 			&& property.expr.value.starts_with('#') && property.expr.value.len == 7 {
 			// Static colors can be used directly without a generated local.

--- a/vlib/v3/parser/qml.v
+++ b/vlib/v3/parser/qml.v
@@ -816,6 +816,12 @@ fn (c &QmlCompiler) expr(expr &QmlExpr, scope QmlScope, use QmlExprUse) string {
 	match expr.kind {
 		.literal {
 			if expr.quoted {
+				if use == .color {
+					if expr.value.starts_with('#') && expr.value.len == 7 {
+						return 'u32(0x${expr.value[1..]})'
+					}
+					return 'ui2.parse_hex_color(${qml_quote(expr.value)})'
+				}
 				return qml_quote(expr.value)
 			}
 			return match use {
@@ -908,7 +914,7 @@ fn qml_prop(properties map[string]string, name string, default_ string) string {
 	return properties[name] or { default_ }
 }
 
-fn (mut c QmlCompiler) compile_node(node &QmlNode, path string, input string, incoming QmlScope, default_key string) {
+fn (mut c QmlCompiler) compile_node(node &QmlNode, path string, input string, incoming QmlScope, default_key string) QmlScope {
 	suffix := qml_var(path)
 	c.out.writeln('\t_ = ${input}')
 	mut scope := qml_clone_scope(incoming)
@@ -933,7 +939,15 @@ fn (mut c QmlCompiler) compile_node(node &QmlNode, path string, input string, in
 			continue
 		}
 		name := 'qml_property_${suffix}_${qml_var(property.name)}'
-		c.out.writeln('\t${name} := ${c.expr(property.expr, scope, qml_property_use(property))}')
+		property_use := qml_property_use(property)
+		value := c.expr(property.expr, scope, property_use)
+		if property_use == .color && property.expr.kind in [.literal, .path]
+			&& property.expr.value.starts_with('#') && property.expr.value.len == 7 {
+			// Static colors can be used directly without a generated local.
+			properties[property.name] = value
+			continue
+		}
+		c.out.writeln('\t${name} := ${value}')
 		properties[property.name] = name
 	}
 	frame := 'qml_frame_${suffix}'
@@ -960,21 +974,29 @@ fn (mut c QmlCompiler) compile_node(node &QmlNode, path string, input string, in
 		c.out.writeln('\tmut ${cursor} := ${qml_prop(properties, 'padding', 'f64(0)')}')
 	}
 	for child_index, child in node.children {
-		if !container || child.tag in ['MenuItem', 'Option'] {
+		child_path := '${path}.${child_index}'
+		if child.tag == 'MenuItem' {
+			c.write_action_type_checks(child, '${qml_var(child_path)}_menu_action', scope)
 			continue
 		}
-		child_path := '${path}.${child_index}'
+		if !container || child.tag == 'Option' {
+			continue
+		}
 		if child.tag == 'Repeater' {
 			c.compile_repeater(child, child_path, frame, node.tag, properties, cursor, scope, children)
 			continue
 		}
 		child_input := 'qml_input_${qml_var(child_path)}'
 		c.out.writeln('\t${child_input} := ${qml_child_input(node.tag, frame, properties, cursor)}')
-		c.compile_node(child, child_path, child_input, scope, '')
+		child_scope := c.compile_node(child, child_path, child_input, scope, '')
+		for id, named in child_scope.ids {
+			scope.ids[id] = named
+		}
 		c.out.writeln('\t${children} << qml_element_${qml_var(child_path)}')
 		qml_advance_cursor(mut c.out, node.tag, cursor, child_path, properties)
 	}
 	c.compile_element(node, suffix, frame, children, properties, scope, default_key)
+	return scope
 }
 
 fn (mut c QmlCompiler) write_action_type_checks(node &QmlNode, suffix string, scope QmlScope) {

--- a/vlib/v3/parser/qml.v
+++ b/vlib/v3/parser/qml.v
@@ -810,9 +810,6 @@ fn (c &QmlCompiler) resolve_path(path string, scope QmlScope) (string, bool) {
 }
 
 fn (c &QmlCompiler) expr(expr &QmlExpr, scope QmlScope, use QmlExprUse) string {
-	if use == .string_ && expr.kind == .call {
-		return qml_quote(qml_expr_text(expr))
-	}
 	match expr.kind {
 		.literal {
 			if expr.quoted {
@@ -858,7 +855,8 @@ fn (c &QmlCompiler) expr(expr &QmlExpr, scope QmlScope, use QmlExprUse) string {
 		.call {
 			args := expr.args.map(c.expr(it, scope, .raw)).join(', ')
 			resolved, _ := c.resolve_path(expr.value, scope)
-			return '${resolved}(${args})'
+			call := '${resolved}(${args})'
+			return if use == .string_ { qml_stringify(call) } else { call }
 		}
 		.unary {
 			operand_use := if expr.value == '!' { QmlExprUse.bool_ } else { .number }
@@ -880,7 +878,10 @@ fn (c &QmlCompiler) expr(expr &QmlExpr, scope QmlScope, use QmlExprUse) string {
 				return '(${c.expr(expr.left, scope, .raw)} ${expr.value} ${c.expr(expr.right, scope, .raw)})'
 			}
 			if expr.value == '+' && use == .string_ {
-				return '(${c.expr(expr.left, scope, .string_)} + ${c.expr(expr.right, scope, .string_)})'
+				if qml_expr_is_string(expr.left) || qml_expr_is_string(expr.right) {
+					return '(${c.expr(expr.left, scope, .string_)} + ${c.expr(expr.right, scope, .string_)})'
+				}
+				return qml_stringify('(${c.expr(expr.left, scope, .raw)} + ${c.expr(expr.right, scope, .raw)})')
 			}
 			if expr.value == '%' {
 				return 'f64(int(${c.expr(expr.left, scope, .number)}) % int(${c.expr(expr.right, scope, .number)}))'

--- a/vlib/v3/parser/qml.v
+++ b/vlib/v3/parser/qml.v
@@ -754,6 +754,7 @@ fn qml_property_use(property QmlProperty) QmlExprUse {
 			'f64', 'f32', 'int' { .number }
 			'bool' { .bool_ }
 			'string' { .string_ }
+			'color' { .color }
 			else { .raw }
 		}
 	}
@@ -870,8 +871,15 @@ fn (c &QmlCompiler) expr(expr &QmlExpr, scope QmlScope, use QmlExprUse) string {
 			}
 		}
 		.unary {
-			operand_use := if expr.value == '!' { QmlExprUse.bool_ } else { .number }
-			return '(${expr.value}${c.expr(expr.left, scope, operand_use)})'
+			operand_use := if use in [.raw, .string_] {
+				QmlExprUse.raw
+			} else if expr.value == '!' {
+				QmlExprUse.bool_
+			} else {
+				QmlExprUse.number
+			}
+			result := '(${expr.value}${c.expr(expr.left, scope, operand_use)})'
+			return if use == .string_ { qml_stringify(result) } else { result }
 		}
 		.binary {
 			if expr.value in ['&&', '||'] {
@@ -893,6 +901,9 @@ fn (c &QmlCompiler) expr(expr &QmlExpr, scope QmlScope, use QmlExprUse) string {
 					return '(${c.expr(expr.left, scope, .string_)} + ${c.expr(expr.right, scope, .string_)})'
 				}
 				return qml_stringify('(${c.expr(expr.left, scope, .raw)} + ${c.expr(expr.right, scope, .raw)})')
+			}
+			if use == .string_ && expr.value in ['-', '*', '/', '%'] {
+				return qml_stringify('(${c.expr(expr.left, scope, .raw)} ${expr.value} ${c.expr(expr.right, scope, .raw)})')
 			}
 			if expr.value == '%' {
 				return 'f64(int(${c.expr(expr.left, scope, .number)}) % int(${c.expr(expr.right, scope, .number)}))'
@@ -995,7 +1006,8 @@ fn (mut c QmlCompiler) compile_node(node &QmlNode, path string, input string, in
 		} else {
 			c.expr(property.expr, scope, property_use)
 		}
-		if property_use == .color && property.expr.kind in [.literal, .path]
+		if property.declared_type.len == 0 && property_use == .color
+			&& property.expr.kind in [.literal, .path]
 			&& property.expr.value.starts_with('#') && property.expr.value.len == 7 {
 			// Static colors can be used directly without a generated local.
 			properties[property.name] = value
@@ -1297,6 +1309,7 @@ fn (mut c QmlCompiler) compile_element(node &QmlNode, suffix string, frame strin
 	on_active := c.compiled_event_value(node, 'on_active', scope, id)
 	on_text := c.compiled_event_value(node, 'on_text', scope, id)
 	on_submit := c.compiled_event_value(node, 'on_submit', scope, id)
+	text_action := if qml_find_property(node, 'on_text') != none { on_text } else { on_change }
 	action := match node.tag {
 		'Button', 'Checkbox' { on_tap }
 		'Dropdown', 'Slider' { 'if ${on_change}.len > 0 { ${on_change} } else { ${on_tap} }' }
@@ -1306,7 +1319,7 @@ fn (mut c QmlCompiler) compile_element(node &QmlNode, suffix string, frame strin
 		'Spinner' {
 			'if ${on_text}.len > 0 { ${on_text} } else if ${on_change}.len > 0 { ${on_change} } else { ${on_tap} }'
 		}
-		'TextArea', 'TextField' { on_change }
+		'TextArea', 'TextField' { text_action }
 		else { on_tap }
 	}
 	if node.tag == 'MessageBox' {
@@ -1363,11 +1376,11 @@ fn (mut c QmlCompiler) compile_element(node &QmlNode, suffix string, frame strin
 		c.out.writeln('\t\tplaceholder: ${qml_prop(properties, 'placeholder', "''")}')
 		keyboard := qml_prop(properties, 'keyboard', "''")
 		c.out.writeln("\t\tkeyboard: if ${keyboard} in ['decimal', 'numeric', 'number'] { ui2.keyboard_decimal } else { ui2.keyboard_default }")
-		c.out.writeln('\t\temit_change: ${qml_prop(properties, 'emit_change', 'false')} || ${on_change}.len > 0')
+		c.out.writeln('\t\temit_change: ${qml_prop(properties, 'emit_change', 'false')} || ${text_action}.len > 0')
 	}
 	if node.tag == 'TextArea' {
 		c.out.writeln('\t\treadonly: ${qml_prop(properties, 'editable', 'true')} == false')
-		c.out.writeln('\t\temit_change: ${on_change}.len > 0')
+		c.out.writeln('\t\temit_change: ${text_action}.len > 0')
 	}
 	if node.tag == 'Screen' {
 		c.out.writeln('\t\tbox: ui2.BoxStyle{bg: ${qml_prop(properties, 'background', 'u32(0xffffff)')}}')

--- a/vlib/v3/parser/qml.v
+++ b/vlib/v3/parser/qml.v
@@ -863,7 +863,11 @@ fn (c &QmlCompiler) expr(expr &QmlExpr, scope QmlScope, use QmlExprUse) string {
 			args := expr.args.map(c.expr(it, scope, .raw)).join(', ')
 			resolved, _ := c.resolve_path(expr.value, scope)
 			call := '${resolved}(${args})'
-			return if use == .string_ { qml_stringify(call) } else { call }
+			return match use {
+				.string_ { qml_stringify(call) }
+				.number { 'f64(${call})' }
+				else { call }
+			}
 		}
 		.unary {
 			operand_use := if expr.value == '!' { QmlExprUse.bool_ } else { .number }

--- a/vlib/v3/parser/qml.v
+++ b/vlib/v3/parser/qml.v
@@ -876,6 +876,9 @@ fn (c &QmlCompiler) expr(expr &QmlExpr, scope QmlScope, use QmlExprUse) string {
 				}
 				return '${c.expr(expr.left, scope, operand_use)} ${expr.value} ${c.expr(expr.right, scope, operand_use)}'
 			}
+			if use == .raw {
+				return '(${c.expr(expr.left, scope, .raw)} ${expr.value} ${c.expr(expr.right, scope, .raw)})'
+			}
 			if expr.value == '+' && use == .string_ {
 				return '(${c.expr(expr.left, scope, .string_)} + ${c.expr(expr.right, scope, .string_)})'
 			}
@@ -1068,7 +1071,10 @@ fn (mut c QmlCompiler) compile_repeater(node &QmlNode, path string, parent_frame
 		} else {
 			"'" + r'$' + '{' + key_name + '}' + ':${visible_index}' + "'"
 		}
-		c.compile_node(child, child_path, child_input, scope, default_key)
+		child_scope := c.compile_node(child, child_path, child_input, scope, default_key)
+		for id, named in child_scope.ids {
+			scope.ids[id] = named
+		}
 		c.out.writeln('\t\t${output} << qml_element_${qml_var(child_path)}')
 		qml_advance_cursor(mut c.out, parent_tag, cursor, child_path, parent_properties)
 		visible_index++
@@ -1126,7 +1132,7 @@ fn (c &QmlCompiler) compiled_event_value(node &QmlNode, event_name string, scope
 		if property.expr.kind == .call {
 			action_name = property.expr.value.all_after('app.')
 			for argument in property.expr.args {
-				arguments << c.expr(argument, scope, .string_)
+				arguments << qml_stringify(c.expr(argument, scope, .raw))
 			}
 		}
 	}

--- a/vlib/v3/parser/qml.v
+++ b/vlib/v3/parser/qml.v
@@ -542,7 +542,7 @@ fn validate_compiled_qml_node(node &QmlNode) ! {
 				return error('`${property.name}` must target a mutable top-level app field at line ${property.expr.line}')
 			}
 		}
-		if property.name in ['on_tap', 'on_change', 'on_active', 'on_submit']
+		if property.name in ['on_tap', 'on_change', 'on_active', 'on_text', 'on_submit']
 			&& property.expr.kind == .call {
 			if !property.expr.value.starts_with('app.') || property.expr.value.count('.') != 1 {
 				return error('event handlers must call an app action at line ${property.expr.line}')
@@ -764,7 +764,8 @@ fn qml_property_use(property QmlProperty) QmlExprUse {
 	}
 	if property.name in ['checked', 'hidden', 'enabled', 'native', 'editable', 'emit_change', 'secure',
 		'clickable', 'draggable', 'long_press', 'swipe_left', 'persistent', 'autocorrect', 'bold',
-		'italic', 'underline', 'strikethrough', 'shadow', 'outline', 'value_track', 'active']
+		'italic', 'underline', 'strikethrough', 'shadow', 'outline', 'value_track', 'active',
+		'text_autoupdate']
 		|| property.name in ['bind.checked', 'bind.active'] {
 		return .bool_
 	}
@@ -918,7 +919,7 @@ fn (mut c QmlCompiler) compile_node(node &QmlNode, path string, input string, in
 	mut properties := map[string]string{}
 	for property in node.properties {
 		if property.name == 'id'
-			|| property.name in ['on_tap', 'on_change', 'on_active', 'on_submit'] {
+			|| property.name in ['on_tap', 'on_change', 'on_active', 'on_text', 'on_submit'] {
 			continue
 		}
 		name := 'qml_property_${suffix}_${qml_var(property.name)}'
@@ -938,7 +939,7 @@ fn (mut c QmlCompiler) compile_node(node &QmlNode, path string, input string, in
 	children := 'qml_children_${suffix}'
 	container := node.tag in ['Screen', 'View', 'Rectangle', 'Column', 'Row', 'Scroll']
 		|| node.tag !in ['Label', 'Image', 'Button', 'MessageBox', 'Checkbox', 'Dropdown', 'TextArea',
-			'TextField', 'ProgressBar', 'Slider', 'Switch']
+			'TextField', 'ProgressBar', 'Slider', 'Switch', 'Spinner']
 	visible_children := if container {
 		node.children.filter(it.tag !in ['MenuItem', 'Option'])
 	} else {
@@ -972,7 +973,7 @@ fn (mut c QmlCompiler) compile_node(node &QmlNode, path string, input string, in
 
 fn (mut c QmlCompiler) write_action_type_checks(node &QmlNode, suffix string, scope QmlScope) {
 	for property in node.properties {
-		if property.name !in ['on_tap', 'on_change', 'on_active', 'on_submit'] || property.expr.kind != .call {
+		if property.name !in ['on_tap', 'on_change', 'on_active', 'on_text', 'on_submit'] || property.expr.kind != .call {
 			continue
 		}
 		method_name := property.expr.value.all_after('app.')
@@ -1072,6 +1073,9 @@ fn qml_binding_for_event(node &QmlNode, event_name string) ?QmlProperty {
 	if event_name == 'on_active' {
 		return qml_find_property(node, 'bind.active')
 	}
+	if event_name == 'on_text' {
+		return qml_find_property(node, 'bind.text')
+	}
 	return none
 }
 
@@ -1155,7 +1159,7 @@ fn (c &QmlCompiler) menu_value(node &QmlNode, scope QmlScope) string {
 		}
 		return '[]ui2.MenuEntry{${entries.join(', ')}}'
 	}
-	if node.tag == 'Dropdown' {
+	if node.tag in ['Dropdown', 'Spinner'] {
 		mut entries := []string{}
 		for option in node.children {
 			if option.tag != 'Option' {
@@ -1171,6 +1175,22 @@ fn (c &QmlCompiler) menu_value(node &QmlNode, scope QmlScope) string {
 		return '[]ui2.MenuEntry{${entries.join(', ')}}'
 	}
 	return '[]ui2.MenuEntry{}'
+}
+
+fn (c &QmlCompiler) option_values(node &QmlNode, scope QmlScope) string {
+	mut values := []string{}
+	for option in node.children {
+		if option.tag != 'Option' {
+			continue
+		}
+		value := if property := qml_find_property(option, 'text') {
+			c.expr(property.expr, scope, .string_)
+		} else {
+			"''"
+		}
+		values << value
+	}
+	return '[]string{${values.join(', ')}}'
 }
 
 fn (mut c QmlCompiler) compile_element(node &QmlNode, suffix string, frame string, children string, properties map[string]string, scope QmlScope, default_key string) {
@@ -1190,12 +1210,16 @@ fn (mut c QmlCompiler) compile_element(node &QmlNode, suffix string, frame strin
 	on_tap := c.compiled_event_value(node, 'on_tap', scope, id)
 	on_change := c.compiled_event_value(node, 'on_change', scope, id)
 	on_active := c.compiled_event_value(node, 'on_active', scope, id)
+	on_text := c.compiled_event_value(node, 'on_text', scope, id)
 	on_submit := c.compiled_event_value(node, 'on_submit', scope, id)
 	action := match node.tag {
 		'Button', 'Checkbox' { on_tap }
 		'Dropdown', 'Slider' { 'if ${on_change}.len > 0 { ${on_change} } else { ${on_tap} }' }
 		'Switch' {
 			'if ${on_active}.len > 0 { ${on_active} } else if ${on_change}.len > 0 { ${on_change} } else { ${on_tap} }'
+		}
+		'Spinner' {
+			'if ${on_text}.len > 0 { ${on_text} } else if ${on_change}.len > 0 { ${on_change} } else { ${on_tap} }'
 		}
 		'TextArea', 'TextField' { on_change }
 		else { on_tap }
@@ -1214,6 +1238,10 @@ fn (mut c QmlCompiler) compile_element(node &QmlNode, suffix string, frame strin
 	}
 	if node.tag == 'Switch' {
 		c.compile_switch(node, suffix, frame, properties, scope, key, action)
+		return
+	}
+	if node.tag == 'Spinner' {
+		c.compile_spinner(node, suffix, frame, properties, scope, key, action)
 		return
 	}
 	kind := match node.tag {
@@ -1376,6 +1404,29 @@ fn (mut c QmlCompiler) compile_switch(node &QmlNode, suffix string, frame string
 	c.out.writeln('\t\tframe: ${frame}')
 	c.out.writeln('\t\tactive: ${qml_value(properties, 'active', 'bind.active', 'false')}')
 	c.out.writeln('\t\tstyle: ${style}')
+	c.out.writeln('\t)')
+	c.out.writeln('\tqml_element_${suffix} := ui2.Element{')
+	c.out.writeln('\t\t...${base}')
+	c.out.writeln('\t\tkey: ${key}')
+	c.write_common_fields(node, properties, scope, '${base}.accessibility_role', '${base}.accessibility_label', '${base}.accessibility_value')
+	c.out.writeln('\t}')
+}
+
+fn (mut c QmlCompiler) compile_spinner(node &QmlNode, suffix string, frame string, properties map[string]string, scope QmlScope, key string, action string) {
+	base := 'qml_spinner_${suffix}'
+	box := '${base}_box'
+	text_style := '${base}_text_style'
+	c.out.writeln('\t${box} := ${c.box_style(properties)}')
+	c.out.writeln('\t${text_style} := ${c.text_style(properties)}')
+	c.out.writeln('\t${base} := ui2.spinner(')
+	c.out.writeln('\t\tid: ${qml_quote(node.id)}')
+	c.out.writeln('\t\taction_id: ${action}')
+	c.out.writeln('\t\tframe: ${frame}')
+	c.out.writeln('\t\ttext: ${qml_value(properties, 'text', 'bind.text', "''")}')
+	c.out.writeln('\t\tvalues: ${c.option_values(node, scope)}')
+	c.out.writeln('\t\ttext_autoupdate: ${qml_prop(properties, 'text_autoupdate', 'false')}')
+	c.out.writeln('\t\tbox: ${box}')
+	c.out.writeln('\t\ttext_style: ${text_style}')
 	c.out.writeln('\t)')
 	c.out.writeln('\tqml_element_${suffix} := ui2.Element{')
 	c.out.writeln('\t\t...${base}')

--- a/vlib/v3/parser/qml.v
+++ b/vlib/v3/parser/qml.v
@@ -733,6 +733,11 @@ fn qml_stringify(expression string) string {
 	return "'" + r'$' + '{' + expression + "}'"
 }
 
+fn qml_color_call(expression string) string {
+	value := qml_stringify(expression)
+	return "(if typeof(${expression}).name == 'string' { ui2.parse_hex_color(${value}) } else { u32(${value}.u64()) })"
+}
+
 fn qml_numeric_cast(type_name string, expression string) string {
 	if expression.starts_with('(') && expression.ends_with(')') {
 		return type_name + expression
@@ -805,12 +810,12 @@ fn (c &QmlCompiler) resolve_path(path string, scope QmlScope) (string, bool) {
 		return replacement + if parts.len > 1 { '.' + parts[1..].join('.') } else { '' }, true
 	}
 	if named := scope.ids[parts[0]] {
-		if parts.len == 2 && parts[1] in ['x', 'y', 'width', 'height'] {
-			return '${named.frame}.${parts[1]}', true
-		}
 		if parts.len == 2 {
 			if prop := named.props[parts[1]] {
 				return prop, true
+			}
+			if parts[1] in ['x', 'y', 'width', 'height'] {
+				return '${named.frame}.${parts[1]}', true
 			}
 		}
 	}
@@ -867,6 +872,7 @@ fn (c &QmlCompiler) expr(expr &QmlExpr, scope QmlScope, use QmlExprUse) string {
 			return match use {
 				.string_ { qml_stringify(call) }
 				.number { 'f64(${call})' }
+				.color { qml_color_call(call) }
 				else { call }
 			}
 		}
@@ -942,8 +948,12 @@ fn qml_prop(properties map[string]string, name string, default_ string) string {
 	return properties[name] or { default_ }
 }
 
-fn qml_order_declared_properties(properties []QmlProperty, node_id string) []QmlProperty {
-	mut remaining := properties.filter(it.declared_type.len > 0)
+fn qml_property_is_geometry(property QmlProperty) bool {
+	return property.name in ['x', 'y', 'width', 'height']
+}
+
+fn qml_order_properties_by_dependencies(properties []QmlProperty, node_id string) []QmlProperty {
+	mut remaining := properties.clone()
 	if node_id.len == 0 || remaining.len < 2 {
 		return remaining
 	}
@@ -981,9 +991,9 @@ fn (mut c QmlCompiler) compile_node(node &QmlNode, path string, input string, in
 	c.out.writeln('\t_ = ${input}')
 	mut scope := qml_clone_scope(incoming)
 	mut named_props := map[string]string{}
-	// Register every declared property before resolving expressions, then emit
-	// those declarations before ordinary bindings. This lets an earlier binding
-	// such as `width: root.half` refer to a custom property declared later.
+	// Declared properties are visible before expressions are resolved. Geometry
+	// bindings are added after they are emitted below, so self-geometry can use an
+	// earlier computed binding while declared properties can still read the input.
 	for property in node.properties {
 		if property.declared_type.len > 0 {
 			named_props[property.name] = 'qml_property_${suffix}_${qml_var(property.name)}'
@@ -993,8 +1003,11 @@ fn (mut c QmlCompiler) compile_node(node &QmlNode, path string, input string, in
 		scope.ids[node.id] = QmlNamedValue{ frame: input, props: named_props.clone() }
 	}
 	mut properties := map[string]string{}
-	mut ordered_properties := qml_order_declared_properties(node.properties, node.id)
-	ordered_properties << node.properties.filter(it.declared_type.len == 0)
+	mut ordered_properties := qml_order_properties_by_dependencies(node.properties.filter(it.declared_type.len > 0), node.id)
+	ordered_properties << qml_order_properties_by_dependencies(node.properties.filter(it.declared_type.len == 0
+		&& qml_property_is_geometry(it)), node.id)
+	ordered_properties << node.properties.filter(it.declared_type.len == 0
+		&& !qml_property_is_geometry(it))
 	for property in ordered_properties {
 		if property.name == 'id'
 			|| property.name in ['on_tap', 'on_change', 'on_active', 'on_text', 'on_submit'] {
@@ -1017,6 +1030,12 @@ fn (mut c QmlCompiler) compile_node(node &QmlNode, path string, input string, in
 		}
 		c.out.writeln('\t${name} := ${value}')
 		properties[property.name] = name
+		if property.declared_type.len == 0 && qml_property_is_geometry(property) {
+			named_props[property.name] = name
+			if node.id.len > 0 {
+				scope.ids[node.id] = QmlNamedValue{ frame: input, props: named_props.clone() }
+			}
+		}
 	}
 	frame := 'qml_frame_${suffix}'
 	c.out.writeln('\t${frame} := ui2.rect(${qml_prop(properties, 'x', input + '.x')}, ${qml_prop(properties, 'y', input + '.y')}, ${qml_prop(properties, 'width', input + '.width')}, ${qml_prop(properties, 'height', input + '.height')})')

--- a/vlib/v3/parser/qml.v
+++ b/vlib/v3/parser/qml.v
@@ -1,0 +1,1418 @@
+module parser
+
+import os
+import strings
+import v3.flat
+
+enum QmlTokenKind {
+	name
+	string_
+	number
+	lbrace
+	rbrace
+	colon
+	lpar
+	rpar
+	comma
+	question
+	plus
+	minus
+	mul
+	div
+	mod
+	not
+	eq
+	ne
+	lt
+	le
+	gt
+	ge
+	and
+	or
+	eof
+}
+
+struct QmlToken {
+	kind QmlTokenKind
+	text string
+	line int
+}
+
+struct QmlLexer {
+	source string
+mut:
+	pos  int
+	line int = 1
+}
+
+fn (mut l QmlLexer) advance() u8 {
+	c := l.source[l.pos]
+	l.pos++
+	if c == `\n` {
+		l.line++
+	}
+	return c
+}
+
+fn (mut l QmlLexer) skip_space() {
+	for l.pos < l.source.len {
+		c := l.source[l.pos]
+		if c in [` `, `\t`, `\r`, `\n`] {
+			l.advance()
+		} else if c == `/` && l.pos + 1 < l.source.len && l.source[l.pos + 1] == `/` {
+			for l.pos < l.source.len && l.source[l.pos] != `\n` {
+				l.pos++
+			}
+		} else {
+			break
+		}
+	}
+}
+
+fn qml_is_name_char(c u8) bool {
+	return c.is_alnum() || c in [`_`, `-`, `.`, `#`]
+}
+
+fn (mut l QmlLexer) read_name() QmlToken {
+	start := l.pos
+	line := l.line
+	for l.pos < l.source.len && qml_is_name_char(l.source[l.pos]) {
+		if l.source[l.pos] == `-` && l.pos > start {
+			prefix := l.source[start..l.pos]
+			if prefix.contains('.') || prefix == 'index' {
+				break
+			}
+		}
+		l.pos++
+	}
+	return QmlToken{.name, l.source[start..l.pos], line}
+}
+
+fn (mut l QmlLexer) read_number() QmlToken {
+	start := l.pos
+	line := l.line
+	mut dot := false
+	for l.pos < l.source.len {
+		c := l.source[l.pos]
+		if c.is_digit() {
+			l.pos++
+		} else if c == `.` && !dot {
+			dot = true
+			l.pos++
+		} else {
+			break
+		}
+	}
+	return QmlToken{.number, l.source[start..l.pos], line}
+}
+
+fn (mut l QmlLexer) read_string() !QmlToken {
+	line := l.line
+	l.advance()
+	mut value := []u8{}
+	for l.pos < l.source.len {
+		c := l.advance()
+		if c == `\\` && l.pos < l.source.len {
+			next := l.advance()
+			match next {
+				`n` { value << `\n` }
+				`t` { value << `\t` }
+				`\\` { value << `\\` }
+				`"` { value << `"` }
+				else { value << next }
+			}
+		} else if c == `"` {
+			return QmlToken{.string_, value.bytestr(), line}
+		} else {
+			value << c
+		}
+	}
+	return error('unterminated string at line ${line}')
+}
+
+fn tokenize_qml(source string) ![]QmlToken {
+	mut lexer := QmlLexer{ source: source }
+	mut tokens := []QmlToken{}
+	for {
+		lexer.skip_space()
+		if lexer.pos >= source.len {
+			tokens << QmlToken{.eof, '', lexer.line}
+			return tokens
+		}
+		line := lexer.line
+		c := source[lexer.pos]
+		match c {
+			`{` { tokens << QmlToken{.lbrace, '{', line} }
+			`}` { tokens << QmlToken{.rbrace, '}', line} }
+			`:` { tokens << QmlToken{.colon, ':', line} }
+			`(` { tokens << QmlToken{.lpar, '(', line} }
+			`)` { tokens << QmlToken{.rpar, ')', line} }
+			`,` { tokens << QmlToken{.comma, ',', line} }
+			`?` { tokens << QmlToken{.question, '?', line} }
+			`+` { tokens << QmlToken{.plus, '+', line} }
+			`-` { tokens << QmlToken{.minus, '-', line} }
+			`*` { tokens << QmlToken{.mul, '*', line} }
+			`/` { tokens << QmlToken{.div, '/', line} }
+			`%` { tokens << QmlToken{.mod, '%', line} }
+			`!` {
+				lexer.pos++
+				if lexer.pos < source.len && source[lexer.pos] == `=` {
+					tokens << QmlToken{.ne, '!=', line}
+				} else {
+					tokens << QmlToken{.not, '!', line}
+					continue
+				}
+			}
+			`=` {
+				lexer.pos++
+				if lexer.pos >= source.len || source[lexer.pos] != `=` {
+					return error('expected `==` at line ${line}')
+				}
+				tokens << QmlToken{.eq, '==', line}
+			}
+			`<` {
+				lexer.pos++
+				if lexer.pos < source.len && source[lexer.pos] == `=` {
+					tokens << QmlToken{.le, '<=', line}
+				} else {
+					tokens << QmlToken{.lt, '<', line}
+					continue
+				}
+			}
+			`>` {
+				lexer.pos++
+				if lexer.pos < source.len && source[lexer.pos] == `=` {
+					tokens << QmlToken{.ge, '>=', line}
+				} else {
+					tokens << QmlToken{.gt, '>', line}
+					continue
+				}
+			}
+			`&` {
+				lexer.pos++
+				if lexer.pos >= source.len || source[lexer.pos] != `&` {
+					return error('expected `&&` at line ${line}')
+				}
+				tokens << QmlToken{.and, '&&', line}
+			}
+			`|` {
+				lexer.pos++
+				if lexer.pos >= source.len || source[lexer.pos] != `|` {
+					return error('expected `||` at line ${line}')
+				}
+				tokens << QmlToken{.or, '||', line}
+			}
+			`"` {
+				tokens << lexer.read_string()!
+				continue
+			}
+			else {
+				if c.is_digit() {
+					tokens << lexer.read_number()
+					continue
+				}
+				if qml_is_name_char(c) {
+					tokens << lexer.read_name()
+					continue
+				}
+				return error('unexpected character `${[c].bytestr()}` at line ${line}')
+			}
+		}
+		lexer.pos++
+	}
+	return tokens
+}
+
+enum QmlExprKind {
+	literal
+	path
+	call
+	unary
+	binary
+	conditional
+	interpolation
+}
+
+struct QmlInterpolationPart {
+	text string
+	expr &QmlExpr = unsafe { nil }
+}
+
+struct QmlExpr {
+	kind   QmlExprKind
+	value  string
+	line   int
+	left   &QmlExpr = unsafe { nil }
+	right  &QmlExpr = unsafe { nil }
+	third  &QmlExpr = unsafe { nil }
+	args   []&QmlExpr
+	parts  []QmlInterpolationPart
+	quoted bool
+}
+
+struct QmlProperty {
+	name          string
+	declared_type string
+	expr          &QmlExpr
+}
+
+struct QmlNode {
+	tag  string
+	line int
+mut:
+	id         string
+	properties []QmlProperty
+	children   []&QmlNode
+}
+
+struct QmlSourceParser {
+	tokens []QmlToken
+mut:
+	pos int
+}
+
+fn (p &QmlSourceParser) at() QmlToken {
+	return if p.pos < p.tokens.len { p.tokens[p.pos] } else { QmlToken{.eof, '', 0} }
+}
+
+fn (mut p QmlSourceParser) take(kind QmlTokenKind) !QmlToken {
+	token := p.at()
+	if token.kind != kind {
+		return error('expected ${kind}, got ${token.kind} (`${token.text}`) at line ${token.line}')
+	}
+	p.pos++
+	return token
+}
+
+fn (mut p QmlSourceParser) parse_node() !&QmlNode {
+	tag := p.take(.name)!
+	p.take(.lbrace)!
+	mut node := &QmlNode{ tag: tag.text, line: tag.line }
+	for p.at().kind !in [.rbrace, .eof] {
+		if p.at().kind != .name {
+			return error('unexpected token `${p.at().text}` at line ${p.at().line}')
+		}
+		if p.at().text == 'property' {
+			p.pos++
+			typ := p.take(.name)!
+			name := p.take(.name)!
+			p.take(.colon)!
+			node.properties << QmlProperty{ name: name.text, declared_type: typ.text, expr: p.parse_expression()! }
+		} else if p.pos + 1 < p.tokens.len && p.tokens[p.pos + 1].kind == .lbrace {
+			node.children << p.parse_node()!
+		} else if p.pos + 1 < p.tokens.len && p.tokens[p.pos + 1].kind == .colon {
+			name := p.take(.name)!
+			p.take(.colon)!
+			expr := p.parse_expression()!
+			if name.text == 'id' {
+				if expr.kind !in [.literal, .path] {
+					return error('id must be a literal identifier at line ${name.line}')
+				}
+				node.id = expr.value
+			}
+			node.properties << QmlProperty{ name: name.text, expr: expr }
+		} else {
+			return error('unexpected token `${p.at().text}` at line ${p.at().line}')
+		}
+	}
+	p.take(.rbrace)!
+	return node
+}
+
+fn (mut p QmlSourceParser) parse_expression() !&QmlExpr {
+	return p.parse_conditional()
+}
+
+fn (mut p QmlSourceParser) parse_conditional() !&QmlExpr {
+	condition := p.parse_or()!
+	if p.at().kind != .question {
+		return condition
+	}
+	line := p.take(.question)!.line
+	when_true := p.parse_expression()!
+	p.take(.colon)!
+	return &QmlExpr{
+		kind: .conditional
+		line: line
+		left: condition
+		right: when_true
+		third: p.parse_expression()!
+	}
+}
+
+fn (mut p QmlSourceParser) parse_or() !&QmlExpr {
+	mut left := p.parse_and()!
+	for p.at().kind == .or {
+		op := p.at()
+		p.pos++
+		left = &QmlExpr{
+			kind: .binary
+			value: op.text
+			line: op.line
+			left: left
+			right: p.parse_and()!
+		}
+	}
+	return left
+}
+
+fn (mut p QmlSourceParser) parse_and() !&QmlExpr {
+	mut left := p.parse_equality()!
+	for p.at().kind == .and {
+		op := p.at()
+		p.pos++
+		left = &QmlExpr{
+			kind: .binary
+			value: op.text
+			line: op.line
+			left: left
+			right: p.parse_equality()!
+		}
+	}
+	return left
+}
+
+fn (mut p QmlSourceParser) parse_equality() !&QmlExpr {
+	mut left := p.parse_comparison()!
+	for p.at().kind in [.eq, .ne] {
+		op := p.at()
+		p.pos++
+		left = &QmlExpr{
+			kind: .binary
+			value: op.text
+			line: op.line
+			left: left
+			right: p.parse_comparison()!
+		}
+	}
+	return left
+}
+
+fn (mut p QmlSourceParser) parse_comparison() !&QmlExpr {
+	mut left := p.parse_term()!
+	for p.at().kind in [.lt, .le, .gt, .ge] {
+		op := p.at()
+		p.pos++
+		left = &QmlExpr{
+			kind: .binary
+			value: op.text
+			line: op.line
+			left: left
+			right: p.parse_term()!
+		}
+	}
+	return left
+}
+
+fn (mut p QmlSourceParser) parse_term() !&QmlExpr {
+	mut left := p.parse_factor()!
+	for p.at().kind in [.plus, .minus] {
+		op := p.at()
+		p.pos++
+		left = &QmlExpr{
+			kind: .binary
+			value: op.text
+			line: op.line
+			left: left
+			right: p.parse_factor()!
+		}
+	}
+	return left
+}
+
+fn (mut p QmlSourceParser) parse_factor() !&QmlExpr {
+	mut left := p.parse_unary()!
+	for p.at().kind in [.mul, .div, .mod] {
+		op := p.at()
+		p.pos++
+		left = &QmlExpr{
+			kind: .binary
+			value: op.text
+			line: op.line
+			left: left
+			right: p.parse_unary()!
+		}
+	}
+	return left
+}
+
+fn (mut p QmlSourceParser) parse_unary() !&QmlExpr {
+	if p.at().kind in [.not, .minus] {
+		op := p.at()
+		p.pos++
+		return &QmlExpr{ kind: .unary, value: op.text, line: op.line, left: p.parse_unary()! }
+	}
+	return p.parse_primary()
+}
+
+fn (mut p QmlSourceParser) parse_primary() !&QmlExpr {
+	token := p.at()
+	match token.kind {
+		.string_ {
+			p.pos++
+			return parse_qml_interpolation(token.text, token.line)!
+		}
+		.name, .number {
+			p.pos++
+			if p.at().kind == .lpar {
+				p.pos++
+				mut args := []&QmlExpr{}
+				if p.at().kind != .rpar {
+					for {
+						args << p.parse_expression()!
+						if p.at().kind != .comma {
+							break
+						}
+						p.pos++
+					}
+				}
+				p.take(.rpar)!
+				return &QmlExpr{ kind: .call, value: token.text, line: token.line, args: args }
+			}
+			return &QmlExpr{
+				kind: if token.kind == .number || token.text in ['true', 'false'] {
+					QmlExprKind.literal
+				} else {
+					QmlExprKind.path
+				}
+				value: token.text
+				line: token.line
+			}
+		}
+		.lpar {
+			p.pos++
+			expr := p.parse_expression()!
+			p.take(.rpar)!
+			return expr
+		}
+		else {
+			return error('expected expression, got ${token.kind} (`${token.text}`) at line ${token.line}')
+		}
+	}
+}
+
+fn parse_qml_interpolation(value string, line int) !&QmlExpr {
+	if !value.contains(r'${') {
+		return &QmlExpr{ kind: .literal, value: value, line: line, quoted: true }
+	}
+	mut parts := []QmlInterpolationPart{}
+	mut cursor := 0
+	for cursor < value.len {
+		start_relative := value[cursor..].index(r'${') or {
+			parts << QmlInterpolationPart{ text: value[cursor..] }
+			break
+		}
+		start := cursor + start_relative
+		if start > cursor {
+			parts << QmlInterpolationPart{ text: value[cursor..start] }
+		}
+		end_relative := value[start + 2..].index('}') or {
+			return error('unterminated interpolation at line ${line}')
+		}
+		end := start + 2 + end_relative
+		tokens := tokenize_qml(value[start + 2..end])!
+		mut parser := QmlSourceParser{ tokens: tokens }
+		parts << QmlInterpolationPart{ expr: parser.parse_expression()! }
+		parser.take(.eof) or { return error('invalid interpolation at line ${line}: ${err}') }
+		cursor = end + 1
+	}
+	return &QmlExpr{ kind: .interpolation, line: line, parts: parts }
+}
+
+fn parse_qml_source(source string) !&QmlNode {
+	tokens := tokenize_qml(source)!
+	mut parser := QmlSourceParser{ tokens: tokens }
+	root := parser.parse_node()!
+	parser.take(.eof)!
+	validate_compiled_qml_node(root)!
+	return root
+}
+
+fn validate_compiled_qml_node(node &QmlNode) ! {
+	mut bindings := 0
+	for property in node.properties {
+		if property.name.starts_with('bind.') {
+			bindings++
+			bound_property := property.name.all_after('bind.')
+			if bound_property !in ['text', 'checked', 'active', 'value'] {
+				return error('two-way binding is not supported for `${bound_property}` at line ${property.expr.line}')
+			}
+			if property.expr.kind != .path || !property.expr.value.starts_with('app.')
+				|| property.expr.value.count('.') != 1 {
+				return error('`${property.name}` must target a mutable top-level app field at line ${property.expr.line}')
+			}
+		}
+		if property.name in ['on_tap', 'on_change', 'on_active', 'on_submit']
+			&& property.expr.kind == .call {
+			if !property.expr.value.starts_with('app.') || property.expr.value.count('.') != 1 {
+				return error('event handlers must call an app action at line ${property.expr.line}')
+			}
+			if property.expr.args.len > 1 {
+				return error('app actions support at most one argument at line ${property.expr.line}')
+			}
+		}
+	}
+	if bindings > 1 {
+		return error('an element can only have one two-way binding at line ${node.line}')
+	}
+	if node.tag == 'Repeater' {
+		if qml_find_property(node, 'model') == none {
+			return error('Repeater requires `model` at line ${node.line}')
+		}
+		if qml_find_property(node, 'key') == none {
+			return error('Repeater requires a stable `key` at line ${node.line}')
+		}
+	}
+	for child in node.children {
+		validate_compiled_qml_node(child)!
+	}
+}
+
+fn qml_expr_text(expr &QmlExpr) string {
+	return match expr.kind {
+		.literal, .path { expr.value }
+		.call { expr.value + '(' + expr.args.map(qml_expr_text(it)).join(', ') + ')' }
+		.unary { expr.value + qml_expr_text(expr.left) }
+		.binary { '${qml_expr_text(expr.left)} ${expr.value} ${qml_expr_text(expr.right)}' }
+		.conditional {
+			'${qml_expr_text(expr.left)} ? ${qml_expr_text(expr.right)} : ${qml_expr_text(expr.third)}'
+		}
+		.interpolation {
+			mut value := ''
+			for part in expr.parts {
+				value += if isnil(part.expr) {
+					part.text
+				} else {
+					r'${' + qml_expr_text(part.expr) + '}'
+				}
+			}
+			value
+		}
+	}
+}
+
+// parse_qml_template_expr compiles `$qml('file.qml')` into a direct ui2.Element builder.
+fn (mut p Parser) parse_qml_template_expr(call_start int) flat.NodeId {
+	p.next() // qml
+	if p.tok != .lpar {
+		p.record_diagnostic('expected `(` after `\$qml`', p.tok_pos)
+		return p.add_val_id(5, '')
+	}
+	p.next()
+	arg_id := p.expr(.lowest)
+	arg := p.resolve_tmpl_path_arg(arg_id)
+	for p.tok != .rpar && p.tok != .eof && p.tok != .semicolon {
+		p.next()
+	}
+	if p.tok == .rpar {
+		p.next()
+	}
+	if arg.len == 0 {
+		p.record_diagnostic('`\$qml()` path must be a compile-time string', call_start)
+		return p.add_val_id(5, '')
+	}
+	path := p.resolve_veb_template_path(false, arg)
+	if !os.exists(path) {
+		p.record_diagnostic('QML file `${path}` does not exist', call_start)
+		return p.add_val_id(5, '')
+	}
+	source := os.read_file(path) or {
+		p.record_diagnostic('cannot read QML file `${path}`: ${err.msg()}', call_start)
+		return p.add_val_id(5, '')
+	}
+	root := parse_qml_source(source) or {
+		p.record_diagnostic('${path}: ${err.msg()}', call_start)
+		return p.add_val_id(5, '')
+	}
+	mut compiler := QmlCompiler{
+		uses_app: qml_node_uses_path(root, 'app')
+	}
+	generated := compiler.compile(root)
+	template := flat.Node{
+		value: path
+		pos: p.span_to(call_start)
+	}
+	return p.parse_veb_template_replacement_expr(generated, template, []TemplateSourceLine{}) or {
+		p.record_diagnostic('could not lower QML file `${path}`', call_start)
+		p.add_val_id(5, '')
+	}
+}
+
+fn qml_node_uses_path(node &QmlNode, base string) bool {
+	for property in node.properties {
+		if qml_expr_uses_path(property.expr, base) {
+			return true
+		}
+	}
+	for child in node.children {
+		if qml_node_uses_path(child, base) {
+			return true
+		}
+	}
+	return false
+}
+
+fn qml_expr_uses_path(expr &QmlExpr, base string) bool {
+	if expr.kind in [.path, .call] && (expr.value == base || expr.value.starts_with(base + '.')) {
+		return true
+	}
+	if !isnil(expr.left) && qml_expr_uses_path(expr.left, base) {
+		return true
+	}
+	if !isnil(expr.right) && qml_expr_uses_path(expr.right, base) {
+		return true
+	}
+	if !isnil(expr.third) && qml_expr_uses_path(expr.third, base) {
+		return true
+	}
+	for arg in expr.args {
+		if qml_expr_uses_path(arg, base) {
+			return true
+		}
+	}
+	for part in expr.parts {
+		if !isnil(part.expr) && qml_expr_uses_path(part.expr, base) {
+			return true
+		}
+	}
+	return false
+}
+
+struct QmlNamedValue {
+	frame string
+	props map[string]string
+}
+
+struct QmlScope {
+mut:
+	ids     map[string]QmlNamedValue
+	special map[string]string
+}
+
+struct QmlCompiler {
+	uses_app bool
+mut:
+	out strings.Builder
+}
+
+fn (mut c QmlCompiler) compile(root &QmlNode) string {
+	c.out = strings.new_builder(4096)
+	capture := if c.uses_app { '[app] ' } else { '' }
+	c.out.writeln('(fn ${capture}() ui2.Element {')
+	c.out.writeln('\tqml_input_0 := ui2.bounds()')
+	scope := QmlScope{
+		ids: map[string]QmlNamedValue{}
+		special: map[string]string{}
+	}
+	c.compile_node(root, '0', 'qml_input_0', scope, '')
+	c.out.writeln('\treturn qml_element_0')
+	c.out.write_string('}())')
+	return c.out.str()
+}
+
+fn qml_clone_scope(scope QmlScope) QmlScope {
+	return QmlScope{
+		ids: scope.ids.clone()
+		special: scope.special.clone()
+	}
+}
+
+fn qml_var(path string) string {
+	return path.replace('.', '_').replace('-', '_')
+}
+
+fn qml_quote(value string) string {
+	return "'" + value.replace('\\', '\\\\').replace("'", "\\'").replace('\n', '\\n').replace('\r', '\\r').replace('\t', '\\t').replace(r'$', r'\$') + "'"
+}
+
+fn qml_interpolation_text(value string) string {
+	return value.replace('\\', '\\\\').replace("'", "\\'").replace('\n', '\\n').replace('\r', '\\r').replace('\t', '\\t').replace(r'$', r'\$')
+}
+
+fn qml_stringify(expression string) string {
+	return "'" + r'$' + '{' + expression + "}'"
+}
+
+enum QmlExprUse {
+	raw
+	number
+	string_
+	bool_
+	color
+}
+
+fn qml_property_use(property QmlProperty) QmlExprUse {
+	if property.declared_type.len > 0 {
+		return match property.declared_type {
+			'f64', 'f32', 'int' { .number }
+			'bool' { .bool_ }
+			'string' { .string_ }
+			else { .raw }
+		}
+	}
+	if property.name in ['x', 'y', 'width', 'height', 'padding', 'spacing', 'corner_radius', 'radius',
+		'rotation', 'font_size', 'size', 'head_indent', 'first_line_indent', 'hyphenation_factor',
+		'lines', 'pad_left', 'dialog_width', 'dialog_height', 'border_width', 'border_left',
+		'border_top', 'border_right', 'border_bottom', 'value', 'min', 'max', 'step', 'track_width',
+		'thumb_size'] {
+		return .number
+	}
+	if property.name in ['background', 'color', 'background_color', 'border_color',
+		'value_track_color', 'thumb_color', 'inactive_color', 'active_color', 'disabled_track_color',
+		'disabled_thumb_color'] {
+		return .color
+	}
+	if property.name in ['checked', 'hidden', 'enabled', 'native', 'editable', 'emit_change', 'secure',
+		'clickable', 'draggable', 'long_press', 'swipe_left', 'persistent', 'autocorrect', 'bold',
+		'italic', 'underline', 'strikethrough', 'shadow', 'outline', 'value_track', 'active']
+		|| property.name in ['bind.checked', 'bind.active'] {
+		return .bool_
+	}
+	if property.name == 'bind.value' {
+		return .number
+	}
+	if property.name == 'model' {
+		return .raw
+	}
+	return .string_
+}
+
+fn qml_expr_is_string(expr &QmlExpr) bool {
+	if expr.kind == .interpolation || (expr.kind == .literal && expr.quoted) {
+		return true
+	}
+	if expr.kind == .conditional {
+		return qml_expr_is_string(expr.right) || qml_expr_is_string(expr.third)
+	}
+	return false
+}
+
+fn (c &QmlCompiler) resolve_path(path string, scope QmlScope) (string, bool) {
+	parts := path.split('.')
+	if parts.len == 0 {
+		return path, false
+	}
+	if replacement := scope.special[parts[0]] {
+		return replacement + if parts.len > 1 { '.' + parts[1..].join('.') } else { '' }, true
+	}
+	if named := scope.ids[parts[0]] {
+		if parts.len == 2 && parts[1] in ['x', 'y', 'width', 'height'] {
+			return '${named.frame}.${parts[1]}', true
+		}
+		if parts.len == 2 {
+			if prop := named.props[parts[1]] {
+				return prop, true
+			}
+		}
+	}
+	return path, path.contains('.')
+}
+
+fn (c &QmlCompiler) expr(expr &QmlExpr, scope QmlScope, use QmlExprUse) string {
+	if use == .string_ && expr.kind == .call {
+		return qml_quote(qml_expr_text(expr))
+	}
+	match expr.kind {
+		.literal {
+			if expr.quoted {
+				return qml_quote(expr.value)
+			}
+			return match use {
+				.string_ { qml_quote(expr.value) }
+				.number { 'f64(${expr.value})' }
+				else { expr.value }
+			}
+		}
+		.path {
+			resolved, known := c.resolve_path(expr.value, scope)
+			if use == .color {
+				if expr.value.starts_with('#') && expr.value.len == 7 {
+					return 'u32(0x${expr.value[1..]})'
+				}
+				if known && resolved != expr.value {
+					return resolved
+				}
+				if !known {
+					return 'u32(0xffffff)'
+				}
+				return 'ui2.parse_hex_color(${qml_stringify(resolved)})'
+			}
+			if use == .string_ {
+				if !known {
+					return qml_quote(expr.value)
+				}
+				return qml_stringify(resolved)
+			}
+			if use == .number {
+				return 'f64(${resolved})'
+			}
+			return resolved
+		}
+		.call {
+			args := expr.args.map(c.expr(it, scope, .raw)).join(', ')
+			resolved, _ := c.resolve_path(expr.value, scope)
+			return '${resolved}(${args})'
+		}
+		.unary {
+			operand_use := if expr.value == '!' { QmlExprUse.bool_ } else { .number }
+			return '(${expr.value}${c.expr(expr.left, scope, operand_use)})'
+		}
+		.binary {
+			if expr.value in ['&&', '||'] {
+				return '${c.expr(expr.left, scope, .bool_)} ${expr.value} ${c.expr(expr.right, scope, .bool_)}'
+			}
+			if expr.value in ['==', '!=', '<', '<=', '>', '>='] {
+				operand_use := if qml_expr_is_string(expr.left) || qml_expr_is_string(expr.right) {
+					QmlExprUse.string_
+				} else {
+					QmlExprUse.raw
+				}
+				return '${c.expr(expr.left, scope, operand_use)} ${expr.value} ${c.expr(expr.right, scope, operand_use)}'
+			}
+			if expr.value == '+' && use == .string_ {
+				return '(${c.expr(expr.left, scope, .string_)} + ${c.expr(expr.right, scope, .string_)})'
+			}
+			if expr.value == '%' {
+				return 'f64(int(${c.expr(expr.left, scope, .number)}) % int(${c.expr(expr.right, scope, .number)}))'
+			}
+			return '(${c.expr(expr.left, scope, .number)} ${expr.value} ${c.expr(expr.right, scope, .number)})'
+		}
+		.conditional {
+			return '(if ${c.expr(expr.left, scope, .bool_)} { ${c.expr(expr.right, scope, use)} } else { ${c.expr(expr.third, scope, use)} })'
+		}
+		.interpolation {
+			mut value := "'"
+			for part in expr.parts {
+				if isnil(part.expr) {
+					value += qml_interpolation_text(part.text)
+				} else {
+					value += r'$' + '{' + c.expr(part.expr, scope, .raw) + '}'
+				}
+			}
+			return value + "'"
+		}
+	}
+}
+
+fn qml_find_property(node &QmlNode, name string) ?QmlProperty {
+	for property in node.properties {
+		if property.name == name {
+			return property
+		}
+	}
+	return none
+}
+
+fn qml_prop(properties map[string]string, name string, default_ string) string {
+	return properties[name] or { default_ }
+}
+
+fn (mut c QmlCompiler) compile_node(node &QmlNode, path string, input string, incoming QmlScope, default_key string) {
+	suffix := qml_var(path)
+	c.out.writeln('\t_ = ${input}')
+	mut scope := qml_clone_scope(incoming)
+	mut named_props := map[string]string{}
+	if node.id.len > 0 {
+		scope.ids[node.id] = QmlNamedValue{ frame: input, props: named_props }
+	}
+	mut properties := map[string]string{}
+	for property in node.properties {
+		if property.name == 'id'
+			|| property.name in ['on_tap', 'on_change', 'on_active', 'on_submit'] {
+			continue
+		}
+		name := 'qml_property_${suffix}_${qml_var(property.name)}'
+		c.out.writeln('\t${name} := ${c.expr(property.expr, scope, qml_property_use(property))}')
+		properties[property.name] = name
+		if property.declared_type.len > 0 && node.id.len > 0 {
+			named_props[property.name] = name
+			scope.ids[node.id] = QmlNamedValue{ frame: input, props: named_props.clone() }
+		}
+	}
+	frame := 'qml_frame_${suffix}'
+	c.out.writeln('\t${frame} := ui2.rect(${qml_prop(properties, 'x', input + '.x')}, ${qml_prop(properties, 'y', input + '.y')}, ${qml_prop(properties, 'width', input + '.width')}, ${qml_prop(properties, 'height', input + '.height')})')
+	if node.id.len > 0 {
+		scope.ids[node.id] = QmlNamedValue{ frame: frame, props: named_props.clone() }
+	}
+	c.write_action_type_checks(node, suffix, scope)
+	children := 'qml_children_${suffix}'
+	container := node.tag in ['Screen', 'View', 'Rectangle', 'Column', 'Row', 'Scroll']
+		|| node.tag !in ['Label', 'Image', 'Button', 'MessageBox', 'Checkbox', 'Dropdown', 'TextArea',
+			'TextField', 'ProgressBar', 'Slider', 'Switch']
+	visible_children := if container {
+		node.children.filter(it.tag !in ['MenuItem', 'Option'])
+	} else {
+		[]&QmlNode{}
+	}
+	if container {
+		c.out.writeln('\tmut ${children} := []ui2.Element{cap: ${visible_children.len}}')
+	}
+	mut cursor := ''
+	if container && node.tag in ['Column', 'Row'] {
+		cursor = 'qml_cursor_${suffix}'
+		c.out.writeln('\tmut ${cursor} := ${qml_prop(properties, 'padding', 'f64(0)')}')
+	}
+	for child_index, child in node.children {
+		if !container || child.tag in ['MenuItem', 'Option'] {
+			continue
+		}
+		child_path := '${path}.${child_index}'
+		if child.tag == 'Repeater' {
+			c.compile_repeater(child, child_path, frame, node.tag, properties, cursor, scope, children)
+			continue
+		}
+		child_input := 'qml_input_${qml_var(child_path)}'
+		c.out.writeln('\t${child_input} := ${qml_child_input(node.tag, frame, properties, cursor)}')
+		c.compile_node(child, child_path, child_input, scope, '')
+		c.out.writeln('\t${children} << qml_element_${qml_var(child_path)}')
+		qml_advance_cursor(mut c.out, node.tag, cursor, child_path, properties)
+	}
+	c.compile_element(node, suffix, frame, children, properties, scope, default_key)
+}
+
+fn (mut c QmlCompiler) write_action_type_checks(node &QmlNode, suffix string, scope QmlScope) {
+	for property in node.properties {
+		if property.name !in ['on_tap', 'on_change', 'on_active', 'on_submit'] || property.expr.kind != .call {
+			continue
+		}
+		method_name := property.expr.value.all_after('app.')
+		check_name := 'qml_action_check_${suffix}_${qml_var(property.name)}'
+		arguments := property.expr.args.map(c.expr(it, scope, .raw)).join(', ')
+		// The branch is never taken, but V still checks that the method exists and
+		// that its argument has the declared type.
+		c.out.writeln('\tif false {')
+		c.out.writeln('\t\tmut ${check_name} := *app')
+		c.out.writeln('\t\t${check_name}.${method_name}(${arguments})')
+		c.out.writeln('\t}')
+	}
+}
+
+fn qml_child_input(tag string, frame string, properties map[string]string, cursor string) string {
+	padding := qml_prop(properties, 'padding', 'f64(0)')
+	return match tag {
+		'Column' {
+			'ui2.rect(${padding}, ${cursor}, ${frame}.width - ${padding} * f64(2), f64(32))'
+		}
+		'Row' {
+			'ui2.rect(${cursor}, ${padding}, f64(80), ${frame}.height - ${padding} * f64(2))'
+		}
+		else { 'ui2.rect(f64(0), f64(0), ${frame}.width, ${frame}.height)' }
+	}
+}
+
+fn qml_advance_cursor(mut out strings.Builder, tag string, cursor string, child_path string, properties map[string]string) {
+	spacing := qml_prop(properties, 'spacing', 'f64(0)')
+	if tag == 'Column' {
+		out.writeln('\t${cursor} += qml_frame_${qml_var(child_path)}.height + ${spacing}')
+	} else if tag == 'Row' {
+		out.writeln('\t${cursor} += qml_frame_${qml_var(child_path)}.width + ${spacing}')
+	}
+}
+
+fn (mut c QmlCompiler) compile_repeater(node &QmlNode, path string, parent_frame string, parent_tag string, parent_properties map[string]string, cursor string, incoming QmlScope, output string) {
+	model := qml_find_property(node, 'model') or { return }
+	key := qml_find_property(node, 'key') or { return }
+	suffix := qml_var(path)
+	index_name := 'qml_index_${suffix}'
+	item_name := 'qml_item_${suffix}'
+	key_name := 'qml_key_${suffix}'
+	c.out.writeln('\tfor ${index_name}, ${item_name} in ${c.expr(model.expr, incoming, .raw)} {')
+	mut scope := qml_clone_scope(incoming)
+	scope.special['item'] = item_name
+	scope.special['index'] = index_name
+	c.out.writeln('\t\t${key_name} := ${c.expr(key.expr, scope, .string_)}')
+	visible_count := node.children.filter(it.tag !in ['MenuItem', 'Option']).len
+	mut visible_index := 0
+	for child_index, child in node.children {
+		if child.tag in ['MenuItem', 'Option'] {
+			continue
+		}
+		child_path := '${path}.${child_index}'
+		if child.tag == 'Repeater' {
+			c.compile_repeater(child, child_path, parent_frame, parent_tag, parent_properties, cursor, scope, output)
+			continue
+		}
+		child_input := 'qml_input_${qml_var(child_path)}'
+		c.out.writeln('\t\t${child_input} := ${qml_child_input(parent_tag, parent_frame, parent_properties, cursor)}')
+		default_key := if visible_count == 1 {
+			key_name
+		} else {
+			"'" + r'$' + '{' + key_name + '}' + ':${visible_index}' + "'"
+		}
+		c.compile_node(child, child_path, child_input, scope, default_key)
+		c.out.writeln('\t\t${output} << qml_element_${qml_var(child_path)}')
+		qml_advance_cursor(mut c.out, parent_tag, cursor, child_path, parent_properties)
+		visible_index++
+	}
+	c.out.writeln('\t}')
+}
+
+fn qml_value(properties map[string]string, name string, alternative string, default_ string) string {
+	if value := properties[name] {
+		return value
+	}
+	if alternative.len > 0 {
+		if value := properties[alternative] {
+			return value
+		}
+	}
+	return default_
+}
+
+fn qml_binding_for_event(node &QmlNode, event_name string) ?QmlProperty {
+	if event_name == 'on_change' {
+		if binding := qml_find_property(node, 'bind.value') {
+			return binding
+		}
+		return qml_find_property(node, 'bind.text')
+	}
+	if event_name == 'on_tap' {
+		return qml_find_property(node, 'bind.checked')
+	}
+	if event_name == 'on_active' {
+		return qml_find_property(node, 'bind.active')
+	}
+	return none
+}
+
+fn (c &QmlCompiler) compiled_event_value(node &QmlNode, event_name string, scope QmlScope, control string) string {
+	action := qml_find_property(node, event_name)
+	binding := qml_binding_for_event(node, event_name)
+	if action == none && binding == none {
+		return "''"
+	}
+	if property := action {
+		if property.expr.kind != .call && binding == none {
+			return c.expr(property.expr, scope, .string_)
+		}
+	}
+	binding_property := if property := binding { property.name.all_after('bind.') } else { '' }
+	binding_target := if property := binding { qml_expr_text(property.expr) } else { '' }
+	mut action_name := ''
+	mut arguments := []string{}
+	if property := action {
+		if property.expr.kind == .call {
+			action_name = property.expr.value.all_after('app.')
+			for argument in property.expr.args {
+				arguments << c.expr(argument, scope, .string_)
+			}
+		}
+	}
+	if arguments.len == 0 {
+		return 'ui2.compiled_qml_event(${control}, ${qml_quote(binding_property)}, ${qml_quote(binding_target)}, ${qml_quote(action_name)})'
+	}
+	if property := action {
+		argument := property.expr.args[0]
+		if argument.kind == .path && argument.value.starts_with('app.') {
+			return 'ui2.compiled_qml_event_arg_path(${control}, ${qml_quote(binding_property)}, ${qml_quote(binding_target)}, ${qml_quote(action_name)}, ${qml_quote(argument.value)})'
+		}
+	}
+	return 'ui2.compiled_qml_event_arg(${control}, ${qml_quote(binding_property)}, ${qml_quote(binding_target)}, ${qml_quote(action_name)}, ${arguments[0]})'
+}
+
+fn (c &QmlCompiler) box_style(properties map[string]string) string {
+	border_width := qml_prop(properties, 'border_width', 'f64(0)')
+	return 'ui2.BoxStyle{bg: ${qml_prop(properties, 'background', 'u32(0xffffff)')}, radius: ${qml_value(properties, 'corner_radius', 'radius', 'f64(0)')}, border_color: ${qml_prop(properties, 'border_color', 'u32(0)')}, border_left: ${qml_prop(properties, 'border_left', border_width)}, border_top: ${qml_prop(properties, 'border_top', border_width)}, border_right: ${qml_prop(properties, 'border_right', border_width)}, border_bottom: ${qml_prop(properties, 'border_bottom', border_width)}}'
+}
+
+fn (c &QmlCompiler) text_style(properties map[string]string) string {
+	align := qml_prop(properties, 'align', "''")
+	fields := [
+		'color: ${qml_prop(properties, 'color', 'u32(0x111111)')}',
+		'background_color: ${qml_prop(properties, 'background_color', 'u32(0)')}',
+		'size: ${qml_value(properties, 'font_size', 'size', 'f64(15)')}',
+		'font_family: ${qml_prop(properties, 'font_family', "''")}',
+		'bold: ${qml_prop(properties, 'bold', 'false')}',
+		'italic: ${qml_prop(properties, 'italic', 'false')}',
+		'underline: ${qml_prop(properties, 'underline', 'false')}',
+		'strikethrough: ${qml_prop(properties, 'strikethrough', 'false')}',
+		'shadow: ${qml_prop(properties, 'shadow', 'false')}',
+		'outline: ${qml_prop(properties, 'outline', 'false')}',
+		'vertical_align: ${qml_prop(properties, 'vertical_align', "''")}',
+		'link: ${qml_prop(properties, 'link', "''")}',
+		"align: match ${align} { 'center' { .center } 'right' { .right } else { .left } }",
+		'head_indent: ${qml_prop(properties, 'head_indent', 'f64(0)')}',
+		'first_line_indent: ${qml_prop(properties, 'first_line_indent', 'f64(0)')}',
+		'hyphenation_factor: ${qml_prop(properties, 'hyphenation_factor', 'f64(0)')}',
+		'lines: int(${qml_prop(properties, 'lines', 'f64(1)')})',
+	]
+	return 'ui2.TextStyle{${fields.join(', ')}}'
+}
+
+fn (c &QmlCompiler) menu_value(node &QmlNode, scope QmlScope) string {
+	menu_items := node.children.filter(it.tag == 'MenuItem')
+	if menu_items.len > 0 {
+		mut entries := []string{cap: menu_items.len}
+		for item in menu_items {
+			fallback_id := qml_quote(item.id)
+			id := c.compiled_event_value(item, 'on_tap', scope, fallback_id)
+			text := if property := qml_find_property(item, 'text') {
+				c.expr(property.expr, scope, .string_)
+			} else {
+				"''"
+			}
+			entries << 'ui2.MenuEntry{id: if ${id}.len > 0 { ${id} } else { ${fallback_id} }, title: ${text}}'
+		}
+		return '[]ui2.MenuEntry{${entries.join(', ')}}'
+	}
+	if node.tag == 'Dropdown' {
+		mut entries := []string{}
+		for option in node.children {
+			if option.tag != 'Option' {
+				continue
+			}
+			text := if property := qml_find_property(option, 'text') {
+				c.expr(property.expr, scope, .string_)
+			} else {
+				"''"
+			}
+			entries << 'ui2.MenuEntry{id: ${text}, title: ${text}}'
+		}
+		return '[]ui2.MenuEntry{${entries.join(', ')}}'
+	}
+	return '[]ui2.MenuEntry{}'
+}
+
+fn (mut c QmlCompiler) compile_element(node &QmlNode, suffix string, frame string, children string, properties map[string]string, scope QmlScope, default_key string) {
+	has_binding := qml_find_property(node, 'bind.text') != none
+		|| qml_find_property(node, 'bind.checked') != none
+		|| qml_find_property(node, 'bind.active') != none || qml_find_property(node, 'bind.value') != none
+	id := if node.id.len > 0 {
+		qml_quote(node.id)
+	} else if has_binding && default_key.len > 0 {
+		"'__qml_control_${suffix}_" + r'$' + '{' + default_key + "}'"
+	} else if has_binding {
+		qml_quote('__qml_control_${suffix}')
+	} else {
+		"''"
+	}
+	key := qml_prop(properties, 'key', if default_key.len > 0 { default_key } else { "''" })
+	on_tap := c.compiled_event_value(node, 'on_tap', scope, id)
+	on_change := c.compiled_event_value(node, 'on_change', scope, id)
+	on_active := c.compiled_event_value(node, 'on_active', scope, id)
+	on_submit := c.compiled_event_value(node, 'on_submit', scope, id)
+	action := match node.tag {
+		'Button', 'Checkbox' { on_tap }
+		'Dropdown', 'Slider' { 'if ${on_change}.len > 0 { ${on_change} } else { ${on_tap} }' }
+		'Switch' {
+			'if ${on_active}.len > 0 { ${on_active} } else if ${on_change}.len > 0 { ${on_change} } else { ${on_tap} }'
+		}
+		'TextArea', 'TextField' { on_change }
+		else { on_tap }
+	}
+	if node.tag == 'MessageBox' {
+		c.compile_message_box(node, suffix, frame, properties, scope, key, action)
+		return
+	}
+	if node.tag == 'ProgressBar' {
+		c.compile_progress_bar(node, suffix, frame, properties, scope, key, action)
+		return
+	}
+	if node.tag == 'Slider' {
+		c.compile_slider(node, suffix, frame, properties, scope, key, action)
+		return
+	}
+	if node.tag == 'Switch' {
+		c.compile_switch(node, suffix, frame, properties, scope, key, action)
+		return
+	}
+	kind := match node.tag {
+		'Screen' { 'screen' }
+		'Label' { 'label' }
+		'Image' { 'image' }
+		'Button' { 'button' }
+		'Checkbox' { 'checkbox' }
+		'Dropdown' { 'dropdown' }
+		'TextField' { 'text_field' }
+		'TextArea' { 'text_area' }
+		'Scroll' { 'scroll' }
+		else { 'view' }
+	}
+	c.out.writeln('\tqml_element_${suffix} := ui2.Element{')
+	c.out.writeln('\t\tkind: .${kind}')
+	if node.tag != 'Screen' {
+		c.out.writeln('\t\tid: ${id}')
+		c.out.writeln('\t\tframe: ${frame}')
+	}
+	c.out.writeln('\t\taction_id: ${action}')
+	c.out.writeln('\t\tsubmit_id: ${on_submit}')
+	c.out.writeln('\t\tkey: ${key}')
+	if node.tag in ['Label', 'Button', 'Checkbox', 'Dropdown', 'TextField', 'TextArea'] {
+		c.out.writeln('\t\ttext: ${qml_value(properties, 'text', 'bind.text', "''")}')
+	}
+	if node.tag == 'Checkbox' {
+		c.out.writeln('\t\tchecked: ${qml_value(properties, 'checked', 'bind.checked', 'false')}')
+	}
+	if node.tag == 'Image' {
+		c.out.writeln('\t\timage_path: ${qml_value(properties, 'source', 'path', "''")}')
+	}
+	if node.tag == 'TextField' {
+		c.out.writeln('\t\tplaceholder: ${qml_prop(properties, 'placeholder', "''")}')
+		keyboard := qml_prop(properties, 'keyboard', "''")
+		c.out.writeln("\t\tkeyboard: if ${keyboard} in ['decimal', 'numeric', 'number'] { ui2.keyboard_decimal } else { ui2.keyboard_default }")
+		c.out.writeln('\t\temit_change: ${qml_prop(properties, 'emit_change', 'false')} || ${on_change}.len > 0')
+	}
+	if node.tag == 'TextArea' {
+		c.out.writeln('\t\treadonly: ${qml_prop(properties, 'editable', 'true')} == false')
+		c.out.writeln('\t\temit_change: ${on_change}.len > 0')
+	}
+	if node.tag == 'Screen' {
+		c.out.writeln('\t\tbox: ui2.BoxStyle{bg: ${qml_prop(properties, 'background', 'u32(0xffffff)')}}')
+	} else if node.tag == 'Scroll' {
+		c.out.writeln('\t\tbox: ${c.box_style(properties)}')
+		c.out.writeln('\t\tpersistent_scrollbars: ${qml_prop(properties, 'persistent', 'false')}')
+	} else if node.tag == 'Checkbox' {
+		c.out.writeln('\t\tbox: ui2.BoxStyle{transparent: true}')
+	} else if node.tag in ['View', 'Rectangle', 'Column', 'Row', 'Button', 'Dropdown', 'TextField',
+		'TextArea'] || kind == 'view' {
+		c.out.writeln('\t\tbox: ${c.box_style(properties)}')
+	}
+	if node.tag in ['Label', 'Button', 'Checkbox', 'Dropdown', 'TextField', 'TextArea'] {
+		c.out.writeln('\t\ttext_style: ${c.text_style(properties)}')
+	}
+	if node.tag in ['Screen', 'View', 'Rectangle', 'Column', 'Row', 'Scroll'] || kind == 'view' {
+		c.out.writeln('\t\tchildren: ${children}')
+	}
+	role_default := if node.tag == 'Checkbox' { "'checkbox'" } else { "''" }
+	label_default := if node.tag == 'Checkbox' {
+		qml_value(properties, 'text', 'bind.text', "''")
+	} else {
+		"''"
+	}
+	value_default := if node.tag == 'Checkbox' {
+		"if ${qml_value(properties, 'checked', 'bind.checked', 'false')} { 'checked' } else { 'unchecked' }"
+	} else {
+		"''"
+	}
+	c.write_common_fields(node, properties, scope, role_default, label_default, value_default)
+	c.out.writeln('\t}')
+}
+
+fn (mut c QmlCompiler) write_common_fields(node &QmlNode, properties map[string]string, scope QmlScope, role_default string, label_default string, value_default string) {
+	c.out.writeln('\t\tmenu: ${c.menu_value(node, scope)}')
+	c.out.writeln('\t\tsecure: ${qml_prop(properties, 'secure', 'false')}')
+	c.out.writeln('\t\tclickable: ${qml_prop(properties, 'clickable', 'false')}')
+	c.out.writeln('\t\tdraggable: ${qml_prop(properties, 'draggable', 'false')}')
+	c.out.writeln('\t\tlong_press: ${qml_prop(properties, 'long_press', 'false')}')
+	c.out.writeln('\t\tswipe_left: ${qml_prop(properties, 'swipe_left', 'false')}')
+	c.out.writeln('\t\trotation: ${qml_prop(properties, 'rotation', 'f64(0)')}')
+	c.out.writeln('\t\tcursor: ${qml_prop(properties, 'cursor', "''")}')
+	c.out.writeln('\t\ttooltip: ${qml_prop(properties, 'tooltip', "''")}')
+	c.out.writeln('\t\thidden: ${qml_prop(properties, 'hidden', 'false')}')
+	c.out.writeln('\t\tenabled: ${qml_prop(properties, 'enabled', 'true')}')
+	c.out.writeln('\t\taccessibility_role: ${qml_prop(properties, 'accessibility_role', role_default)}')
+	c.out.writeln('\t\taccessibility_label: ${qml_prop(properties, 'accessibility_label', label_default)}')
+	c.out.writeln('\t\taccessibility_value: ${qml_prop(properties, 'accessibility_value', value_default)}')
+	c.out.writeln('\t\tnative_style: ${qml_prop(properties, 'native', 'false')}')
+	c.out.writeln('\t\tautocorrect: ${qml_prop(properties, 'autocorrect', 'true')}')
+	c.out.writeln('\t\tpadding_left: ${qml_prop(properties, 'pad_left', 'f64(12)')}')
+}
+
+fn (mut c QmlCompiler) compile_progress_bar(node &QmlNode, suffix string, frame string, properties map[string]string, scope QmlScope, key string, action string) {
+	base := 'qml_progress_${suffix}'
+	c.out.writeln('\t${base} := ui2.progress_bar(')
+	c.out.writeln('\t\tid: ${qml_quote(node.id)}')
+	c.out.writeln('\t\tframe: ${frame}')
+	c.out.writeln('\t\tvalue: ${qml_prop(properties, 'value', 'f64(0)')}')
+	c.out.writeln('\t\tmax: ${qml_prop(properties, 'max', 'f64(100)')}')
+	c.out.writeln('\t\tbackground: ${qml_prop(properties, 'background', 'u32(0xe2e8f0)')}')
+	c.out.writeln('\t\tcolor: ${qml_prop(properties, 'color', 'u32(0x3b82f6)')}')
+	c.out.writeln('\t\tradius: ${qml_value(properties, 'corner_radius', 'radius', 'f64(4)')}')
+	c.out.writeln('\t)')
+	c.out.writeln('\tqml_element_${suffix} := ui2.Element{')
+	c.out.writeln('\t\t...${base}')
+	c.out.writeln('\t\taction_id: ${action}')
+	c.out.writeln('\t\tkey: ${key}')
+	c.write_common_fields(node, properties, scope, '${base}.accessibility_role', '${base}.accessibility_label', '${base}.accessibility_value')
+	c.out.writeln('\t}')
+}
+
+fn (mut c QmlCompiler) compile_slider(node &QmlNode, suffix string, frame string, properties map[string]string, scope QmlScope, key string, action string) {
+	base := 'qml_slider_${suffix}'
+	style := '${base}_style'
+	orientation_value := '${base}_orientation'
+	orientation := qml_prop(properties, 'orientation', "''")
+	c.out.writeln('\t${style} := ui2.SliderStyle{')
+	c.out.writeln('\t\ttrack_color: ${qml_prop(properties, 'background', 'u32(0xcbd5e1)')}')
+	c.out.writeln('\t\tvalue_track_color: ${qml_value(properties, 'value_track_color', 'color', 'u32(0x93c5fd)')}')
+	c.out.writeln('\t\tthumb_color: ${qml_prop(properties, 'thumb_color', 'u32(0x2563eb)')}')
+	c.out.writeln('\t\ttrack_width: ${qml_prop(properties, 'track_width', 'f64(4)')}')
+	c.out.writeln('\t\tthumb_size: ${qml_prop(properties, 'thumb_size', 'f64(20)')}')
+	c.out.writeln('\t}')
+	c.out.writeln("\t${orientation_value} := if ${orientation} == 'vertical' { ui2.Orientation.vertical } else { ui2.Orientation.horizontal }")
+	c.out.writeln('\t${base} := ui2.slider(')
+	c.out.writeln('\t\tid: ${qml_quote(node.id)}')
+	c.out.writeln('\t\taction_id: ${action}')
+	c.out.writeln('\t\tframe: ${frame}')
+	c.out.writeln('\t\tmin: ${qml_prop(properties, 'min', 'f64(0)')}')
+	c.out.writeln('\t\tmax: ${qml_prop(properties, 'max', 'f64(100)')}')
+	c.out.writeln('\t\tvalue: ${qml_value(properties, 'value', 'bind.value', 'f64(0)')}')
+	c.out.writeln('\t\tstep: ${qml_prop(properties, 'step', 'f64(0)')}')
+	c.out.writeln('\t\torientation: ${orientation_value}')
+	c.out.writeln('\t\tpadding: ${qml_prop(properties, 'padding', 'f64(16)')}')
+	c.out.writeln('\t\tvalue_track: ${qml_prop(properties, 'value_track', 'false')}')
+	c.out.writeln('\t\tstyle: ${style}')
+	c.out.writeln('\t)')
+	c.out.writeln('\tqml_element_${suffix} := ui2.Element{')
+	c.out.writeln('\t\t...${base}')
+	c.out.writeln('\t\tkey: ${key}')
+	c.write_common_fields(node, properties, scope, '${base}.accessibility_role', '${base}.accessibility_label', '${base}.accessibility_value')
+	c.out.writeln('\t}')
+}
+
+fn (mut c QmlCompiler) compile_switch(node &QmlNode, suffix string, frame string, properties map[string]string, scope QmlScope, key string, action string) {
+	base := 'qml_switch_${suffix}'
+	style := '${base}_style'
+	c.out.writeln('\t${style} := ui2.SwitchStyle{')
+	c.out.writeln('\t\tinactive_track_color: ${qml_prop(properties, 'inactive_color', 'u32(0xcbd5e1)')}')
+	c.out.writeln('\t\tactive_track_color: ${qml_value(properties, 'active_color', 'color', 'u32(0x22c55e)')}')
+	c.out.writeln('\t\tthumb_color: ${qml_prop(properties, 'thumb_color', 'u32(0xffffff)')}')
+	c.out.writeln('\t\tdisabled_track_color: ${qml_prop(properties, 'disabled_track_color', 'u32(0xe2e8f0)')}')
+	c.out.writeln('\t\tdisabled_thumb_color: ${qml_prop(properties, 'disabled_thumb_color', 'u32(0xf8fafc)')}')
+	c.out.writeln('\t}')
+	c.out.writeln('\t${base} := ui2.switch_control(')
+	c.out.writeln('\t\tid: ${qml_quote(node.id)}')
+	c.out.writeln('\t\taction_id: ${action}')
+	c.out.writeln('\t\tframe: ${frame}')
+	c.out.writeln('\t\tactive: ${qml_value(properties, 'active', 'bind.active', 'false')}')
+	c.out.writeln('\t\tstyle: ${style}')
+	c.out.writeln('\t)')
+	c.out.writeln('\tqml_element_${suffix} := ui2.Element{')
+	c.out.writeln('\t\t...${base}')
+	c.out.writeln('\t\tkey: ${key}')
+	c.write_common_fields(node, properties, scope, '${base}.accessibility_role', '${base}.accessibility_label', '${base}.accessibility_value')
+	c.out.writeln('\t}')
+}
+
+fn (mut c QmlCompiler) compile_message_box(node &QmlNode, suffix string, frame string, properties map[string]string, scope QmlScope, key string, action string) {
+	mut actions := []string{}
+	for child in node.children {
+		if child.tag != 'Button' {
+			continue
+		}
+		child_id := qml_quote(child.id)
+		child_action := c.compiled_event_value(child, 'on_tap', scope, child_id)
+		text := if property := qml_find_property(child, 'text') {
+			c.expr(property.expr, scope, .string_)
+		} else {
+			"''"
+		}
+		actions << 'ui2.MessageBoxAction{id: ${qml_quote(child.id)}, action_id: ${child_action}, title: ${text}}'
+	}
+	c.out.writeln('\tqml_message_box_${suffix} := ui2.custom_message_box(')
+	c.out.writeln('\t\tid: ${qml_quote(node.id)}')
+	c.out.writeln('\t\tframe: ${frame}')
+	c.out.writeln('\t\ttitle: ${qml_prop(properties, 'title', "''")}')
+	c.out.writeln('\t\ttext: ${qml_prop(properties, 'text', "''")}')
+	c.out.writeln('\t\thidden: ${qml_prop(properties, 'hidden', 'false')}')
+	c.out.writeln('\t\twidth: ${qml_prop(properties, 'dialog_width', 'f64(300)')}')
+	c.out.writeln('\t\theight: ${qml_prop(properties, 'dialog_height', 'f64(150)')}')
+	c.out.writeln('\t\tactions: []ui2.MessageBoxAction{${actions.join(', ')}}')
+	c.out.writeln('\t)')
+	c.out.writeln('\tqml_element_${suffix} := ui2.Element{')
+	c.out.writeln('\t\t...qml_message_box_${suffix}')
+	c.out.writeln('\t\taction_id: ${action}')
+	c.out.writeln('\t\tkey: ${key}')
+	c.write_common_fields(node, properties, scope, "''", "''", "''")
+	c.out.writeln('\t}')
+}

--- a/vlib/v3/parser/qml.v
+++ b/vlib/v3/parser/qml.v
@@ -883,7 +883,8 @@ fn (c &QmlCompiler) expr(expr &QmlExpr, scope QmlScope, use QmlExprUse) string {
 		}
 		.binary {
 			if expr.value in ['&&', '||'] {
-				return '${c.expr(expr.left, scope, .bool_)} ${expr.value} ${c.expr(expr.right, scope, .bool_)}'
+				result := '(${c.expr(expr.left, scope, .bool_)} ${expr.value} ${c.expr(expr.right, scope, .bool_)})'
+				return if use == .string_ { qml_stringify(result) } else { result }
 			}
 			if expr.value in ['==', '!=', '<', '<=', '>', '>='] {
 				operand_use := if qml_expr_is_string(expr.left) || qml_expr_is_string(expr.right) {
@@ -891,7 +892,8 @@ fn (c &QmlCompiler) expr(expr &QmlExpr, scope QmlScope, use QmlExprUse) string {
 				} else {
 					QmlExprUse.raw
 				}
-				return '${c.expr(expr.left, scope, operand_use)} ${expr.value} ${c.expr(expr.right, scope, operand_use)}'
+				result := '(${c.expr(expr.left, scope, operand_use)} ${expr.value} ${c.expr(expr.right, scope, operand_use)})'
+				return if use == .string_ { qml_stringify(result) } else { result }
 			}
 			if use == .raw {
 				return '(${c.expr(expr.left, scope, .raw)} ${expr.value} ${c.expr(expr.right, scope, .raw)})'
@@ -1049,7 +1051,7 @@ fn (mut c QmlCompiler) compile_node(node &QmlNode, path string, input string, in
 			continue
 		}
 		if child.tag == 'Repeater' {
-			c.compile_repeater(child, child_path, frame, node.tag, properties, cursor, scope, children)
+			c.compile_repeater(child, child_path, frame, node.tag, properties, cursor, scope, children, '')
 			continue
 		}
 		child_input := 'qml_input_${qml_var(child_path)}'
@@ -1104,7 +1106,7 @@ fn qml_advance_cursor(mut out strings.Builder, tag string, cursor string, child_
 	}
 }
 
-fn (mut c QmlCompiler) compile_repeater(node &QmlNode, path string, parent_frame string, parent_tag string, parent_properties map[string]string, cursor string, incoming QmlScope, output string) {
+fn (mut c QmlCompiler) compile_repeater(node &QmlNode, path string, parent_frame string, parent_tag string, parent_properties map[string]string, cursor string, incoming QmlScope, output string, outer_key string) {
 	model := qml_find_property(node, 'model') or { return }
 	key := qml_find_property(node, 'key') or { return }
 	suffix := qml_var(path)
@@ -1115,7 +1117,14 @@ fn (mut c QmlCompiler) compile_repeater(node &QmlNode, path string, parent_frame
 	mut scope := qml_clone_scope(incoming)
 	scope.special['item'] = item_name
 	scope.special['index'] = index_name
-	c.out.writeln('\t\t${key_name} := ${c.expr(key.expr, scope, .string_)}')
+	key_value := c.expr(key.expr, scope, .string_)
+	if outer_key.len > 0 {
+		local_key_name := '${key_name}_local'
+		c.out.writeln('\t\t${local_key_name} := ${key_value}')
+		c.out.writeln("\t\t${key_name} := ${outer_key} + ':' + ${local_key_name}")
+	} else {
+		c.out.writeln('\t\t${key_name} := ${key_value}')
+	}
 	visible_count := node.children.filter(it.tag !in ['MenuItem', 'Option']).len
 	mut visible_index := 0
 	for child_index, child in node.children {
@@ -1124,7 +1133,7 @@ fn (mut c QmlCompiler) compile_repeater(node &QmlNode, path string, parent_frame
 		}
 		child_path := '${path}.${child_index}'
 		if child.tag == 'Repeater' {
-			c.compile_repeater(child, child_path, parent_frame, parent_tag, parent_properties, cursor, scope, output)
+			c.compile_repeater(child, child_path, parent_frame, parent_tag, parent_properties, cursor, scope, output, key_name)
 			continue
 		}
 		child_input := 'qml_input_${qml_var(child_path)}'

--- a/vlib/v3/parser/qml.v
+++ b/vlib/v3/parser/qml.v
@@ -913,11 +913,21 @@ fn (mut c QmlCompiler) compile_node(node &QmlNode, path string, input string, in
 	c.out.writeln('\t_ = ${input}')
 	mut scope := qml_clone_scope(incoming)
 	mut named_props := map[string]string{}
+	// Register every declared property before resolving expressions, then emit
+	// those declarations before ordinary bindings. This lets an earlier binding
+	// such as `width: root.half` refer to a custom property declared later.
+	for property in node.properties {
+		if property.declared_type.len > 0 {
+			named_props[property.name] = 'qml_property_${suffix}_${qml_var(property.name)}'
+		}
+	}
 	if node.id.len > 0 {
-		scope.ids[node.id] = QmlNamedValue{ frame: input, props: named_props }
+		scope.ids[node.id] = QmlNamedValue{ frame: input, props: named_props.clone() }
 	}
 	mut properties := map[string]string{}
-	for property in node.properties {
+	mut ordered_properties := node.properties.filter(it.declared_type.len > 0)
+	ordered_properties << node.properties.filter(it.declared_type.len == 0)
+	for property in ordered_properties {
 		if property.name == 'id'
 			|| property.name in ['on_tap', 'on_change', 'on_active', 'on_text', 'on_submit'] {
 			continue
@@ -925,10 +935,6 @@ fn (mut c QmlCompiler) compile_node(node &QmlNode, path string, input string, in
 		name := 'qml_property_${suffix}_${qml_var(property.name)}'
 		c.out.writeln('\t${name} := ${c.expr(property.expr, scope, qml_property_use(property))}')
 		properties[property.name] = name
-		if property.declared_type.len > 0 && node.id.len > 0 {
-			named_props[property.name] = name
-			scope.ids[node.id] = QmlNamedValue{ frame: input, props: named_props.clone() }
-		}
 	}
 	frame := 'qml_frame_${suffix}'
 	c.out.writeln('\t${frame} := ui2.rect(${qml_prop(properties, 'x', input + '.x')}, ${qml_prop(properties, 'y', input + '.y')}, ${qml_prop(properties, 'width', input + '.width')}, ${qml_prop(properties, 'height', input + '.height')})')
@@ -1437,10 +1443,11 @@ fn (mut c QmlCompiler) compile_spinner(node &QmlNode, suffix string, frame strin
 
 fn (mut c QmlCompiler) compile_message_box(node &QmlNode, suffix string, frame string, properties map[string]string, scope QmlScope, key string, action string) {
 	mut actions := []string{}
-	for child in node.children {
+	for child_index, child in node.children {
 		if child.tag != 'Button' {
 			continue
 		}
+		c.write_action_type_checks(child, '${suffix}_message_action_${child_index}', scope)
 		child_id := qml_quote(child.id)
 		child_action := c.compiled_event_value(child, 'on_tap', scope, child_id)
 		text := if property := qml_find_property(child, 'text') {

--- a/vlib/v3/tests/comptime_review_round4_test.v
+++ b/vlib/v3/tests/comptime_review_round4_test.v
@@ -3224,6 +3224,44 @@ fn main() {
 		'compile-time error: present method selected')
 }
 
+fn test_generic_method_reflection_preserves_main_specialization_origin() {
+	v3_bin := round4_build_v3()
+	out := round4_run_good_project(v3_bin, 'generic_method_reflection_main_origin', {
+		'v.mod':     "Module { name: 'generic_method_reflection_main_origin' }\n"
+		'pkg/pkg.v': 'module pkg
+
+pub struct App {}
+
+fn (app App) package_method() {
+	_ = app
+}
+
+pub fn method_names[T]() string {
+	mut names := []string{}
+	$for method in T.methods {
+		names << method.name
+	}
+	return names.join(",")
+}
+'
+		'main.v':    'module main
+
+import pkg
+
+struct App {}
+
+fn (app App) main_method() {
+	_ = app
+}
+
+fn main() {
+	println(pkg.method_names[App]())
+}
+'
+	}, 'main.v')
+	assert out == 'main_method'
+}
+
 fn test_selected_comptime_if_expression_keeps_setup_statements() {
 	v3_bin := round4_build_v3()
 	out := round4_run_good(v3_bin, 'comptime_if_expr_setup_statements', "fn main() {

--- a/vlib/v3/tests/qml_codegen_test.v
+++ b/vlib/v3/tests/qml_codegen_test.v
@@ -56,6 +56,14 @@ fn test_qml_lowers_to_direct_ui2_elements() {
 		on_change: app.select(4)
 	}
 	Switch { id: notifications bind.active: app.enabled on_active: app.select(5) }
+	Spinner {
+		id: location
+		bind.text: app.location
+		text_autoupdate: true
+		on_text: app.choose("Work")
+		Option { text: "Home" }
+		Option { text: "Work" }
+	}
 	Checkbox { text: "Ready" checked: true }
 	Rectangle { border_width: 2 border_right: 4 }
 	Button { text: "Select" on_tap: app.select(app.selected) }
@@ -75,10 +83,15 @@ pub mut:
 	selected int
 	level    f64
 	enabled  bool
+	location string
 }
 
 pub fn (mut app App) select(id int) {
 	app.selected = id
+}
+
+pub fn (mut app App) choose(value string) {
+	app.location = value
 }
 
 fn build(app &App) ui2.Element {
@@ -86,7 +99,7 @@ fn build(app &App) ui2.Element {
 }
 
 fn main() {
-	app := App{items: [Item{id: 7, name: 'a'}, Item{id: 8, name: 'b'}], level: 12.5}
+	app := App{items: [Item{id: 7, name: 'a'}, Item{id: 8, name: 'b'}], level: 12.5, location: 'Home'}
 	root := build(&app)
 	mut mutable_app := app
 	ui2.dispatch[App](mut mutable_app, 'select', 9) or { panic(err) }
@@ -94,7 +107,8 @@ fn main() {
 	println(mutable_app.selected.str() + ' ' + root.children[2].accessibility_role)
 	println(root.children[3].accessibility_role + ' ' + root.children[3].value.str() + ':' + root.children[3].min_value.str() + ':' + root.children[3].max_value.str() + ' ' + root.children[3].action_id)
 	println(root.children[4].accessibility_role + ' ' + root.children[4].checked.str() + ' ' + root.children[4].action_id)
-	println(root.children[5].accessibility_role + ' ' + root.children[6].box.border_left.str() + ':' + root.children[6].box.border_right.str() + ' ' + root.children[7].action_id)
+	println(root.children[5].accessibility_role + ' ' + root.children[5].text + ' ' + root.children[5].action_id)
+	println(root.children[6].accessibility_role + ' ' + root.children[7].box.border_left.str() + ':' + root.children[7].box.border_right.str() + ' ' + root.children[8].action_id)
 }
 "
 	main_path := os.join_path(root, 'main.v')
@@ -105,7 +119,7 @@ fn main() {
 	assert !compile.output.contains('C compilation failed'), compile.output
 	run := os.execute(bin)
 	assert run.exit_code == 0, run.output
-	assert run.output.trim_space() == '8 a:0 7 select:7\n9 progressbar\nslider 12.5:0.0:100.0 select:4\nswitch false select:5\ncheckbox 2.0:4.0 select:app.selected', run.output
+	assert run.output.trim_space() == '9 a:0 7 select:7\n9 progressbar\nslider 12.5:0.0:100.0 select:4\nswitch false select:5\ncombobox Home choose:Work\ncheckbox 2.0:4.0 select:app.selected', run.output
 	os.write_file(os.join_path(root, 'form.qml'), 'Screen { Button { on_tap: app.missing() } }') or { panic(err) }
 	invalid := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${main_path}')
 	assert invalid.exit_code != 0, invalid.output
@@ -136,6 +150,8 @@ pub struct SliderConfig { pub: id string action_id string frame Rect min f64 max
 pub fn slider(config SliderConfig) Element { return Element{kind: .slider, id: config.id, action_id: config.action_id, frame: config.frame, value: config.value, min_value: config.min, max_value: config.max, step: config.step, orientation: config.orientation, padding: config.padding, value_track: config.value_track, slider_style: config.style, accessibility_role: 'slider', accessibility_label: 'Slider', accessibility_value: config.value.str()} }
 pub struct SwitchConfig { pub: id string action_id string frame Rect active bool style SwitchStyle }
 pub fn switch_control(config SwitchConfig) Element { return Element{kind: .switch_control, id: config.id, action_id: config.action_id, frame: config.frame, checked: config.active, switch_style: config.style, accessibility_role: 'switch', accessibility_label: 'Switch', accessibility_value: if config.active { 'on' } else { 'off' }} }
+pub struct SpinnerConfig { pub: id string action_id string frame Rect text string values []string text_autoupdate bool box BoxStyle text_style TextStyle }
+pub fn spinner(config SpinnerConfig) Element { return Element{kind: .dropdown, id: config.id, action_id: config.action_id, frame: config.frame, text: if config.text_autoupdate && config.values.len > 0 { config.values[0] } else { config.text }, box: config.box, text_style: config.text_style, accessibility_role: 'combobox', accessibility_label: 'Spinner'} }
 pub fn compiled_qml_event(_ string, _ string, _ string, action string) string { return action }
 pub fn compiled_qml_event_arg(_ string, _ string, _ string, action string, argument string) string { return action + ':' + argument }
 pub fn compiled_qml_event_arg_path(_ string, _ string, _ string, action string, path string) string { return action + ':' + path }

--- a/vlib/v3/tests/qml_codegen_test.v
+++ b/vlib/v3/tests/qml_codegen_test.v
@@ -125,16 +125,22 @@ fn main() {
 	background: "#ff0000"
 	Rectangle { id: first width: 123 }
 	Label { width: first.width }
+	Repeater {
+		model: app.items
+		key: item
+		Rectangle { id: repeated_first width: 77 }
+		Button { width: repeated_first.width on_tap: app.select(index + 1) }
+	}
 }') or { panic(err) }
 	review_path := os.join_path(root, 'review.v')
-	os.write_file(review_path, "module main\n\nimport ui2\n\nfn main() {\n\troot := \$qml('review.qml')\n\tprintln(root.box.bg.str() + ' ' + root.children[1].frame.width.str())\n}\n") or {
+	os.write_file(review_path, "module main\n\nimport ui2\n\nstruct App {\n\titems []int\npub mut:\n\tselected int\n}\n\npub fn (mut app App) select(value int) {\n\tapp.selected = value\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$qml('review.qml')\n}\n\nfn main() {\n\tapp := App{items: [10]}\n\troot := build(&app)\n\tprintln(root.box.bg.str() + ' ' + root.children[1].frame.width.str() + ' ' + root.children[3].frame.width.str() + ' ' + root.children[3].action_id)\n}\n") or {
 		panic(err)
 	}
 	review_compile := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${review_path}')
 	assert review_compile.exit_code == 0, review_compile.output
 	review_run := os.execute(bin)
 	assert review_run.exit_code == 0, review_run.output
-	assert review_run.output.trim_space() == '16711680 123.0', review_run.output
+	assert review_run.output.trim_space() == '16711680 123.0 77.0 select:1', review_run.output
 	os.write_file(os.join_path(root, 'form.qml'), 'Screen { MessageBox { Button { on_tap: app.missing() } } }') or { panic(err) }
 	invalid := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${main_path}')
 	assert invalid.exit_code != 0, invalid.output

--- a/vlib/v3/tests/qml_codegen_test.v
+++ b/vlib/v3/tests/qml_codegen_test.v
@@ -34,6 +34,7 @@ fn test_qml_lowers_to_direct_ui2_elements() {
 	}
 	os.write_file(os.join_path(root, 'form.qml'), 'Screen {
     id: root
+    width: root.half
     property f64 half: root.width / 2
     Repeater {
         model: app.items
@@ -120,7 +121,7 @@ fn main() {
 	run := os.execute(bin)
 	assert run.exit_code == 0, run.output
 	assert run.output.trim_space() == '9 a:0 7 select:7\n9 progressbar\nslider 12.5:0.0:100.0 select:4\nswitch false select:5\ncombobox Home choose:Work\ncheckbox 2.0:4.0 select:app.selected', run.output
-	os.write_file(os.join_path(root, 'form.qml'), 'Screen { Button { on_tap: app.missing() } }') or { panic(err) }
+	os.write_file(os.join_path(root, 'form.qml'), 'Screen { MessageBox { Button { on_tap: app.missing() } } }') or { panic(err) }
 	invalid := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${main_path}')
 	assert invalid.exit_code != 0, invalid.output
 	assert invalid.output.contains('missing'), invalid.output
@@ -152,6 +153,9 @@ pub struct SwitchConfig { pub: id string action_id string frame Rect active bool
 pub fn switch_control(config SwitchConfig) Element { return Element{kind: .switch_control, id: config.id, action_id: config.action_id, frame: config.frame, checked: config.active, switch_style: config.style, accessibility_role: 'switch', accessibility_label: 'Switch', accessibility_value: if config.active { 'on' } else { 'off' }} }
 pub struct SpinnerConfig { pub: id string action_id string frame Rect text string values []string text_autoupdate bool box BoxStyle text_style TextStyle }
 pub fn spinner(config SpinnerConfig) Element { return Element{kind: .dropdown, id: config.id, action_id: config.action_id, frame: config.frame, text: if config.text_autoupdate && config.values.len > 0 { config.values[0] } else { config.text }, box: config.box, text_style: config.text_style, accessibility_role: 'combobox', accessibility_label: 'Spinner'} }
+pub struct MessageBoxAction { pub: id string action_id string title string }
+pub struct MessageBoxConfig { pub: id string frame Rect title string text string hidden bool width f64 height f64 actions []MessageBoxAction }
+pub fn custom_message_box(config MessageBoxConfig) Element { return Element{kind: .view, id: config.id, frame: config.frame, text: config.text, hidden: config.hidden} }
 pub fn compiled_qml_event(_ string, _ string, _ string, action string) string { return action }
 pub fn compiled_qml_event_arg(_ string, _ string, _ string, action string, argument string) string { return action + ':' + argument }
 pub fn compiled_qml_event_arg_path(_ string, _ string, _ string, action string, path string) string { return action + ':' + path }

--- a/vlib/v3/tests/qml_codegen_test.v
+++ b/vlib/v3/tests/qml_codegen_test.v
@@ -121,10 +121,28 @@ fn main() {
 	run := os.execute(bin)
 	assert run.exit_code == 0, run.output
 	assert run.output.trim_space() == '9 a:0 7 select:7\n9 progressbar\nslider 12.5:0.0:100.0 select:4\nswitch false select:5\ncombobox Home choose:Work\ncheckbox 2.0:4.0 select:app.selected', run.output
+	os.write_file(os.join_path(root, 'review.qml'), 'Screen {
+	background: "#ff0000"
+	Rectangle { id: first width: 123 }
+	Label { width: first.width }
+}') or { panic(err) }
+	review_path := os.join_path(root, 'review.v')
+	os.write_file(review_path, "module main\n\nimport ui2\n\nfn main() {\n\troot := \$qml('review.qml')\n\tprintln(root.box.bg.str() + ' ' + root.children[1].frame.width.str())\n}\n") or {
+		panic(err)
+	}
+	review_compile := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${review_path}')
+	assert review_compile.exit_code == 0, review_compile.output
+	review_run := os.execute(bin)
+	assert review_run.exit_code == 0, review_run.output
+	assert review_run.output.trim_space() == '16711680 123.0', review_run.output
 	os.write_file(os.join_path(root, 'form.qml'), 'Screen { MessageBox { Button { on_tap: app.missing() } } }') or { panic(err) }
 	invalid := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${main_path}')
 	assert invalid.exit_code != 0, invalid.output
 	assert invalid.output.contains('missing'), invalid.output
+	os.write_file(os.join_path(root, 'form.qml'), 'Screen { Button { MenuItem { on_tap: app.missing() } } }') or { panic(err) }
+	invalid_menu := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${main_path}')
+	assert invalid_menu.exit_code != 0, invalid_menu.output
+	assert invalid_menu.output.contains('missing'), invalid_menu.output
 }
 
 /* MOCK_UI2

--- a/vlib/v3/tests/qml_codegen_test.v
+++ b/vlib/v3/tests/qml_codegen_test.v
@@ -131,16 +131,20 @@ fn main() {
 		Rectangle { id: repeated_first width: 77 }
 		Button { width: repeated_first.width on_tap: app.select(index + 1) }
 	}
+	Label { text: 1 + 2 }
+	Label { text: app.count + 1 }
+	Label { text: "count:" + app.count }
+	Label { text: app.display_name() }
 }') or { panic(err) }
 	review_path := os.join_path(root, 'review.v')
-	os.write_file(review_path, "module main\n\nimport ui2\n\nstruct App {\n\titems []int\npub mut:\n\tselected int\n}\n\npub fn (mut app App) select(value int) {\n\tapp.selected = value\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$qml('review.qml')\n}\n\nfn main() {\n\tapp := App{items: [10]}\n\troot := build(&app)\n\tprintln(root.box.bg.str() + ' ' + root.children[1].frame.width.str() + ' ' + root.children[3].frame.width.str() + ' ' + root.children[3].action_id)\n}\n") or {
+	os.write_file(review_path, "module main\n\nimport ui2\n\nstruct App {\n\titems []int\n\tcount int\npub mut:\n\tselected int\n}\n\npub fn (mut app App) select(value int) {\n\tapp.selected = value\n}\n\npub fn (app &App) display_name() string {\n\treturn 'display:\${app.count}'\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$qml('review.qml')\n}\n\nfn main() {\n\tapp := App{items: [10], count: 2}\n\troot := build(&app)\n\tprintln(root.box.bg.str() + ' ' + root.children[1].frame.width.str() + ' ' + root.children[3].frame.width.str() + ' ' + root.children[3].action_id + ' ' + root.children[4].text + ' ' + root.children[5].text + ' ' + root.children[6].text + ' ' + root.children[7].text)\n}\n") or {
 		panic(err)
 	}
 	review_compile := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${review_path}')
 	assert review_compile.exit_code == 0, review_compile.output
 	review_run := os.execute(bin)
 	assert review_run.exit_code == 0, review_run.output
-	assert review_run.output.trim_space() == '16711680 123.0 77.0 select:1', review_run.output
+	assert review_run.output.trim_space() == '16711680 123.0 77.0 select:1 3 3 count:2 display:2', review_run.output
 	os.write_file(os.join_path(root, 'form.qml'), 'Screen { MessageBox { Button { on_tap: app.missing() } } }') or { panic(err) }
 	invalid := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${main_path}')
 	assert invalid.exit_code != 0, invalid.output

--- a/vlib/v3/tests/qml_codegen_test.v
+++ b/vlib/v3/tests/qml_codegen_test.v
@@ -1,0 +1,155 @@
+import os
+
+const qml_codegen_vexe = @VEXE
+const qml_codegen_tests_dir = os.dir(@FILE)
+const qml_codegen_v3_dir = os.dir(qml_codegen_tests_dir)
+const qml_codegen_vlib_dir = os.dir(qml_codegen_v3_dir)
+const qml_codegen_v3_src = os.join_path(qml_codegen_v3_dir, 'v3.v')
+
+fn qml_codegen_build_v3() string {
+	pid := os.getpid()
+	v3_bin := os.join_path(os.temp_dir(), 'v3_qml_codegen_test_${pid}')
+	os.rm(v3_bin) or {}
+	build := os.execute('${qml_codegen_vexe} -gc none -path "${qml_codegen_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${qml_codegen_v3_src}')
+	assert build.exit_code == 0, build.output
+	return v3_bin
+}
+
+fn qml_codegen_mock_ui2() string {
+	return (os.read_file(@FILE) or { panic(err) }).all_after('/* MOCK_UI2\n').all_before('\nMOCK_UI2 */')
+}
+
+fn test_qml_lowers_to_direct_ui2_elements() {
+	v3_bin := qml_codegen_build_v3()
+	pid := os.getpid()
+	root := os.join_path(os.temp_dir(), 'v3_qml_codegen_${pid}_project')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(os.join_path(root, 'ui2', 'core')) or { panic(err) }
+	os.write_file(os.join_path(root, 'v.mod'), "Module { name: 'qml_codegen' }\n") or {
+		panic(err)
+	}
+	os.write_file(os.join_path(root, 'ui2', 'v.mod'), "Module { name: 'ui2', subdirs: ['core'] }\n") or { panic(err) }
+	os.write_file(os.join_path(root, 'ui2', 'core', 'ui2.v'), qml_codegen_mock_ui2()) or {
+		panic(err)
+	}
+	os.write_file(os.join_path(root, 'form.qml'), 'Screen {
+    id: root
+    property f64 half: root.width / 2
+    Repeater {
+        model: app.items
+        key: item.id
+        Label {
+            text: "\${item.name}:\${index}"
+            width: root.half
+            on_tap: app.select(item.id)
+        }
+    }
+	ProgressBar { value: 25 max: 50 }
+	Slider {
+		id: volume
+		bind.value: app.level
+		min: 0
+		max: 100
+		step: 0.5
+		orientation: vertical
+		value_track: true
+		on_change: app.select(4)
+	}
+	Switch { id: notifications bind.active: app.enabled on_active: app.select(5) }
+	Checkbox { text: "Ready" checked: true }
+	Rectangle { border_width: 2 border_right: 4 }
+	Button { text: "Select" on_tap: app.select(app.selected) }
+}') or { panic(err) }
+	source := "module main
+
+import ui2
+
+struct Item {
+	id int
+	name string
+}
+
+struct App {
+	items []Item
+pub mut:
+	selected int
+	level    f64
+	enabled  bool
+}
+
+pub fn (mut app App) select(id int) {
+	app.selected = id
+}
+
+fn build(app &App) ui2.Element {
+	return \$qml('form.qml')
+}
+
+fn main() {
+	app := App{items: [Item{id: 7, name: 'a'}, Item{id: 8, name: 'b'}], level: 12.5}
+	root := build(&app)
+	mut mutable_app := app
+	ui2.dispatch[App](mut mutable_app, 'select', 9) or { panic(err) }
+	println(root.children.len.str() + ' ' + root.children[0].text + ' ' + root.children[0].key + ' ' + root.children[0].action_id)
+	println(mutable_app.selected.str() + ' ' + root.children[2].accessibility_role)
+	println(root.children[3].accessibility_role + ' ' + root.children[3].value.str() + ':' + root.children[3].min_value.str() + ':' + root.children[3].max_value.str() + ' ' + root.children[3].action_id)
+	println(root.children[4].accessibility_role + ' ' + root.children[4].checked.str() + ' ' + root.children[4].action_id)
+	println(root.children[5].accessibility_role + ' ' + root.children[6].box.border_left.str() + ':' + root.children[6].box.border_right.str() + ' ' + root.children[7].action_id)
+}
+"
+	main_path := os.join_path(root, 'main.v')
+	os.write_file(main_path, source) or { panic(err) }
+	bin := os.join_path(root, 'qml_codegen')
+	compile := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${main_path}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == '8 a:0 7 select:7\n9 progressbar\nslider 12.5:0.0:100.0 select:4\nswitch false select:5\ncheckbox 2.0:4.0 select:app.selected', run.output
+	os.write_file(os.join_path(root, 'form.qml'), 'Screen { Button { on_tap: app.missing() } }') or { panic(err) }
+	invalid := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${main_path}')
+	assert invalid.exit_code != 0, invalid.output
+	assert invalid.output.contains('missing'), invalid.output
+}
+
+/* MOCK_UI2
+module ui2
+
+pub enum Kind { screen view label image button checkbox dropdown text_field text_area scroll slider switch_control }
+pub enum Align { left center right }
+pub enum Orientation { horizontal vertical }
+pub struct Rect { pub: x f64 y f64 width f64 height f64 }
+pub struct BoxStyle { pub: bg u32 = 0xffffff radius f64 transparent bool border_color u32 border_left f64 border_top f64 border_right f64 border_bottom f64 }
+pub struct TextStyle { pub: color u32 = 0x111111 background_color u32 size f64 = 15 font_family string bold bool italic bool underline bool strikethrough bool shadow bool outline bool vertical_align string link string align Align head_indent f64 first_line_indent f64 hyphenation_factor f64 lines int = 1 }
+pub struct MenuEntry { pub: id string title string }
+pub struct SliderStyle { pub: track_color u32 value_track_color u32 thumb_color u32 track_width f64 thumb_size f64 }
+pub struct SwitchStyle { pub: inactive_track_color u32 active_track_color u32 thumb_color u32 disabled_track_color u32 disabled_thumb_color u32 }
+pub struct Element { pub: kind Kind id string action_id string submit_id string key string text string checked bool image_path string tooltip string placeholder string frame Rect box BoxStyle text_style TextStyle native_style bool keyboard int emit_change bool long_press bool swipe_left bool readonly bool persistent_scrollbars bool secure bool clickable bool draggable bool rotation f64 cursor string menu []MenuEntry children []Element hidden bool enabled bool = true accessibility_role string accessibility_label string accessibility_value string autocorrect bool = true padding_left f64 = 12 value f64 min_value f64 max_value f64 step f64 orientation Orientation padding f64 value_track bool slider_style SliderStyle switch_style SwitchStyle }
+pub const keyboard_default = 0
+pub const keyboard_decimal = 8
+pub fn bounds() Rect { return Rect{width: 800, height: 600} }
+pub fn rect(x f64, y f64, width f64, height f64) Rect { return Rect{x, y, width, height} }
+pub fn parse_hex_color(_ string) u32 { return 0 }
+pub struct ProgressBarConfig { pub: id string frame Rect value f64 max f64 = 100 background u32 color u32 radius f64 }
+pub fn progress_bar(config ProgressBarConfig) Element { return Element{kind: .view, id: config.id, frame: config.frame, accessibility_role: 'progressbar', accessibility_label: 'Progress', accessibility_value: '${config.value} of ${config.max}'} }
+pub struct SliderConfig { pub: id string action_id string frame Rect min f64 max f64 = 100 value f64 step f64 orientation Orientation padding f64 value_track bool style SliderStyle }
+pub fn slider(config SliderConfig) Element { return Element{kind: .slider, id: config.id, action_id: config.action_id, frame: config.frame, value: config.value, min_value: config.min, max_value: config.max, step: config.step, orientation: config.orientation, padding: config.padding, value_track: config.value_track, slider_style: config.style, accessibility_role: 'slider', accessibility_label: 'Slider', accessibility_value: config.value.str()} }
+pub struct SwitchConfig { pub: id string action_id string frame Rect active bool style SwitchStyle }
+pub fn switch_control(config SwitchConfig) Element { return Element{kind: .switch_control, id: config.id, action_id: config.action_id, frame: config.frame, checked: config.active, switch_style: config.style, accessibility_role: 'switch', accessibility_label: 'Switch', accessibility_value: if config.active { 'on' } else { 'off' }} }
+pub fn compiled_qml_event(_ string, _ string, _ string, action string) string { return action }
+pub fn compiled_qml_event_arg(_ string, _ string, _ string, action string, argument string) string { return action + ':' + argument }
+pub fn compiled_qml_event_arg_path(_ string, _ string, _ string, action string, path string) string { return action + ':' + path }
+pub fn dispatch[T](mut model T, name string, argument int) ! {
+	$for method in T.methods {
+		if method.name == name {
+			$if method.is_pub && method.typ is fn ( int ) {
+				model.$method(argument)
+				return
+			} $else {
+				return error('unsupported method')
+			}
+		}
+	}
+	return error('unknown method')
+}
+MOCK_UI2 */

--- a/vlib/v3/tests/qml_codegen_test.v
+++ b/vlib/v3/tests/qml_codegen_test.v
@@ -126,6 +126,7 @@ fn main() {
 	property f64 half: review_root.quarter * 2
 	property f64 quarter: 25
 	property int custom_selected: 1
+	property color accent: "#00ff00"
 	width: review_root.half
 	background: "#ff0000"
 	Rectangle { id: first width: 123 }
@@ -141,17 +142,35 @@ fn main() {
 	Label { text: "count:" + app.count }
 	Label { text: app.display_name() }
 	Button { on_tap: app.select(review_root.custom_selected) }
-	Rectangle { width: app.content_width() }
+	Rectangle { width: app.content_width() background: review_root.accent }
+	Label { text: 4 - 1 }
+	Label { text: 3 * 4 }
+	Label { text: 8 / 2 }
+	Label { text: 7 % 4 }
+	Button { on_tap: app.select(-1) }
 }') or { panic(err) }
 	review_path := os.join_path(root, 'review.v')
-	os.write_file(review_path, "module main\n\nimport ui2\n\nstruct App {\n\titems []int\n\tcount int\npub mut:\n\tselected int\n}\n\npub fn (mut app App) select(value int) {\n\tapp.selected = value\n}\n\npub fn (app &App) display_name() string {\n\treturn 'display:\${app.count}'\n}\n\npub fn (app &App) content_width() int {\n\treturn 88\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$qml('review.qml')\n}\n\nfn main() {\n\tapp := App{items: [10], count: 2}\n\troot := build(&app)\n\tprintln(root.children[4].frame.width.str() + ' ' + root.box.bg.str() + ' ' + root.children[1].frame.width.str() + ' ' + root.children[3].frame.width.str() + ' ' + root.children[3].action_id + ' ' + root.children[4].text + ' ' + root.children[5].text + ' ' + root.children[6].text + ' ' + root.children[7].text + ' ' + root.children[8].action_id + ' ' + root.children[9].frame.width.str())\n}\n") or {
+	os.write_file(review_path, "module main\n\nimport ui2\n\nstruct App {\n\titems []int\n\tcount int\npub mut:\n\tselected int\n}\n\npub fn (mut app App) select(value int) {\n\tapp.selected = value\n}\n\npub fn (app &App) display_name() string {\n\treturn 'display:\${app.count}'\n}\n\npub fn (app &App) content_width() int {\n\treturn 88\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$qml('review.qml')\n}\n\nfn main() {\n\tapp := App{items: [10], count: 2}\n\troot := build(&app)\n\tprintln(root.children[4].frame.width.str() + ' ' + root.box.bg.str() + ' ' + root.children[1].frame.width.str() + ' ' + root.children[3].frame.width.str() + ' ' + root.children[3].action_id + ' ' + root.children[4].text + ' ' + root.children[5].text + ' ' + root.children[6].text + ' ' + root.children[7].text + ' ' + root.children[8].action_id + ' ' + root.children[9].frame.width.str() + ':' + root.children[9].box.bg.str() + ' ' + root.children[10].text + ' ' + root.children[11].text + ' ' + root.children[12].text + ' ' + root.children[13].text + ' ' + root.children[14].action_id)\n}\n") or {
 		panic(err)
 	}
 	review_compile := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${review_path}')
 	assert review_compile.exit_code == 0, review_compile.output
 	review_run := os.execute(bin)
 	assert review_run.exit_code == 0, review_run.output
-	assert review_run.output.trim_space() == '50.0 16711680 123.0 77.0 select:1 3 3 count:2 display:2 select:1 88.0', review_run.output
+	assert review_run.output.trim_space() == '50.0 16711680 123.0 77.0 select:1 3 3 count:2 display:2 select:1 88.0:65280 3 12 4 3 select:-1', review_run.output
+	os.write_file(os.join_path(root, 'events.qml'), 'Screen {
+	TextField { id: message on_text: app.choose("Typed") }
+	TextArea { id: notes on_text: app.choose("Notes") }
+}') or { panic(err) }
+	events_path := os.join_path(root, 'events.v')
+	os.write_file(events_path, "module main\n\nimport ui2\n\nstruct App {}\n\npub fn (mut app App) choose(value string) {\n\t_ = app\n\t_ = value\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$qml('events.qml')\n}\n\nfn main() {\n\tapp := App{}\n\troot := build(&app)\n\tprintln(root.children[0].action_id + ':' + root.children[0].emit_change.str() + ' ' + root.children[1].action_id + ':' + root.children[1].emit_change.str())\n}\n") or {
+		panic(err)
+	}
+	events_compile := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${events_path}')
+	assert events_compile.exit_code == 0, events_compile.output
+	events_run := os.execute(bin)
+	assert events_run.exit_code == 0, events_run.output
+	assert events_run.output.trim_space() == 'choose:Typed:true choose:Notes:true', events_run.output
 	os.write_file(os.join_path(root, 'form.qml'), 'Screen { MessageBox { Button { on_tap: app.missing() } } }') or { panic(err) }
 	invalid := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${main_path}')
 	assert invalid.exit_code != 0, invalid.output

--- a/vlib/v3/tests/qml_codegen_test.v
+++ b/vlib/v3/tests/qml_codegen_test.v
@@ -95,6 +95,10 @@ pub fn (mut app App) choose(value string) {
 	app.location = value
 }
 
+fn (mut app App) private_action() {
+	app.selected = -1
+}
+
 fn build(app &App) ui2.Element {
 	return \$qml('form.qml')
 }
@@ -222,6 +226,28 @@ fn main() {
 	custom_run := os.execute(bin)
 	assert custom_run.exit_code == 0, custom_run.output
 	assert custom_run.output.trim_space() == 'chosen 0.5', custom_run.output
+	os.write_file(os.join_path(root, 'expressions.qml'), r'Screen {
+	Repeater {
+		model: app.values
+		key: item
+		Label { text: item-1 }
+	}
+	Repeater {
+		model: app.items
+		key: item.value
+		Rectangle { background: item.color }
+	}
+	Label { text: "${app.label(\"}\")}" }
+}') or { panic(err) }
+	expressions_path := os.join_path(root, 'expressions.v')
+	os.write_file(expressions_path, "module main\n\nimport ui2\n\nstruct Item {\n\tvalue int\n\tcolor string\n}\n\nstruct App {\n\tvalues []int\n\titems []Item\n}\n\nfn (app &App) label(value string) string {\n\t_ = app\n\treturn value\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$qml('expressions.qml')\n}\n\nfn main() {\n\tapp := App{values: [10], items: [Item{value: 1, color: '#112233'}]}\n\troot := build(&app)\n\tprintln(root.children[0].text + ' ' + root.children[1].box.bg.str() + ' ' + root.children[2].text)\n}\n") or {
+		panic(err)
+	}
+	expressions_compile := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${expressions_path}')
+	assert expressions_compile.exit_code == 0, expressions_compile.output
+	expressions_run := os.execute(bin)
+	assert expressions_run.exit_code == 0, expressions_run.output
+	assert expressions_run.output.trim_space() == '9 1122867 }', expressions_run.output
 	os.write_file(os.join_path(root, 'form.qml'), 'Screen { MessageBox { Button { on_tap: app.missing() } } }') or { panic(err) }
 	invalid := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${main_path}')
 	assert invalid.exit_code != 0, invalid.output
@@ -230,6 +256,10 @@ fn main() {
 	invalid_menu := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${main_path}')
 	assert invalid_menu.exit_code != 0, invalid_menu.output
 	assert invalid_menu.output.contains('missing'), invalid_menu.output
+	os.write_file(os.join_path(root, 'form.qml'), 'Screen { Button { on_tap: app.private_action() } }') or { panic(err) }
+	invalid_private := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${main_path}')
+	assert invalid_private.exit_code != 0, invalid_private.output
+	assert invalid_private.output.contains('must be public'), invalid_private.output
 }
 
 /* MOCK_UI2

--- a/vlib/v3/tests/qml_codegen_test.v
+++ b/vlib/v3/tests/qml_codegen_test.v
@@ -141,16 +141,17 @@ fn main() {
 	Label { text: "count:" + app.count }
 	Label { text: app.display_name() }
 	Button { on_tap: app.select(review_root.custom_selected) }
+	Rectangle { width: app.content_width() }
 }') or { panic(err) }
 	review_path := os.join_path(root, 'review.v')
-	os.write_file(review_path, "module main\n\nimport ui2\n\nstruct App {\n\titems []int\n\tcount int\npub mut:\n\tselected int\n}\n\npub fn (mut app App) select(value int) {\n\tapp.selected = value\n}\n\npub fn (app &App) display_name() string {\n\treturn 'display:\${app.count}'\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$qml('review.qml')\n}\n\nfn main() {\n\tapp := App{items: [10], count: 2}\n\troot := build(&app)\n\tprintln(root.children[4].frame.width.str() + ' ' + root.box.bg.str() + ' ' + root.children[1].frame.width.str() + ' ' + root.children[3].frame.width.str() + ' ' + root.children[3].action_id + ' ' + root.children[4].text + ' ' + root.children[5].text + ' ' + root.children[6].text + ' ' + root.children[7].text + ' ' + root.children[8].action_id)\n}\n") or {
+	os.write_file(review_path, "module main\n\nimport ui2\n\nstruct App {\n\titems []int\n\tcount int\npub mut:\n\tselected int\n}\n\npub fn (mut app App) select(value int) {\n\tapp.selected = value\n}\n\npub fn (app &App) display_name() string {\n\treturn 'display:\${app.count}'\n}\n\npub fn (app &App) content_width() int {\n\treturn 88\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$qml('review.qml')\n}\n\nfn main() {\n\tapp := App{items: [10], count: 2}\n\troot := build(&app)\n\tprintln(root.children[4].frame.width.str() + ' ' + root.box.bg.str() + ' ' + root.children[1].frame.width.str() + ' ' + root.children[3].frame.width.str() + ' ' + root.children[3].action_id + ' ' + root.children[4].text + ' ' + root.children[5].text + ' ' + root.children[6].text + ' ' + root.children[7].text + ' ' + root.children[8].action_id + ' ' + root.children[9].frame.width.str())\n}\n") or {
 		panic(err)
 	}
 	review_compile := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${review_path}')
 	assert review_compile.exit_code == 0, review_compile.output
 	review_run := os.execute(bin)
 	assert review_run.exit_code == 0, review_run.output
-	assert review_run.output.trim_space() == '50.0 16711680 123.0 77.0 select:1 3 3 count:2 display:2 select:1', review_run.output
+	assert review_run.output.trim_space() == '50.0 16711680 123.0 77.0 select:1 3 3 count:2 display:2 select:1 88.0', review_run.output
 	os.write_file(os.join_path(root, 'form.qml'), 'Screen { MessageBox { Button { on_tap: app.missing() } } }') or { panic(err) }
 	invalid := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${main_path}')
 	assert invalid.exit_code != 0, invalid.output

--- a/vlib/v3/tests/qml_codegen_test.v
+++ b/vlib/v3/tests/qml_codegen_test.v
@@ -206,6 +206,22 @@ fn main() {
 	geometry_color_run := os.execute(bin)
 	assert geometry_color_run.exit_code == 0, geometry_color_run.output
 	assert geometry_color_run.output.trim_space() == '100.0:100.0:1122867 4478310', geometry_color_run.output
+	os.write_file(os.join_path(root, 'custom.qml'), 'Screen {
+	id: root
+	property Item selected: app.item
+	property f32 ratio: 1 / 2
+	Label { text: root.selected.name }
+	Rectangle { width: root.ratio }
+}') or { panic(err) }
+	custom_path := os.join_path(root, 'custom.v')
+	os.write_file(custom_path, "module main\n\nimport ui2\n\nstruct Item {\n\tname string\n}\n\nstruct App {\n\titem Item\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$qml('custom.qml')\n}\n\nfn main() {\n\tapp := App{item: Item{name: 'chosen'}}\n\troot := build(&app)\n\tprintln(root.children[0].text + ' ' + root.children[1].frame.width.str())\n}\n") or {
+		panic(err)
+	}
+	custom_compile := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${custom_path}')
+	assert custom_compile.exit_code == 0, custom_compile.output
+	custom_run := os.execute(bin)
+	assert custom_run.exit_code == 0, custom_run.output
+	assert custom_run.output.trim_space() == 'chosen 0.5', custom_run.output
 	os.write_file(os.join_path(root, 'form.qml'), 'Screen { MessageBox { Button { on_tap: app.missing() } } }') or { panic(err) }
 	invalid := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${main_path}')
 	assert invalid.exit_code != 0, invalid.output

--- a/vlib/v3/tests/qml_codegen_test.v
+++ b/vlib/v3/tests/qml_codegen_test.v
@@ -122,6 +122,11 @@ fn main() {
 	assert run.exit_code == 0, run.output
 	assert run.output.trim_space() == '9 a:0 7 select:7\n9 progressbar\nslider 12.5:0.0:100.0 select:4\nswitch false select:5\ncombobox Home choose:Work\ncheckbox 2.0:4.0 select:app.selected', run.output
 	os.write_file(os.join_path(root, 'review.qml'), 'Screen {
+	id: review_root
+	property f64 half: review_root.quarter * 2
+	property f64 quarter: 25
+	property int custom_selected: 1
+	width: review_root.half
 	background: "#ff0000"
 	Rectangle { id: first width: 123 }
 	Label { width: first.width }
@@ -135,16 +140,17 @@ fn main() {
 	Label { text: app.count + 1 }
 	Label { text: "count:" + app.count }
 	Label { text: app.display_name() }
+	Button { on_tap: app.select(review_root.custom_selected) }
 }') or { panic(err) }
 	review_path := os.join_path(root, 'review.v')
-	os.write_file(review_path, "module main\n\nimport ui2\n\nstruct App {\n\titems []int\n\tcount int\npub mut:\n\tselected int\n}\n\npub fn (mut app App) select(value int) {\n\tapp.selected = value\n}\n\npub fn (app &App) display_name() string {\n\treturn 'display:\${app.count}'\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$qml('review.qml')\n}\n\nfn main() {\n\tapp := App{items: [10], count: 2}\n\troot := build(&app)\n\tprintln(root.box.bg.str() + ' ' + root.children[1].frame.width.str() + ' ' + root.children[3].frame.width.str() + ' ' + root.children[3].action_id + ' ' + root.children[4].text + ' ' + root.children[5].text + ' ' + root.children[6].text + ' ' + root.children[7].text)\n}\n") or {
+	os.write_file(review_path, "module main\n\nimport ui2\n\nstruct App {\n\titems []int\n\tcount int\npub mut:\n\tselected int\n}\n\npub fn (mut app App) select(value int) {\n\tapp.selected = value\n}\n\npub fn (app &App) display_name() string {\n\treturn 'display:\${app.count}'\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$qml('review.qml')\n}\n\nfn main() {\n\tapp := App{items: [10], count: 2}\n\troot := build(&app)\n\tprintln(root.children[4].frame.width.str() + ' ' + root.box.bg.str() + ' ' + root.children[1].frame.width.str() + ' ' + root.children[3].frame.width.str() + ' ' + root.children[3].action_id + ' ' + root.children[4].text + ' ' + root.children[5].text + ' ' + root.children[6].text + ' ' + root.children[7].text + ' ' + root.children[8].action_id)\n}\n") or {
 		panic(err)
 	}
 	review_compile := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${review_path}')
 	assert review_compile.exit_code == 0, review_compile.output
 	review_run := os.execute(bin)
 	assert review_run.exit_code == 0, review_run.output
-	assert review_run.output.trim_space() == '16711680 123.0 77.0 select:1 3 3 count:2 display:2', review_run.output
+	assert review_run.output.trim_space() == '50.0 16711680 123.0 77.0 select:1 3 3 count:2 display:2 select:1', review_run.output
 	os.write_file(os.join_path(root, 'form.qml'), 'Screen { MessageBox { Button { on_tap: app.missing() } } }') or { panic(err) }
 	invalid := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${main_path}')
 	assert invalid.exit_code != 0, invalid.output

--- a/vlib/v3/tests/qml_codegen_test.v
+++ b/vlib/v3/tests/qml_codegen_test.v
@@ -193,6 +193,19 @@ fn main() {
 	nested_run := os.execute(bin)
 	assert nested_run.exit_code == 0, nested_run.output
 	assert nested_run.output.trim_space() == '10:1 20:1', nested_run.output
+	os.write_file(os.join_path(root, 'geometry_color.qml'), 'Screen {
+	Rectangle { id: box width: 100 height: box.width background: app.theme_color() }
+	Rectangle { background: app.numeric_color() }
+}') or { panic(err) }
+	geometry_color_path := os.join_path(root, 'geometry_color.v')
+	os.write_file(geometry_color_path, "module main\n\nimport ui2\n\nstruct App {}\n\npub fn (app &App) theme_color() string {\n\treturn '#112233'\n}\n\npub fn (app &App) numeric_color() u32 {\n\treturn u32(0x445566)\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$qml('geometry_color.qml')\n}\n\nfn main() {\n\tapp := App{}\n\troot := build(&app)\n\tprintln(root.children[0].frame.width.str() + ':' + root.children[0].frame.height.str() + ':' + root.children[0].box.bg.str() + ' ' + root.children[1].box.bg.str())\n}\n") or {
+		panic(err)
+	}
+	geometry_color_compile := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${geometry_color_path}')
+	assert geometry_color_compile.exit_code == 0, geometry_color_compile.output
+	geometry_color_run := os.execute(bin)
+	assert geometry_color_run.exit_code == 0, geometry_color_run.output
+	assert geometry_color_run.output.trim_space() == '100.0:100.0:1122867 4478310', geometry_color_run.output
 	os.write_file(os.join_path(root, 'form.qml'), 'Screen { MessageBox { Button { on_tap: app.missing() } } }') or { panic(err) }
 	invalid := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${main_path}')
 	assert invalid.exit_code != 0, invalid.output
@@ -220,7 +233,7 @@ pub const keyboard_default = 0
 pub const keyboard_decimal = 8
 pub fn bounds() Rect { return Rect{width: 800, height: 600} }
 pub fn rect(x f64, y f64, width f64, height f64) Rect { return Rect{x, y, width, height} }
-pub fn parse_hex_color(_ string) u32 { return 0 }
+pub fn parse_hex_color(value string) u32 { return if value == '#112233' { u32(0x112233) } else { u32(0) } }
 pub struct ProgressBarConfig { pub: id string frame Rect value f64 max f64 = 100 background u32 color u32 radius f64 }
 pub fn progress_bar(config ProgressBarConfig) Element { return Element{kind: .view, id: config.id, frame: config.frame, accessibility_role: 'progressbar', accessibility_label: 'Progress', accessibility_value: '${config.value} of ${config.max}'} }
 pub struct SliderConfig { pub: id string action_id string frame Rect min f64 max f64 = 100 value f64 step f64 orientation Orientation padding f64 value_track bool style SliderStyle }

--- a/vlib/v3/tests/qml_codegen_test.v
+++ b/vlib/v3/tests/qml_codegen_test.v
@@ -148,16 +148,18 @@ fn main() {
 	Label { text: 8 / 2 }
 	Label { text: 7 % 4 }
 	Button { on_tap: app.select(-1) }
+	Label { text: app.ready && app.enabled }
+	Label { text: app.count > 0 }
 }') or { panic(err) }
 	review_path := os.join_path(root, 'review.v')
-	os.write_file(review_path, "module main\n\nimport ui2\n\nstruct App {\n\titems []int\n\tcount int\npub mut:\n\tselected int\n}\n\npub fn (mut app App) select(value int) {\n\tapp.selected = value\n}\n\npub fn (app &App) display_name() string {\n\treturn 'display:\${app.count}'\n}\n\npub fn (app &App) content_width() int {\n\treturn 88\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$qml('review.qml')\n}\n\nfn main() {\n\tapp := App{items: [10], count: 2}\n\troot := build(&app)\n\tprintln(root.children[4].frame.width.str() + ' ' + root.box.bg.str() + ' ' + root.children[1].frame.width.str() + ' ' + root.children[3].frame.width.str() + ' ' + root.children[3].action_id + ' ' + root.children[4].text + ' ' + root.children[5].text + ' ' + root.children[6].text + ' ' + root.children[7].text + ' ' + root.children[8].action_id + ' ' + root.children[9].frame.width.str() + ':' + root.children[9].box.bg.str() + ' ' + root.children[10].text + ' ' + root.children[11].text + ' ' + root.children[12].text + ' ' + root.children[13].text + ' ' + root.children[14].action_id)\n}\n") or {
+	os.write_file(review_path, "module main\n\nimport ui2\n\nstruct App {\n\titems []int\n\tcount int\n\tready bool\n\tenabled bool\npub mut:\n\tselected int\n}\n\npub fn (mut app App) select(value int) {\n\tapp.selected = value\n}\n\npub fn (app &App) display_name() string {\n\treturn 'display:\${app.count}'\n}\n\npub fn (app &App) content_width() int {\n\treturn 88\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$qml('review.qml')\n}\n\nfn main() {\n\tapp := App{items: [10], count: 2, ready: true}\n\troot := build(&app)\n\tprintln(root.children[4].frame.width.str() + ' ' + root.box.bg.str() + ' ' + root.children[1].frame.width.str() + ' ' + root.children[3].frame.width.str() + ' ' + root.children[3].action_id + ' ' + root.children[4].text + ' ' + root.children[5].text + ' ' + root.children[6].text + ' ' + root.children[7].text + ' ' + root.children[8].action_id + ' ' + root.children[9].frame.width.str() + ':' + root.children[9].box.bg.str() + ' ' + root.children[10].text + ' ' + root.children[11].text + ' ' + root.children[12].text + ' ' + root.children[13].text + ' ' + root.children[14].action_id + ' ' + root.children[15].text + ' ' + root.children[16].text)\n}\n") or {
 		panic(err)
 	}
 	review_compile := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${review_path}')
 	assert review_compile.exit_code == 0, review_compile.output
 	review_run := os.execute(bin)
 	assert review_run.exit_code == 0, review_run.output
-	assert review_run.output.trim_space() == '50.0 16711680 123.0 77.0 select:1 3 3 count:2 display:2 select:1 88.0:65280 3 12 4 3 select:-1', review_run.output
+	assert review_run.output.trim_space() == '50.0 16711680 123.0 77.0 select:1 3 3 count:2 display:2 select:1 88.0:65280 3 12 4 3 select:-1 false true', review_run.output
 	os.write_file(os.join_path(root, 'events.qml'), 'Screen {
 	TextField { id: message on_text: app.choose("Typed") }
 	TextArea { id: notes on_text: app.choose("Notes") }
@@ -171,6 +173,26 @@ fn main() {
 	events_run := os.execute(bin)
 	assert events_run.exit_code == 0, events_run.output
 	assert events_run.output.trim_space() == 'choose:Typed:true choose:Notes:true', events_run.output
+	os.write_file(os.join_path(root, 'nested.qml'), 'Screen {
+	Repeater {
+		model: app.rows
+		key: item.id
+		Repeater {
+			model: item.values
+			key: item
+			Label { text: item }
+		}
+	}
+}') or { panic(err) }
+	nested_path := os.join_path(root, 'nested.v')
+	os.write_file(nested_path, "module main\n\nimport ui2\n\nstruct Row {\n\tid int\n\tvalues []int\n}\n\nstruct App {\n\trows []Row\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$qml('nested.qml')\n}\n\nfn main() {\n\tapp := App{rows: [Row{id: 10, values: [1]}, Row{id: 20, values: [1]}]}\n\troot := build(&app)\n\tprintln(root.children[0].key + ' ' + root.children[1].key)\n}\n") or {
+		panic(err)
+	}
+	nested_compile := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${nested_path}')
+	assert nested_compile.exit_code == 0, nested_compile.output
+	nested_run := os.execute(bin)
+	assert nested_run.exit_code == 0, nested_run.output
+	assert nested_run.output.trim_space() == '10:1 20:1', nested_run.output
 	os.write_file(os.join_path(root, 'form.qml'), 'Screen { MessageBox { Button { on_tap: app.missing() } } }') or { panic(err) }
 	invalid := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${main_path}')
 	assert invalid.exit_code != 0, invalid.output

--- a/vlib/v3/transform/comptime.v
+++ b/vlib/v3/transform/comptime.v
@@ -1143,6 +1143,7 @@ fn (t &Transformer) comptime_method_source_type(raw string) string {
 fn (t &Transformer) comptime_method_metas(base_type string) []MethodMeta {
 	requested := t.comptime_method_source_type(base_type)
 	normalized := t.comptime_normalize_type_alias_chain(requested)
+	requested_module := t.comptime_method_requested_module(requested)
 	mut module_name := ''
 	mut file_name := ''
 	mut methods := []MethodMeta{}
@@ -1164,7 +1165,8 @@ fn (t &Transformer) comptime_method_metas(base_type string) []MethodMeta {
 		}
 		first := t.a.child_node(&node, 0)
 		if first.kind != .param || first.op != .dot || first.value.len == 0
-			|| !comptime_method_receiver_matches(first.typ, requested, normalized, module_name, t.cur_module) {
+			|| !comptime_method_receiver_matches(first.typ, requested, normalized, module_name,
+				requested_module) {
 			continue
 		}
 		name := node.value.all_after_last('.')
@@ -1214,6 +1216,32 @@ fn (t &Transformer) comptime_method_metas(base_type string) []MethodMeta {
 		}
 	}
 	return methods
+}
+
+fn (t &Transformer) comptime_method_requested_module(raw string) string {
+	name := comptime_method_receiver_base(raw)
+	if name.starts_with('main.') {
+		return 'main'
+	}
+	if name.contains('.') {
+		return name.all_before_last('.')
+	}
+	if !isnil(t.tc) {
+		local := if t.cur_module in ['', 'main', 'builtin'] {
+			name
+		} else {
+			'${t.cur_module}.${name}'
+		}
+		if local in t.tc.structs || local in t.tc.sum_types {
+			return t.cur_module
+		}
+		// Main-module types are stored without a qualifier. A generic function in
+		// another module can therefore receive `App`, not `main.App`.
+		if name in t.tc.structs || name in t.tc.sum_types {
+			return 'main'
+		}
+	}
+	return t.cur_module
 }
 
 fn (t &Transformer) comptime_method_receiver_generic_args(receiver string, requested string, normalized string) ([]string, []string) {

--- a/vlib/v3/transform/comptime.v
+++ b/vlib/v3/transform/comptime.v
@@ -1226,6 +1226,12 @@ fn (t &Transformer) comptime_method_requested_module(raw string) string {
 	if name.contains('.') {
 		return name.all_before_last('.')
 	}
+	// Generic specializations retain the caller-owned main types that were passed
+	// into an imported declaration. Prefer that provenance over a same-named type
+	// declared beside the generic function.
+	if t.active_specialization_main_types[name] {
+		return 'main'
+	}
 	if !isnil(t.tc) {
 		local := if t.cur_module in ['', 'main', 'builtin'] {
 			name


### PR DESCRIPTION
## Summary

- add a V3 `$qml()` compile-time expression that reads and validates QML, then lowers it to direct `ui2.Element` constructors and repeater loops
- preserve typed model actions and two-way text, checked, active, and numeric value bindings through compiled event identifiers
- track referenced QML files in V3 module-cache signatures so QML-only edits invalidate cached output
- support UI2 modules declared through `v.mod` subdirectories and cross-module generic `T.methods` dispatch
- cover the current UI2 controls through ProgressBar, Slider, Switch, and Spinner

## Performance

The companion UI2 benchmark parses the runtime-QML baseline once and times only repeated tree construction. Seven runs of 10,000 builds on Apple M5 Max produced a median 31.15x speedup: about 119.8 us/build for runtime QML versus 3.9 us/build for compiled QML.

## Verification

- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -silent test vlib/v3/tests/qml_codegen_test.v`
- `./vnew -silent test vlib/v3/modulecache/modulecache_test.v`
- production UI2 benchmark: checksum 420000