### PR TITLE
GNUmakefile: bootstrap Windows from vc/v_win.c, not vc/v.c

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -218,8 +218,8 @@ ifdef WIN32
 	$(RM) v2$(EXE_EXT)
 else
 ifdef LEGACY
-	$(MAKE) -C $(TMPLEGACY) CPPFLAGS='$(CPPFLAGS)' CFLAGS='$(CFLAGS)' LDFLAGS='$(LDFLAGS)'
-	$(MAKE) -C $(TMPLEGACY) PREFIX=$(realpath $(LEGACYLIBS)) CPPFLAGS='$(CPPFLAGS)' CFLAGS='$(CFLAGS)' LDFLAGS='$(LDFLAGS)' install
+	'$(MAKE)' -C $(TMPLEGACY) CPPFLAGS='$(CPPFLAGS)' CFLAGS='$(CFLAGS)' LDFLAGS='$(LDFLAGS)'
+	'$(MAKE)' -C $(TMPLEGACY) PREFIX=$(realpath $(LEGACYLIBS)) CPPFLAGS='$(CPPFLAGS)' CFLAGS='$(CFLAGS)' LDFLAGS='$(LDFLAGS)' install
 	rm -rf $(TMPLEGACY)
 	$(eval override LDFLAGS+=-L$(realpath $(LEGACYLIBS))/lib -lMacportsLegacySupport)
 endif
@@ -320,13 +320,13 @@ else
 endif
 endif
 ifneq (,$(wildcard ./tcc.exe))
-	@$(MAKE) --quiet check_for_working_tcc 2> /dev/null
+	@'$(MAKE)' --quiet check_for_working_tcc 2> /dev/null
 endif
 
 else
 latest_tcc:
 	@echo "Using local tcc"
-	@$(MAKE) --quiet check_for_working_tcc 2> /dev/null
+	@'$(MAKE)' --quiet check_for_working_tcc 2> /dev/null
 endif
 
 # Rebuild the bundled TCC in-place from upstream tinycc, while preserving the
@@ -346,7 +346,7 @@ ifeq ($(TCCOS),linux)
 else
 	@TCC_FOLDER='$(TMPTCC)' $(if $(strip $(TCC_COMMIT)),TCC_COMMIT='$(TCC_COMMIT)') CC='$(CC)' bash '$(TCCBUILDSCRIPT)'
 endif
-	@$(MAKE) --quiet check_for_working_tcc 2> /dev/null
+	@'$(MAKE)' --quiet check_for_working_tcc 2> /dev/null
 else
 	@echo 'No upstream TinyCC build script is available for thirdparty-$(TCCOS)-$(TCCARCH).'
 	@echo 'Use `make latest_tcc` to refresh the prebuilt bundle from $(TCCREPO).'
@@ -387,9 +387,9 @@ ifeq ($(HAS_GIT),1)
 		fi; \
 		if ! "$(TMPTCC)/tcc.exe" --version > /dev/null 2> /dev/null; then \
 			echo "Pre-built TCC bundle $$selected_branch did not run; V will use the system compiler: $(CC)"; \
-			$(MAKE) --quiet check_for_working_tcc 2> /dev/null; \
+			'$(MAKE)' --quiet check_for_working_tcc 2> /dev/null; \
 		else \
-			$(MAKE) --quiet check_for_working_tcc 2> /dev/null; \
+			'$(MAKE)' --quiet check_for_working_tcc 2> /dev/null; \
 		fi; \
 	fi
 else
@@ -399,7 +399,7 @@ endif
 endif
 else
 	@echo "Using local tccbin"
-	@$(MAKE) --quiet check_for_working_tcc 2> /dev/null
+	@'$(MAKE)' --quiet check_for_working_tcc 2> /dev/null
 endif
 
 ifndef local
@@ -445,10 +445,10 @@ endif
 $(TMPTCC)/.git/config:
 ifeq ($(TCCOS),linux)
 	@bash '$(GIT_ARGV_RUNNER)' check
-	$(MAKE) fresh_tcc
+	'$(MAKE)' fresh_tcc
 else
 ifeq ($(HAS_GIT),1)
-	$(MAKE) fresh_tcc
+	'$(MAKE)' fresh_tcc
 else
 	@echo "git not found; skipping bootstrap of $(TMPTCC), system compiler $(CC) will be used"
 endif
@@ -457,7 +457,7 @@ endif
 $(VC)/.git/config:
 ifeq ($(TCCOS),linux)
 	@if bash '$(GIT_ARGV_RUNNER)' check > /dev/null 2>&1; then \
-		$(MAKE) fresh_vc; \
+		'$(MAKE)' fresh_vc; \
 	elif [ -f "$(VC)/$(VCFILE)" ]; then \
 		echo "git not found; using existing $(VC)/$(VCFILE)"; \
 	else \
@@ -466,7 +466,7 @@ ifeq ($(TCCOS),linux)
 	fi
 else
 ifeq ($(HAS_GIT),1)
-	$(MAKE) fresh_vc
+	'$(MAKE)' fresh_vc
 else
 	@if [ -f "$(VC)/$(VCFILE)" ]; then \
 		echo "git not found; using existing $(VC)/$(VCFILE)"; \
@@ -481,7 +481,7 @@ $(TMPLEGACY)/.git/config:
 ifdef LEGACY
 ifeq ($(TCCOS),linux)
 	@if bash '$(GIT_ARGV_RUNNER)' check > /dev/null 2>&1; then \
-		$(MAKE) fresh_legacy; \
+		'$(MAKE)' fresh_legacy; \
 	elif [ -d "$(TMPLEGACY)" ]; then \
 		echo "git not found; using existing $(TMPLEGACY)"; \
 	else \
@@ -490,7 +490,7 @@ ifeq ($(TCCOS),linux)
 	fi
 else
 ifeq ($(HAS_GIT),1)
-	$(MAKE) fresh_legacy
+	'$(MAKE)' fresh_legacy
 else
 	@if [ -d "$(TMPLEGACY)" ]; then \
 		echo "git not found; using existing $(TMPLEGACY)"; \
@@ -503,7 +503,7 @@ endif
 endif
 
 asan:
-	$(MAKE) all CFLAGS='-fsanitize=address,undefined'
+	'$(MAKE)' all CFLAGS='-fsanitize=address,undefined'
 
 selfcompile:
 	$(VEXE)$(EXE_EXT) -cg -o v cmd/v

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -36,6 +36,10 @@ _SYS := $(patsubst MINGW%,MinGW,$(_SYS))
 ifneq ($(filter $(_SYS),MSYS MinGW),)
 WIN32 := 1
 EXE_EXT := .exe
+# vc/v.c is generated with `-cross` targeting the host OS that ran gen_vc_ci.yml
+# (Linux), so it only guards *nix headers/APIs, not Windows. The dedicated
+# `-os windows` snapshot lives in vc/v_win.c; that is the one Windows needs.
+VCFILE := v_win.c
 # GNU make defaults CC to `cc`, but mingw32-make installations often only
 # provide `gcc`. Switch only the implicit default and preserve explicit CC=...
 ifneq ($(filter $(origin CC),default file),)


### PR DESCRIPTION
This PR fixes `make` on Windows (MSYS/MinGW), which currently fails to bootstrap.

**Wrong VC snapshot on Windows.** `GNUmakefile` hardcoded `VCFILE` to `v.c` for every platform. `vc/v.c` is produced by `./v -o vc/v.c -cross cmd/v` on Linux CI (see `gen_vc_ci.yml`), so its file selection still resolves to the host's *nix sources (`os_nix.c.v`, `termios_linux.c.v`, `closure_nix.c.v`, ...) — `-cross` only changes how some comptime conditions are lowered to C, not which OS-suffixed files get included. Compiling that snapshot with MinGW gcc fails outright, since it `#include`s POSIX-only headers (`sys/mman.h`, `termios.h`, `sys/ptrace.h`, `sys/wait.h`, `sys/utsname.h`, `sys/statvfs.h`) and calls POSIX-only APIs (`mmap`/`mprotect`, `sysconf`, `uname`, `flock`, ...) that MinGW doesn't provide.

The dedicated Windows snapshot is `vc/v_win.c`, generated with `-os windows`, and is already what `make.bat`, `vself.v`, and `vgit.v` use to bootstrap on Windows. This PR overrides `VCFILE` to `v_win.c` when `WIN32` is detected in `GNUmakefile`, matching those other tools.

**Unquoted recursive `$(MAKE)` calls.** Also quotes the recursive `$(MAKE)` invocations throughout the file, preventing word-splitting when the checkout path or `MAKE` contains spaces, matching how other paths in the file are already quoted.

Verified: `gcc -std=c99 -municode -w -o v1.exe vc/v_win.c -lws2_32` compiles cleanly, and `make` now completes the full v1 -> v2 -> v bootstrap and produces a working `v.exe` under MSYS/MinGW.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
