### PR TITLE
ci: generate vc/v_win.c with -cross, like vc/v.c

### DIFF
--- a/.github/workflows/gen_vc_ci.yml
+++ b/.github/workflows/gen_vc_ci.yml
@@ -55,14 +55,20 @@ jobs:
 
           rm -rf vc/v.c vc/v_win.c
           ./v -o vc/v.c     -cross               cmd/v
-          ./v -o vc/v_win.c -os windows -cc msvc cmd/v
+          ./v -o vc/v_win.c -cross -os windows -cc msvc cmd/v
 
           sed -i "1s/^/#define V_COMMIT_HASH \"$COMMIT_HASH\"\n/" vc/v.c
           sed -i "1s/^/#define V_COMMIT_HASH \"$COMMIT_HASH\"\n/" vc/v_win.c
 
-          # do some sanity checks for the generated v.c file:
+          # do some sanity checks for the generated v.c/v_win.c files. `-cross` makes `$if cross ?`
+          # (and the `?`-guarded v1_fallback/musl branches that key off it, e.g. in
+          # cmd/v/macos_v3_driver_notd_cross.v) resolve statically instead of compiling out empty,
+          # which is what lets GNUmakefile later recompile these snapshots with
+          # -DCUSTOM_DEFINE_v1_fallback to build v1$(EXE_EXT).
           grep 'Turned ON custom defines: no_backtrace,cross'  vc/v.c
           grep '#define CUSTOM_DEFINE_cross' vc/v.c
+          grep 'Turned ON custom defines: no_backtrace,cross'  vc/v_win.c
+          grep '#define CUSTOM_DEFINE_cross' vc/v_win.c
 
           # ensure the generated C files for the compiler, are over 5000 lines long, as a safety measure
           [ "$(wc -l < vc/v.c)" -gt 5000 ]


### PR DESCRIPTION
`vc/v_win.c` is generated via `./v -o vc/v_win.c -os windows -cc msvc cmd/v`, without `-cross`. `cmd/v/macos_v3_driver_notd_cross.v` gates `macos_v3_driver_is_available`/`macos_v3_driver_run` behind:

```v
$if v1_fallback ? {
	...
} $else $if musl ? {
	...
} $else $if macos || linux {
	...
} $else {
	...
}
```

The checker resolves each `?` condition statically against `pref.compile_defines` at generation time (`vlib/v/checker/comptime.v:1749`), so a branch for a flag that wasn't passed during that specific generation compiles out with an **empty** body. Neither `v1_fallback` nor `musl` is passed when generating `vc/v_win.c`, so only the final `$else` (windows stub) body survives in the emitted C.

Several bootstrap paths recompile that same static snapshot with `-DCUSTOM_DEFINE_v1_fallback` to select the `v1_fallback` branch instead — but it's empty, so linking fails with `undefined reference to 'main__macos_v3_driver_is_available'`. This currently breaks:
- `GNUmakefile`'s Windows bootstrap (`VC_BOOTSTRAP_DEFINE`)
- `cmd/tools/vself.v`'s `v up` self-update fallback on Windows (`vself.v:622`)
- `thirdparty/tccbin_automation/bootstrap/bootstrap.sh`'s Windows artifact build

`vc/v.c` doesn't hit this because it's generated with `-cross`, which (`vlib/v/pref/default.v:322`) unconditionally adds `'cross'` to `compile_defines`. `cmd/v/macos_v3_driver_d_cross.v` (selected once `'cross'` is a known define, per the `_d_cross.v`/`_notd_cross.v` filename convention in `vlib/v/pref/should_compile.v`) defines unconditional stub bodies with no `?` branching at all, so there's no empty-branch case to hit.

## Fix

Pass `-cross` when generating `vc/v_win.c` too, so it takes the same always-safe path as `vc/v.c`. This also flips a few other snapshot-wide flags for `vc/v_win.c` (`gc_mode = no_gc`, `skip_unused = false`, a `no_backtrace` define) — the same recipe `vc/v.c` already uses in production for Linux/macOS bootstrapping, since the bootstrap binary is a short-lived, throwaway tool used only to compile the next stage from real source.

This doesn't affect `makev.bat`'s MSVC path: it builds its own transient bootstrap exe from `vc/v_win.c` via tcc/gcc/clang without `-DCUSTOM_DEFINE_v1_fallback` (so it wasn't hitting this bug either way), and MSVC itself only ever compiles the final exe from current source, never the static snapshot.

Also extends the existing `vc/v.c` sanity checks (grep for the custom-define markers) to `vc/v_win.c`, so a regression like this fails CI instead of silently breaking the Windows bootstrap.

## Testing

Regenerated a local snapshot with `-cross -os windows -cc msvc cmd/v` and confirmed:
- `macos_v3_driver_is_available`/`run` now emit unconditionally (no `#if defined(CUSTOM_DEFINE_v1_fallback)` guard at all).
- `gcc -DCUSTOM_DEFINE_v1_fallback -std=c99 -municode -w -o v1.exe <snapshot> -lws2_32` links cleanly.
- The resulting binary runs `-version` successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
