### PR TITLE
v3: fix static call ownership metadata and diagnostics

### DIFF
--- a/vlib/v3/tests/ownership/ownership_test.v
+++ b/vlib/v3/tests/ownership/ownership_test.v
@@ -2118,6 +2118,52 @@ fn main() {
 	assert fail_fn_literal_return.output.contains('use of moved value: `s`'), fail_fn_literal_return.output
 }
 
+fn test_ownership_static_call_return_metadata_reaches_wrapper() {
+	v3_bin := ownership_build_v3()
+	fail := run_ownership_check(v3_bin, 'static_call_return_metadata', "
+struct Factory {}
+
+fn Factory.make() string {
+	return 'hello'.to_owned()
+}
+
+fn wrap() string {
+	return Factory.make()
+}
+
+fn main() {
+	s1 := wrap()
+	s2 := s1
+	println(s1)
+	_ = s2
+}
+")
+	assert fail.exit_code != 0
+	assert fail.output.contains('use of moved value: `s1`'), fail.output
+
+	fail_param := run_ownership_check(v3_bin, 'static_call_return_param_metadata', "
+struct Factory {}
+
+fn Factory.pass(value string) string {
+	return value
+}
+
+fn wrap(value string) string {
+	return Factory.pass(value)
+}
+
+fn main() {
+	owned := 'hello'.to_owned()
+	s1 := wrap(owned)
+	s2 := s1
+	println(s1)
+	_ = s2
+}
+")
+	assert fail_param.exit_code != 0
+	assert fail_param.output.contains('use of moved value: `s1`'), fail_param.output
+}
+
 fn test_ownership_assignment_to_storage_consumes_rhs() {
 	v3_bin := ownership_build_v3()
 	fail_field := run_ownership_check(v3_bin, 'assign_field', '

--- a/vlib/v3/tests/post_merge_review_fixes_test.v
+++ b/vlib/v3/tests/post_merge_review_fixes_test.v
@@ -7099,6 +7099,22 @@ fn unrelated() int {
 	assert tc.errors.any(it.msg.contains('cannot use `string` as type `int` in return argument')), tc.errors.str()
 }
 
+fn test_duplicate_static_function_diagnostic_uses_source_name() {
+	check_src := '${tmp_test_path('duplicate_static_fn')}.v'
+	os.write_file(check_src, 'struct Widget {}\n\nfn Widget.make() {}\n\nfn Widget.make(value int) {}\n') or {
+		panic(err)
+	}
+	prefs := pref.new_preferences()
+	mut p := parser.Parser.new(prefs)
+	mut a := p.parse_file(check_src)
+	mut tc := types.TypeChecker.new(a)
+	tc.collect(a)
+	tc.check_semantics()
+	assert tc.errors.any(it.severity == 'builder error:'
+		&& it.msg == 'redefinition of function `Widget.make`'), tc.errors.str()
+	assert !tc.errors.any(it.msg.contains('@static@')), tc.errors.str()
+}
+
 fn test_repeated_template_lines_keep_distinct_diagnostic_positions() {
 	v3_bin := build_v3()
 	root := '${tmp_test_path('repeated_template_line_diagnostics')}_project'

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -8900,11 +8900,16 @@ fn (mut tc TypeChecker) check_duplicate_fn_declarations() {
 			&& tc.node_is_in_selected_input_file(flat.NodeId(it))) {
 			continue
 		}
-		display_name := tc.a.nodes[indexes[0]].value
-		if display_name.all_after_last('.') == 'init'
-			|| tc.fn_group_name_conflicts_with_import(indexes, display_name.all_after_last('.'))
+		stored_name := tc.a.nodes[indexes[0]].value
+		if stored_name.all_after_last('.') == 'init'
+			|| tc.fn_group_name_conflicts_with_import(indexes, stored_name.all_after_last('.'))
 			|| tc.fn_group_contains_builtin_declaration(indexes) {
 			continue
+		}
+		display_name := if receiver, method := flat.decode_static_type_method_name(stored_name) {
+			'${receiver}.${method}'
+		} else {
+			stored_name
 		}
 		tc.errors << TypeError{
 			msg: 'redefinition of function `${display_name}`'

--- a/vlib/v3/types/checker_ownership_d_ownership.v
+++ b/vlib/v3/types/checker_ownership_d_ownership.v
@@ -4546,7 +4546,7 @@ fn (mut tc TypeChecker) ownership_prescan_call_info(node flat.Node, local_types 
 				}
 			}
 			qbase := tc.qualify_name(base_node.value)
-			static_name := '${qbase}.${fn_node.value}'
+			static_name := flat.encode_static_type_method_name(qbase, fn_node.value)
 			if static_name in tc.fn_ret_types && (qbase in tc.structs
 				|| qbase in tc.enum_names || qbase in tc.sum_types
 				|| qbase in tc.interface_names || qbase in tc.type_aliases) {


### PR DESCRIPTION
## Summary

- resolve static associated calls through the encoded declaration key during ownership prescans
- propagate owned-return and returned-parameter metadata through wrappers
- decode static declaration keys in duplicate-function diagnostics
- add focused ownership and diagnostic regressions

This is a follow-up to #28439 for review feedback that arrived as it was merged.

## Tests

- ./v -g -keepc -o ./vnew cmd/v
- ./vnew -silent -run-only test_duplicate_static_function_diagnostic_uses_source_name vlib/v3/tests/post_merge_review_fixes_test.v
- ./vnew -silent -run-only test_ownership_static_call_return_metadata_reaches_wrapper vlib/v3/tests/ownership/ownership_test.v
- ./vnew -silent vlib/v3/tests/ownership/ownership_test.v