### PR TITLE
v3: validate x86 lock prefix instructions

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -9056,6 +9056,14 @@ println('b: ${b}') // 20
 println('c: ${c}') // 120
 ```
 
+Structured `amd64` and `x86` blocks validate the `lock` prefix. The prefix and its instruction
+must be on the same source line. It may precede `add`, `adc`, `and`, `btc`, `btr`, `bts`,
+`cmpxchg`, `cmpxchg8b`, `cmpxchg16b`, `dec`, `inc`, `neg`, `not`, `or`, `sbb`, `sub`, `xor`,
+`xadd`, or `xchg`. The `b`, `w`, `l`, and `q` size suffixes are also recognized, for example
+`addq` and `cmpxchgq`. Without a permitted same-line instruction, the parser reports
+`The lock prefix cannot be used on this instruction`. A same-line `lock:` remains valid as a
+label; a newline inside a comment also separates the prefix, instruction, or label colon.
+
 The C backend also supports raw GNU assembly templates. In a `raw` block, V passes each
 double-quoted template string through unchanged and still checks the output, input, and clobber
 lists. Operands can use GNU's named form or V's `constraint (expression) as alias` form:

--- a/vlib/v3/parser/asm_test.v
+++ b/vlib/v3/parser/asm_test.v
@@ -27,7 +27,19 @@ fn test_inline_asm_lock_without_instruction_reports_error() {
 fn test_inline_asm_lock_accepts_supported_suffixed_instruction() {
 	diagnostics := parse_amd64_asm_diagnostics('lock_supported_instruction', 'fn main() {
 	asm amd64 {
-		lock cmpxchgq [rdx], rcx
+		retry: lock cmpxchgq [rdx], rcx
+	}
+}
+')
+	assert diagnostics.len == 0, diagnostics.str()
+}
+
+fn test_inline_asm_lock_named_operand_is_not_treated_as_prefix() {
+	diagnostics := parse_amd64_asm_diagnostics('lock_named_operand', 'fn main() {
+	mut value := 0
+	asm amd64 {
+		add lock, 1
+		; +r (value) as lock
 	}
 }
 ')

--- a/vlib/v3/parser/asm_test.v
+++ b/vlib/v3/parser/asm_test.v
@@ -69,3 +69,16 @@ fn test_inline_asm_lock_after_multiline_comment_reports_error() {
 	assert diagnostics.len == 1, diagnostics.str()
 	assert diagnostics[0].message == 'The lock prefix cannot be used on this instruction'
 }
+
+fn test_inline_asm_lock_before_multiline_comment_reports_error() {
+	diagnostics := parse_amd64_asm_diagnostics('lock_before_multiline_comment', 'fn main() {
+	asm amd64 {
+		lock /*
+		comment
+		*/ add [rax], 1
+	}
+}
+')
+	assert diagnostics.len == 1, diagnostics.str()
+	assert diagnostics[0].message == 'The lock prefix cannot be used on this instruction'
+}

--- a/vlib/v3/parser/asm_test.v
+++ b/vlib/v3/parser/asm_test.v
@@ -82,3 +82,16 @@ fn test_inline_asm_lock_before_multiline_comment_reports_error() {
 	assert diagnostics.len == 1, diagnostics.str()
 	assert diagnostics[0].message == 'The lock prefix cannot be used on this instruction'
 }
+
+fn test_inline_asm_lock_label_colon_must_be_on_same_line() {
+	diagnostics := parse_amd64_asm_diagnostics('lock_label_colon_after_multiline_comment', 'fn main() {
+	asm amd64 {
+		lock /*
+		comment
+		*/ :
+	}
+}
+')
+	assert diagnostics.len == 1, diagnostics.str()
+	assert diagnostics[0].message == 'The lock prefix cannot be used on this instruction'
+}

--- a/vlib/v3/parser/asm_test.v
+++ b/vlib/v3/parser/asm_test.v
@@ -56,3 +56,16 @@ fn test_inline_asm_lock_label_is_not_treated_as_prefix() {
 ')
 	assert diagnostics.len == 0, diagnostics.str()
 }
+
+fn test_inline_asm_lock_after_multiline_comment_reports_error() {
+	diagnostics := parse_amd64_asm_diagnostics('lock_after_multiline_comment', 'fn main() {
+	asm amd64 {
+		nop /*
+		comment
+		*/ lock mov rax, rbx
+	}
+}
+')
+	assert diagnostics.len == 1, diagnostics.str()
+	assert diagnostics[0].message == 'The lock prefix cannot be used on this instruction'
+}

--- a/vlib/v3/parser/asm_test.v
+++ b/vlib/v3/parser/asm_test.v
@@ -1,0 +1,35 @@
+module parser
+
+import os
+import v3.pref
+
+fn parse_amd64_asm_diagnostics(name string, source string) []Diagnostic {
+	path := os.join_path(os.temp_dir(), 'v3_asm_${name}_${os.getpid()}.v')
+	os.write_file(path, source) or { panic(err) }
+	defer {
+		os.rm(path) or {}
+	}
+	mut prefs := pref.new_preferences()
+	prefs.target = pref.target_from('linux', 'amd64') or { panic(err) }
+	mut p := Parser.new(prefs)
+	p.parse_file(path)
+	return p.diagnostics
+}
+
+fn test_inline_asm_lock_without_instruction_reports_error() {
+	diagnostics := parse_amd64_asm_diagnostics('lock_missing_instruction', 'fn main() {
+	asm amd64 {
+		lock')
+	assert diagnostics.len == 1, diagnostics.str()
+	assert diagnostics[0].message == 'The lock prefix cannot be used on this instruction'
+}
+
+fn test_inline_asm_lock_accepts_supported_suffixed_instruction() {
+	diagnostics := parse_amd64_asm_diagnostics('lock_supported_instruction', 'fn main() {
+	asm amd64 {
+		lock cmpxchgq [rdx], rcx
+	}
+}
+')
+	assert diagnostics.len == 0, diagnostics.str()
+}

--- a/vlib/v3/parser/asm_test.v
+++ b/vlib/v3/parser/asm_test.v
@@ -45,3 +45,14 @@ fn test_inline_asm_lock_named_operand_is_not_treated_as_prefix() {
 ')
 	assert diagnostics.len == 0, diagnostics.str()
 }
+
+fn test_inline_asm_lock_label_is_not_treated_as_prefix() {
+	diagnostics := parse_amd64_asm_diagnostics('lock_label', 'fn main() {
+	asm amd64 {
+		lock:
+		jmp lock
+	}
+}
+')
+	assert diagnostics.len == 0, diagnostics.str()
+}

--- a/vlib/v3/parser/asm_test.v
+++ b/vlib/v3/parser/asm_test.v
@@ -95,3 +95,16 @@ fn test_inline_asm_lock_label_colon_must_be_on_same_line() {
 	assert diagnostics.len == 1, diagnostics.str()
 	assert diagnostics[0].message == 'The lock prefix cannot be used on this instruction'
 }
+
+fn test_inline_asm_prefix_named_labels_keep_mnemonic_position() {
+	for label in inline_asm_prefixes_before_mnemonic {
+		diagnostics := parse_amd64_asm_diagnostics('${label}_label', 'fn main() {
+	asm amd64 {
+		${label}: lock mov rax, rbx
+	}
+}
+')
+		assert diagnostics.len == 1, '${label}: ${diagnostics.str()}'
+		assert diagnostics[0].message == 'The lock prefix cannot be used on this instruction'
+	}
+}

--- a/vlib/v3/parser/asm_test.v
+++ b/vlib/v3/parser/asm_test.v
@@ -108,3 +108,18 @@ fn test_inline_asm_prefix_named_labels_keep_mnemonic_position() {
 		assert diagnostics[0].message == 'The lock prefix cannot be used on this instruction'
 	}
 }
+
+fn test_inline_asm_encoding_prefixes_keep_mnemonic_position() {
+	for prefix in ['rex', 'vex', 'xop'] {
+		for encoding_prefix in [prefix, '${prefix}.w'] {
+			diagnostics := parse_amd64_asm_diagnostics('${encoding_prefix}_prefix', 'fn main() {
+	asm amd64 {
+		${encoding_prefix} lock push rax
+	}
+}
+')
+			assert diagnostics.len == 1, '${encoding_prefix}: ${diagnostics.str()}'
+			assert diagnostics[0].message == 'The lock prefix cannot be used on this instruction'
+		}
+	}
+}

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -12,6 +12,10 @@ import v3.util
 
 const max_parse_diagnostics = 100
 
+// https://www.felixcloutier.com/x86/lock
+const inline_asm_allowed_lock_instructions = ['add', 'adc', 'and', 'btc', 'btr', 'bts', 'cmpxchg',
+	'cmpxchg8b', 'cmpxchg16b', 'dec', 'inc', 'neg', 'not', 'or', 'sbb', 'sub', 'xor', 'xadd', 'xchg']
+
 const sql_query_data_alias_reserved_tokens = [
 	'select',
 	'from',
@@ -8373,6 +8377,16 @@ fn (mut p Parser) asm_stmt() flat.NodeId {
 					io_exprs << p.expr(.lowest)
 				}
 				p.check(.rpar)
+				continue
+			} else if depth == 1 && section == 0 && p.tok == .key_lock
+				&& pref.normalized_arch(asm_arch) in ['amd64', 'x86'] {
+				p.next()
+				has_suffix := p.lit.len > 0 && p.lit[p.lit.len - 1] in [`b`, `w`, `l`, `q`]
+				if !(p.lit in inline_asm_allowed_lock_instructions
+					|| (has_suffix
+						&& p.lit[..p.lit.len - 1] in inline_asm_allowed_lock_instructions)) {
+					p.record_diagnostic_span('The lock prefix cannot be used on this instruction', p.tok_pos, p.tok_end)
+				}
 				continue
 			} else if depth == 1 && p.tok != .semicolon {
 				if is_raw && section == 0 && !p.prefs.is_fmt {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -8306,7 +8306,12 @@ fn (mut p Parser) track_inline_asm_mnemonic(state InlineAsmMnemonicState, is_x86
 	if p.current_token_is_newline_semicolon() {
 		return .expect_mnemonic
 	}
-	match state {
+	current_state := if p.inline_asm_source_gap_has_newline() {
+		InlineAsmMnemonicState.expect_mnemonic
+	} else {
+		state
+	}
+	match current_state {
 		.expect_mnemonic {
 			if p.tok == .dot {
 				return .after_dot
@@ -8333,6 +8338,18 @@ fn (mut p Parser) track_inline_asm_mnemonic(state InlineAsmMnemonicState, is_x86
 			return .operands
 		}
 	}
+}
+
+fn (p &Parser) inline_asm_source_gap_has_newline() bool {
+	if p.prev_tok_end < 0 || p.prev_tok_end >= p.tok_pos || p.tok_pos > p.s.src.len {
+		return false
+	}
+	for i := p.prev_tok_end; i < p.tok_pos; i++ {
+		if p.s.src[i] == `\n` {
+			return true
+		}
+	}
+	return false
 }
 
 fn (mut p Parser) validate_inline_asm_lock_instruction() {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -18,6 +18,8 @@ const inline_asm_allowed_lock_instructions = ['add', 'adc', 'and', 'btc', 'btr',
 
 const inline_asm_prefixes_before_mnemonic = ['rep', 'repe', 'repz', 'repne', 'repnz']
 
+const inline_asm_encoding_prefixes_before_mnemonic = ['rex', 'vex', 'xop']
+
 const sql_query_data_alias_reserved_tokens = [
 	'select',
 	'from',
@@ -170,6 +172,8 @@ struct ParsedFieldAttrs {
 enum InlineAsmMnemonicState {
 	expect_mnemonic
 	after_dot
+	encoding_prefix
+	encoding_prefix_dot
 	maybe_label
 	operands
 }
@@ -8302,14 +8306,17 @@ fn (mut p Parser) goto_stmt() flat.NodeId {
 	})
 }
 
-fn (mut p Parser) track_inline_asm_mnemonic(state InlineAsmMnemonicState, is_x86 bool) InlineAsmMnemonicState {
+fn (mut p Parser) track_inline_asm_mnemonic(state InlineAsmMnemonicState, is_x86 bool, is_amd64 bool) InlineAsmMnemonicState {
 	if p.current_token_is_newline_semicolon() {
 		return .expect_mnemonic
 	}
-	current_state := if p.inline_asm_source_gap_has_newline(p.prev_tok_end, p.tok_pos) {
+	mut current_state := if p.inline_asm_source_gap_has_newline(p.prev_tok_end, p.tok_pos) {
 		InlineAsmMnemonicState.expect_mnemonic
 	} else {
 		state
+	}
+	if current_state == .encoding_prefix && p.tok != .dot {
+		current_state = .expect_mnemonic
 	}
 	match current_state {
 		.expect_mnemonic {
@@ -8323,6 +8330,12 @@ fn (mut p Parser) track_inline_asm_mnemonic(state InlineAsmMnemonicState, is_x86
 				p.validate_inline_asm_lock_instruction()
 				return .expect_mnemonic
 			}
+			if is_amd64 && p.lit in inline_asm_encoding_prefixes_before_mnemonic {
+				if p.inline_asm_token_is_same_line_label() {
+					return .maybe_label
+				}
+				return .encoding_prefix
+			}
 			if is_x86 && p.lit in inline_asm_prefixes_before_mnemonic {
 				if p.inline_asm_token_is_same_line_label() {
 					return .maybe_label
@@ -8333,6 +8346,12 @@ fn (mut p Parser) track_inline_asm_mnemonic(state InlineAsmMnemonicState, is_x86
 		}
 		.after_dot {
 			return .maybe_label
+		}
+		.encoding_prefix {
+			return .encoding_prefix_dot
+		}
+		.encoding_prefix_dot {
+			return .encoding_prefix
 		}
 		.maybe_label {
 			return if p.tok == .colon { .expect_mnemonic } else { .operands }
@@ -8433,13 +8452,15 @@ fn (mut p Parser) asm_stmt() flat.NodeId {
 	mut section := 0
 	mut io_exprs := []flat.NodeId{}
 	mut mnemonic_state := InlineAsmMnemonicState.expect_mnemonic
-	is_x86_asm := pref.normalized_arch(asm_arch) in ['amd64', 'x86']
+	normalized_asm_arch := pref.normalized_arch(asm_arch)
+	is_x86_asm := normalized_asm_arch in ['amd64', 'x86']
+	is_amd64_asm := normalized_asm_arch == 'amd64'
 	if p.tok == .lcbr {
 		mut depth := 1
 		p.next()
 		for depth > 0 && p.tok != .eof {
 			if depth == 1 && section == 0 {
-				mnemonic_state = p.track_inline_asm_mnemonic(mnemonic_state, is_x86_asm)
+				mnemonic_state = p.track_inline_asm_mnemonic(mnemonic_state, is_x86_asm, is_amd64_asm)
 			}
 			if p.tok == .lcbr {
 				depth++

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -16,6 +16,8 @@ const max_parse_diagnostics = 100
 const inline_asm_allowed_lock_instructions = ['add', 'adc', 'and', 'btc', 'btr', 'bts', 'cmpxchg',
 	'cmpxchg8b', 'cmpxchg16b', 'dec', 'inc', 'neg', 'not', 'or', 'sbb', 'sub', 'xor', 'xadd', 'xchg']
 
+const inline_asm_prefixes_before_mnemonic = ['rep', 'repe', 'repz', 'repne', 'repnz']
+
 const sql_query_data_alias_reserved_tokens = [
 	'select',
 	'from',
@@ -163,6 +165,13 @@ struct ParsedFieldAttrs {
 	attrs   []string
 	kinds   []int
 	sources []string
+}
+
+enum InlineAsmMnemonicState {
+	expect_mnemonic
+	after_dot
+	maybe_label
+	operands
 }
 
 // new creates a Parser value for parser.
@@ -8293,6 +8302,47 @@ fn (mut p Parser) goto_stmt() flat.NodeId {
 	})
 }
 
+fn (mut p Parser) track_inline_asm_mnemonic(state InlineAsmMnemonicState, is_x86 bool) InlineAsmMnemonicState {
+	if p.current_token_is_newline_semicolon() {
+		return .expect_mnemonic
+	}
+	match state {
+		.expect_mnemonic {
+			if p.tok == .dot {
+				return .after_dot
+			}
+			if is_x86 && p.tok == .key_lock {
+				p.validate_inline_asm_lock_instruction()
+				return .expect_mnemonic
+			}
+			if is_x86 && p.lit in inline_asm_prefixes_before_mnemonic {
+				return .expect_mnemonic
+			}
+			return .maybe_label
+		}
+		.after_dot {
+			return .maybe_label
+		}
+		.maybe_label {
+			return if p.tok == .colon { .expect_mnemonic } else { .operands }
+		}
+		.operands {
+			return .operands
+		}
+	}
+}
+
+fn (mut p Parser) validate_inline_asm_lock_instruction() {
+	p.peek()
+	has_suffix := p.peek_lit.len > 0
+		&& p.peek_lit[p.peek_lit.len - 1] in [`b`, `w`, `l`, `q`]
+	if !(p.peek_lit in inline_asm_allowed_lock_instructions
+		|| (has_suffix
+			&& p.peek_lit[..p.peek_lit.len - 1] in inline_asm_allowed_lock_instructions)) {
+		p.record_diagnostic_span('The lock prefix cannot be used on this instruction', p.peek_pos, p.peek_end)
+	}
+}
+
 fn (mut p Parser) asm_stmt() flat.NodeId {
 	asm_pos := p.tok_pos
 	p.next() // skip 'asm'
@@ -8353,10 +8403,15 @@ fn (mut p Parser) asm_stmt() flat.NodeId {
 	mut has_unsupported_content := false
 	mut section := 0
 	mut io_exprs := []flat.NodeId{}
+	mut mnemonic_state := InlineAsmMnemonicState.expect_mnemonic
+	is_x86_asm := pref.normalized_arch(asm_arch) in ['amd64', 'x86']
 	if p.tok == .lcbr {
 		mut depth := 1
 		p.next()
 		for depth > 0 && p.tok != .eof {
+			if depth == 1 && section == 0 {
+				mnemonic_state = p.track_inline_asm_mnemonic(mnemonic_state, is_x86_asm)
+			}
 			if p.tok == .lcbr {
 				depth++
 			} else if p.tok == .rcbr {
@@ -8377,16 +8432,6 @@ fn (mut p Parser) asm_stmt() flat.NodeId {
 					io_exprs << p.expr(.lowest)
 				}
 				p.check(.rpar)
-				continue
-			} else if depth == 1 && section == 0 && p.tok == .key_lock
-				&& pref.normalized_arch(asm_arch) in ['amd64', 'x86'] {
-				p.next()
-				has_suffix := p.lit.len > 0 && p.lit[p.lit.len - 1] in [`b`, `w`, `l`, `q`]
-				if !(p.lit in inline_asm_allowed_lock_instructions
-					|| (has_suffix
-						&& p.lit[..p.lit.len - 1] in inline_asm_allowed_lock_instructions)) {
-					p.record_diagnostic_span('The lock prefix cannot be used on this instruction', p.tok_pos, p.tok_end)
-				}
 				continue
 			} else if depth == 1 && p.tok != .semicolon {
 				if is_raw && section == 0 && !p.prefs.is_fmt {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -8306,7 +8306,7 @@ fn (mut p Parser) track_inline_asm_mnemonic(state InlineAsmMnemonicState, is_x86
 	if p.current_token_is_newline_semicolon() {
 		return .expect_mnemonic
 	}
-	current_state := if p.inline_asm_source_gap_has_newline() {
+	current_state := if p.inline_asm_source_gap_has_newline(p.prev_tok_end, p.tok_pos) {
 		InlineAsmMnemonicState.expect_mnemonic
 	} else {
 		state
@@ -8340,11 +8340,11 @@ fn (mut p Parser) track_inline_asm_mnemonic(state InlineAsmMnemonicState, is_x86
 	}
 }
 
-fn (p &Parser) inline_asm_source_gap_has_newline() bool {
-	if p.prev_tok_end < 0 || p.prev_tok_end >= p.tok_pos || p.tok_pos > p.s.src.len {
+fn (p &Parser) inline_asm_source_gap_has_newline(start int, end int) bool {
+	if start < 0 || start >= end || end > p.s.src.len {
 		return false
 	}
-	for i := p.prev_tok_end; i < p.tok_pos; i++ {
+	for i := start; i < end; i++ {
 		if p.s.src[i] == `\n` {
 			return true
 		}
@@ -8356,9 +8356,10 @@ fn (mut p Parser) validate_inline_asm_lock_instruction() {
 	p.peek()
 	has_suffix := p.peek_lit.len > 0
 		&& p.peek_lit[p.peek_lit.len - 1] in [`b`, `w`, `l`, `q`]
-	if !(p.peek_lit in inline_asm_allowed_lock_instructions
-		|| (has_suffix
-			&& p.peek_lit[..p.peek_lit.len - 1] in inline_asm_allowed_lock_instructions)) {
+	if p.inline_asm_source_gap_has_newline(p.tok_end, p.peek_pos)
+		|| !(p.peek_lit in inline_asm_allowed_lock_instructions
+			|| (has_suffix
+				&& p.peek_lit[..p.peek_lit.len - 1] in inline_asm_allowed_lock_instructions)) {
 		p.record_diagnostic_span('The lock prefix cannot be used on this instruction', p.peek_pos, p.peek_end)
 	}
 }

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -8317,14 +8317,16 @@ fn (mut p Parser) track_inline_asm_mnemonic(state InlineAsmMnemonicState, is_x86
 				return .after_dot
 			}
 			if is_x86 && p.tok == .key_lock {
-				if p.peek() == .colon
-					&& !p.inline_asm_source_gap_has_newline(p.tok_end, p.peek_pos) {
+				if p.inline_asm_token_is_same_line_label() {
 					return .maybe_label
 				}
 				p.validate_inline_asm_lock_instruction()
 				return .expect_mnemonic
 			}
 			if is_x86 && p.lit in inline_asm_prefixes_before_mnemonic {
+				if p.inline_asm_token_is_same_line_label() {
+					return .maybe_label
+				}
 				return .expect_mnemonic
 			}
 			return .maybe_label
@@ -8339,6 +8341,11 @@ fn (mut p Parser) track_inline_asm_mnemonic(state InlineAsmMnemonicState, is_x86
 			return .operands
 		}
 	}
+}
+
+fn (mut p Parser) inline_asm_token_is_same_line_label() bool {
+	return p.peek() == .colon
+		&& !p.inline_asm_source_gap_has_newline(p.tok_end, p.peek_pos)
 }
 
 fn (p &Parser) inline_asm_source_gap_has_newline(start int, end int) bool {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -8317,7 +8317,8 @@ fn (mut p Parser) track_inline_asm_mnemonic(state InlineAsmMnemonicState, is_x86
 				return .after_dot
 			}
 			if is_x86 && p.tok == .key_lock {
-				if p.peek() == .colon {
+				if p.peek() == .colon
+					&& !p.inline_asm_source_gap_has_newline(p.tok_end, p.peek_pos) {
 					return .maybe_label
 				}
 				p.validate_inline_asm_lock_instruction()

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -8312,6 +8312,9 @@ fn (mut p Parser) track_inline_asm_mnemonic(state InlineAsmMnemonicState, is_x86
 				return .after_dot
 			}
 			if is_x86 && p.tok == .key_lock {
+				if p.peek() == .colon {
+					return .maybe_label
+				}
 				p.validate_inline_asm_lock_instruction()
 				return .expect_mnemonic
 			}


### PR DESCRIPTION
## Summary

- port the x86 `lock` prefix validation from #28009 to the V3 parser
- handle a missing instruction without indexing an empty token
- preserve support for valid size-suffixed instructions such as `cmpxchgq`
- add focused parser regression coverage

## Testing

- `./vnew -silent test vlib/v3/parser/`
- `./vnew vlib/v3/tests/inline_asm_c_lowering_test.v`
- built V3 and checked `vlib/v/parser/tests/asm_lock_missing_instruction.vv` against an amd64 target