### PR TITLE
v3: rename QML templates to VML

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -7190,11 +7190,11 @@ numbers: [1, 2, 3]
 
 See more [details](https://github.com/vlang/v/blob/master/vlib/v/TEMPLATES.md)
 
-#### `$qml` for compiling UI2 interfaces
+#### `$vml` for compiling UI2 interfaces
 
-The V3 compiler can compile a QML file directly into an `ui2.Element` expression with
-`$qml(path)`. The QML is parsed while the application is compiled; the resulting program
-constructs UI2 elements directly and does not parse the QML file at runtime.
+The V3 compiler can compile a VML file directly into an `ui2.Element` expression with
+`$vml(path)`. The VML is parsed while the application is compiled; the resulting program
+constructs UI2 elements directly and does not parse the VML file at runtime.
 
 ```v ignore
 import ui2
@@ -7207,13 +7207,13 @@ pub mut:
 pub fn (mut app App) save() {}
 
 fn view(app &App) ui2.Element {
-	return $qml('views/profile.qml')
+	return $vml('views/profile.vml')
 }
 ```
 
-`views/profile.qml`:
+`views/profile.vml`:
 
-```qml
+```vml
 Screen {
     id: root
     background: "#f8fafc"
@@ -7233,7 +7233,7 @@ given. A relative path is searched for in this order:
 3. relative to the nearest parent directory containing `v.mod`;
 4. in that module root's `templates` directory.
 
-The compiled QML subset supports these UI2 elements:
+The compiled VML subset supports these UI2 elements:
 
 - `Screen`, `View`, `Rectangle`, `Column`, `Row`, and `Scroll` containers;
 - `Label`, `Image`, `Button`, `Checkbox`, `Dropdown`, `TextField`, and `TextArea`;

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -264,37 +264,37 @@ fn source_signature_details(source_files []string, build_pseudo_values string, v
 		hash = hash_bytes(hash, content)
 		hash = hash_bytes(hash, [u8(0xff)])
 		source := content.bytestr()
-		qml_paths, qml_lookup_paths, qml_lookup_candidates, has_unresolved_qml_path := compile_time_qml_paths(
+		vml_paths, vml_lookup_paths, vml_lookup_candidates, has_unresolved_vml_path := compile_time_vml_paths(
 			source, path)
-		if has_unresolved_qml_path {
+		if has_unresolved_vml_path {
 			cacheable = false
 		}
-		for lookup_path in qml_lookup_paths {
+		for lookup_path in vml_lookup_paths {
 			resolved := os.real_path(lookup_path)
 			metadata := optional_file_metadata_signature(lookup_path)
-			validation << 'qmllookup=${lookup_path}\t${resolved}\t${metadata}'
+			validation << 'vmllookup=${lookup_path}\t${resolved}\t${metadata}'
 			hash = hash_bytes(hash, [u8(0xf7)])
 			hash = hash_bytes(hash, lookup_path.bytes())
 			hash = hash_bytes(hash, [u8(0)])
 			hash = hash_bytes(hash, resolved.bytes())
 			hash = hash_bytes(hash, [u8(0xff)])
 		}
-		for candidate in qml_lookup_candidates {
+		for candidate in vml_lookup_candidates {
 			metadata := optional_file_metadata_signature(candidate)
-			validation << 'qmlcandidate=${candidate}\t${metadata}'
+			validation << 'vmlcandidate=${candidate}\t${metadata}'
 			hash = hash_bytes(hash, [u8(0xf6)])
 			hash = hash_bytes(hash, candidate.bytes())
 			hash = hash_bytes(hash, [u8(0)])
 			hash = hash_bytes(hash, metadata.bytes())
 			hash = hash_bytes(hash, [u8(0xff)])
 		}
-		for qml_path in qml_paths {
-			qml_content := os.read_bytes(qml_path) or { return SourceSignatureDetails{} }
-			validation << 'qml=${qml_path}\t${file_metadata_signature(qml_path)}'
+		for vml_path in vml_paths {
+			vml_content := os.read_bytes(vml_path) or { return SourceSignatureDetails{} }
+			validation << 'vml=${vml_path}\t${file_metadata_signature(vml_path)}'
 			hash = hash_bytes(hash, [u8(0xf8)])
-			hash = hash_bytes(hash, qml_path.bytes())
+			hash = hash_bytes(hash, vml_path.bytes())
 			hash = hash_bytes(hash, [u8(0)])
-			hash = hash_bytes(hash, qml_content)
+			hash = hash_bytes(hash, vml_content)
 			hash = hash_bytes(hash, [u8(0xff)])
 		}
 		if source_uses_pseudo(source, [
@@ -380,7 +380,7 @@ fn source_signature_details(source_files []string, build_pseudo_values string, v
 	}
 	if !cacheable {
 		// Keep repeated queries consistent inside one compiler process, while
-		// ensuring another process cannot reuse an artifact whose QML input path
+		// ensuring another process cannot reuse an artifact whose VML input path
 		// could not be extracted from source text.
 		hash = hash_bytes(hash, [u8(0xf7)])
 		hash = hash_bytes(hash, os.getpid().str().bytes())
@@ -746,24 +746,24 @@ fn valid_cached_source_signature(content string, metadata string, build_pseudo_v
 			}
 			continue
 		}
-		if line.starts_with('qml=') {
-			parts := line['qml='.len..].split('\t')
+		if line.starts_with('vml=') {
+			parts := line['vml='.len..].split('\t')
 			if parts.len != 2 || parts[0].len == 0
 				|| file_metadata_signature(parts[0]) != parts[1] {
 				return none
 			}
 			continue
 		}
-		if line.starts_with('qmlcandidate=') {
-			parts := line['qmlcandidate='.len..].split('\t')
+		if line.starts_with('vmlcandidate=') {
+			parts := line['vmlcandidate='.len..].split('\t')
 			if parts.len != 2 || parts[0].len == 0
 				|| optional_file_metadata_signature(parts[0]) != parts[1] {
 				return none
 			}
 			continue
 		}
-		if line.starts_with('qmllookup=') {
-			parts := line['qmllookup='.len..].split('\t')
+		if line.starts_with('vmllookup=') {
+			parts := line['vmllookup='.len..].split('\t')
 			if parts.len != 3 || parts[0].len == 0 || os.real_path(parts[0]) != parts[1]
 				|| optional_file_metadata_signature(parts[0]) != parts[2] {
 				return none
@@ -1001,8 +1001,8 @@ fn signature_string_call_arg_prefix(source string, start int) (string, int, bool
 	return '', source.len, false, false
 }
 
-fn compile_time_qml_paths(source string, source_file string) ([]string, []string, []string, bool) {
-	if !source.contains('\$qml') {
+fn compile_time_vml_paths(source string, source_file string) ([]string, []string, []string, bool) {
+	if !source.contains('\$vml') {
 		return []string{}, []string{}, []string{}, false
 	}
 	mut paths := map[string]bool{}
@@ -1024,7 +1024,7 @@ fn compile_time_qml_paths(source string, source_file string) ([]string, []string
 			pos = skip_signature_quoted_text(source, pos + 1, true)
 			continue
 		}
-		if pos + 4 > source.len || source[pos..pos + 4] != '\$qml'
+		if pos + 4 > source.len || source[pos..pos + 4] != '\$vml'
 			|| (pos + 4 < source.len && signature_name_char(source[pos + 4])) {
 			pos++
 			continue
@@ -1032,7 +1032,7 @@ fn compile_time_qml_paths(source string, source_file string) ([]string, []string
 		raw_path, next_pos, ok, is_raw := signature_string_call_arg(source, pos + 4)
 		if ok {
 			path_value := if is_raw { raw_path } else { cached_unescape_v_string(raw_path) }
-			path, candidates := resolve_signature_qml_path(path_value, source_file)
+			path, candidates := resolve_signature_vml_path(path_value, source_file)
 			paths[os.real_path(path)] = true
 			lookup_paths[path] = true
 			for candidate in candidates {
@@ -1052,7 +1052,7 @@ fn compile_time_qml_paths(source string, source_file string) ([]string, []string
 	return result, lookups, candidates, has_unresolved_path
 }
 
-fn resolve_signature_qml_path(path string, source_file string) (string, []string) {
+fn resolve_signature_vml_path(path string, source_file string) (string, []string) {
 	if os.is_abs_path(path) {
 		return path, []string{}
 	}
@@ -1173,7 +1173,7 @@ pub fn (m &Manager) valid_entry_with_metadata_cache(module_name string, source_f
 	}
 	source_details := m.source_signature_details(source_files)
 	if !source_details.cacheable {
-		cache_trace_module_miss(module_name, 'source has an unresolved compile-time QML path')
+		cache_trace_module_miss(module_name, 'source has an unresolved compile-time VML path')
 		return none
 	}
 	expected := entry_stamp(m.salt, source_details.signature)

--- a/vlib/v3/modulecache/modulecache_test.v
+++ b/vlib/v3/modulecache/modulecache_test.v
@@ -416,60 +416,60 @@ fn test_cached_source_signature_keeps_per_file_sha256_digests() {
 	assert cached.source_digests == details.source_digests
 }
 
-fn test_cached_source_signature_tracks_qml_inputs() {
-	root := os.join_path(os.vtmp_dir(), 'v3_modulecache_qml_${os.getpid()}')
+fn test_cached_source_signature_tracks_vml_inputs() {
+	root := os.join_path(os.vtmp_dir(), 'v3_modulecache_vml_${os.getpid()}')
 	os.rmdir_all(root) or {}
 	os.mkdir_all(root) or { panic(err) }
 	defer {
 		os.rmdir_all(root) or {}
 	}
 	source := os.join_path(root, 'main.v')
-	qml := os.join_path(root, 'form.qml')
-	os.write_file(source, "module main\n\nfn build() { _ = \$qml('form.qml') }\n")!
-	os.write_file(qml, 'Label { text: "A" }')!
+	vml := os.join_path(root, 'form.vml')
+	os.write_file(source, "module main\n\nfn build() { _ = \$vml('form.vml') }\n")!
+	os.write_file(vml, 'Label { text: "A" }')!
 	cache_dir := os.join_path(root, 'cache')
 
-	first := cached_source_signature(cache_dir, 'qml', [source])
+	first := cached_source_signature(cache_dir, 'vml', [source])
 	assert first.len > 0
 	assert source_signature_details([source], '', '').cacheable
-	os.write_file(qml, 'Label { text: "Changed" }')!
-	second := cached_source_signature(cache_dir, 'qml', [source])
+	os.write_file(vml, 'Label { text: "Changed" }')!
+	second := cached_source_signature(cache_dir, 'vml', [source])
 	assert second.len > 0
 	assert second != first
-	ignored_paths, ignored_lookups, ignored_candidates, ignored_unresolved := compile_time_qml_paths(
-		"// \$qml('ignored.qml')\nconst s = \"\$qml('also_ignored.qml')\"", source)
+	ignored_paths, ignored_lookups, ignored_candidates, ignored_unresolved := compile_time_vml_paths(
+		"// \$vml('ignored.vml')\nconst s = \"\$vml('also_ignored.vml')\"", source)
 	assert ignored_paths.len == 0
 	assert ignored_lookups.len == 0
 	assert ignored_candidates.len == 0
 	assert !ignored_unresolved
 
 	os.write_file(source,
-		"module main\n\nconst form_path = 'form.qml'\nfn build() { _ = \$qml(form_path) }\n")!
+		"module main\n\nconst form_path = 'form.vml'\nfn build() { _ = \$vml(form_path) }\n")!
 	before_cache_entries := os.ls(cache_dir)!.len
-	dynamic := cached_source_signature_details_with_build_values(cache_dir, 'dynamic-qml', [
+	dynamic := cached_source_signature_details_with_build_values(cache_dir, 'dynamic-vml', [
 		source,
 	], '', '')
 	assert dynamic.signature.len > 0
 	assert !dynamic.cacheable
 	assert os.ls(cache_dir)!.len == before_cache_entries
-	dynamic_paths, dynamic_lookups, dynamic_candidates, dynamic_unresolved := compile_time_qml_paths(
+	dynamic_paths, dynamic_lookups, dynamic_candidates, dynamic_unresolved := compile_time_vml_paths(
 		os.read_file(source)!, source)
 	assert dynamic_paths.len == 0
 	assert dynamic_lookups.len == 0
 	assert dynamic_candidates.len == 0
 	assert dynamic_unresolved
-	concat_paths, concat_lookups, concat_candidates, concat_unresolved := compile_time_qml_paths(
-		"fn build() { _ = \$qml(template_dir + '/form.qml') }", source)
+	concat_paths, concat_lookups, concat_candidates, concat_unresolved := compile_time_vml_paths(
+		"fn build() { _ = \$vml(template_dir + '/form.vml') }", source)
 	assert concat_paths.len == 0
 	assert concat_lookups.len == 0
 	assert concat_candidates.len == 0
 	assert concat_unresolved
 	os.write_file(os.join_path(root, 'form'), 'not the selected template')!
-	os.write_file(source, "module main\n\nfn build() { _ = \$qml('form' + '.qml') }\n")!
+	os.write_file(source, "module main\n\nfn build() { _ = \$vml('form' + '.vml') }\n")!
 	literal_concat := source_signature_details([source], '', '')
 	assert literal_concat.signature.len > 0
 	assert !literal_concat.cacheable
-	literal_paths, literal_lookups, literal_candidates, literal_unresolved := compile_time_qml_paths(
+	literal_paths, literal_lookups, literal_candidates, literal_unresolved := compile_time_vml_paths(
 		os.read_file(source)!, source)
 	assert literal_paths.len == 0
 	assert literal_lookups.len == 0
@@ -478,109 +478,109 @@ fn test_cached_source_signature_tracks_qml_inputs() {
 	manager := Manager{
 		dir: os.join_path(root, 'module-cache')
 		enabled: true
-		salt: 'dynamic-qml-test'
+		salt: 'dynamic-vml-test'
 	}
-	manager.write_header('dynamic_qml', [source], '// generated header')!
-	if _ := manager.valid_header('dynamic_qml', [source]) {
-		assert false, 'an unresolved compile-time QML path must disable cache reuse'
+	manager.write_header('dynamic_vml', [source], '// generated header')!
+	if _ := manager.valid_header('dynamic_vml', [source]) {
+		assert false, 'an unresolved compile-time VML path must disable cache reuse'
 	}
 }
 
-fn test_qml_signature_scanner_preserves_raw_paths() {
-	call := r'$' + r"qml(r'C:\views\form.qml')"
+fn test_vml_signature_scanner_preserves_raw_paths() {
+	call := r'$' + r"vml(r'C:\views\form.vml')"
 	raw_path, next_pos, ok, is_raw := signature_string_call_arg(call, 4)
 	assert ok
 	assert is_raw
 	assert next_pos == call.len
-	assert raw_path == r'C:\views\form.qml'
+	assert raw_path == r'C:\views\form.vml'
 
-	target, expected_candidates := resolve_signature_qml_path(raw_path, @FILE)
-	paths, lookups, candidates, unresolved := compile_time_qml_paths(call, @FILE)
+	target, expected_candidates := resolve_signature_vml_path(raw_path, @FILE)
+	paths, lookups, candidates, unresolved := compile_time_vml_paths(call, @FILE)
 	assert paths == [os.real_path(target)]
 	assert lookups == [target]
 	assert candidates == expected_candidates.map(os.real_path(it))
 	assert !unresolved
 
-	root := os.join_path(os.vtmp_dir(), 'v3_modulecache_qml_raw_${os.getpid()}')
+	root := os.join_path(os.vtmp_dir(), 'v3_modulecache_vml_raw_${os.getpid()}')
 	os.rmdir_all(root) or {}
 	os.mkdir_all(root) or { panic(err) }
 	defer {
 		os.rmdir_all(root) or {}
 	}
 	source := os.join_path(root, 'main.v')
-	relative_call := r'$' + r"qml(r'views\form.qml')"
+	relative_call := r'$' + r"vml(r'views\form.vml')"
 	os.write_file(source, 'module main\n\nfn build() { _ = ' + relative_call + ' }\n')!
-	qml_path, _ := resolve_signature_qml_path(r'views\form.qml', source)
-	os.mkdir_all(os.dir(qml_path))!
-	os.write_file(qml_path, 'Label { text: "Raw" }')!
+	vml_path, _ := resolve_signature_vml_path(r'views\form.vml', source)
+	os.mkdir_all(os.dir(vml_path))!
+	os.write_file(vml_path, 'Label { text: "Raw" }')!
 	cache_dir := os.join_path(root, 'cache')
-	first := cached_source_signature(cache_dir, 'qml-raw', [source])
+	first := cached_source_signature(cache_dir, 'vml-raw', [source])
 	assert first.len > 0
 	assert source_signature_details([source], '', '').cacheable
-	assert cached_source_signature(cache_dir, 'qml-raw', [source]) == first
+	assert cached_source_signature(cache_dir, 'vml-raw', [source]) == first
 }
 
-fn test_cached_source_signature_tracks_shadowing_qml_paths() {
-	root := os.join_path(os.vtmp_dir(), 'v3_modulecache_qml_shadow_${os.getpid()}')
+fn test_cached_source_signature_tracks_shadowing_vml_paths() {
+	root := os.join_path(os.vtmp_dir(), 'v3_modulecache_vml_shadow_${os.getpid()}')
 	os.rmdir_all(root) or {}
 	os.mkdir_all(os.join_path(root, 'templates')) or { panic(err) }
 	defer {
 		os.rmdir_all(root) or {}
 	}
 	source := os.join_path(root, 'main.v')
-	direct_qml := os.join_path(root, 'form.qml')
-	direct_candidate := os.join_path(os.real_path(root), 'form.qml')
-	template_qml := os.join_path(root, 'templates', 'form.qml')
-	os.write_file(source, "module main\n\nfn build() { _ = \$qml('form.qml') }\n")!
-	os.write_file(template_qml, 'Label { text: "Template" }')!
+	direct_vml := os.join_path(root, 'form.vml')
+	direct_candidate := os.join_path(os.real_path(root), 'form.vml')
+	template_vml := os.join_path(root, 'templates', 'form.vml')
+	os.write_file(source, "module main\n\nfn build() { _ = \$vml('form.vml') }\n")!
+	os.write_file(template_vml, 'Label { text: "Template" }')!
 	cache_dir := os.join_path(root, 'cache')
 
-	first := cached_source_signature(cache_dir, 'qml-shadow', [source])
+	first := cached_source_signature(cache_dir, 'vml-shadow', [source])
 	assert first.len > 0
-	paths, lookups, candidates, unresolved := compile_time_qml_paths(os.read_file(source)!, source)
-	assert paths == [os.real_path(template_qml)]
-	assert lookups == [os.join_path(os.real_path(root), 'templates', 'form.qml')]
+	paths, lookups, candidates, unresolved := compile_time_vml_paths(os.read_file(source)!, source)
+	assert paths == [os.real_path(template_vml)]
+	assert lookups == [os.join_path(os.real_path(root), 'templates', 'form.vml')]
 	assert candidates == [direct_candidate]
 	assert !unresolved
 	details := source_signature_details([source], '', '')
-	assert details.validation.any(it == 'qmlcandidate=${direct_candidate}\tmissing')
+	assert details.validation.any(it == 'vmlcandidate=${direct_candidate}\tmissing')
 
-	os.write_file(direct_qml, 'Label { text: "Direct" }')!
-	second := cached_source_signature(cache_dir, 'qml-shadow', [source])
+	os.write_file(direct_vml, 'Label { text: "Direct" }')!
+	second := cached_source_signature(cache_dir, 'vml-shadow', [source])
 	assert second.len > 0
 	assert second != first
-	shadowing_paths, shadowing_lookups, shadowing_candidates, _ := compile_time_qml_paths(os.read_file(source)!, source)
-	assert shadowing_paths == [os.real_path(direct_qml)]
+	shadowing_paths, shadowing_lookups, shadowing_candidates, _ := compile_time_vml_paths(os.read_file(source)!, source)
+	assert shadowing_paths == [os.real_path(direct_vml)]
 	assert shadowing_lookups == [direct_candidate]
 	assert shadowing_candidates.len == 0
 }
 
-fn test_cached_source_signature_tracks_qml_symlink_target() {
-	root := os.join_path(os.vtmp_dir(), 'v3_modulecache_qml_symlink_${os.getpid()}')
+fn test_cached_source_signature_tracks_vml_symlink_target() {
+	root := os.join_path(os.vtmp_dir(), 'v3_modulecache_vml_symlink_${os.getpid()}')
 	os.rmdir_all(root) or {}
 	os.mkdir_all(root) or { panic(err) }
 	defer {
 		os.rmdir_all(root) or {}
 	}
 	source := os.join_path(root, 'main.v')
-	first_target := os.join_path(root, 'first.qml')
-	second_target := os.join_path(root, 'second.qml')
-	qml_link := os.join_path(root, 'form.qml')
-	os.write_file(source, "module main\n\nfn build() { _ = \$qml('form.qml') }\n")!
+	first_target := os.join_path(root, 'first.vml')
+	second_target := os.join_path(root, 'second.vml')
+	vml_link := os.join_path(root, 'form.vml')
+	os.write_file(source, "module main\n\nfn build() { _ = \$vml('form.vml') }\n")!
 	os.write_file(first_target, 'Label { text: "First" }')!
 	os.write_file(second_target, 'Label { text: "Second" }')!
-	os.symlink(first_target, qml_link) or { return }
+	os.symlink(first_target, vml_link) or { return }
 	cache_dir := os.join_path(root, 'cache')
 
-	first := cached_source_signature(cache_dir, 'qml-symlink', [source])
+	first := cached_source_signature(cache_dir, 'vml-symlink', [source])
 	assert first.len > 0
-	lookup_path := os.join_path(os.real_path(root), 'form.qml')
+	lookup_path := os.join_path(os.real_path(root), 'form.vml')
 	details := source_signature_details([source], '', '')
-	assert details.validation.any(it.starts_with('qmllookup=${lookup_path}\t${os.real_path(first_target)}\t'))
+	assert details.validation.any(it.starts_with('vmllookup=${lookup_path}\t${os.real_path(first_target)}\t'))
 
-	os.rm(qml_link)!
-	os.symlink(second_target, qml_link)!
-	second := cached_source_signature(cache_dir, 'qml-symlink', [source])
+	os.rm(vml_link)!
+	os.symlink(second_target, vml_link)!
+	second := cached_source_signature(cache_dir, 'vml-symlink', [source])
 	assert second.len > 0
 	assert second != first
 }

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -5752,8 +5752,8 @@ fn (mut p Parser) parse_comptime_expr() flat.NodeId {
 	if p.tok == .name && p.lit == 'embed_file' {
 		return p.parse_embed_file_expr()
 	}
-	if p.tok == .name && p.lit == 'qml' {
-		return p.parse_qml_template_expr(dollar_pos)
+	if p.tok == .name && p.lit == 'vml' {
+		return p.parse_vml_template_expr(dollar_pos)
 	}
 	if p.tok == .name && p.lit in ['zero', 'new'] {
 		name := p.lit

--- a/vlib/v3/parser/vml.v
+++ b/vlib/v3/parser/vml.v
@@ -4,7 +4,7 @@ import os
 import strings
 import v3.flat
 
-enum QmlTokenKind {
+enum VmlTokenKind {
 	name
 	string_
 	number
@@ -32,20 +32,20 @@ enum QmlTokenKind {
 	eof
 }
 
-struct QmlToken {
-	kind QmlTokenKind
+struct VmlToken {
+	kind VmlTokenKind
 	text string
 	line int
 }
 
-struct QmlLexer {
+struct VmlLexer {
 	source string
 mut:
 	pos  int
 	line int = 1
 }
 
-fn (mut l QmlLexer) advance() u8 {
+fn (mut l VmlLexer) advance() u8 {
 	c := l.source[l.pos]
 	l.pos++
 	if c == `\n` {
@@ -54,7 +54,7 @@ fn (mut l QmlLexer) advance() u8 {
 	return c
 }
 
-fn (mut l QmlLexer) skip_space() {
+fn (mut l VmlLexer) skip_space() {
 	for l.pos < l.source.len {
 		c := l.source[l.pos]
 		if c in [` `, `\t`, `\r`, `\n`] {
@@ -69,20 +69,20 @@ fn (mut l QmlLexer) skip_space() {
 	}
 }
 
-fn qml_is_name_char(c u8) bool {
+fn vml_is_name_char(c u8) bool {
 	return c.is_alnum() || c in [`_`, `.`, `#`]
 }
 
-fn (mut l QmlLexer) read_name() QmlToken {
+fn (mut l VmlLexer) read_name() VmlToken {
 	start := l.pos
 	line := l.line
-	for l.pos < l.source.len && qml_is_name_char(l.source[l.pos]) {
+	for l.pos < l.source.len && vml_is_name_char(l.source[l.pos]) {
 		l.pos++
 	}
-	return QmlToken{.name, l.source[start..l.pos], line}
+	return VmlToken{.name, l.source[start..l.pos], line}
 }
 
-fn (mut l QmlLexer) read_number() QmlToken {
+fn (mut l VmlLexer) read_number() VmlToken {
 	start := l.pos
 	line := l.line
 	mut dot := false
@@ -97,10 +97,10 @@ fn (mut l QmlLexer) read_number() QmlToken {
 			break
 		}
 	}
-	return QmlToken{.number, l.source[start..l.pos], line}
+	return VmlToken{.number, l.source[start..l.pos], line}
 }
 
-fn (mut l QmlLexer) read_string() !QmlToken {
+fn (mut l VmlLexer) read_string() !VmlToken {
 	line := l.line
 	l.advance()
 	mut value := []u8{}
@@ -116,7 +116,7 @@ fn (mut l QmlLexer) read_string() !QmlToken {
 				else { value << next }
 			}
 		} else if c == `"` {
-			return QmlToken{.string_, value.bytestr(), line}
+			return VmlToken{.string_, value.bytestr(), line}
 		} else {
 			value << c
 		}
@@ -124,36 +124,36 @@ fn (mut l QmlLexer) read_string() !QmlToken {
 	return error('unterminated string at line ${line}')
 }
 
-fn tokenize_qml(source string) ![]QmlToken {
-	mut lexer := QmlLexer{ source: source }
-	mut tokens := []QmlToken{}
+fn tokenize_vml(source string) ![]VmlToken {
+	mut lexer := VmlLexer{ source: source }
+	mut tokens := []VmlToken{}
 	for {
 		lexer.skip_space()
 		if lexer.pos >= source.len {
-			tokens << QmlToken{.eof, '', lexer.line}
+			tokens << VmlToken{.eof, '', lexer.line}
 			return tokens
 		}
 		line := lexer.line
 		c := source[lexer.pos]
 		match c {
-			`{` { tokens << QmlToken{.lbrace, '{', line} }
-			`}` { tokens << QmlToken{.rbrace, '}', line} }
-			`:` { tokens << QmlToken{.colon, ':', line} }
-			`(` { tokens << QmlToken{.lpar, '(', line} }
-			`)` { tokens << QmlToken{.rpar, ')', line} }
-			`,` { tokens << QmlToken{.comma, ',', line} }
-			`?` { tokens << QmlToken{.question, '?', line} }
-			`+` { tokens << QmlToken{.plus, '+', line} }
-			`-` { tokens << QmlToken{.minus, '-', line} }
-			`*` { tokens << QmlToken{.mul, '*', line} }
-			`/` { tokens << QmlToken{.div, '/', line} }
-			`%` { tokens << QmlToken{.mod, '%', line} }
+			`{` { tokens << VmlToken{.lbrace, '{', line} }
+			`}` { tokens << VmlToken{.rbrace, '}', line} }
+			`:` { tokens << VmlToken{.colon, ':', line} }
+			`(` { tokens << VmlToken{.lpar, '(', line} }
+			`)` { tokens << VmlToken{.rpar, ')', line} }
+			`,` { tokens << VmlToken{.comma, ',', line} }
+			`?` { tokens << VmlToken{.question, '?', line} }
+			`+` { tokens << VmlToken{.plus, '+', line} }
+			`-` { tokens << VmlToken{.minus, '-', line} }
+			`*` { tokens << VmlToken{.mul, '*', line} }
+			`/` { tokens << VmlToken{.div, '/', line} }
+			`%` { tokens << VmlToken{.mod, '%', line} }
 			`!` {
 				lexer.pos++
 				if lexer.pos < source.len && source[lexer.pos] == `=` {
-					tokens << QmlToken{.ne, '!=', line}
+					tokens << VmlToken{.ne, '!=', line}
 				} else {
-					tokens << QmlToken{.not, '!', line}
+					tokens << VmlToken{.not, '!', line}
 					continue
 				}
 			}
@@ -162,23 +162,23 @@ fn tokenize_qml(source string) ![]QmlToken {
 				if lexer.pos >= source.len || source[lexer.pos] != `=` {
 					return error('expected `==` at line ${line}')
 				}
-				tokens << QmlToken{.eq, '==', line}
+				tokens << VmlToken{.eq, '==', line}
 			}
 			`<` {
 				lexer.pos++
 				if lexer.pos < source.len && source[lexer.pos] == `=` {
-					tokens << QmlToken{.le, '<=', line}
+					tokens << VmlToken{.le, '<=', line}
 				} else {
-					tokens << QmlToken{.lt, '<', line}
+					tokens << VmlToken{.lt, '<', line}
 					continue
 				}
 			}
 			`>` {
 				lexer.pos++
 				if lexer.pos < source.len && source[lexer.pos] == `=` {
-					tokens << QmlToken{.ge, '>=', line}
+					tokens << VmlToken{.ge, '>=', line}
 				} else {
-					tokens << QmlToken{.gt, '>', line}
+					tokens << VmlToken{.gt, '>', line}
 					continue
 				}
 			}
@@ -187,14 +187,14 @@ fn tokenize_qml(source string) ![]QmlToken {
 				if lexer.pos >= source.len || source[lexer.pos] != `&` {
 					return error('expected `&&` at line ${line}')
 				}
-				tokens << QmlToken{.and, '&&', line}
+				tokens << VmlToken{.and, '&&', line}
 			}
 			`|` {
 				lexer.pos++
 				if lexer.pos >= source.len || source[lexer.pos] != `|` {
 					return error('expected `||` at line ${line}')
 				}
-				tokens << QmlToken{.or, '||', line}
+				tokens << VmlToken{.or, '||', line}
 			}
 			`"` {
 				tokens << lexer.read_string()!
@@ -205,7 +205,7 @@ fn tokenize_qml(source string) ![]QmlToken {
 					tokens << lexer.read_number()
 					continue
 				}
-				if qml_is_name_char(c) {
+				if vml_is_name_char(c) {
 					tokens << lexer.read_name()
 					continue
 				}
@@ -217,7 +217,7 @@ fn tokenize_qml(source string) ![]QmlToken {
 	return tokens
 }
 
-enum QmlExprKind {
+enum VmlExprKind {
 	literal
 	path
 	call
@@ -227,53 +227,53 @@ enum QmlExprKind {
 	interpolation
 }
 
-struct QmlInterpolationPart {
+struct VmlInterpolationPart {
 	text string
 	// A nil expression marks a literal-text part. V requires `unsafe` only to
 	// declare that sentinel pointer default; interpolation logic checks it before use.
-	expr &QmlExpr = unsafe { nil }
+	expr &VmlExpr = unsafe { nil }
 }
 
-struct QmlExpr {
-	kind  QmlExprKind
+struct VmlExpr {
+	kind  VmlExprKind
 	value string
 	line  int
 	// The tagged expression tree is recursive. Nil marks child links unused by
 	// the current kind, and V requires `unsafe` only for those pointer defaults.
-	left   &QmlExpr = unsafe { nil }
-	right  &QmlExpr = unsafe { nil }
-	third  &QmlExpr = unsafe { nil }
-	args   []&QmlExpr
-	parts  []QmlInterpolationPart
+	left   &VmlExpr = unsafe { nil }
+	right  &VmlExpr = unsafe { nil }
+	third  &VmlExpr = unsafe { nil }
+	args   []&VmlExpr
+	parts  []VmlInterpolationPart
 	quoted bool
 }
 
-struct QmlProperty {
+struct VmlProperty {
 	name          string
 	declared_type string
-	expr          &QmlExpr
+	expr          &VmlExpr
 }
 
-struct QmlNode {
+struct VmlNode {
 	tag  string
 	line int
 mut:
 	id         string
-	properties []QmlProperty
-	children   []&QmlNode
+	properties []VmlProperty
+	children   []&VmlNode
 }
 
-struct QmlSourceParser {
-	tokens []QmlToken
+struct VmlSourceParser {
+	tokens []VmlToken
 mut:
 	pos int
 }
 
-fn (p &QmlSourceParser) at() QmlToken {
-	return if p.pos < p.tokens.len { p.tokens[p.pos] } else { QmlToken{.eof, '', 0} }
+fn (p &VmlSourceParser) at() VmlToken {
+	return if p.pos < p.tokens.len { p.tokens[p.pos] } else { VmlToken{.eof, '', 0} }
 }
 
-fn (mut p QmlSourceParser) take(kind QmlTokenKind) !QmlToken {
+fn (mut p VmlSourceParser) take(kind VmlTokenKind) !VmlToken {
 	token := p.at()
 	if token.kind != kind {
 		return error('expected ${kind}, got ${token.kind} (`${token.text}`) at line ${token.line}')
@@ -282,10 +282,10 @@ fn (mut p QmlSourceParser) take(kind QmlTokenKind) !QmlToken {
 	return token
 }
 
-fn (mut p QmlSourceParser) parse_node() !&QmlNode {
+fn (mut p VmlSourceParser) parse_node() !&VmlNode {
 	tag := p.take(.name)!
 	p.take(.lbrace)!
-	mut node := &QmlNode{ tag: tag.text, line: tag.line }
+	mut node := &VmlNode{ tag: tag.text, line: tag.line }
 	for p.at().kind !in [.rbrace, .eof] {
 		if p.at().kind != .name {
 			return error('unexpected token `${p.at().text}` at line ${p.at().line}')
@@ -295,7 +295,7 @@ fn (mut p QmlSourceParser) parse_node() !&QmlNode {
 			typ := p.take(.name)!
 			name := p.take(.name)!
 			p.take(.colon)!
-			node.properties << QmlProperty{ name: name.text, declared_type: typ.text, expr: p.parse_expression()! }
+			node.properties << VmlProperty{ name: name.text, declared_type: typ.text, expr: p.parse_expression()! }
 		} else if p.pos + 1 < p.tokens.len && p.tokens[p.pos + 1].kind == .lbrace {
 			node.children << p.parse_node()!
 		} else if p.pos + 1 < p.tokens.len && p.tokens[p.pos + 1].kind == .colon {
@@ -308,7 +308,7 @@ fn (mut p QmlSourceParser) parse_node() !&QmlNode {
 				}
 				node.id = expr.value
 			}
-			node.properties << QmlProperty{ name: name.text, expr: expr }
+			node.properties << VmlProperty{ name: name.text, expr: expr }
 		} else {
 			return error('unexpected token `${p.at().text}` at line ${p.at().line}')
 		}
@@ -317,11 +317,11 @@ fn (mut p QmlSourceParser) parse_node() !&QmlNode {
 	return node
 }
 
-fn (mut p QmlSourceParser) parse_expression() !&QmlExpr {
+fn (mut p VmlSourceParser) parse_expression() !&VmlExpr {
 	return p.parse_conditional()
 }
 
-fn (mut p QmlSourceParser) parse_conditional() !&QmlExpr {
+fn (mut p VmlSourceParser) parse_conditional() !&VmlExpr {
 	condition := p.parse_or()!
 	if p.at().kind != .question {
 		return condition
@@ -329,7 +329,7 @@ fn (mut p QmlSourceParser) parse_conditional() !&QmlExpr {
 	line := p.take(.question)!.line
 	when_true := p.parse_expression()!
 	p.take(.colon)!
-	return &QmlExpr{
+	return &VmlExpr{
 		kind: .conditional
 		line: line
 		left: condition
@@ -338,12 +338,12 @@ fn (mut p QmlSourceParser) parse_conditional() !&QmlExpr {
 	}
 }
 
-fn (mut p QmlSourceParser) parse_or() !&QmlExpr {
+fn (mut p VmlSourceParser) parse_or() !&VmlExpr {
 	mut left := p.parse_and()!
 	for p.at().kind == .or {
 		op := p.at()
 		p.pos++
-		left = &QmlExpr{
+		left = &VmlExpr{
 			kind: .binary
 			value: op.text
 			line: op.line
@@ -354,12 +354,12 @@ fn (mut p QmlSourceParser) parse_or() !&QmlExpr {
 	return left
 }
 
-fn (mut p QmlSourceParser) parse_and() !&QmlExpr {
+fn (mut p VmlSourceParser) parse_and() !&VmlExpr {
 	mut left := p.parse_equality()!
 	for p.at().kind == .and {
 		op := p.at()
 		p.pos++
-		left = &QmlExpr{
+		left = &VmlExpr{
 			kind: .binary
 			value: op.text
 			line: op.line
@@ -370,12 +370,12 @@ fn (mut p QmlSourceParser) parse_and() !&QmlExpr {
 	return left
 }
 
-fn (mut p QmlSourceParser) parse_equality() !&QmlExpr {
+fn (mut p VmlSourceParser) parse_equality() !&VmlExpr {
 	mut left := p.parse_comparison()!
 	for p.at().kind in [.eq, .ne] {
 		op := p.at()
 		p.pos++
-		left = &QmlExpr{
+		left = &VmlExpr{
 			kind: .binary
 			value: op.text
 			line: op.line
@@ -386,12 +386,12 @@ fn (mut p QmlSourceParser) parse_equality() !&QmlExpr {
 	return left
 }
 
-fn (mut p QmlSourceParser) parse_comparison() !&QmlExpr {
+fn (mut p VmlSourceParser) parse_comparison() !&VmlExpr {
 	mut left := p.parse_term()!
 	for p.at().kind in [.lt, .le, .gt, .ge] {
 		op := p.at()
 		p.pos++
-		left = &QmlExpr{
+		left = &VmlExpr{
 			kind: .binary
 			value: op.text
 			line: op.line
@@ -402,12 +402,12 @@ fn (mut p QmlSourceParser) parse_comparison() !&QmlExpr {
 	return left
 }
 
-fn (mut p QmlSourceParser) parse_term() !&QmlExpr {
+fn (mut p VmlSourceParser) parse_term() !&VmlExpr {
 	mut left := p.parse_factor()!
 	for p.at().kind in [.plus, .minus] {
 		op := p.at()
 		p.pos++
-		left = &QmlExpr{
+		left = &VmlExpr{
 			kind: .binary
 			value: op.text
 			line: op.line
@@ -418,12 +418,12 @@ fn (mut p QmlSourceParser) parse_term() !&QmlExpr {
 	return left
 }
 
-fn (mut p QmlSourceParser) parse_factor() !&QmlExpr {
+fn (mut p VmlSourceParser) parse_factor() !&VmlExpr {
 	mut left := p.parse_unary()!
 	for p.at().kind in [.mul, .div, .mod] {
 		op := p.at()
 		p.pos++
-		left = &QmlExpr{
+		left = &VmlExpr{
 			kind: .binary
 			value: op.text
 			line: op.line
@@ -434,27 +434,27 @@ fn (mut p QmlSourceParser) parse_factor() !&QmlExpr {
 	return left
 }
 
-fn (mut p QmlSourceParser) parse_unary() !&QmlExpr {
+fn (mut p VmlSourceParser) parse_unary() !&VmlExpr {
 	if p.at().kind in [.not, .minus] {
 		op := p.at()
 		p.pos++
-		return &QmlExpr{ kind: .unary, value: op.text, line: op.line, left: p.parse_unary()! }
+		return &VmlExpr{ kind: .unary, value: op.text, line: op.line, left: p.parse_unary()! }
 	}
 	return p.parse_primary()
 }
 
-fn (mut p QmlSourceParser) parse_primary() !&QmlExpr {
+fn (mut p VmlSourceParser) parse_primary() !&VmlExpr {
 	token := p.at()
 	match token.kind {
 		.string_ {
 			p.pos++
-			return parse_qml_interpolation(token.text, token.line)!
+			return parse_vml_interpolation(token.text, token.line)!
 		}
 		.name, .number {
 			p.pos++
 			if p.at().kind == .lpar {
 				p.pos++
-				mut args := []&QmlExpr{}
+				mut args := []&VmlExpr{}
 				if p.at().kind != .rpar {
 					for {
 						args << p.parse_expression()!
@@ -465,13 +465,13 @@ fn (mut p QmlSourceParser) parse_primary() !&QmlExpr {
 					}
 				}
 				p.take(.rpar)!
-				return &QmlExpr{ kind: .call, value: token.text, line: token.line, args: args }
+				return &VmlExpr{ kind: .call, value: token.text, line: token.line, args: args }
 			}
-			return &QmlExpr{
+			return &VmlExpr{
 				kind: if token.kind == .number || token.text in ['true', 'false'] {
-					QmlExprKind.literal
+					VmlExprKind.literal
 				} else {
-					QmlExprKind.path
+					VmlExprKind.path
 				}
 				value: token.text
 				line: token.line
@@ -489,7 +489,7 @@ fn (mut p QmlSourceParser) parse_primary() !&QmlExpr {
 	}
 }
 
-fn qml_interpolation_end(value string, start int) ?int {
+fn vml_interpolation_end(value string, start int) ?int {
 	mut quoted := false
 	mut escaped := false
 	mut nested_braces := 0
@@ -519,43 +519,43 @@ fn qml_interpolation_end(value string, start int) ?int {
 	return none
 }
 
-fn parse_qml_interpolation(value string, line int) !&QmlExpr {
+fn parse_vml_interpolation(value string, line int) !&VmlExpr {
 	if !value.contains(r'${') {
-		return &QmlExpr{ kind: .literal, value: value, line: line, quoted: true }
+		return &VmlExpr{ kind: .literal, value: value, line: line, quoted: true }
 	}
-	mut parts := []QmlInterpolationPart{}
+	mut parts := []VmlInterpolationPart{}
 	mut cursor := 0
 	for cursor < value.len {
 		start_relative := value[cursor..].index(r'${') or {
-			parts << QmlInterpolationPart{ text: value[cursor..] }
+			parts << VmlInterpolationPart{ text: value[cursor..] }
 			break
 		}
 		start := cursor + start_relative
 		if start > cursor {
-			parts << QmlInterpolationPart{ text: value[cursor..start] }
+			parts << VmlInterpolationPart{ text: value[cursor..start] }
 		}
-		end := qml_interpolation_end(value, start + 2) or {
+		end := vml_interpolation_end(value, start + 2) or {
 			return error('unterminated interpolation at line ${line}')
 		}
-		tokens := tokenize_qml(value[start + 2..end])!
-		mut parser := QmlSourceParser{ tokens: tokens }
-		parts << QmlInterpolationPart{ expr: parser.parse_expression()! }
+		tokens := tokenize_vml(value[start + 2..end])!
+		mut parser := VmlSourceParser{ tokens: tokens }
+		parts << VmlInterpolationPart{ expr: parser.parse_expression()! }
 		parser.take(.eof) or { return error('invalid interpolation at line ${line}: ${err}') }
 		cursor = end + 1
 	}
-	return &QmlExpr{ kind: .interpolation, line: line, parts: parts }
+	return &VmlExpr{ kind: .interpolation, line: line, parts: parts }
 }
 
-fn parse_qml_source(source string) !&QmlNode {
-	tokens := tokenize_qml(source)!
-	mut parser := QmlSourceParser{ tokens: tokens }
+fn parse_vml_source(source string) !&VmlNode {
+	tokens := tokenize_vml(source)!
+	mut parser := VmlSourceParser{ tokens: tokens }
 	root := parser.parse_node()!
 	parser.take(.eof)!
-	validate_compiled_qml_node(root)!
+	validate_compiled_vml_node(root)!
 	return root
 }
 
-fn validate_compiled_qml_node(node &QmlNode) ! {
+fn validate_compiled_vml_node(node &VmlNode) ! {
 	mut bindings := 0
 	for property in node.properties {
 		if property.name.starts_with('bind.') {
@@ -583,26 +583,26 @@ fn validate_compiled_qml_node(node &QmlNode) ! {
 		return error('an element can only have one two-way binding at line ${node.line}')
 	}
 	if node.tag == 'Repeater' {
-		if qml_find_property(node, 'model') == none {
+		if vml_find_property(node, 'model') == none {
 			return error('Repeater requires `model` at line ${node.line}')
 		}
-		if qml_find_property(node, 'key') == none {
+		if vml_find_property(node, 'key') == none {
 			return error('Repeater requires a stable `key` at line ${node.line}')
 		}
 	}
 	for child in node.children {
-		validate_compiled_qml_node(child)!
+		validate_compiled_vml_node(child)!
 	}
 }
 
-fn qml_expr_text(expr &QmlExpr) string {
+fn vml_expr_text(expr &VmlExpr) string {
 	return match expr.kind {
 		.literal, .path { expr.value }
-		.call { expr.value + '(' + expr.args.map(qml_expr_text(it)).join(', ') + ')' }
-		.unary { expr.value + qml_expr_text(expr.left) }
-		.binary { '${qml_expr_text(expr.left)} ${expr.value} ${qml_expr_text(expr.right)}' }
+		.call { expr.value + '(' + expr.args.map(vml_expr_text(it)).join(', ') + ')' }
+		.unary { expr.value + vml_expr_text(expr.left) }
+		.binary { '${vml_expr_text(expr.left)} ${expr.value} ${vml_expr_text(expr.right)}' }
 		.conditional {
-			'${qml_expr_text(expr.left)} ? ${qml_expr_text(expr.right)} : ${qml_expr_text(expr.third)}'
+			'${vml_expr_text(expr.left)} ? ${vml_expr_text(expr.right)} : ${vml_expr_text(expr.third)}'
 		}
 		.interpolation {
 			mut value := ''
@@ -610,7 +610,7 @@ fn qml_expr_text(expr &QmlExpr) string {
 				value += if isnil(part.expr) {
 					part.text
 				} else {
-					r'${' + qml_expr_text(part.expr) + '}'
+					r'${' + vml_expr_text(part.expr) + '}'
 				}
 			}
 			value
@@ -618,11 +618,11 @@ fn qml_expr_text(expr &QmlExpr) string {
 	}
 }
 
-// parse_qml_template_expr compiles `$qml('file.qml')` into a direct ui2.Element builder.
-fn (mut p Parser) parse_qml_template_expr(call_start int) flat.NodeId {
-	p.next() // qml
+// parse_vml_template_expr compiles `$vml('file.vml')` into a direct ui2.Element builder.
+fn (mut p Parser) parse_vml_template_expr(call_start int) flat.NodeId {
+	p.next() // vml
 	if p.tok != .lpar {
-		p.record_diagnostic('expected `(` after `\$qml`', p.tok_pos)
+		p.record_diagnostic('expected `(` after `\$vml`', p.tok_pos)
 		return p.add_val_id(5, '')
 	}
 	p.next()
@@ -635,24 +635,24 @@ fn (mut p Parser) parse_qml_template_expr(call_start int) flat.NodeId {
 		p.next()
 	}
 	if arg.len == 0 {
-		p.record_diagnostic('`\$qml()` path must be a compile-time string', call_start)
+		p.record_diagnostic('`\$vml()` path must be a compile-time string', call_start)
 		return p.add_val_id(5, '')
 	}
 	path := p.resolve_veb_template_path(false, arg)
 	if !os.exists(path) {
-		p.record_diagnostic('QML file `${path}` does not exist', call_start)
+		p.record_diagnostic('VML file `${path}` does not exist', call_start)
 		return p.add_val_id(5, '')
 	}
 	source := os.read_file(path) or {
-		p.record_diagnostic('cannot read QML file `${path}`: ${err.msg()}', call_start)
+		p.record_diagnostic('cannot read VML file `${path}`: ${err.msg()}', call_start)
 		return p.add_val_id(5, '')
 	}
-	root := parse_qml_source(source) or {
+	root := parse_vml_source(source) or {
 		p.record_diagnostic('${path}: ${err.msg()}', call_start)
 		return p.add_val_id(5, '')
 	}
-	mut compiler := QmlCompiler{
-		uses_app: qml_node_uses_path(root, 'app')
+	mut compiler := VmlCompiler{
+		uses_app: vml_node_uses_path(root, 'app')
 	}
 	generated := compiler.compile(root)
 	template := flat.Node{
@@ -660,119 +660,119 @@ fn (mut p Parser) parse_qml_template_expr(call_start int) flat.NodeId {
 		pos: p.span_to(call_start)
 	}
 	return p.parse_veb_template_replacement_expr(generated, template, []TemplateSourceLine{}) or {
-		p.record_diagnostic('could not lower QML file `${path}`', call_start)
+		p.record_diagnostic('could not lower VML file `${path}`', call_start)
 		p.add_val_id(5, '')
 	}
 }
 
-fn qml_node_uses_path(node &QmlNode, base string) bool {
+fn vml_node_uses_path(node &VmlNode, base string) bool {
 	for property in node.properties {
-		if qml_expr_uses_path(property.expr, base) {
+		if vml_expr_uses_path(property.expr, base) {
 			return true
 		}
 	}
 	for child in node.children {
-		if qml_node_uses_path(child, base) {
+		if vml_node_uses_path(child, base) {
 			return true
 		}
 	}
 	return false
 }
 
-fn qml_expr_uses_path(expr &QmlExpr, base string) bool {
+fn vml_expr_uses_path(expr &VmlExpr, base string) bool {
 	if expr.kind in [.path, .call] && (expr.value == base || expr.value.starts_with(base + '.')) {
 		return true
 	}
-	if !isnil(expr.left) && qml_expr_uses_path(expr.left, base) {
+	if !isnil(expr.left) && vml_expr_uses_path(expr.left, base) {
 		return true
 	}
-	if !isnil(expr.right) && qml_expr_uses_path(expr.right, base) {
+	if !isnil(expr.right) && vml_expr_uses_path(expr.right, base) {
 		return true
 	}
-	if !isnil(expr.third) && qml_expr_uses_path(expr.third, base) {
+	if !isnil(expr.third) && vml_expr_uses_path(expr.third, base) {
 		return true
 	}
 	for arg in expr.args {
-		if qml_expr_uses_path(arg, base) {
+		if vml_expr_uses_path(arg, base) {
 			return true
 		}
 	}
 	for part in expr.parts {
-		if !isnil(part.expr) && qml_expr_uses_path(part.expr, base) {
+		if !isnil(part.expr) && vml_expr_uses_path(part.expr, base) {
 			return true
 		}
 	}
 	return false
 }
 
-struct QmlNamedValue {
+struct VmlNamedValue {
 	frame string
 	props map[string]string
 }
 
-struct QmlScope {
+struct VmlScope {
 mut:
-	ids     map[string]QmlNamedValue
+	ids     map[string]VmlNamedValue
 	special map[string]string
 }
 
-struct QmlCompiler {
+struct VmlCompiler {
 	uses_app bool
 mut:
 	out strings.Builder
 }
 
-fn (mut c QmlCompiler) compile(root &QmlNode) string {
+fn (mut c VmlCompiler) compile(root &VmlNode) string {
 	c.out = strings.new_builder(4096)
 	capture := if c.uses_app { '[app] ' } else { '' }
 	c.out.writeln('(fn ${capture}() ui2.Element {')
-	c.out.writeln('\tqml_input_0 := ui2.bounds()')
-	scope := QmlScope{
-		ids: map[string]QmlNamedValue{}
+	c.out.writeln('\tvml_input_0 := ui2.bounds()')
+	scope := VmlScope{
+		ids: map[string]VmlNamedValue{}
 		special: map[string]string{}
 	}
-	c.compile_node(root, '0', 'qml_input_0', scope, '')
-	c.out.writeln('\treturn qml_element_0')
+	c.compile_node(root, '0', 'vml_input_0', scope, '')
+	c.out.writeln('\treturn vml_element_0')
 	c.out.write_string('}())')
 	return c.out.str()
 }
 
-fn qml_clone_scope(scope QmlScope) QmlScope {
-	return QmlScope{
+fn vml_clone_scope(scope VmlScope) VmlScope {
+	return VmlScope{
 		ids: scope.ids.clone()
 		special: scope.special.clone()
 	}
 }
 
-fn qml_var(path string) string {
+fn vml_var(path string) string {
 	return path.replace('.', '_').replace('-', '_')
 }
 
-fn qml_quote(value string) string {
+fn vml_quote(value string) string {
 	return "'" + value.replace('\\', '\\\\').replace("'", "\\'").replace('\n', '\\n').replace('\r', '\\r').replace('\t', '\\t').replace(r'$', r'\$') + "'"
 }
 
-fn qml_interpolation_text(value string) string {
+fn vml_interpolation_text(value string) string {
 	return value.replace('\\', '\\\\').replace("'", "\\'").replace('\n', '\\n').replace('\r', '\\r').replace('\t', '\\t').replace(r'$', r'\$')
 }
 
-fn qml_stringify(expression string) string {
+fn vml_stringify(expression string) string {
 	return "'" + r'$' + '{' + expression + "}'"
 }
 
-fn qml_color_call(expression string) string {
-	value := qml_stringify(expression)
+fn vml_color_call(expression string) string {
+	value := vml_stringify(expression)
 	return "(if typeof(${expression}).name == 'string' { ui2.parse_hex_color(${value}) } else { u32(${value}.u64()) })"
 }
 
-fn qml_numeric_cast(type_name string, expression string) string {
+fn vml_numeric_cast(type_name string, expression string) string {
 	if expression.starts_with('(') && expression.ends_with(')') {
 		return type_name + expression
 	}
 	return '${type_name}(${expression})'
 }
 
-enum QmlExprUse {
+enum VmlExprUse {
 	raw
 	number
 	string_
@@ -780,7 +780,7 @@ enum QmlExprUse {
 	color
 }
 
-fn qml_property_use(property QmlProperty) QmlExprUse {
+fn vml_property_use(property VmlProperty) VmlExprUse {
 	if property.declared_type.len > 0 {
 		return match property.declared_type {
 			'f64', 'f32', 'int' { .number }
@@ -818,17 +818,17 @@ fn qml_property_use(property QmlProperty) QmlExprUse {
 	return .string_
 }
 
-fn qml_expr_is_string(expr &QmlExpr) bool {
+fn vml_expr_is_string(expr &VmlExpr) bool {
 	if expr.kind == .interpolation || (expr.kind == .literal && expr.quoted) {
 		return true
 	}
 	if expr.kind == .conditional {
-		return qml_expr_is_string(expr.right) || qml_expr_is_string(expr.third)
+		return vml_expr_is_string(expr.right) || vml_expr_is_string(expr.third)
 	}
 	return false
 }
 
-fn (c &QmlCompiler) resolve_path(path string, scope QmlScope) (string, bool) {
+fn (c &VmlCompiler) resolve_path(path string, scope VmlScope) (string, bool) {
 	parts := path.split('.')
 	if parts.len == 0 {
 		return path, false
@@ -851,7 +851,7 @@ fn (c &QmlCompiler) resolve_path(path string, scope QmlScope) (string, bool) {
 	return path, path.contains('.')
 }
 
-fn (c &QmlCompiler) expr(expr &QmlExpr, scope QmlScope, use QmlExprUse) string {
+fn (c &VmlCompiler) expr(expr &VmlExpr, scope VmlScope, use VmlExprUse) string {
 	match expr.kind {
 		.literal {
 			if expr.quoted {
@@ -859,12 +859,12 @@ fn (c &QmlCompiler) expr(expr &QmlExpr, scope QmlScope, use QmlExprUse) string {
 					if expr.value.starts_with('#') && expr.value.len == 7 {
 						return 'u32(0x${expr.value[1..]})'
 					}
-					return 'ui2.parse_hex_color(${qml_quote(expr.value)})'
+					return 'ui2.parse_hex_color(${vml_quote(expr.value)})'
 				}
-				return qml_quote(expr.value)
+				return vml_quote(expr.value)
 			}
 			return match use {
-				.string_ { qml_quote(expr.value) }
+				.string_ { vml_quote(expr.value) }
 				.number { 'f64(${expr.value})' }
 				else { expr.value }
 			}
@@ -878,13 +878,13 @@ fn (c &QmlCompiler) expr(expr &QmlExpr, scope QmlScope, use QmlExprUse) string {
 				if !known {
 					return 'u32(0xffffff)'
 				}
-				return qml_color_call(resolved)
+				return vml_color_call(resolved)
 			}
 			if use == .string_ {
 				if !known {
-					return qml_quote(expr.value)
+					return vml_quote(expr.value)
 				}
-				return qml_stringify(resolved)
+				return vml_stringify(resolved)
 			}
 			if use == .number {
 				return 'f64(${resolved})'
@@ -896,48 +896,48 @@ fn (c &QmlCompiler) expr(expr &QmlExpr, scope QmlScope, use QmlExprUse) string {
 			resolved, _ := c.resolve_path(expr.value, scope)
 			call := '${resolved}(${args})'
 			return match use {
-				.string_ { qml_stringify(call) }
+				.string_ { vml_stringify(call) }
 				.number { 'f64(${call})' }
-				.color { qml_color_call(call) }
+				.color { vml_color_call(call) }
 				else { call }
 			}
 		}
 		.unary {
 			operand_use := if use in [.raw, .string_] {
-				QmlExprUse.raw
+				VmlExprUse.raw
 			} else if expr.value == '!' {
-				QmlExprUse.bool_
+				VmlExprUse.bool_
 			} else {
-				QmlExprUse.number
+				VmlExprUse.number
 			}
 			result := '(${expr.value}${c.expr(expr.left, scope, operand_use)})'
-			return if use == .string_ { qml_stringify(result) } else { result }
+			return if use == .string_ { vml_stringify(result) } else { result }
 		}
 		.binary {
 			if expr.value in ['&&', '||'] {
 				result := '(${c.expr(expr.left, scope, .bool_)} ${expr.value} ${c.expr(expr.right, scope, .bool_)})'
-				return if use == .string_ { qml_stringify(result) } else { result }
+				return if use == .string_ { vml_stringify(result) } else { result }
 			}
 			if expr.value in ['==', '!=', '<', '<=', '>', '>='] {
-				operand_use := if qml_expr_is_string(expr.left) || qml_expr_is_string(expr.right) {
-					QmlExprUse.string_
+				operand_use := if vml_expr_is_string(expr.left) || vml_expr_is_string(expr.right) {
+					VmlExprUse.string_
 				} else {
-					QmlExprUse.raw
+					VmlExprUse.raw
 				}
 				result := '(${c.expr(expr.left, scope, operand_use)} ${expr.value} ${c.expr(expr.right, scope, operand_use)})'
-				return if use == .string_ { qml_stringify(result) } else { result }
+				return if use == .string_ { vml_stringify(result) } else { result }
 			}
 			if use == .raw {
 				return '(${c.expr(expr.left, scope, .raw)} ${expr.value} ${c.expr(expr.right, scope, .raw)})'
 			}
 			if expr.value == '+' && use == .string_ {
-				if qml_expr_is_string(expr.left) || qml_expr_is_string(expr.right) {
+				if vml_expr_is_string(expr.left) || vml_expr_is_string(expr.right) {
 					return '(${c.expr(expr.left, scope, .string_)} + ${c.expr(expr.right, scope, .string_)})'
 				}
-				return qml_stringify('(${c.expr(expr.left, scope, .raw)} + ${c.expr(expr.right, scope, .raw)})')
+				return vml_stringify('(${c.expr(expr.left, scope, .raw)} + ${c.expr(expr.right, scope, .raw)})')
 			}
 			if use == .string_ && expr.value in ['-', '*', '/', '%'] {
-				return qml_stringify('(${c.expr(expr.left, scope, .raw)} ${expr.value} ${c.expr(expr.right, scope, .raw)})')
+				return vml_stringify('(${c.expr(expr.left, scope, .raw)} ${expr.value} ${c.expr(expr.right, scope, .raw)})')
 			}
 			if expr.value == '%' {
 				return 'f64(int(${c.expr(expr.left, scope, .number)}) % int(${c.expr(expr.right, scope, .number)}))'
@@ -951,7 +951,7 @@ fn (c &QmlCompiler) expr(expr &QmlExpr, scope QmlScope, use QmlExprUse) string {
 			mut value := "'"
 			for part in expr.parts {
 				if isnil(part.expr) {
-					value += qml_interpolation_text(part.text)
+					value += vml_interpolation_text(part.text)
 				} else {
 					value += r'$' + '{' + c.expr(part.expr, scope, .raw) + '}'
 				}
@@ -961,7 +961,7 @@ fn (c &QmlCompiler) expr(expr &QmlExpr, scope QmlScope, use QmlExprUse) string {
 	}
 }
 
-fn qml_find_property(node &QmlNode, name string) ?QmlProperty {
+fn vml_find_property(node &VmlNode, name string) ?VmlProperty {
 	for property in node.properties {
 		if property.name == name {
 			return property
@@ -970,27 +970,27 @@ fn qml_find_property(node &QmlNode, name string) ?QmlProperty {
 	return none
 }
 
-fn qml_prop(properties map[string]string, name string, default_ string) string {
+fn vml_prop(properties map[string]string, name string, default_ string) string {
 	return properties[name] or { default_ }
 }
 
-fn qml_property_is_geometry(property QmlProperty) bool {
+fn vml_property_is_geometry(property VmlProperty) bool {
 	return property.name in ['x', 'y', 'width', 'height']
 }
 
-fn qml_order_properties_by_dependencies(properties []QmlProperty, node_id string) []QmlProperty {
+fn vml_order_properties_by_dependencies(properties []VmlProperty, node_id string) []VmlProperty {
 	mut remaining := properties.clone()
 	if node_id.len == 0 || remaining.len < 2 {
 		return remaining
 	}
-	mut ordered := []QmlProperty{cap: remaining.len}
+	mut ordered := []VmlProperty{cap: remaining.len}
 	for remaining.len > 0 {
-		mut deferred := []QmlProperty{cap: remaining.len}
+		mut deferred := []VmlProperty{cap: remaining.len}
 		for property in remaining {
 			mut has_pending_dependency := false
 			for candidate in remaining {
 				if candidate.name != property.name
-					&& qml_expr_uses_path(property.expr, '${node_id}.${candidate.name}') {
+					&& vml_expr_uses_path(property.expr, '${node_id}.${candidate.name}') {
 					has_pending_dependency = true
 					break
 				}
@@ -1012,41 +1012,41 @@ fn qml_order_properties_by_dependencies(properties []QmlProperty, node_id string
 	return ordered
 }
 
-fn (mut c QmlCompiler) compile_node(node &QmlNode, path string, input string, incoming QmlScope, default_key string) QmlScope {
-	suffix := qml_var(path)
+fn (mut c VmlCompiler) compile_node(node &VmlNode, path string, input string, incoming VmlScope, default_key string) VmlScope {
+	suffix := vml_var(path)
 	c.out.writeln('\t_ = ${input}')
-	mut scope := qml_clone_scope(incoming)
+	mut scope := vml_clone_scope(incoming)
 	mut named_props := map[string]string{}
 	// Declared properties are visible before expressions are resolved. Geometry
 	// bindings are added after they are emitted below, so self-geometry can use an
 	// earlier computed binding while declared properties can still read the input.
 	for property in node.properties {
 		if property.declared_type.len > 0 {
-			named_props[property.name] = 'qml_property_${suffix}_${qml_var(property.name)}'
+			named_props[property.name] = 'vml_property_${suffix}_${vml_var(property.name)}'
 		}
 	}
 	if node.id.len > 0 {
-		scope.ids[node.id] = QmlNamedValue{ frame: input, props: named_props.clone() }
+		scope.ids[node.id] = VmlNamedValue{ frame: input, props: named_props.clone() }
 	}
 	mut properties := map[string]string{}
-	mut ordered_properties := qml_order_properties_by_dependencies(node.properties.filter(it.declared_type.len > 0), node.id)
-	ordered_properties << qml_order_properties_by_dependencies(node.properties.filter(it.declared_type.len == 0
-		&& qml_property_is_geometry(it)), node.id)
+	mut ordered_properties := vml_order_properties_by_dependencies(node.properties.filter(it.declared_type.len > 0), node.id)
+	ordered_properties << vml_order_properties_by_dependencies(node.properties.filter(it.declared_type.len == 0
+		&& vml_property_is_geometry(it)), node.id)
 	ordered_properties << node.properties.filter(it.declared_type.len == 0
-		&& !qml_property_is_geometry(it))
+		&& !vml_property_is_geometry(it))
 	for property in ordered_properties {
 		if property.name == 'id'
 			|| property.name in ['on_tap', 'on_change', 'on_active', 'on_text', 'on_submit'] {
 			continue
 		}
-		name := 'qml_property_${suffix}_${qml_var(property.name)}'
-		property_use := qml_property_use(property)
+		name := 'vml_property_${suffix}_${vml_var(property.name)}'
+		property_use := vml_property_use(property)
 		value := if property.declared_type == 'int' {
 			numeric_value := c.expr(property.expr, scope, .raw)
-			qml_numeric_cast(property.declared_type, numeric_value)
+			vml_numeric_cast(property.declared_type, numeric_value)
 		} else if property.declared_type == 'f32' {
 			numeric_value := c.expr(property.expr, scope, .number)
-			qml_numeric_cast(property.declared_type, numeric_value)
+			vml_numeric_cast(property.declared_type, numeric_value)
 		} else {
 			c.expr(property.expr, scope, property_use)
 		}
@@ -1059,40 +1059,40 @@ fn (mut c QmlCompiler) compile_node(node &QmlNode, path string, input string, in
 		}
 		c.out.writeln('\t${name} := ${value}')
 		properties[property.name] = name
-		if property.declared_type.len == 0 && qml_property_is_geometry(property) {
+		if property.declared_type.len == 0 && vml_property_is_geometry(property) {
 			named_props[property.name] = name
 			if node.id.len > 0 {
-				scope.ids[node.id] = QmlNamedValue{ frame: input, props: named_props.clone() }
+				scope.ids[node.id] = VmlNamedValue{ frame: input, props: named_props.clone() }
 			}
 		}
 	}
-	frame := 'qml_frame_${suffix}'
-	c.out.writeln('\t${frame} := ui2.rect(${qml_prop(properties, 'x', input + '.x')}, ${qml_prop(properties, 'y', input + '.y')}, ${qml_prop(properties, 'width', input + '.width')}, ${qml_prop(properties, 'height', input + '.height')})')
+	frame := 'vml_frame_${suffix}'
+	c.out.writeln('\t${frame} := ui2.rect(${vml_prop(properties, 'x', input + '.x')}, ${vml_prop(properties, 'y', input + '.y')}, ${vml_prop(properties, 'width', input + '.width')}, ${vml_prop(properties, 'height', input + '.height')})')
 	if node.id.len > 0 {
-		scope.ids[node.id] = QmlNamedValue{ frame: frame, props: named_props.clone() }
+		scope.ids[node.id] = VmlNamedValue{ frame: frame, props: named_props.clone() }
 	}
 	c.write_action_type_checks(node, suffix, scope)
-	children := 'qml_children_${suffix}'
+	children := 'vml_children_${suffix}'
 	container := node.tag in ['Screen', 'View', 'Rectangle', 'Column', 'Row', 'Scroll']
 		|| node.tag !in ['Label', 'Image', 'Button', 'MessageBox', 'Checkbox', 'Dropdown', 'TextArea',
 			'TextField', 'ProgressBar', 'Slider', 'Switch', 'Spinner']
 	visible_children := if container {
 		node.children.filter(it.tag !in ['MenuItem', 'Option'])
 	} else {
-		[]&QmlNode{}
+		[]&VmlNode{}
 	}
 	if container {
 		c.out.writeln('\tmut ${children} := []ui2.Element{cap: ${visible_children.len}}')
 	}
 	mut cursor := ''
 	if container && node.tag in ['Column', 'Row'] {
-		cursor = 'qml_cursor_${suffix}'
-		c.out.writeln('\tmut ${cursor} := ${qml_prop(properties, 'padding', 'f64(0)')}')
+		cursor = 'vml_cursor_${suffix}'
+		c.out.writeln('\tmut ${cursor} := ${vml_prop(properties, 'padding', 'f64(0)')}')
 	}
 	for child_index, child in node.children {
 		child_path := '${path}.${child_index}'
 		if child.tag == 'MenuItem' {
-			c.write_action_type_checks(child, '${qml_var(child_path)}_menu_action', scope)
+			c.write_action_type_checks(child, '${vml_var(child_path)}_menu_action', scope)
 			continue
 		}
 		if !container || child.tag == 'Option' {
@@ -1102,26 +1102,26 @@ fn (mut c QmlCompiler) compile_node(node &QmlNode, path string, input string, in
 			c.compile_repeater(child, child_path, frame, node.tag, properties, cursor, scope, children, '')
 			continue
 		}
-		child_input := 'qml_input_${qml_var(child_path)}'
-		c.out.writeln('\t${child_input} := ${qml_child_input(node.tag, frame, properties, cursor)}')
+		child_input := 'vml_input_${vml_var(child_path)}'
+		c.out.writeln('\t${child_input} := ${vml_child_input(node.tag, frame, properties, cursor)}')
 		child_scope := c.compile_node(child, child_path, child_input, scope, '')
 		for id, named in child_scope.ids {
 			scope.ids[id] = named
 		}
-		c.out.writeln('\t${children} << qml_element_${qml_var(child_path)}')
-		qml_advance_cursor(mut c.out, node.tag, cursor, child_path, properties)
+		c.out.writeln('\t${children} << vml_element_${vml_var(child_path)}')
+		vml_advance_cursor(mut c.out, node.tag, cursor, child_path, properties)
 	}
 	c.compile_element(node, suffix, frame, children, properties, scope, default_key)
 	return scope
 }
 
-fn (mut c QmlCompiler) write_action_type_checks(node &QmlNode, suffix string, scope QmlScope) {
+fn (mut c VmlCompiler) write_action_type_checks(node &VmlNode, suffix string, scope VmlScope) {
 	for property in node.properties {
 		if property.name !in ['on_tap', 'on_change', 'on_active', 'on_text', 'on_submit'] || property.expr.kind != .call {
 			continue
 		}
 		method_name := property.expr.value.all_after('app.')
-		check_name := 'qml_action_check_${suffix}_${qml_var(property.name)}'
+		check_name := 'vml_action_check_${suffix}_${vml_var(property.name)}'
 		arguments := property.expr.args.map(c.expr(it, scope, .raw)).join(', ')
 		// The branch is never taken, but V still checks that the method exists and
 		// that its argument has the declared type.
@@ -1130,9 +1130,9 @@ fn (mut c QmlCompiler) write_action_type_checks(node &QmlNode, suffix string, sc
 		// The runtime dispatcher exposes public methods only. Reflection makes a
 		// same-module private method a compile error before its action is serialized.
 		c.out.writeln('\t\t\$for method in ${check_name}.methods {')
-		c.out.writeln('\t\t\t\$if method.name == ${qml_quote(method_name)} {')
+		c.out.writeln('\t\t\t\$if method.name == ${vml_quote(method_name)} {')
 		c.out.writeln('\t\t\t\t\$if !method.is_pub {')
-		c.out.writeln('\t\t\t\t\t\$compile_error(${qml_quote('QML action method `${method_name}` must be public')})')
+		c.out.writeln('\t\t\t\t\t\$compile_error(${vml_quote('VML action method `${method_name}` must be public')})')
 		c.out.writeln('\t\t\t\t}')
 		c.out.writeln('\t\t\t}')
 		c.out.writeln('\t\t}')
@@ -1141,8 +1141,8 @@ fn (mut c QmlCompiler) write_action_type_checks(node &QmlNode, suffix string, sc
 	}
 }
 
-fn qml_child_input(tag string, frame string, properties map[string]string, cursor string) string {
-	padding := qml_prop(properties, 'padding', 'f64(0)')
+fn vml_child_input(tag string, frame string, properties map[string]string, cursor string) string {
+	padding := vml_prop(properties, 'padding', 'f64(0)')
 	return match tag {
 		'Column' {
 			'ui2.rect(${padding}, ${cursor}, ${frame}.width - ${padding} * f64(2), f64(32))'
@@ -1154,24 +1154,24 @@ fn qml_child_input(tag string, frame string, properties map[string]string, curso
 	}
 }
 
-fn qml_advance_cursor(mut out strings.Builder, tag string, cursor string, child_path string, properties map[string]string) {
-	spacing := qml_prop(properties, 'spacing', 'f64(0)')
+fn vml_advance_cursor(mut out strings.Builder, tag string, cursor string, child_path string, properties map[string]string) {
+	spacing := vml_prop(properties, 'spacing', 'f64(0)')
 	if tag == 'Column' {
-		out.writeln('\t${cursor} += qml_frame_${qml_var(child_path)}.height + ${spacing}')
+		out.writeln('\t${cursor} += vml_frame_${vml_var(child_path)}.height + ${spacing}')
 	} else if tag == 'Row' {
-		out.writeln('\t${cursor} += qml_frame_${qml_var(child_path)}.width + ${spacing}')
+		out.writeln('\t${cursor} += vml_frame_${vml_var(child_path)}.width + ${spacing}')
 	}
 }
 
-fn (mut c QmlCompiler) compile_repeater(node &QmlNode, path string, parent_frame string, parent_tag string, parent_properties map[string]string, cursor string, incoming QmlScope, output string, outer_key string) {
-	model := qml_find_property(node, 'model') or { return }
-	key := qml_find_property(node, 'key') or { return }
-	suffix := qml_var(path)
-	index_name := 'qml_index_${suffix}'
-	item_name := 'qml_item_${suffix}'
-	key_name := 'qml_key_${suffix}'
+fn (mut c VmlCompiler) compile_repeater(node &VmlNode, path string, parent_frame string, parent_tag string, parent_properties map[string]string, cursor string, incoming VmlScope, output string, outer_key string) {
+	model := vml_find_property(node, 'model') or { return }
+	key := vml_find_property(node, 'key') or { return }
+	suffix := vml_var(path)
+	index_name := 'vml_index_${suffix}'
+	item_name := 'vml_item_${suffix}'
+	key_name := 'vml_key_${suffix}'
 	c.out.writeln('\tfor ${index_name}, ${item_name} in ${c.expr(model.expr, incoming, .raw)} {')
-	mut scope := qml_clone_scope(incoming)
+	mut scope := vml_clone_scope(incoming)
 	scope.special['item'] = item_name
 	scope.special['index'] = index_name
 	key_value := c.expr(key.expr, scope, .string_)
@@ -1193,8 +1193,8 @@ fn (mut c QmlCompiler) compile_repeater(node &QmlNode, path string, parent_frame
 			c.compile_repeater(child, child_path, parent_frame, parent_tag, parent_properties, cursor, scope, output, key_name)
 			continue
 		}
-		child_input := 'qml_input_${qml_var(child_path)}'
-		c.out.writeln('\t\t${child_input} := ${qml_child_input(parent_tag, parent_frame, parent_properties, cursor)}')
+		child_input := 'vml_input_${vml_var(child_path)}'
+		c.out.writeln('\t\t${child_input} := ${vml_child_input(parent_tag, parent_frame, parent_properties, cursor)}')
 		default_key := if visible_count == 1 {
 			key_name
 		} else {
@@ -1204,14 +1204,14 @@ fn (mut c QmlCompiler) compile_repeater(node &QmlNode, path string, parent_frame
 		for id, named in child_scope.ids {
 			scope.ids[id] = named
 		}
-		c.out.writeln('\t\t${output} << qml_element_${qml_var(child_path)}')
-		qml_advance_cursor(mut c.out, parent_tag, cursor, child_path, parent_properties)
+		c.out.writeln('\t\t${output} << vml_element_${vml_var(child_path)}')
+		vml_advance_cursor(mut c.out, parent_tag, cursor, child_path, parent_properties)
 		visible_index++
 	}
 	c.out.writeln('\t}')
 }
 
-fn qml_value(properties map[string]string, name string, alternative string, default_ string) string {
+fn vml_value(properties map[string]string, name string, alternative string, default_ string) string {
 	if value := properties[name] {
 		return value
 	}
@@ -1223,28 +1223,28 @@ fn qml_value(properties map[string]string, name string, alternative string, defa
 	return default_
 }
 
-fn qml_binding_for_event(node &QmlNode, event_name string) ?QmlProperty {
+fn vml_binding_for_event(node &VmlNode, event_name string) ?VmlProperty {
 	if event_name == 'on_change' {
-		if binding := qml_find_property(node, 'bind.value') {
+		if binding := vml_find_property(node, 'bind.value') {
 			return binding
 		}
-		return qml_find_property(node, 'bind.text')
+		return vml_find_property(node, 'bind.text')
 	}
 	if event_name == 'on_tap' {
-		return qml_find_property(node, 'bind.checked')
+		return vml_find_property(node, 'bind.checked')
 	}
 	if event_name == 'on_active' {
-		return qml_find_property(node, 'bind.active')
+		return vml_find_property(node, 'bind.active')
 	}
 	if event_name == 'on_text' {
-		return qml_find_property(node, 'bind.text')
+		return vml_find_property(node, 'bind.text')
 	}
 	return none
 }
 
-fn (c &QmlCompiler) compiled_event_value(node &QmlNode, event_name string, scope QmlScope, control string) string {
-	action := qml_find_property(node, event_name)
-	binding := qml_binding_for_event(node, event_name)
+fn (c &VmlCompiler) compiled_event_value(node &VmlNode, event_name string, scope VmlScope, control string) string {
+	action := vml_find_property(node, event_name)
+	binding := vml_binding_for_event(node, event_name)
 	if action == none && binding == none {
 		return "''"
 	}
@@ -1254,66 +1254,66 @@ fn (c &QmlCompiler) compiled_event_value(node &QmlNode, event_name string, scope
 		}
 	}
 	binding_property := if property := binding { property.name.all_after('bind.') } else { '' }
-	binding_target := if property := binding { qml_expr_text(property.expr) } else { '' }
+	binding_target := if property := binding { vml_expr_text(property.expr) } else { '' }
 	mut action_name := ''
 	mut arguments := []string{}
 	if property := action {
 		if property.expr.kind == .call {
 			action_name = property.expr.value.all_after('app.')
 			for argument in property.expr.args {
-				arguments << qml_stringify(c.expr(argument, scope, .raw))
+				arguments << vml_stringify(c.expr(argument, scope, .raw))
 			}
 		}
 	}
 	if arguments.len == 0 {
-		return 'ui2.compiled_qml_event(${control}, ${qml_quote(binding_property)}, ${qml_quote(binding_target)}, ${qml_quote(action_name)})'
+		return 'ui2.compiled_vml_event(${control}, ${vml_quote(binding_property)}, ${vml_quote(binding_target)}, ${vml_quote(action_name)})'
 	}
 	if property := action {
 		argument := property.expr.args[0]
 		if argument.kind == .path && argument.value.starts_with('app.') {
-			return 'ui2.compiled_qml_event_arg_path(${control}, ${qml_quote(binding_property)}, ${qml_quote(binding_target)}, ${qml_quote(action_name)}, ${qml_quote(argument.value)})'
+			return 'ui2.compiled_vml_event_arg_path(${control}, ${vml_quote(binding_property)}, ${vml_quote(binding_target)}, ${vml_quote(action_name)}, ${vml_quote(argument.value)})'
 		}
 	}
-	return 'ui2.compiled_qml_event_arg(${control}, ${qml_quote(binding_property)}, ${qml_quote(binding_target)}, ${qml_quote(action_name)}, ${arguments[0]})'
+	return 'ui2.compiled_vml_event_arg(${control}, ${vml_quote(binding_property)}, ${vml_quote(binding_target)}, ${vml_quote(action_name)}, ${arguments[0]})'
 }
 
-fn (c &QmlCompiler) box_style(properties map[string]string) string {
-	border_width := qml_prop(properties, 'border_width', 'f64(0)')
-	return 'ui2.BoxStyle{bg: ${qml_prop(properties, 'background', 'u32(0xffffff)')}, radius: ${qml_value(properties, 'corner_radius', 'radius', 'f64(0)')}, border_color: ${qml_prop(properties, 'border_color', 'u32(0)')}, border_left: ${qml_prop(properties, 'border_left', border_width)}, border_top: ${qml_prop(properties, 'border_top', border_width)}, border_right: ${qml_prop(properties, 'border_right', border_width)}, border_bottom: ${qml_prop(properties, 'border_bottom', border_width)}}'
+fn (c &VmlCompiler) box_style(properties map[string]string) string {
+	border_width := vml_prop(properties, 'border_width', 'f64(0)')
+	return 'ui2.BoxStyle{bg: ${vml_prop(properties, 'background', 'u32(0xffffff)')}, radius: ${vml_value(properties, 'corner_radius', 'radius', 'f64(0)')}, border_color: ${vml_prop(properties, 'border_color', 'u32(0)')}, border_left: ${vml_prop(properties, 'border_left', border_width)}, border_top: ${vml_prop(properties, 'border_top', border_width)}, border_right: ${vml_prop(properties, 'border_right', border_width)}, border_bottom: ${vml_prop(properties, 'border_bottom', border_width)}}'
 }
 
-fn (c &QmlCompiler) text_style(properties map[string]string) string {
-	align := qml_prop(properties, 'align', "''")
+fn (c &VmlCompiler) text_style(properties map[string]string) string {
+	align := vml_prop(properties, 'align', "''")
 	fields := [
-		'color: ${qml_prop(properties, 'color', 'u32(0x111111)')}',
-		'background_color: ${qml_prop(properties, 'background_color', 'u32(0)')}',
-		'size: ${qml_value(properties, 'font_size', 'size', 'f64(15)')}',
-		'font_family: ${qml_prop(properties, 'font_family', "''")}',
-		'bold: ${qml_prop(properties, 'bold', 'false')}',
-		'italic: ${qml_prop(properties, 'italic', 'false')}',
-		'underline: ${qml_prop(properties, 'underline', 'false')}',
-		'strikethrough: ${qml_prop(properties, 'strikethrough', 'false')}',
-		'shadow: ${qml_prop(properties, 'shadow', 'false')}',
-		'outline: ${qml_prop(properties, 'outline', 'false')}',
-		'vertical_align: ${qml_prop(properties, 'vertical_align', "''")}',
-		'link: ${qml_prop(properties, 'link', "''")}',
+		'color: ${vml_prop(properties, 'color', 'u32(0x111111)')}',
+		'background_color: ${vml_prop(properties, 'background_color', 'u32(0)')}',
+		'size: ${vml_value(properties, 'font_size', 'size', 'f64(15)')}',
+		'font_family: ${vml_prop(properties, 'font_family', "''")}',
+		'bold: ${vml_prop(properties, 'bold', 'false')}',
+		'italic: ${vml_prop(properties, 'italic', 'false')}',
+		'underline: ${vml_prop(properties, 'underline', 'false')}',
+		'strikethrough: ${vml_prop(properties, 'strikethrough', 'false')}',
+		'shadow: ${vml_prop(properties, 'shadow', 'false')}',
+		'outline: ${vml_prop(properties, 'outline', 'false')}',
+		'vertical_align: ${vml_prop(properties, 'vertical_align', "''")}',
+		'link: ${vml_prop(properties, 'link', "''")}',
 		"align: match ${align} { 'center' { .center } 'right' { .right } else { .left } }",
-		'head_indent: ${qml_prop(properties, 'head_indent', 'f64(0)')}',
-		'first_line_indent: ${qml_prop(properties, 'first_line_indent', 'f64(0)')}',
-		'hyphenation_factor: ${qml_prop(properties, 'hyphenation_factor', 'f64(0)')}',
-		'lines: int(${qml_prop(properties, 'lines', 'f64(1)')})',
+		'head_indent: ${vml_prop(properties, 'head_indent', 'f64(0)')}',
+		'first_line_indent: ${vml_prop(properties, 'first_line_indent', 'f64(0)')}',
+		'hyphenation_factor: ${vml_prop(properties, 'hyphenation_factor', 'f64(0)')}',
+		'lines: int(${vml_prop(properties, 'lines', 'f64(1)')})',
 	]
 	return 'ui2.TextStyle{${fields.join(', ')}}'
 }
 
-fn (c &QmlCompiler) menu_value(node &QmlNode, scope QmlScope) string {
+fn (c &VmlCompiler) menu_value(node &VmlNode, scope VmlScope) string {
 	menu_items := node.children.filter(it.tag == 'MenuItem')
 	if menu_items.len > 0 {
 		mut entries := []string{cap: menu_items.len}
 		for item in menu_items {
-			fallback_id := qml_quote(item.id)
+			fallback_id := vml_quote(item.id)
 			id := c.compiled_event_value(item, 'on_tap', scope, fallback_id)
-			text := if property := qml_find_property(item, 'text') {
+			text := if property := vml_find_property(item, 'text') {
 				c.expr(property.expr, scope, .string_)
 			} else {
 				"''"
@@ -1328,7 +1328,7 @@ fn (c &QmlCompiler) menu_value(node &QmlNode, scope QmlScope) string {
 			if option.tag != 'Option' {
 				continue
 			}
-			text := if property := qml_find_property(option, 'text') {
+			text := if property := vml_find_property(option, 'text') {
 				c.expr(property.expr, scope, .string_)
 			} else {
 				"''"
@@ -1340,13 +1340,13 @@ fn (c &QmlCompiler) menu_value(node &QmlNode, scope QmlScope) string {
 	return '[]ui2.MenuEntry{}'
 }
 
-fn (c &QmlCompiler) option_values(node &QmlNode, scope QmlScope) string {
+fn (c &VmlCompiler) option_values(node &VmlNode, scope VmlScope) string {
 	mut values := []string{}
 	for option in node.children {
 		if option.tag != 'Option' {
 			continue
 		}
-		value := if property := qml_find_property(option, 'text') {
+		value := if property := vml_find_property(option, 'text') {
 			c.expr(property.expr, scope, .string_)
 		} else {
 			"''"
@@ -1356,26 +1356,26 @@ fn (c &QmlCompiler) option_values(node &QmlNode, scope QmlScope) string {
 	return '[]string{${values.join(', ')}}'
 }
 
-fn (mut c QmlCompiler) compile_element(node &QmlNode, suffix string, frame string, children string, properties map[string]string, scope QmlScope, default_key string) {
-	has_binding := qml_find_property(node, 'bind.text') != none
-		|| qml_find_property(node, 'bind.checked') != none
-		|| qml_find_property(node, 'bind.active') != none || qml_find_property(node, 'bind.value') != none
+fn (mut c VmlCompiler) compile_element(node &VmlNode, suffix string, frame string, children string, properties map[string]string, scope VmlScope, default_key string) {
+	has_binding := vml_find_property(node, 'bind.text') != none
+		|| vml_find_property(node, 'bind.checked') != none
+		|| vml_find_property(node, 'bind.active') != none || vml_find_property(node, 'bind.value') != none
 	id := if node.id.len > 0 {
-		qml_quote(node.id)
+		vml_quote(node.id)
 	} else if has_binding && default_key.len > 0 {
-		"'__qml_control_${suffix}_" + r'$' + '{' + default_key + "}'"
+		"'__vml_control_${suffix}_" + r'$' + '{' + default_key + "}'"
 	} else if has_binding {
-		qml_quote('__qml_control_${suffix}')
+		vml_quote('__vml_control_${suffix}')
 	} else {
 		"''"
 	}
-	key := qml_prop(properties, 'key', if default_key.len > 0 { default_key } else { "''" })
+	key := vml_prop(properties, 'key', if default_key.len > 0 { default_key } else { "''" })
 	on_tap := c.compiled_event_value(node, 'on_tap', scope, id)
 	on_change := c.compiled_event_value(node, 'on_change', scope, id)
 	on_active := c.compiled_event_value(node, 'on_active', scope, id)
 	on_text := c.compiled_event_value(node, 'on_text', scope, id)
 	on_submit := c.compiled_event_value(node, 'on_submit', scope, id)
-	text_action := if qml_find_property(node, 'on_text') != none { on_text } else { on_change }
+	text_action := if vml_find_property(node, 'on_text') != none { on_text } else { on_change }
 	action := match node.tag {
 		'Button', 'Checkbox' { on_tap }
 		'Dropdown', 'Slider' { 'if ${on_change}.len > 0 { ${on_change} } else { ${on_tap} }' }
@@ -1420,7 +1420,7 @@ fn (mut c QmlCompiler) compile_element(node &QmlNode, suffix string, frame strin
 		'Scroll' { 'scroll' }
 		else { 'view' }
 	}
-	c.out.writeln('\tqml_element_${suffix} := ui2.Element{')
+	c.out.writeln('\tvml_element_${suffix} := ui2.Element{')
 	c.out.writeln('\t\tkind: .${kind}')
 	if node.tag != 'Screen' {
 		c.out.writeln('\t\tid: ${id}')
@@ -1430,29 +1430,29 @@ fn (mut c QmlCompiler) compile_element(node &QmlNode, suffix string, frame strin
 	c.out.writeln('\t\tsubmit_id: ${on_submit}')
 	c.out.writeln('\t\tkey: ${key}')
 	if node.tag in ['Label', 'Button', 'Checkbox', 'Dropdown', 'TextField', 'TextArea'] {
-		c.out.writeln('\t\ttext: ${qml_value(properties, 'text', 'bind.text', "''")}')
+		c.out.writeln('\t\ttext: ${vml_value(properties, 'text', 'bind.text', "''")}')
 	}
 	if node.tag == 'Checkbox' {
-		c.out.writeln('\t\tchecked: ${qml_value(properties, 'checked', 'bind.checked', 'false')}')
+		c.out.writeln('\t\tchecked: ${vml_value(properties, 'checked', 'bind.checked', 'false')}')
 	}
 	if node.tag == 'Image' {
-		c.out.writeln('\t\timage_path: ${qml_value(properties, 'source', 'path', "''")}')
+		c.out.writeln('\t\timage_path: ${vml_value(properties, 'source', 'path', "''")}')
 	}
 	if node.tag == 'TextField' {
-		c.out.writeln('\t\tplaceholder: ${qml_prop(properties, 'placeholder', "''")}')
-		keyboard := qml_prop(properties, 'keyboard', "''")
+		c.out.writeln('\t\tplaceholder: ${vml_prop(properties, 'placeholder', "''")}')
+		keyboard := vml_prop(properties, 'keyboard', "''")
 		c.out.writeln("\t\tkeyboard: if ${keyboard} in ['decimal', 'numeric', 'number'] { ui2.keyboard_decimal } else { ui2.keyboard_default }")
-		c.out.writeln('\t\temit_change: ${qml_prop(properties, 'emit_change', 'false')} || ${text_action}.len > 0')
+		c.out.writeln('\t\temit_change: ${vml_prop(properties, 'emit_change', 'false')} || ${text_action}.len > 0')
 	}
 	if node.tag == 'TextArea' {
-		c.out.writeln('\t\treadonly: ${qml_prop(properties, 'editable', 'true')} == false')
+		c.out.writeln('\t\treadonly: ${vml_prop(properties, 'editable', 'true')} == false')
 		c.out.writeln('\t\temit_change: ${text_action}.len > 0')
 	}
 	if node.tag == 'Screen' {
-		c.out.writeln('\t\tbox: ui2.BoxStyle{bg: ${qml_prop(properties, 'background', 'u32(0xffffff)')}}')
+		c.out.writeln('\t\tbox: ui2.BoxStyle{bg: ${vml_prop(properties, 'background', 'u32(0xffffff)')}}')
 	} else if node.tag == 'Scroll' {
 		c.out.writeln('\t\tbox: ${c.box_style(properties)}')
-		c.out.writeln('\t\tpersistent_scrollbars: ${qml_prop(properties, 'persistent', 'false')}')
+		c.out.writeln('\t\tpersistent_scrollbars: ${vml_prop(properties, 'persistent', 'false')}')
 	} else if node.tag == 'Checkbox' {
 		c.out.writeln('\t\tbox: ui2.BoxStyle{transparent: true}')
 	} else if node.tag in ['View', 'Rectangle', 'Column', 'Row', 'Button', 'Dropdown', 'TextField',
@@ -1467,12 +1467,12 @@ fn (mut c QmlCompiler) compile_element(node &QmlNode, suffix string, frame strin
 	}
 	role_default := if node.tag == 'Checkbox' { "'checkbox'" } else { "''" }
 	label_default := if node.tag == 'Checkbox' {
-		qml_value(properties, 'text', 'bind.text', "''")
+		vml_value(properties, 'text', 'bind.text', "''")
 	} else {
 		"''"
 	}
 	value_default := if node.tag == 'Checkbox' {
-		"if ${qml_value(properties, 'checked', 'bind.checked', 'false')} { 'checked' } else { 'unchecked' }"
+		"if ${vml_value(properties, 'checked', 'bind.checked', 'false')} { 'checked' } else { 'unchecked' }"
 	} else {
 		"''"
 	}
@@ -1480,38 +1480,38 @@ fn (mut c QmlCompiler) compile_element(node &QmlNode, suffix string, frame strin
 	c.out.writeln('\t}')
 }
 
-fn (mut c QmlCompiler) write_common_fields(node &QmlNode, properties map[string]string, scope QmlScope, role_default string, label_default string, value_default string) {
+fn (mut c VmlCompiler) write_common_fields(node &VmlNode, properties map[string]string, scope VmlScope, role_default string, label_default string, value_default string) {
 	c.out.writeln('\t\tmenu: ${c.menu_value(node, scope)}')
-	c.out.writeln('\t\tsecure: ${qml_prop(properties, 'secure', 'false')}')
-	c.out.writeln('\t\tclickable: ${qml_prop(properties, 'clickable', 'false')}')
-	c.out.writeln('\t\tdraggable: ${qml_prop(properties, 'draggable', 'false')}')
-	c.out.writeln('\t\tlong_press: ${qml_prop(properties, 'long_press', 'false')}')
-	c.out.writeln('\t\tswipe_left: ${qml_prop(properties, 'swipe_left', 'false')}')
-	c.out.writeln('\t\trotation: ${qml_prop(properties, 'rotation', 'f64(0)')}')
-	c.out.writeln('\t\tcursor: ${qml_prop(properties, 'cursor', "''")}')
-	c.out.writeln('\t\ttooltip: ${qml_prop(properties, 'tooltip', "''")}')
-	c.out.writeln('\t\thidden: ${qml_prop(properties, 'hidden', 'false')}')
-	c.out.writeln('\t\tenabled: ${qml_prop(properties, 'enabled', 'true')}')
-	c.out.writeln('\t\taccessibility_role: ${qml_prop(properties, 'accessibility_role', role_default)}')
-	c.out.writeln('\t\taccessibility_label: ${qml_prop(properties, 'accessibility_label', label_default)}')
-	c.out.writeln('\t\taccessibility_value: ${qml_prop(properties, 'accessibility_value', value_default)}')
-	c.out.writeln('\t\tnative_style: ${qml_prop(properties, 'native', 'false')}')
-	c.out.writeln('\t\tautocorrect: ${qml_prop(properties, 'autocorrect', 'true')}')
-	c.out.writeln('\t\tpadding_left: ${qml_prop(properties, 'pad_left', 'f64(12)')}')
+	c.out.writeln('\t\tsecure: ${vml_prop(properties, 'secure', 'false')}')
+	c.out.writeln('\t\tclickable: ${vml_prop(properties, 'clickable', 'false')}')
+	c.out.writeln('\t\tdraggable: ${vml_prop(properties, 'draggable', 'false')}')
+	c.out.writeln('\t\tlong_press: ${vml_prop(properties, 'long_press', 'false')}')
+	c.out.writeln('\t\tswipe_left: ${vml_prop(properties, 'swipe_left', 'false')}')
+	c.out.writeln('\t\trotation: ${vml_prop(properties, 'rotation', 'f64(0)')}')
+	c.out.writeln('\t\tcursor: ${vml_prop(properties, 'cursor', "''")}')
+	c.out.writeln('\t\ttooltip: ${vml_prop(properties, 'tooltip', "''")}')
+	c.out.writeln('\t\thidden: ${vml_prop(properties, 'hidden', 'false')}')
+	c.out.writeln('\t\tenabled: ${vml_prop(properties, 'enabled', 'true')}')
+	c.out.writeln('\t\taccessibility_role: ${vml_prop(properties, 'accessibility_role', role_default)}')
+	c.out.writeln('\t\taccessibility_label: ${vml_prop(properties, 'accessibility_label', label_default)}')
+	c.out.writeln('\t\taccessibility_value: ${vml_prop(properties, 'accessibility_value', value_default)}')
+	c.out.writeln('\t\tnative_style: ${vml_prop(properties, 'native', 'false')}')
+	c.out.writeln('\t\tautocorrect: ${vml_prop(properties, 'autocorrect', 'true')}')
+	c.out.writeln('\t\tpadding_left: ${vml_prop(properties, 'pad_left', 'f64(12)')}')
 }
 
-fn (mut c QmlCompiler) compile_progress_bar(node &QmlNode, suffix string, frame string, properties map[string]string, scope QmlScope, key string, action string) {
-	base := 'qml_progress_${suffix}'
+fn (mut c VmlCompiler) compile_progress_bar(node &VmlNode, suffix string, frame string, properties map[string]string, scope VmlScope, key string, action string) {
+	base := 'vml_progress_${suffix}'
 	c.out.writeln('\t${base} := ui2.progress_bar(')
-	c.out.writeln('\t\tid: ${qml_quote(node.id)}')
+	c.out.writeln('\t\tid: ${vml_quote(node.id)}')
 	c.out.writeln('\t\tframe: ${frame}')
-	c.out.writeln('\t\tvalue: ${qml_prop(properties, 'value', 'f64(0)')}')
-	c.out.writeln('\t\tmax: ${qml_prop(properties, 'max', 'f64(100)')}')
-	c.out.writeln('\t\tbackground: ${qml_prop(properties, 'background', 'u32(0xe2e8f0)')}')
-	c.out.writeln('\t\tcolor: ${qml_prop(properties, 'color', 'u32(0x3b82f6)')}')
-	c.out.writeln('\t\tradius: ${qml_value(properties, 'corner_radius', 'radius', 'f64(4)')}')
+	c.out.writeln('\t\tvalue: ${vml_prop(properties, 'value', 'f64(0)')}')
+	c.out.writeln('\t\tmax: ${vml_prop(properties, 'max', 'f64(100)')}')
+	c.out.writeln('\t\tbackground: ${vml_prop(properties, 'background', 'u32(0xe2e8f0)')}')
+	c.out.writeln('\t\tcolor: ${vml_prop(properties, 'color', 'u32(0x3b82f6)')}')
+	c.out.writeln('\t\tradius: ${vml_value(properties, 'corner_radius', 'radius', 'f64(4)')}')
 	c.out.writeln('\t)')
-	c.out.writeln('\tqml_element_${suffix} := ui2.Element{')
+	c.out.writeln('\tvml_element_${suffix} := ui2.Element{')
 	c.out.writeln('\t\t...${base}')
 	c.out.writeln('\t\taction_id: ${action}')
 	c.out.writeln('\t\tkey: ${key}')
@@ -1519,114 +1519,114 @@ fn (mut c QmlCompiler) compile_progress_bar(node &QmlNode, suffix string, frame 
 	c.out.writeln('\t}')
 }
 
-fn (mut c QmlCompiler) compile_slider(node &QmlNode, suffix string, frame string, properties map[string]string, scope QmlScope, key string, action string) {
-	base := 'qml_slider_${suffix}'
+fn (mut c VmlCompiler) compile_slider(node &VmlNode, suffix string, frame string, properties map[string]string, scope VmlScope, key string, action string) {
+	base := 'vml_slider_${suffix}'
 	style := '${base}_style'
 	orientation_value := '${base}_orientation'
-	orientation := qml_prop(properties, 'orientation', "''")
+	orientation := vml_prop(properties, 'orientation', "''")
 	c.out.writeln('\t${style} := ui2.SliderStyle{')
-	c.out.writeln('\t\ttrack_color: ${qml_prop(properties, 'background', 'u32(0xcbd5e1)')}')
-	c.out.writeln('\t\tvalue_track_color: ${qml_value(properties, 'value_track_color', 'color', 'u32(0x93c5fd)')}')
-	c.out.writeln('\t\tthumb_color: ${qml_prop(properties, 'thumb_color', 'u32(0x2563eb)')}')
-	c.out.writeln('\t\ttrack_width: ${qml_prop(properties, 'track_width', 'f64(4)')}')
-	c.out.writeln('\t\tthumb_size: ${qml_prop(properties, 'thumb_size', 'f64(20)')}')
+	c.out.writeln('\t\ttrack_color: ${vml_prop(properties, 'background', 'u32(0xcbd5e1)')}')
+	c.out.writeln('\t\tvalue_track_color: ${vml_value(properties, 'value_track_color', 'color', 'u32(0x93c5fd)')}')
+	c.out.writeln('\t\tthumb_color: ${vml_prop(properties, 'thumb_color', 'u32(0x2563eb)')}')
+	c.out.writeln('\t\ttrack_width: ${vml_prop(properties, 'track_width', 'f64(4)')}')
+	c.out.writeln('\t\tthumb_size: ${vml_prop(properties, 'thumb_size', 'f64(20)')}')
 	c.out.writeln('\t}')
 	c.out.writeln("\t${orientation_value} := if ${orientation} == 'vertical' { ui2.Orientation.vertical } else { ui2.Orientation.horizontal }")
 	c.out.writeln('\t${base} := ui2.slider(')
-	c.out.writeln('\t\tid: ${qml_quote(node.id)}')
+	c.out.writeln('\t\tid: ${vml_quote(node.id)}')
 	c.out.writeln('\t\taction_id: ${action}')
 	c.out.writeln('\t\tframe: ${frame}')
-	c.out.writeln('\t\tmin: ${qml_prop(properties, 'min', 'f64(0)')}')
-	c.out.writeln('\t\tmax: ${qml_prop(properties, 'max', 'f64(100)')}')
-	c.out.writeln('\t\tvalue: ${qml_value(properties, 'value', 'bind.value', 'f64(0)')}')
-	c.out.writeln('\t\tstep: ${qml_prop(properties, 'step', 'f64(0)')}')
+	c.out.writeln('\t\tmin: ${vml_prop(properties, 'min', 'f64(0)')}')
+	c.out.writeln('\t\tmax: ${vml_prop(properties, 'max', 'f64(100)')}')
+	c.out.writeln('\t\tvalue: ${vml_value(properties, 'value', 'bind.value', 'f64(0)')}')
+	c.out.writeln('\t\tstep: ${vml_prop(properties, 'step', 'f64(0)')}')
 	c.out.writeln('\t\torientation: ${orientation_value}')
-	c.out.writeln('\t\tpadding: ${qml_prop(properties, 'padding', 'f64(16)')}')
-	c.out.writeln('\t\tvalue_track: ${qml_prop(properties, 'value_track', 'false')}')
+	c.out.writeln('\t\tpadding: ${vml_prop(properties, 'padding', 'f64(16)')}')
+	c.out.writeln('\t\tvalue_track: ${vml_prop(properties, 'value_track', 'false')}')
 	c.out.writeln('\t\tstyle: ${style}')
 	c.out.writeln('\t)')
-	c.out.writeln('\tqml_element_${suffix} := ui2.Element{')
+	c.out.writeln('\tvml_element_${suffix} := ui2.Element{')
 	c.out.writeln('\t\t...${base}')
 	c.out.writeln('\t\tkey: ${key}')
 	c.write_common_fields(node, properties, scope, '${base}.accessibility_role', '${base}.accessibility_label', '${base}.accessibility_value')
 	c.out.writeln('\t}')
 }
 
-fn (mut c QmlCompiler) compile_switch(node &QmlNode, suffix string, frame string, properties map[string]string, scope QmlScope, key string, action string) {
-	base := 'qml_switch_${suffix}'
+fn (mut c VmlCompiler) compile_switch(node &VmlNode, suffix string, frame string, properties map[string]string, scope VmlScope, key string, action string) {
+	base := 'vml_switch_${suffix}'
 	style := '${base}_style'
 	c.out.writeln('\t${style} := ui2.SwitchStyle{')
-	c.out.writeln('\t\tinactive_track_color: ${qml_prop(properties, 'inactive_color', 'u32(0xcbd5e1)')}')
-	c.out.writeln('\t\tactive_track_color: ${qml_value(properties, 'active_color', 'color', 'u32(0x22c55e)')}')
-	c.out.writeln('\t\tthumb_color: ${qml_prop(properties, 'thumb_color', 'u32(0xffffff)')}')
-	c.out.writeln('\t\tdisabled_track_color: ${qml_prop(properties, 'disabled_track_color', 'u32(0xe2e8f0)')}')
-	c.out.writeln('\t\tdisabled_thumb_color: ${qml_prop(properties, 'disabled_thumb_color', 'u32(0xf8fafc)')}')
+	c.out.writeln('\t\tinactive_track_color: ${vml_prop(properties, 'inactive_color', 'u32(0xcbd5e1)')}')
+	c.out.writeln('\t\tactive_track_color: ${vml_value(properties, 'active_color', 'color', 'u32(0x22c55e)')}')
+	c.out.writeln('\t\tthumb_color: ${vml_prop(properties, 'thumb_color', 'u32(0xffffff)')}')
+	c.out.writeln('\t\tdisabled_track_color: ${vml_prop(properties, 'disabled_track_color', 'u32(0xe2e8f0)')}')
+	c.out.writeln('\t\tdisabled_thumb_color: ${vml_prop(properties, 'disabled_thumb_color', 'u32(0xf8fafc)')}')
 	c.out.writeln('\t}')
 	c.out.writeln('\t${base} := ui2.switch_control(')
-	c.out.writeln('\t\tid: ${qml_quote(node.id)}')
+	c.out.writeln('\t\tid: ${vml_quote(node.id)}')
 	c.out.writeln('\t\taction_id: ${action}')
 	c.out.writeln('\t\tframe: ${frame}')
-	c.out.writeln('\t\tactive: ${qml_value(properties, 'active', 'bind.active', 'false')}')
+	c.out.writeln('\t\tactive: ${vml_value(properties, 'active', 'bind.active', 'false')}')
 	c.out.writeln('\t\tstyle: ${style}')
 	c.out.writeln('\t)')
-	c.out.writeln('\tqml_element_${suffix} := ui2.Element{')
+	c.out.writeln('\tvml_element_${suffix} := ui2.Element{')
 	c.out.writeln('\t\t...${base}')
 	c.out.writeln('\t\tkey: ${key}')
 	c.write_common_fields(node, properties, scope, '${base}.accessibility_role', '${base}.accessibility_label', '${base}.accessibility_value')
 	c.out.writeln('\t}')
 }
 
-fn (mut c QmlCompiler) compile_spinner(node &QmlNode, suffix string, frame string, properties map[string]string, scope QmlScope, key string, action string) {
-	base := 'qml_spinner_${suffix}'
+fn (mut c VmlCompiler) compile_spinner(node &VmlNode, suffix string, frame string, properties map[string]string, scope VmlScope, key string, action string) {
+	base := 'vml_spinner_${suffix}'
 	box := '${base}_box'
 	text_style := '${base}_text_style'
 	c.out.writeln('\t${box} := ${c.box_style(properties)}')
 	c.out.writeln('\t${text_style} := ${c.text_style(properties)}')
 	c.out.writeln('\t${base} := ui2.spinner(')
-	c.out.writeln('\t\tid: ${qml_quote(node.id)}')
+	c.out.writeln('\t\tid: ${vml_quote(node.id)}')
 	c.out.writeln('\t\taction_id: ${action}')
 	c.out.writeln('\t\tframe: ${frame}')
-	c.out.writeln('\t\ttext: ${qml_value(properties, 'text', 'bind.text', "''")}')
+	c.out.writeln('\t\ttext: ${vml_value(properties, 'text', 'bind.text', "''")}')
 	c.out.writeln('\t\tvalues: ${c.option_values(node, scope)}')
-	c.out.writeln('\t\ttext_autoupdate: ${qml_prop(properties, 'text_autoupdate', 'false')}')
+	c.out.writeln('\t\ttext_autoupdate: ${vml_prop(properties, 'text_autoupdate', 'false')}')
 	c.out.writeln('\t\tbox: ${box}')
 	c.out.writeln('\t\ttext_style: ${text_style}')
 	c.out.writeln('\t)')
-	c.out.writeln('\tqml_element_${suffix} := ui2.Element{')
+	c.out.writeln('\tvml_element_${suffix} := ui2.Element{')
 	c.out.writeln('\t\t...${base}')
 	c.out.writeln('\t\tkey: ${key}')
 	c.write_common_fields(node, properties, scope, '${base}.accessibility_role', '${base}.accessibility_label', '${base}.accessibility_value')
 	c.out.writeln('\t}')
 }
 
-fn (mut c QmlCompiler) compile_message_box(node &QmlNode, suffix string, frame string, properties map[string]string, scope QmlScope, key string, action string) {
+fn (mut c VmlCompiler) compile_message_box(node &VmlNode, suffix string, frame string, properties map[string]string, scope VmlScope, key string, action string) {
 	mut actions := []string{}
 	for child_index, child in node.children {
 		if child.tag != 'Button' {
 			continue
 		}
 		c.write_action_type_checks(child, '${suffix}_message_action_${child_index}', scope)
-		child_id := qml_quote(child.id)
+		child_id := vml_quote(child.id)
 		child_action := c.compiled_event_value(child, 'on_tap', scope, child_id)
-		text := if property := qml_find_property(child, 'text') {
+		text := if property := vml_find_property(child, 'text') {
 			c.expr(property.expr, scope, .string_)
 		} else {
 			"''"
 		}
-		actions << 'ui2.MessageBoxAction{id: ${qml_quote(child.id)}, action_id: ${child_action}, title: ${text}}'
+		actions << 'ui2.MessageBoxAction{id: ${vml_quote(child.id)}, action_id: ${child_action}, title: ${text}}'
 	}
-	c.out.writeln('\tqml_message_box_${suffix} := ui2.custom_message_box(')
-	c.out.writeln('\t\tid: ${qml_quote(node.id)}')
+	c.out.writeln('\tvml_message_box_${suffix} := ui2.custom_message_box(')
+	c.out.writeln('\t\tid: ${vml_quote(node.id)}')
 	c.out.writeln('\t\tframe: ${frame}')
-	c.out.writeln('\t\ttitle: ${qml_prop(properties, 'title', "''")}')
-	c.out.writeln('\t\ttext: ${qml_prop(properties, 'text', "''")}')
-	c.out.writeln('\t\thidden: ${qml_prop(properties, 'hidden', 'false')}')
-	c.out.writeln('\t\twidth: ${qml_prop(properties, 'dialog_width', 'f64(300)')}')
-	c.out.writeln('\t\theight: ${qml_prop(properties, 'dialog_height', 'f64(150)')}')
+	c.out.writeln('\t\ttitle: ${vml_prop(properties, 'title', "''")}')
+	c.out.writeln('\t\ttext: ${vml_prop(properties, 'text', "''")}')
+	c.out.writeln('\t\thidden: ${vml_prop(properties, 'hidden', 'false')}')
+	c.out.writeln('\t\twidth: ${vml_prop(properties, 'dialog_width', 'f64(300)')}')
+	c.out.writeln('\t\theight: ${vml_prop(properties, 'dialog_height', 'f64(150)')}')
 	c.out.writeln('\t\tactions: []ui2.MessageBoxAction{${actions.join(', ')}}')
 	c.out.writeln('\t)')
-	c.out.writeln('\tqml_element_${suffix} := ui2.Element{')
-	c.out.writeln('\t\t...qml_message_box_${suffix}')
+	c.out.writeln('\tvml_element_${suffix} := ui2.Element{')
+	c.out.writeln('\t\t...vml_message_box_${suffix}')
 	c.out.writeln('\t\taction_id: ${action}')
 	c.out.writeln('\t\tkey: ${key}')
 	c.write_common_fields(node, properties, scope, "''", "''", "''")

--- a/vlib/v3/tests/vml_codegen_test.v
+++ b/vlib/v3/tests/vml_codegen_test.v
@@ -1,38 +1,38 @@
 import os
 
-const qml_codegen_vexe = @VEXE
-const qml_codegen_tests_dir = os.dir(@FILE)
-const qml_codegen_v3_dir = os.dir(qml_codegen_tests_dir)
-const qml_codegen_vlib_dir = os.dir(qml_codegen_v3_dir)
-const qml_codegen_v3_src = os.join_path(qml_codegen_v3_dir, 'v3.v')
+const vml_codegen_vexe = @VEXE
+const vml_codegen_tests_dir = os.dir(@FILE)
+const vml_codegen_v3_dir = os.dir(vml_codegen_tests_dir)
+const vml_codegen_vlib_dir = os.dir(vml_codegen_v3_dir)
+const vml_codegen_v3_src = os.join_path(vml_codegen_v3_dir, 'v3.v')
 
-fn qml_codegen_build_v3() string {
+fn vml_codegen_build_v3() string {
 	pid := os.getpid()
-	v3_bin := os.join_path(os.temp_dir(), 'v3_qml_codegen_test_${pid}')
+	v3_bin := os.join_path(os.temp_dir(), 'v3_vml_codegen_test_${pid}')
 	os.rm(v3_bin) or {}
-	build := os.execute('${qml_codegen_vexe} -gc none -path "${qml_codegen_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${qml_codegen_v3_src}')
+	build := os.execute('${vml_codegen_vexe} -gc none -path "${vml_codegen_vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${vml_codegen_v3_src}')
 	assert build.exit_code == 0, build.output
 	return v3_bin
 }
 
-fn qml_codegen_mock_ui2() string {
+fn vml_codegen_mock_ui2() string {
 	return (os.read_file(@FILE) or { panic(err) }).all_after('/* MOCK_UI2\n').all_before('\nMOCK_UI2 */')
 }
 
-fn test_qml_lowers_to_direct_ui2_elements() {
-	v3_bin := qml_codegen_build_v3()
+fn test_vml_lowers_to_direct_ui2_elements() {
+	v3_bin := vml_codegen_build_v3()
 	pid := os.getpid()
-	root := os.join_path(os.temp_dir(), 'v3_qml_codegen_${pid}_project')
+	root := os.join_path(os.temp_dir(), 'v3_vml_codegen_${pid}_project')
 	os.rmdir_all(root) or {}
 	os.mkdir_all(os.join_path(root, 'ui2', 'core')) or { panic(err) }
-	os.write_file(os.join_path(root, 'v.mod'), "Module { name: 'qml_codegen' }\n") or {
+	os.write_file(os.join_path(root, 'v.mod'), "Module { name: 'vml_codegen' }\n") or {
 		panic(err)
 	}
 	os.write_file(os.join_path(root, 'ui2', 'v.mod'), "Module { name: 'ui2', subdirs: ['core'] }\n") or { panic(err) }
-	os.write_file(os.join_path(root, 'ui2', 'core', 'ui2.v'), qml_codegen_mock_ui2()) or {
+	os.write_file(os.join_path(root, 'ui2', 'core', 'ui2.v'), vml_codegen_mock_ui2()) or {
 		panic(err)
 	}
-	os.write_file(os.join_path(root, 'form.qml'), 'Screen {
+	os.write_file(os.join_path(root, 'form.vml'), 'Screen {
     id: root
     width: root.half
     property f64 half: root.width / 2
@@ -100,7 +100,7 @@ fn (mut app App) private_action() {
 }
 
 fn build(app &App) ui2.Element {
-	return \$qml('form.qml')
+	return \$vml('form.vml')
 }
 
 fn main() {
@@ -118,14 +118,14 @@ fn main() {
 "
 	main_path := os.join_path(root, 'main.v')
 	os.write_file(main_path, source) or { panic(err) }
-	bin := os.join_path(root, 'qml_codegen')
-	compile := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${main_path}')
+	bin := os.join_path(root, 'vml_codegen')
+	compile := os.execute('${v3_bin} -nocache -path "${root}|${vml_codegen_vlib_dir}" -b c -o ${bin} ${main_path}')
 	assert compile.exit_code == 0, compile.output
 	assert !compile.output.contains('C compilation failed'), compile.output
 	run := os.execute(bin)
 	assert run.exit_code == 0, run.output
 	assert run.output.trim_space() == '9 a:0 7 select:7\n9 progressbar\nslider 12.5:0.0:100.0 select:4\nswitch false select:5\ncombobox Home choose:Work\ncheckbox 2.0:4.0 select:app.selected', run.output
-	os.write_file(os.join_path(root, 'review.qml'), 'Screen {
+	os.write_file(os.join_path(root, 'review.vml'), 'Screen {
 	id: review_root
 	property f64 half: review_root.quarter * 2
 	property f64 quarter: 25
@@ -156,28 +156,28 @@ fn main() {
 	Label { text: app.count > 0 }
 }') or { panic(err) }
 	review_path := os.join_path(root, 'review.v')
-	os.write_file(review_path, "module main\n\nimport ui2\n\nstruct App {\n\titems []int\n\tcount int\n\tready bool\n\tenabled bool\npub mut:\n\tselected int\n}\n\npub fn (mut app App) select(value int) {\n\tapp.selected = value\n}\n\npub fn (app &App) display_name() string {\n\treturn 'display:\${app.count}'\n}\n\npub fn (app &App) content_width() int {\n\treturn 88\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$qml('review.qml')\n}\n\nfn main() {\n\tapp := App{items: [10], count: 2, ready: true}\n\troot := build(&app)\n\tprintln(root.children[4].frame.width.str() + ' ' + root.box.bg.str() + ' ' + root.children[1].frame.width.str() + ' ' + root.children[3].frame.width.str() + ' ' + root.children[3].action_id + ' ' + root.children[4].text + ' ' + root.children[5].text + ' ' + root.children[6].text + ' ' + root.children[7].text + ' ' + root.children[8].action_id + ' ' + root.children[9].frame.width.str() + ':' + root.children[9].box.bg.str() + ' ' + root.children[10].text + ' ' + root.children[11].text + ' ' + root.children[12].text + ' ' + root.children[13].text + ' ' + root.children[14].action_id + ' ' + root.children[15].text + ' ' + root.children[16].text)\n}\n") or {
+	os.write_file(review_path, "module main\n\nimport ui2\n\nstruct App {\n\titems []int\n\tcount int\n\tready bool\n\tenabled bool\npub mut:\n\tselected int\n}\n\npub fn (mut app App) select(value int) {\n\tapp.selected = value\n}\n\npub fn (app &App) display_name() string {\n\treturn 'display:\${app.count}'\n}\n\npub fn (app &App) content_width() int {\n\treturn 88\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$vml('review.vml')\n}\n\nfn main() {\n\tapp := App{items: [10], count: 2, ready: true}\n\troot := build(&app)\n\tprintln(root.children[4].frame.width.str() + ' ' + root.box.bg.str() + ' ' + root.children[1].frame.width.str() + ' ' + root.children[3].frame.width.str() + ' ' + root.children[3].action_id + ' ' + root.children[4].text + ' ' + root.children[5].text + ' ' + root.children[6].text + ' ' + root.children[7].text + ' ' + root.children[8].action_id + ' ' + root.children[9].frame.width.str() + ':' + root.children[9].box.bg.str() + ' ' + root.children[10].text + ' ' + root.children[11].text + ' ' + root.children[12].text + ' ' + root.children[13].text + ' ' + root.children[14].action_id + ' ' + root.children[15].text + ' ' + root.children[16].text)\n}\n") or {
 		panic(err)
 	}
-	review_compile := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${review_path}')
+	review_compile := os.execute('${v3_bin} -nocache -path "${root}|${vml_codegen_vlib_dir}" -b c -o ${bin} ${review_path}')
 	assert review_compile.exit_code == 0, review_compile.output
 	review_run := os.execute(bin)
 	assert review_run.exit_code == 0, review_run.output
 	assert review_run.output.trim_space() == '50.0 16711680 123.0 77.0 select:1 3 3 count:2 display:2 select:1 88.0:65280 3 12 4 3 select:-1 false true', review_run.output
-	os.write_file(os.join_path(root, 'events.qml'), 'Screen {
+	os.write_file(os.join_path(root, 'events.vml'), 'Screen {
 	TextField { id: message on_text: app.choose("Typed") }
 	TextArea { id: notes on_text: app.choose("Notes") }
 }') or { panic(err) }
 	events_path := os.join_path(root, 'events.v')
-	os.write_file(events_path, "module main\n\nimport ui2\n\nstruct App {}\n\npub fn (mut app App) choose(value string) {\n\t_ = app\n\t_ = value\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$qml('events.qml')\n}\n\nfn main() {\n\tapp := App{}\n\troot := build(&app)\n\tprintln(root.children[0].action_id + ':' + root.children[0].emit_change.str() + ' ' + root.children[1].action_id + ':' + root.children[1].emit_change.str())\n}\n") or {
+	os.write_file(events_path, "module main\n\nimport ui2\n\nstruct App {}\n\npub fn (mut app App) choose(value string) {\n\t_ = app\n\t_ = value\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$vml('events.vml')\n}\n\nfn main() {\n\tapp := App{}\n\troot := build(&app)\n\tprintln(root.children[0].action_id + ':' + root.children[0].emit_change.str() + ' ' + root.children[1].action_id + ':' + root.children[1].emit_change.str())\n}\n") or {
 		panic(err)
 	}
-	events_compile := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${events_path}')
+	events_compile := os.execute('${v3_bin} -nocache -path "${root}|${vml_codegen_vlib_dir}" -b c -o ${bin} ${events_path}')
 	assert events_compile.exit_code == 0, events_compile.output
 	events_run := os.execute(bin)
 	assert events_run.exit_code == 0, events_run.output
 	assert events_run.output.trim_space() == 'choose:Typed:true choose:Notes:true', events_run.output
-	os.write_file(os.join_path(root, 'nested.qml'), 'Screen {
+	os.write_file(os.join_path(root, 'nested.vml'), 'Screen {
 	Repeater {
 		model: app.rows
 		key: item.id
@@ -189,28 +189,28 @@ fn main() {
 	}
 }') or { panic(err) }
 	nested_path := os.join_path(root, 'nested.v')
-	os.write_file(nested_path, "module main\n\nimport ui2\n\nstruct Row {\n\tid int\n\tvalues []int\n}\n\nstruct App {\n\trows []Row\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$qml('nested.qml')\n}\n\nfn main() {\n\tapp := App{rows: [Row{id: 10, values: [1]}, Row{id: 20, values: [1]}]}\n\troot := build(&app)\n\tprintln(root.children[0].key + ' ' + root.children[1].key)\n}\n") or {
+	os.write_file(nested_path, "module main\n\nimport ui2\n\nstruct Row {\n\tid int\n\tvalues []int\n}\n\nstruct App {\n\trows []Row\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$vml('nested.vml')\n}\n\nfn main() {\n\tapp := App{rows: [Row{id: 10, values: [1]}, Row{id: 20, values: [1]}]}\n\troot := build(&app)\n\tprintln(root.children[0].key + ' ' + root.children[1].key)\n}\n") or {
 		panic(err)
 	}
-	nested_compile := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${nested_path}')
+	nested_compile := os.execute('${v3_bin} -nocache -path "${root}|${vml_codegen_vlib_dir}" -b c -o ${bin} ${nested_path}')
 	assert nested_compile.exit_code == 0, nested_compile.output
 	nested_run := os.execute(bin)
 	assert nested_run.exit_code == 0, nested_run.output
 	assert nested_run.output.trim_space() == '10:1 20:1', nested_run.output
-	os.write_file(os.join_path(root, 'geometry_color.qml'), 'Screen {
+	os.write_file(os.join_path(root, 'geometry_color.vml'), 'Screen {
 	Rectangle { id: box width: 100 height: box.width background: app.theme_color() }
 	Rectangle { background: app.numeric_color() }
 }') or { panic(err) }
 	geometry_color_path := os.join_path(root, 'geometry_color.v')
-	os.write_file(geometry_color_path, "module main\n\nimport ui2\n\nstruct App {}\n\npub fn (app &App) theme_color() string {\n\treturn '#112233'\n}\n\npub fn (app &App) numeric_color() u32 {\n\treturn u32(0x445566)\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$qml('geometry_color.qml')\n}\n\nfn main() {\n\tapp := App{}\n\troot := build(&app)\n\tprintln(root.children[0].frame.width.str() + ':' + root.children[0].frame.height.str() + ':' + root.children[0].box.bg.str() + ' ' + root.children[1].box.bg.str())\n}\n") or {
+	os.write_file(geometry_color_path, "module main\n\nimport ui2\n\nstruct App {}\n\npub fn (app &App) theme_color() string {\n\treturn '#112233'\n}\n\npub fn (app &App) numeric_color() u32 {\n\treturn u32(0x445566)\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$vml('geometry_color.vml')\n}\n\nfn main() {\n\tapp := App{}\n\troot := build(&app)\n\tprintln(root.children[0].frame.width.str() + ':' + root.children[0].frame.height.str() + ':' + root.children[0].box.bg.str() + ' ' + root.children[1].box.bg.str())\n}\n") or {
 		panic(err)
 	}
-	geometry_color_compile := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${geometry_color_path}')
+	geometry_color_compile := os.execute('${v3_bin} -nocache -path "${root}|${vml_codegen_vlib_dir}" -b c -o ${bin} ${geometry_color_path}')
 	assert geometry_color_compile.exit_code == 0, geometry_color_compile.output
 	geometry_color_run := os.execute(bin)
 	assert geometry_color_run.exit_code == 0, geometry_color_run.output
 	assert geometry_color_run.output.trim_space() == '100.0:100.0:1122867 4478310', geometry_color_run.output
-	os.write_file(os.join_path(root, 'custom.qml'), 'Screen {
+	os.write_file(os.join_path(root, 'custom.vml'), 'Screen {
 	id: root
 	property Item selected: app.item
 	property f32 ratio: 1 / 2
@@ -218,15 +218,15 @@ fn main() {
 	Rectangle { width: root.ratio }
 }') or { panic(err) }
 	custom_path := os.join_path(root, 'custom.v')
-	os.write_file(custom_path, "module main\n\nimport ui2\n\nstruct Item {\n\tname string\n}\n\nstruct App {\n\titem Item\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$qml('custom.qml')\n}\n\nfn main() {\n\tapp := App{item: Item{name: 'chosen'}}\n\troot := build(&app)\n\tprintln(root.children[0].text + ' ' + root.children[1].frame.width.str())\n}\n") or {
+	os.write_file(custom_path, "module main\n\nimport ui2\n\nstruct Item {\n\tname string\n}\n\nstruct App {\n\titem Item\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$vml('custom.vml')\n}\n\nfn main() {\n\tapp := App{item: Item{name: 'chosen'}}\n\troot := build(&app)\n\tprintln(root.children[0].text + ' ' + root.children[1].frame.width.str())\n}\n") or {
 		panic(err)
 	}
-	custom_compile := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${custom_path}')
+	custom_compile := os.execute('${v3_bin} -nocache -path "${root}|${vml_codegen_vlib_dir}" -b c -o ${bin} ${custom_path}')
 	assert custom_compile.exit_code == 0, custom_compile.output
 	custom_run := os.execute(bin)
 	assert custom_run.exit_code == 0, custom_run.output
 	assert custom_run.output.trim_space() == 'chosen 0.5', custom_run.output
-	os.write_file(os.join_path(root, 'expressions.qml'), r'Screen {
+	os.write_file(os.join_path(root, 'expressions.vml'), r'Screen {
 	Repeater {
 		model: app.values
 		key: item
@@ -240,24 +240,24 @@ fn main() {
 	Label { text: "${app.label(\"}\")}" }
 }') or { panic(err) }
 	expressions_path := os.join_path(root, 'expressions.v')
-	os.write_file(expressions_path, "module main\n\nimport ui2\n\nstruct Item {\n\tvalue int\n\tcolor string\n}\n\nstruct App {\n\tvalues []int\n\titems []Item\n}\n\nfn (app &App) label(value string) string {\n\t_ = app\n\treturn value\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$qml('expressions.qml')\n}\n\nfn main() {\n\tapp := App{values: [10], items: [Item{value: 1, color: '#112233'}]}\n\troot := build(&app)\n\tprintln(root.children[0].text + ' ' + root.children[1].box.bg.str() + ' ' + root.children[2].text)\n}\n") or {
+	os.write_file(expressions_path, "module main\n\nimport ui2\n\nstruct Item {\n\tvalue int\n\tcolor string\n}\n\nstruct App {\n\tvalues []int\n\titems []Item\n}\n\nfn (app &App) label(value string) string {\n\t_ = app\n\treturn value\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$vml('expressions.vml')\n}\n\nfn main() {\n\tapp := App{values: [10], items: [Item{value: 1, color: '#112233'}]}\n\troot := build(&app)\n\tprintln(root.children[0].text + ' ' + root.children[1].box.bg.str() + ' ' + root.children[2].text)\n}\n") or {
 		panic(err)
 	}
-	expressions_compile := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${expressions_path}')
+	expressions_compile := os.execute('${v3_bin} -nocache -path "${root}|${vml_codegen_vlib_dir}" -b c -o ${bin} ${expressions_path}')
 	assert expressions_compile.exit_code == 0, expressions_compile.output
 	expressions_run := os.execute(bin)
 	assert expressions_run.exit_code == 0, expressions_run.output
 	assert expressions_run.output.trim_space() == '9 1122867 }', expressions_run.output
-	os.write_file(os.join_path(root, 'form.qml'), 'Screen { MessageBox { Button { on_tap: app.missing() } } }') or { panic(err) }
-	invalid := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${main_path}')
+	os.write_file(os.join_path(root, 'form.vml'), 'Screen { MessageBox { Button { on_tap: app.missing() } } }') or { panic(err) }
+	invalid := os.execute('${v3_bin} -nocache -path "${root}|${vml_codegen_vlib_dir}" -b c -o ${bin} ${main_path}')
 	assert invalid.exit_code != 0, invalid.output
 	assert invalid.output.contains('missing'), invalid.output
-	os.write_file(os.join_path(root, 'form.qml'), 'Screen { Button { MenuItem { on_tap: app.missing() } } }') or { panic(err) }
-	invalid_menu := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${main_path}')
+	os.write_file(os.join_path(root, 'form.vml'), 'Screen { Button { MenuItem { on_tap: app.missing() } } }') or { panic(err) }
+	invalid_menu := os.execute('${v3_bin} -nocache -path "${root}|${vml_codegen_vlib_dir}" -b c -o ${bin} ${main_path}')
 	assert invalid_menu.exit_code != 0, invalid_menu.output
 	assert invalid_menu.output.contains('missing'), invalid_menu.output
-	os.write_file(os.join_path(root, 'form.qml'), 'Screen { Button { on_tap: app.private_action() } }') or { panic(err) }
-	invalid_private := os.execute('${v3_bin} -nocache -path "${root}|${qml_codegen_vlib_dir}" -b c -o ${bin} ${main_path}')
+	os.write_file(os.join_path(root, 'form.vml'), 'Screen { Button { on_tap: app.private_action() } }') or { panic(err) }
+	invalid_private := os.execute('${v3_bin} -nocache -path "${root}|${vml_codegen_vlib_dir}" -b c -o ${bin} ${main_path}')
 	assert invalid_private.exit_code != 0, invalid_private.output
 	assert invalid_private.output.contains('must be public'), invalid_private.output
 }
@@ -291,9 +291,9 @@ pub fn spinner(config SpinnerConfig) Element { return Element{kind: .dropdown, i
 pub struct MessageBoxAction { pub: id string action_id string title string }
 pub struct MessageBoxConfig { pub: id string frame Rect title string text string hidden bool width f64 height f64 actions []MessageBoxAction }
 pub fn custom_message_box(config MessageBoxConfig) Element { return Element{kind: .view, id: config.id, frame: config.frame, text: config.text, hidden: config.hidden} }
-pub fn compiled_qml_event(_ string, _ string, _ string, action string) string { return action }
-pub fn compiled_qml_event_arg(_ string, _ string, _ string, action string, argument string) string { return action + ':' + argument }
-pub fn compiled_qml_event_arg_path(_ string, _ string, _ string, action string, path string) string { return action + ':' + path }
+pub fn compiled_vml_event(_ string, _ string, _ string, action string) string { return action }
+pub fn compiled_vml_event_arg(_ string, _ string, _ string, action string, argument string) string { return action + ':' + argument }
+pub fn compiled_vml_event_arg_path(_ string, _ string, _ string, action string, path string) string { return action + ':' + path }
 pub fn dispatch[T](mut model T, name string, argument int) ! {
 	$for method in T.methods {
 		if method.name == name {

--- a/vlib/v3/transform/fn_test.v
+++ b/vlib/v3/transform/fn_test.v
@@ -212,9 +212,9 @@ fn test_or_payload_type_qualifies_generic_base_in_own_module() {
 	expr_type, value_type := t.specialized_or_expr_types('!QueryBuilder[sapp.Event]')
 	assert expr_type == '!orm.QueryBuilder[sapp.Event]'
 	assert value_type == 'orm.QueryBuilder[sapp.Event]'
-	tuple_expr_type, tuple_value_type := t.specialized_or_expr_types('!(&ui.QNode, map[string]ui.QmlEvent)')
-	assert tuple_expr_type == '!(&ui.QNode, map[string]ui.QmlEvent)'
-	assert tuple_value_type == '(&ui.QNode, map[string]ui.QmlEvent)'
+	tuple_expr_type, tuple_value_type := t.specialized_or_expr_types('!(&ui.QNode, map[string]ui.VmlEvent)')
+	assert tuple_expr_type == '!(&ui.QNode, map[string]ui.VmlEvent)'
+	assert tuple_value_type == '(&ui.QNode, map[string]ui.VmlEvent)'
 }
 
 fn test_specialized_receiver_method_qualifies_imported_generic_base() {


### PR DESCRIPTION
## Summary

- rename the V3 UI2 compile-time template syntax from `$qml` to `$vml`
- rename parser, generated symbols, cache dependency tracking, diagnostics, and tests from QML to VML
- document `.vml` templates and the `$vml` entry point

UI2 counterpart: https://github.com/vlang/ui2/commit/d13259f

## Verification

- V3 VML code-generation test
- V3 module-cache test
- V3 transform function test
- built the renamed V3 compiler and used it to compile and run UI2s real VML benchmark