### PR TITLE
cmd: fix VC bootstrap after Windows compiler validation

### DIFF
--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -105,6 +105,23 @@ fn test_vc_bootstrap_builds_a_v1_compatibility_compiler() {
 	}
 }
 
+fn test_v1_fallback_can_bootstrap_cmd_v_without_target_define() {
+	$if macos || linux {
+		fallback := os.join_path(macos_v3_test_vroot, macos_v3_v1_fallback_binary)
+		if !os.is_executable(fallback) {
+			return
+		}
+		compiler := os.join_path(os.vtmp_dir(), 'v1_bootstrap_cmd_v_${os.getpid()}')
+		defer {
+			os.rm(compiler) or {}
+		}
+		result := run_macos_v3_test_process(fallback, ['-no-parallel', '-nocache', '-gc', 'none',
+			'-o', compiler, 'cmd/v'], macos_v3_test_vroot, {})
+		assert result.exit_code == 0, result.output
+		assert os.is_executable(compiler)
+	}
+}
+
 fn test_macos_v3_old_compiler_uses_external_v1_command() {
 	$if macos || linux {
 		fallback := os.join_path(macos_v3_test_vroot, macos_v3_v1_fallback_binary)

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -205,17 +205,7 @@ fn main() {
 	if prefs.is_help {
 		invoke_help_and_exit(args)
 	}
-	$if windows {
-		// An invalid `-cc` setting should take precedence over an unknown command,
-		// but must not affect commands that do not compile code.
-		if builder.should_find_windows_host_c_compiler(prefs) && prefs.ccompiler_set_by_flag
-			&& prefs.ccompiler != 'msvc' {
-			mut probe := builder.Builder{
-				pref: unsafe { prefs }
-			}
-			probe.find_win_cc() or { builder.verror(err.msg()) }
-		}
-	}
+	validate_windows_c_compiler_for_unknown_command(prefs)
 
 	other_commands := ['run', 'crun', 'build', 'build-module', 'help', 'version', 'new', 'init',
 		'install', 'link', 'list', 'outdated', 'remove', 'search', 'show', 'unlink', 'update',

--- a/cmd/v/windows_ccompiler_default.c.v
+++ b/cmd/v/windows_ccompiler_default.c.v
@@ -1,0 +1,5 @@
+module main
+
+import v.pref
+
+fn validate_windows_c_compiler_for_unknown_command(_ &pref.Preferences) {}

--- a/cmd/v/windows_ccompiler_windows.c.v
+++ b/cmd/v/windows_ccompiler_windows.c.v
@@ -1,0 +1,16 @@
+module main
+
+import v.builder
+import v.pref
+
+fn validate_windows_c_compiler_for_unknown_command(prefs &pref.Preferences) {
+	// An invalid `-cc` setting should take precedence over an unknown command,
+	// but must not affect commands that do not compile code.
+	if builder.should_find_windows_host_c_compiler(prefs) && prefs.ccompiler_set_by_flag
+		&& prefs.ccompiler != 'msvc' {
+		mut probe := builder.Builder{
+			pref: unsafe { prefs }
+		}
+		probe.find_win_cc() or { builder.verror(err.msg()) }
+	}
+}


### PR DESCRIPTION
## Summary

- move the Windows-only C compiler validation behind platform-specific implementations
- keep `v.builder` out of macOS/Linux V3 compiler builds
- add a regression test that compiles `cmd/v` through `v1_fallback` without a target define

## Testing

- `make`
- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -silent cmd/v/macos_v3_test.v`
- `./vnew -silent cmd/v/macos_v3_external_fallback_test.v`
- `./vnew -silent cmd/v/v_windows_test.v`
- `./vnew -old-compiler -silent vlib/v/compiler_errors_test.v`
- `./vnew -old-compiler -no-parallel -os windows -o /tmp/v-bootstrap-windows-latest.c cmd/v`
