### PR TITLE
cgen: compare reference parameters by address

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -3452,6 +3452,38 @@ fn (foo &Foo) bar() {
 `foo` is still immutable and can't be changed. For that,
 `(mut foo Foo)` must be used.
 
+When immutable reference parameters to structs are compared with `==` or `!=`,
+V compares their addresses, not their fields. Dereference the parameters explicitly
+to compare their values instead:
+
+```v
+struct Point {
+	x int
+}
+
+fn same_reference(a &Point, b &Point) bool {
+	return a == b
+}
+
+fn same_value(a &Point, b &Point) bool {
+	return *a == *b
+}
+
+a := Point{
+	x: 1
+}
+b := Point{
+	x: 1
+}
+assert !same_reference(a, b)
+assert same_reference(a, a)
+assert same_value(a, b)
+```
+
+This address-comparison rule also applies when reference parameters are captured by
+a closure or their reference types are written through aliases. A user-defined `==`
+operator takes precedence over the default address or value comparison.
+
 In general, V's references are similar to Go pointers and C++ references.
 For example, a generic tree structure definition would look like this:
 

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -177,6 +177,18 @@ fn (mut g Gen) infix_expr_arrow_op(node ast.InfixExpr) {
 	}
 }
 
+fn infix_operand_requests_pointer_identity(expr ast.Expr) bool {
+	mut unwrapped := expr
+	for unwrapped is ast.ParExpr {
+		unwrapped = unwrapped.expr
+	}
+	if unwrapped is ast.PrefixExpr {
+		return unwrapped.op == .amp && unwrapped.right.is_lvalue()
+	}
+	return unwrapped is ast.Ident && unwrapped.obj is ast.Var && unwrapped.obj.is_arg
+		&& !unwrapped.obj.is_auto_deref
+}
+
 // infix_expr_eq_op generates code for `==` and `!=`
 fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 	mut left_type := g.type_resolver.get_type_or_default(node.left, node.left_type)
@@ -395,6 +407,13 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 			g.expr(node.right)
 		}
 		g.write(')')
+	} else if !left_is_option && !right_is_option && left.unaliased_sym.kind == .struct
+		&& right.unaliased_sym.kind == .struct
+		&& g.table.fully_unaliased_type(left.typ).is_ptr()
+		&& g.table.fully_unaliased_type(right.typ).is_ptr()
+		&& (infix_operand_requests_pointer_identity(node.left)
+		|| infix_operand_requests_pointer_identity(node.right)) {
+		g.gen_plain_infix_expr(node)
 	} else if (left.unaliased.idx() == right.unaliased.idx()
 		&& left.sym.kind in [.array, .array_fixed, .alias, .map, .struct, .sum_type, .interface])
 		|| (left.unaliased_sym.kind == .array_fixed && right.unaliased_sym.kind == .array_fixed) {
@@ -557,21 +576,7 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 				} else {
 					ptr_typ := g.equality_fn(left.unaliased)
 					if left.typ.is_ptr() || right.typ.is_ptr() {
-						left_is_addr_of_lvalue := node.left is ast.PrefixExpr
-							&& node.left.op == .amp && node.left.right.is_lvalue()
-						right_is_addr_of_lvalue := node.right is ast.PrefixExpr
-							&& node.right.op == .amp && node.right.right.is_lvalue()
-						left_is_ref_param := node.left is ast.Ident && node.left.obj is ast.Var
-							&& node.left.obj.is_arg && !node.left.obj.is_auto_deref
-						right_is_ref_param := node.right is ast.Ident && node.right.obj is ast.Var
-							&& node.right.obj.is_arg && !node.right.obj.is_auto_deref
-						if left.typ.is_ptr() && right.typ.is_ptr()
-							&& (left_is_addr_of_lvalue || right_is_addr_of_lvalue
-								|| left_is_ref_param || right_is_ref_param) {
-							g.gen_plain_infix_expr(node)
-						} else {
-							g.gen_struct_pointer_eq_op(node, left_type, right_type, ptr_typ)
-						}
+						g.gen_struct_pointer_eq_op(node, left_type, right_type, ptr_typ)
 					} else {
 						if node.op == .ne {
 							g.write('!')

--- a/vlib/v/gen/c/infix.v
+++ b/vlib/v/gen/c/infix.v
@@ -561,8 +561,13 @@ fn (mut g Gen) infix_expr_eq_op(node ast.InfixExpr) {
 							&& node.left.op == .amp && node.left.right.is_lvalue()
 						right_is_addr_of_lvalue := node.right is ast.PrefixExpr
 							&& node.right.op == .amp && node.right.right.is_lvalue()
+						left_is_ref_param := node.left is ast.Ident && node.left.obj is ast.Var
+							&& node.left.obj.is_arg && !node.left.obj.is_auto_deref
+						right_is_ref_param := node.right is ast.Ident && node.right.obj is ast.Var
+							&& node.right.obj.is_arg && !node.right.obj.is_auto_deref
 						if left.typ.is_ptr() && right.typ.is_ptr()
-							&& (left_is_addr_of_lvalue || right_is_addr_of_lvalue) {
+							&& (left_is_addr_of_lvalue || right_is_addr_of_lvalue
+								|| left_is_ref_param || right_is_ref_param) {
 							g.gen_plain_infix_expr(node)
 						} else {
 							g.gen_struct_pointer_eq_op(node, left_type, right_type, ptr_typ)

--- a/vlib/v/tests/fns/lambda_expr_test.v
+++ b/vlib/v/tests/fns/lambda_expr_test.v
@@ -59,3 +59,23 @@ fn test_lambda_expr_can_omit_unused_callback_params() {
 	assert f1(|| 4) == 4
 	assert f2(|x| x + 4) == 14
 }
+
+struct LambdaData {
+	value int
+}
+
+fn compare_lambda_data(compare fn (&LambdaData, &LambdaData) bool, a &LambdaData, b &LambdaData) bool {
+	return compare(a, b)
+}
+
+fn test_inferred_lambda_reference_parameters_compare_values() {
+	a := LambdaData{}
+	b := LambdaData{}
+	c := LambdaData{
+		value: 1
+	}
+	assert compare_lambda_data(|x, y| x == y, a, b)
+	assert !compare_lambda_data(|x, y| x != y, a, b)
+	assert !compare_lambda_data(|x, y| x == y, a, c)
+	assert compare_lambda_data(|x, y| x != y, a, c)
+}

--- a/vlib/v/tests/structs/operator_overloading_with_reference_operands_test.v
+++ b/vlib/v/tests/structs/operator_overloading_with_reference_operands_test.v
@@ -51,6 +51,33 @@ fn test_eq_operator_with_reference_operands() {
 	assert false
 }
 
+struct AliasFoo {
+	id    int
+	value int
+}
+
+type AliasFooEquality = AliasFoo
+
+fn (a AliasFooEquality) == (b AliasFooEquality) bool {
+	return a.id == b.id
+}
+
+fn alias_foo_references_are_equal(a &AliasFooEquality, b &AliasFooEquality) bool {
+	return a == b
+}
+
+fn test_alias_eq_operator_with_reference_operands() {
+	a := AliasFooEquality{
+		id:    1
+		value: 4
+	}
+	b := AliasFooEquality{
+		id:    1
+		value: 9
+	}
+	assert alias_foo_references_are_equal(&a, &b)
+}
+
 struct Sum {
 	value int
 }

--- a/vlib/v/tests/structs/operator_overloading_with_reference_operands_test.v
+++ b/vlib/v/tests/structs/operator_overloading_with_reference_operands_test.v
@@ -36,9 +36,14 @@ fn (f &Foo) == (o &Foo) bool {
 	return f.id == o.id
 }
 
+fn foo_references_are_equal(a &Foo, b &Foo) bool {
+	return a == b
+}
+
 fn test_eq_operator_with_reference_operands() {
 	a := Foo{1, 4, 5}
 	b := Foo{1, 9, 10}
+	assert foo_references_are_equal(a, b)
 	if a == b {
 		assert true
 		return

--- a/vlib/v/tests/structs/struct_address_of_field_comparison_test.v
+++ b/vlib/v/tests/structs/struct_address_of_field_comparison_test.v
@@ -70,3 +70,12 @@ fn test_indexed_lvalue_addresses_compare_addresses() {
 	assert &items[0] != &items[1]
 	assert &items[0] == &items[0]
 }
+
+fn test_dereferenced_lvalue_addresses_compare_addresses() {
+	a := Data{}
+	b := Data{}
+	p := &a
+	q := &b
+	assert &*p != &*q
+	assert &*p == &*p
+}

--- a/vlib/v/tests/structs/struct_address_of_field_comparison_test.v
+++ b/vlib/v/tests/structs/struct_address_of_field_comparison_test.v
@@ -14,6 +14,8 @@ mut:
 	ref &Data = unsafe { nil }
 }
 
+type DataRef = &Data
+
 fn test_address_of_field_compares_addresses() {
 	mut t := Holder{}
 	// `t.ref` is nil, so address comparison must be true (nil != &t.buf).
@@ -30,15 +32,41 @@ fn references_are_equal(a &Data, b &Data) bool {
 	return a == b
 }
 
+// vfmt off
+fn parenthesized_references_are_equal(a &Data, b &Data) bool {
+	return (a) == (b)
+}
+// vfmt on
+
+fn reference_aliases_are_equal(a DataRef, b DataRef) bool {
+	return a == b
+}
+
 fn test_reference_parameters_compare_addresses() {
 	a := Data{}
 	b := Data{}
 	assert !references_are_equal(a, b)
 	assert references_are_equal(a, a)
+	assert !parenthesized_references_are_equal(a, b)
+	assert parenthesized_references_are_equal(a, a)
+	assert !reference_aliases_are_equal(&a, &b)
+	assert reference_aliases_are_equal(&a, &a)
 
 	compare := fn (left &Data, right &Data) bool {
 		return left == right
 	}
 	assert !compare(a, b)
 	assert compare(a, a)
+
+	alias_compare := fn (left DataRef, right DataRef) bool {
+		return left == right
+	}
+	assert !alias_compare(&a, &b)
+	assert alias_compare(&a, &a)
+}
+
+fn test_indexed_lvalue_addresses_compare_addresses() {
+	items := [Data{}, Data{}]
+	assert &items[0] != &items[1]
+	assert &items[0] == &items[0]
 }

--- a/vlib/v/tests/structs/struct_address_of_field_comparison_test.v
+++ b/vlib/v/tests/structs/struct_address_of_field_comparison_test.v
@@ -42,6 +42,13 @@ fn reference_aliases_are_equal(a DataRef, b DataRef) bool {
 	return a == b
 }
 
+fn captured_references_are_equal(a &Data, b &Data) bool {
+	compare := fn [a, b] () bool {
+		return a == b
+	}
+	return compare()
+}
+
 fn test_reference_parameters_compare_addresses() {
 	a := Data{}
 	b := Data{}
@@ -51,6 +58,8 @@ fn test_reference_parameters_compare_addresses() {
 	assert parenthesized_references_are_equal(a, a)
 	assert !reference_aliases_are_equal(&a, &b)
 	assert reference_aliases_are_equal(&a, &a)
+	assert !captured_references_are_equal(a, b)
+	assert captured_references_are_equal(a, a)
 
 	compare := fn (left &Data, right &Data) bool {
 		return left == right

--- a/vlib/v/tests/structs/struct_address_of_field_comparison_test.v
+++ b/vlib/v/tests/structs/struct_address_of_field_comparison_test.v
@@ -25,3 +25,20 @@ fn test_address_of_field_compares_addresses() {
 	// Different addresses with structurally equal contents must still be unequal.
 	assert &other != &t.buf
 }
+
+fn references_are_equal(a &Data, b &Data) bool {
+	return a == b
+}
+
+fn test_reference_parameters_compare_addresses() {
+	a := Data{}
+	b := Data{}
+	assert !references_are_equal(a, b)
+	assert references_are_equal(a, a)
+
+	compare := fn (left &Data, right &Data) bool {
+		return left == right
+	}
+	assert !compare(a, b)
+	assert compare(a, a)
+}

--- a/vlib/v3/tests/selfhost_transform_regression_test.v
+++ b/vlib/v3/tests/selfhost_transform_regression_test.v
@@ -374,6 +374,34 @@ fn main() {
 	assert out.split_into_lines() == ['false', 'true', 'true', 'false']
 }
 
+// Resolve every hop in a function literal parameter alias before deciding whether the parameter
+// has explicit reference semantics.
+fn test_fn_literal_chained_pointer_alias_params_keep_identity() {
+	out := selfhost_regression_run('fn_literal_chained_pointer_alias_identity', 'struct Data {
+	value int
+}
+
+type DataRef = &Data
+type NestedRef = DataRef
+
+fn main() {
+	a := Data{}
+	b := Data{}
+	equal := fn (x NestedRef, y NestedRef) bool {
+		return x == y
+	}
+	not_equal := fn (x NestedRef, y NestedRef) bool {
+		return x != y
+	}
+	println(equal(&a, &b))
+	println(not_equal(&a, &b))
+	println(equal(&a, &a))
+	println(not_equal(&a, &a))
+}
+')
+	assert out.split_into_lines() == ['false', 'true', 'true', 'false']
+}
+
 // Only `for k, mut v in m` binds the map value by reference. A container that is merely a map
 // reference (`m &map[string]bool`) still binds a plain value copy, so the binding must not be
 // typed `&V` — that made every use of it emit a dereference of a non-pointer local.

--- a/vlib/v3/tests/selfhost_transform_regression_test.v
+++ b/vlib/v3/tests/selfhost_transform_regression_test.v
@@ -342,6 +342,38 @@ fn main() {
 	assert out == 'posts'
 }
 
+// A generic fn literal with explicit reference parameters keeps pointer identity after its
+// parameters are specialized to the concrete callback signature. Only inferred pipe-lambda
+// pointer parameters use auto-dereferenced value equality.
+fn test_generic_fn_literal_reference_params_keep_identity() {
+	out := selfhost_regression_run('generic_fn_literal_reference_identity', 'struct Data {
+	value int
+}
+
+fn compare_data(compare fn (&Data, &Data) bool, a &Data, b &Data) bool {
+	return compare(a, b)
+}
+
+fn main() {
+	a := Data{}
+	b := Data{}
+	println(compare_data(fn [T](x &T, y &T) bool {
+		return x == y
+	}, a, b))
+	println(compare_data(fn [T](x &T, y &T) bool {
+		return x != y
+	}, a, b))
+	println(compare_data(fn [T](x &T, y &T) bool {
+		return x == y
+	}, a, a))
+	println(compare_data(fn [T](x &T, y &T) bool {
+		return x != y
+	}, a, a))
+}
+')
+	assert out.split_into_lines() == ['false', 'true', 'true', 'false']
+}
+
 // Only `for k, mut v in m` binds the map value by reference. A container that is merely a map
 // reference (`m &map[string]bool`) still binds a plain value copy, so the binding must not be
 // typed `&V` — that made every use of it emit a dereference of a non-pointer local.

--- a/vlib/v3/tests/selfhost_transform_regression_test.v
+++ b/vlib/v3/tests/selfhost_transform_regression_test.v
@@ -402,6 +402,37 @@ fn main() {
 	assert out.split_into_lines() == ['false', 'true', 'true', 'false']
 }
 
+// Regular function parameters need the same complete alias resolution as lifted literals before
+// deciding whether equality has explicit reference semantics.
+fn test_regular_param_chained_pointer_aliases_keep_identity() {
+	out := selfhost_regression_run('regular_param_chained_pointer_alias_identity', 'struct Data {
+	value int
+}
+
+type A = &Data
+type B = A
+type DeepRef = B
+
+fn same(x DeepRef, y DeepRef) bool {
+	return x == y
+}
+
+fn different(x DeepRef, y DeepRef) bool {
+	return x != y
+}
+
+fn main() {
+	a := Data{}
+	b := Data{}
+	println(same(&a, &b))
+	println(different(&a, &b))
+	println(same(&a, &a))
+	println(different(&a, &a))
+}
+')
+	assert out.split_into_lines() == ['false', 'true', 'true', 'false']
+}
+
 // Only `for k, mut v in m` binds the map value by reference. A container that is merely a map
 // reference (`m &map[string]bool`) still binds a plain value copy, so the binding must not be
 // typed `&V` — that made every use of it emit a dereference of a non-pointer local.

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -1007,7 +1007,14 @@ fn (mut t Transformer) transform_pointer_value_struct_eq(node flat.Node, lhs_id 
 			|| t.infix_operand_requests_pointer_identity(rhs_id) {
 			// A user-defined equality operator takes precedence over the identity
 			// semantics requested by reference parameters or explicit addresses.
-			if call_info := t.struct_operator_call_info(lhs_struct, node.op) {
+			mut operator_type := lhs_struct
+			mut is_alias_operator := false
+			if alias_type := t.operator_alias_type_for_operand(lhs_id, node.op) {
+				operator_type = alias_type
+				is_alias_operator = true
+			}
+			if call_info := t.struct_operator_call_info_for_operand(operator_type, node.op,
+				is_alias_operator) {
 				if t.is_disabled_fn_name(call_info.name) {
 					return t.make_bool_literal(node.op == .ne)
 				}

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -1034,10 +1034,14 @@ fn (t &Transformer) infix_operand_requests_pointer_identity(id flat.NodeId) bool
 	if node.kind == .ident {
 		return t.var_is_ref_param(node.value)
 	}
+	if node.kind == .paren && node.children_count == 1 {
+		child_id := t.source_expr_child(id, node, 0) or { return false }
+		return t.infix_operand_requests_pointer_identity(child_id)
+	}
 	if node.kind != .prefix || node.op != .amp || node.children_count != 1 {
 		return false
 	}
-	child_id := t.source_unary_expr_child(id, node) or { return false }
+	child_id := t.source_expr_child(id, node, 0) or { return false }
 	return t.source_expr_is_plain_lvalue(child_id)
 }
 
@@ -1049,24 +1053,37 @@ fn (t &Transformer) source_expr_is_plain_lvalue(id flat.NodeId) bool {
 	if node.kind == .ident {
 		return node.value.len > 0
 	}
-	if node.kind != .selector || node.children_count == 0 {
+	if node.kind !in [.selector, .index, .paren] || node.children_count == 0 {
 		return false
 	}
-	child_id := t.source_unary_expr_child(id, node) or { return false }
+	if node.kind == .index && node.value == 'range' {
+		return false
+	}
+	child_id := t.source_expr_child(id, node, 0) or { return false }
 	return t.source_expr_is_plain_lvalue(child_id)
 }
 
-fn (t &Transformer) source_unary_expr_child(id flat.NodeId, node &flat.Node) ?flat.NodeId {
-	child_id := t.a.child(node, 0)
+fn (t &Transformer) source_expr_child(id flat.NodeId, node &flat.Node, child_idx int) ?flat.NodeId {
+	if child_idx < 0 || child_idx >= int(node.children_count) {
+		return none
+	}
+	child_id := t.a.child(node, child_idx)
 	if int(child_id) >= 0 {
 		return child_id
 	}
 	// In-place transform passes can consume a source child slot. Source nodes are
-	// built post-order, so the direct child of a unary expression immediately
-	// precedes it and remains linked by the immutable source-parent index.
-	source_child := int(id) - 1
-	if source_child >= 0 && t.source_parent_id(source_child) == int(id) {
-		return flat.NodeId(source_child)
+	// built post-order, so recover the requested direct child from the immutable
+	// source-parent index. Walking backwards visits direct children right-to-left.
+	target_from_right := int(node.children_count) - 1 - child_idx
+	mut direct_child_from_right := 0
+	for source_child := int(id) - 1; source_child >= 0; source_child-- {
+		if t.source_parent_id(source_child) != int(id) {
+			continue
+		}
+		if direct_child_from_right == target_from_right {
+			return flat.NodeId(source_child)
+		}
+		direct_child_from_right++
 	}
 	return none
 }

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -1005,6 +1005,22 @@ fn (mut t Transformer) transform_pointer_value_struct_eq(node flat.Node, lhs_id 
 	if lhs_is_ptr && rhs_is_ptr {
 		if t.infix_operand_requests_pointer_identity(lhs_id)
 			|| t.infix_operand_requests_pointer_identity(rhs_id) {
+			// A user-defined equality operator takes precedence over the identity
+			// semantics requested by reference parameters or explicit addresses.
+			if call_info := t.struct_operator_call_info(lhs_struct, node.op) {
+				if t.is_disabled_fn_name(call_info.name) {
+					return t.make_bool_literal(node.op == .ne)
+				}
+				lhs := t.transform_expr_preserving_pointer_value(lhs_id)
+				rhs := t.transform_expr_preserving_pointer_value(rhs_id)
+				args := if call_info.reverse { [rhs, lhs] } else { [lhs, rhs] }
+				t.mark_struct_operator_used_name(call_info.name)
+				call := t.make_call_typed(call_info.name, args, 'bool')
+				if call_info.negate {
+					return t.make_prefix(.not, call)
+				}
+				return call
+			}
 			return none
 		}
 		return t.transform_struct_pointer_eq(node, lhs_id, rhs_id, lhs_type, rhs_type, lhs_clean,

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -1053,6 +1053,13 @@ fn (t &Transformer) source_expr_is_plain_lvalue(id flat.NodeId) bool {
 	if node.kind == .ident {
 		return node.value.len > 0
 	}
+	if node.kind == .prefix {
+		if node.op != .mul || node.children_count != 1 {
+			return false
+		}
+		child_id := t.source_expr_child(id, node, 0) or { return false }
+		return t.source_expr_is_plain_lvalue(child_id)
+	}
 	if node.kind !in [.selector, .index, .paren] || node.children_count == 0 {
 		return false
 	}

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -1003,6 +1003,10 @@ fn (mut t Transformer) transform_pointer_value_struct_eq(node flat.Node, lhs_id 
 		return none
 	}
 	if lhs_is_ptr && rhs_is_ptr {
+		if t.infix_operand_requests_pointer_identity(lhs_id)
+			|| t.infix_operand_requests_pointer_identity(rhs_id) {
+			return none
+		}
 		return t.transform_struct_pointer_eq(node, lhs_id, rhs_id, lhs_type, rhs_type, lhs_clean,
 			rhs_clean)
 	}
@@ -1018,6 +1022,51 @@ fn (mut t Transformer) transform_pointer_value_struct_eq(node flat.Node, lhs_id 
 	}
 	if eq := t.transform_transformed_struct_eq(node, lhs, rhs) {
 		return eq
+	}
+	return none
+}
+
+fn (t &Transformer) infix_operand_requests_pointer_identity(id flat.NodeId) bool {
+	if int(id) < 0 || int(id) >= t.a.nodes.len {
+		return false
+	}
+	node := t.a.node(id)
+	if node.kind == .ident {
+		return t.var_is_ref_param(node.value)
+	}
+	if node.kind != .prefix || node.op != .amp || node.children_count != 1 {
+		return false
+	}
+	child_id := t.source_unary_expr_child(id, node) or { return false }
+	return t.source_expr_is_plain_lvalue(child_id)
+}
+
+fn (t &Transformer) source_expr_is_plain_lvalue(id flat.NodeId) bool {
+	if int(id) < 0 || int(id) >= t.a.nodes.len {
+		return false
+	}
+	node := t.a.node(id)
+	if node.kind == .ident {
+		return node.value.len > 0
+	}
+	if node.kind != .selector || node.children_count == 0 {
+		return false
+	}
+	child_id := t.source_unary_expr_child(id, node) or { return false }
+	return t.source_expr_is_plain_lvalue(child_id)
+}
+
+fn (t &Transformer) source_unary_expr_child(id flat.NodeId, node &flat.Node) ?flat.NodeId {
+	child_id := t.a.child(node, 0)
+	if int(child_id) >= 0 {
+		return child_id
+	}
+	// In-place transform passes can consume a source child slot. Source nodes are
+	// built post-order, so the direct child of a unary expression immediately
+	// precedes it and remains linked by the immutable source-parent index.
+	source_child := int(id) - 1
+	if source_child >= 0 && t.source_parent_id(source_child) == int(id) {
+		return flat.NodeId(source_child)
 	}
 	return none
 }

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -11086,7 +11086,7 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 			}
 			t.pointer_value_lvalues.delete(param.value)
 			t.pointer_value_rvalues.delete(param.value)
-			resolved_param_type := t.normalize_type_alias(param.typ)
+			resolved_param_type := t.comptime_normalize_type_alias_chain(param.typ)
 			t.set_var_type_with_raw(param.value, resolved_param_type, param.typ)
 			// An immutable `.amp` parameter was inferred for a pipe lambda and retains
 			// the source language's auto-dereferenced value semantics. Adapted function

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -11083,6 +11083,9 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 			t.pointer_value_lvalues.delete(param.value)
 			t.pointer_value_rvalues.delete(param.value)
 			t.set_var_type(param.value, param.typ)
+			if !param.is_mut && param.typ.starts_with('&') {
+				t.mark_var_as_ref_param(param.value)
+			}
 			if t.is_fixed_array_type(param.typ) {
 				t.fixed_array_param_values[param.value] = true
 			}

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -11088,7 +11088,9 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 			t.pointer_value_rvalues.delete(param.value)
 			resolved_param_type := t.normalize_type_alias(param.typ)
 			t.set_var_type_with_raw(param.value, resolved_param_type, param.typ)
-			if !param.is_mut && resolved_param_type.starts_with('&') {
+			// An immutable `.amp` parameter was inferred for a pipe lambda and retains
+			// the source language's auto-dereferenced value semantics.
+			if !param.is_mut && param.op != .amp && resolved_param_type.starts_with('&') {
 				t.mark_var_as_ref_param(param.value)
 			}
 			if t.is_fixed_array_type(param.typ) {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -3614,7 +3614,7 @@ fn (mut t Transformer) lift_fn_literal_for_fn_param(_id flat.NodeId, node flat.N
 				kind: .param
 				value: param.value
 				typ: param_type_name
-				op: if param_type_name.starts_with('&') { .amp } else { param.op }
+				op: param.op
 				is_mut: param.is_mut
 			})
 		}
@@ -3625,7 +3625,7 @@ fn (mut t Transformer) lift_fn_literal_for_fn_param(_id flat.NodeId, node flat.N
 			kind: .param
 			value: '_unused_${i}'
 			typ: param_type_name
-			op: if param_type_name.starts_with('&') { .amp } else { .none }
+			op: .none
 		})
 	}
 	children << body_ids
@@ -11089,7 +11089,8 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 			resolved_param_type := t.normalize_type_alias(param.typ)
 			t.set_var_type_with_raw(param.value, resolved_param_type, param.typ)
 			// An immutable `.amp` parameter was inferred for a pipe lambda and retains
-			// the source language's auto-dereferenced value semantics.
+			// the source language's auto-dereferenced value semantics. Adapted function
+			// literals preserve their source parameter operator instead.
 			if !param.is_mut && param.op != .amp && resolved_param_type.starts_with('&') {
 				t.mark_var_as_ref_param(param.value)
 			}

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -11082,8 +11082,9 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 			}
 			t.pointer_value_lvalues.delete(param.value)
 			t.pointer_value_rvalues.delete(param.value)
-			t.set_var_type(param.value, param.typ)
-			if !param.is_mut && param.typ.starts_with('&') {
+			resolved_param_type := t.normalize_type_alias(param.typ)
+			t.set_var_type_with_raw(param.value, resolved_param_type, param.typ)
+			if !param.is_mut && resolved_param_type.starts_with('&') {
 				t.mark_var_as_ref_param(param.value)
 			}
 			if t.is_fixed_array_type(param.typ) {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -10952,6 +10952,7 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 	mut capture_by_ref := map[string]bool{}
 	mut capture_from_context := map[string]bool{}
 	mut capture_from_heap := map[string]bool{}
+	mut capture_is_ref_param := map[string]bool{}
 	mut body_ids := []flat.NodeId{}
 	for i in 0 .. node.children_count {
 		child_id := t.a.child(&node, i)
@@ -10972,6 +10973,9 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 				continue
 			}
 			if child.value.len > 0 && child.value !in capture_names {
+				if t.var_is_ref_param(child.value) {
+					capture_is_ref_param[child.value] = true
+				}
 				mut capture_type := t.raw_var_type(child.value)
 				if capture_type.len == 0 {
 					capture_type = t.var_type(child.value)
@@ -11147,13 +11151,25 @@ fn (mut t Transformer) lift_fn_literal(_id flat.NodeId, node flat.Node) flat.Nod
 		}
 		lifted_body << capture_decl
 	}
+	synthetic_decl_count := lifted_body.len
 	for body_id in body_ids {
 		lifted_body << body_id
 	}
 	outer_pending := t.pending_stmts.clone()
 	t.pending_stmts.clear()
 	t.mark_local_closure_cleanup_decls(lifted_body)
-	new_body := t.transform_stmts(lifted_body)
+	mut new_body := []flat.NodeId{}
+	if capture_is_ref_param.len == 0 {
+		new_body = t.transform_stmts(lifted_body)
+	} else {
+		new_body = t.transform_stmts(lifted_body[..synthetic_decl_count])
+		// Transforming the synthetic capture declarations recreates their bindings.
+		// Restore reference-parameter identity before transforming the lifted body.
+		for capture_name, _ in capture_is_ref_param {
+			t.mark_var_as_ref_param(capture_name)
+		}
+		new_body << t.transform_stmts(lifted_body[synthetic_decl_count..])
+	}
 	t.pending_stmts = outer_pending
 	for param_name in param_names {
 		if saved_param_pointer_flags[param_name] or { false } {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -8785,7 +8785,7 @@ fn (mut t Transformer) transform_fn_body(fn_idx int) {
 		}
 		if typ.len > 0 {
 			t.set_var_type_with_raw(child.value, typ, raw_source_typ)
-			if !child.is_mut && raw_source_typ.starts_with('&') {
+			if !child.is_mut && t.normalize_type_alias(typ).starts_with('&') {
 				t.mark_var_as_ref_param(child.value)
 			}
 			if t.is_fixed_array_type(typ) {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -823,6 +823,8 @@ struct VarTypeBinding {
 	typ             string
 	raw_typ         string
 	is_implicit_err bool
+mut:
+	is_ref_param bool
 }
 
 struct BoundMethodArrayInfo {
@@ -2445,6 +2447,18 @@ fn (mut t Transformer) set_var_type(name string, typ string) {
 
 fn (mut t Transformer) set_implicit_err_var_type() {
 	t.set_var_type_binding('err', 'IError', 'IError', true)
+}
+
+fn (mut t Transformer) mark_var_as_ref_param(name string) {
+	i := t.var_type_index(name)
+	if i >= 0 {
+		t.var_types[i].is_ref_param = true
+	}
+}
+
+fn (t &Transformer) var_is_ref_param(name string) bool {
+	i := t.var_type_index(name)
+	return i >= 0 && t.var_types[i].is_ref_param
 }
 
 fn (t &Transformer) implicit_err_binding_active() bool {
@@ -8771,6 +8785,9 @@ fn (mut t Transformer) transform_fn_body(fn_idx int) {
 		}
 		if typ.len > 0 {
 			t.set_var_type_with_raw(child.value, typ, raw_source_typ)
+			if !child.is_mut && raw_source_typ.starts_with('&') {
+				t.mark_var_as_ref_param(child.value)
+			}
 			if t.is_fixed_array_type(typ) {
 				t.fixed_array_param_values[child.value] = true
 			}

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -8785,7 +8785,7 @@ fn (mut t Transformer) transform_fn_body(fn_idx int) {
 		}
 		if typ.len > 0 {
 			t.set_var_type_with_raw(child.value, typ, raw_source_typ)
-			if !child.is_mut && t.normalize_type_alias(typ).starts_with('&') {
+			if !child.is_mut && t.comptime_normalize_type_alias_chain(typ).starts_with('&') {
 				t.mark_var_as_ref_param(child.value)
 			}
 			if t.is_fixed_array_type(typ) {


### PR DESCRIPTION
Reference parameters such as `a &Data` denote an existing object, so equality between them should compare pointer identity. The V3 struct-pointer equality transform instead lowered these comparisons to deep struct equality, producing invalid generated C in the reported case. The legacy backend had the same gap for named reference parameters.

This change:
- preserves pointer identity for immutable reference parameters in V3, including function literals
- preserves pointer identity for explicit address-of lvalue expressions in V3
- adds equivalent reference-parameter handling to the legacy C backend
- keeps semantic/deep equality for ordinary heap-allocated struct pointers
- extends the regression test from #27089 with regular and anonymous function parameters

Tests:
- `./vnew test vlib/v/tests/structs/struct_address_of_field_comparison_test.v`
- `./v1new test vlib/v/tests/structs/struct_address_of_field_comparison_test.v`
- `./vnew test vlib/v/tests/structs/struct_pointer_nil_comparison_test.v`
- `./v1new test vlib/v/tests/structs/struct_pointer_nil_comparison_test.v`
- `./v1new -silent vlib/v/compiler_errors_test.v` (1707 passed, 1 skipped)

Generated C inspection confirms that both named and anonymous reference parameters now emit direct pointer comparisons.