### PR TITLE
test: cover SIMD inline assembly kernels

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -9120,6 +9120,14 @@ asm amd64 raw {
 assert value == 42
 ```
 
+SIMD kernels use the same named operands. A pointer to a fixed array, such as `&[16]u8` or
+`&[4]u32`, can use an `r` constraint and an explicit byte offset; an `m` constraint is useful when
+the compiler should choose the memory form. Keep alignment requirements in the kernel contract.
+List every vector register that the template overwrites, including `xmm6` through `xmm15` on
+Win64: GCC and Clang use those registers as nonvolatile and can preserve them when they are listed
+as clobbers. MSVC x64 does not support GNU inline assembly, so GNU raw fixtures use `!msvc` guards.
+Instructions such as `pclmulqdq` and ARM64 `pmull` are optional CPU features; tests that execute
+them must check the host feature before entering the raw block.
 `asm goto` emits GNU `asm goto` and is available only with the C backend. Its fifth semicolon
 section lists the V labels that the assembly may branch to. Use the label name in a structured
 branch instruction; a `raw` template uses GNU's `%l[label]` form. Targets cannot enter or leave a

--- a/vlib/v/slow_tests/assembly/asm_raw_chacha20_test.amd64.v
+++ b/vlib/v/slow_tests/assembly/asm_raw_chacha20_test.amd64.v
@@ -1,0 +1,140 @@
+// vtest build: !msvc
+
+import encoding.binary
+import encoding.hex
+
+// raw_chacha20_block_sse2 keeps one ChaCha state row in each XMM register.
+// The lane shuffles turn the column round into the diagonal round without scalar work.
+fn raw_chacha20_block_sse2(state &[16]u32) [16]u32 {
+	mut output := [16]u32{}
+	// The raw block writes the fixed array through its first element.
+	output_ptr := unsafe { &output[0] }
+	asm amd64 raw {
+		"movdqu 0(%[state]), %%xmm0\n\t"
+		"movdqu 16(%[state]), %%xmm1\n\t"
+		"movdqu 32(%[state]), %%xmm2\n\t"
+		"movdqu 48(%[state]), %%xmm3\n\t"
+		"movdqa %%xmm0, %%xmm8\n\t"
+		"movdqa %%xmm1, %%xmm9\n\t"
+		"movdqa %%xmm2, %%xmm10\n\t"
+		"movdqa %%xmm3, %%xmm11\n\t"
+		".rept 10\n\t"
+
+		// Column quarter round.
+		"paddd %%xmm1, %%xmm0\n\t"
+		"pxor %%xmm0, %%xmm3\n\t"
+		"movdqa %%xmm3, %%xmm4\n\t"
+		"pslld $16, %%xmm3\n\t"
+		"psrld $16, %%xmm4\n\t"
+		"por %%xmm4, %%xmm3\n\t"
+		"paddd %%xmm3, %%xmm2\n\t"
+		"pxor %%xmm2, %%xmm1\n\t"
+		"movdqa %%xmm1, %%xmm4\n\t"
+		"pslld $12, %%xmm1\n\t"
+		"psrld $20, %%xmm4\n\t"
+		"por %%xmm4, %%xmm1\n\t"
+		"paddd %%xmm1, %%xmm0\n\t"
+		"pxor %%xmm0, %%xmm3\n\t"
+		"movdqa %%xmm3, %%xmm4\n\t"
+		"pslld $8, %%xmm3\n\t"
+		"psrld $24, %%xmm4\n\t"
+		"por %%xmm4, %%xmm3\n\t"
+		"paddd %%xmm3, %%xmm2\n\t"
+		"pxor %%xmm2, %%xmm1\n\t"
+		"movdqa %%xmm1, %%xmm4\n\t"
+		"pslld $7, %%xmm1\n\t"
+		"psrld $25, %%xmm4\n\t"
+		"por %%xmm4, %%xmm1\n\t"
+
+		// Diagonal quarter round.
+		"pshufd $0x39, %%xmm1, %%xmm1\n\t"
+		"pshufd $0x4e, %%xmm2, %%xmm2\n\t"
+		"pshufd $0x93, %%xmm3, %%xmm3\n\t"
+		"paddd %%xmm1, %%xmm0\n\t"
+		"pxor %%xmm0, %%xmm3\n\t"
+		"movdqa %%xmm3, %%xmm4\n\t"
+		"pslld $16, %%xmm3\n\t"
+		"psrld $16, %%xmm4\n\t"
+		"por %%xmm4, %%xmm3\n\t"
+		"paddd %%xmm3, %%xmm2\n\t"
+		"pxor %%xmm2, %%xmm1\n\t"
+		"movdqa %%xmm1, %%xmm4\n\t"
+		"pslld $12, %%xmm1\n\t"
+		"psrld $20, %%xmm4\n\t	"
+		"por %%xmm4, %%xmm1\n\t"
+		"paddd %%xmm1, %%xmm0\n\t"
+		"pxor %%xmm0, %%xmm3\n\t"
+		"movdqa %%xmm3, %%xmm4\n\t"
+		"pslld $8, %%xmm3\n\t"
+		"psrld $24, %%xmm4\n\t"
+		"por %%xmm4, %%xmm3\n\t"
+		"paddd %%xmm3, %%xmm2\n\t"
+		"pxor %%xmm2, %%xmm1\n\t"
+		"movdqa %%xmm1, %%xmm4\n\t"
+		"pslld $7, %%xmm1\n\t"
+		"psrld $25, %%xmm4\n\t"
+		"por %%xmm4, %%xmm1\n\t"
+		"pshufd $0x93, %%xmm1, %%xmm1\n\t"
+		"pshufd $0x4e, %%xmm2, %%xmm2\n\t"
+		"pshufd $0x39, %%xmm3, %%xmm3\n\t"
+		".endr\n\t"
+		"paddd %%xmm8, %%xmm0\n\t"
+		"paddd %%xmm9, %%xmm1\n\t"
+		"paddd %%xmm10, %%xmm2\n\t"
+		"paddd %%xmm11, %%xmm3\n\t"
+		"movdqu %%xmm0, 0(%[output])\n\t"
+		"movdqu %%xmm1, 16(%[output])\n\t"
+		"movdqu %%xmm2, 32(%[output])\n\t"
+		"movdqu %%xmm3, 48(%[output])"
+		;
+		; [state] "r" (state)
+		  [output] "r" (output_ptr)
+		; xmm0
+		  xmm1
+		  xmm2
+		  xmm3
+		  xmm4
+		  xmm8
+		  xmm9
+		  xmm10
+		  xmm11
+		  memory
+	}
+	return output
+}
+
+fn chacha20_row_state() [16]u32 {
+	mut state := [16]u32{}
+	state[0] = 0x61707865
+	state[1] = 0x3320646e
+	state[2] = 0x79622d32
+	state[3] = 0x6b206574
+	state[4] = 0x03020100
+	state[5] = 0x07060504
+	state[6] = 0x0b0a0908
+	state[7] = 0x0f0e0d0c
+	state[8] = 0x13121110
+	state[9] = 0x17161514
+	state[10] = 0x1b1a1918
+	state[11] = 0x1f1e1d1c
+	state[12] = 1
+	state[13] = 0x09000000
+	state[14] = 0x4a000000
+	state[15] = 0
+	return state
+}
+
+fn chacha20_state_bytes(state [16]u32) []u8 {
+	mut result := []u8{len: 64}
+	for i, word in state {
+		binary.little_endian_put_u32(mut result[i * 4..i * 4 + 4], word)
+	}
+	return result
+}
+
+fn test_raw_chacha20_simd_block_rfc8439() {
+	state := chacha20_row_state()
+	actual := chacha20_state_bytes(raw_chacha20_block_sse2(&state))
+	expected := hex.decode('10f1e7e4d13b5915500fdd1fa32071c4c7d1f4c733c068030422aa9ac3d46c4ed2826446079faa0914c2d705d98b02a2b5129cd1de164eb9cbd083e8a2503c4e')!
+	assert actual == expected
+}

--- a/vlib/v/slow_tests/assembly/asm_raw_ghash_clmul_test.amd64.v
+++ b/vlib/v/slow_tests/assembly/asm_raw_ghash_clmul_test.amd64.v
@@ -1,0 +1,147 @@
+// vtest build: !msvc
+
+import encoding.hex
+
+// raw_ghash_clmul_product returns the unreduced 256-bit polynomial product.
+// GHASH reduction is kept in V below so this fixture checks the CLMUL product exactly.
+fn raw_ghash_clmul_product(x &[2]u64, h &[2]u64) [4]u64 {
+	mut output := [4]u64{}
+	// The raw block writes the fixed array through its first element.
+	output_ptr := unsafe { &output[0] }
+	asm amd64 raw {
+		"movdqu 0(%[x]), %%xmm0\n\t"
+		"movdqu 0(%[h]), %%xmm1\n\t"
+		"movdqa %%xmm0, %%xmm2\n\t"
+		"pclmulqdq $0x00, %%xmm1, %%xmm2\n\t"
+		"movdqa %%xmm0, %%xmm3\n\t"
+		"pclmulqdq $0x10, %%xmm1, %%xmm3\n\t"
+		"movdqa %%xmm1, %%xmm4\n\t"
+		"pclmulqdq $0x10, %%xmm0, %%xmm4\n\t"
+		"movdqa %%xmm0, %%xmm5\n\t"
+		"pclmulqdq $0x11, %%xmm1, %%xmm5\n\t"
+		"pxor %%xmm4, %%xmm3\n\t"
+		"movdqa %%xmm3, %%xmm6\n\t"
+		"pslldq $8, %%xmm6\n\t"
+		"pxor %%xmm6, %%xmm2\n\t"
+		"psrldq $8, %%xmm3\n\t"
+		"pxor %%xmm3, %%xmm5\n\t"
+		"movdqu %%xmm2, 0(%[output])\n\t"
+		"movdqu %%xmm5, 16(%[output])"
+		;
+		; [x] "r" (x)
+		  [h] "r" (h)
+		  [output] "r" (output_ptr)
+		; xmm0
+		  xmm1
+		  xmm2
+		  xmm3
+		  xmm4
+		  xmm5
+		  xmm6
+		  memory
+	}
+	return output
+}
+
+fn ghash_clmul_product_reference(x [2]u64, h [2]u64) [4]u64 {
+	mut product := [4]u64{}
+	for x_word in 0 .. 2 {
+		for x_bit in 0 .. 64 {
+			if ((x[x_word] >> x_bit) & 1) == 0 {
+				continue
+			}
+			x_position := x_word * 64 + x_bit
+			for h_word in 0 .. 2 {
+				for h_bit in 0 .. 64 {
+					if ((h[h_word] >> h_bit) & 1) == 0 {
+						continue
+					}
+					position := x_position + h_word * 64 + h_bit
+					product[position / 64] ^= u64(1) << (position & 63)
+				}
+			}
+		}
+	}
+	return product
+}
+
+fn ghash_reduce_product(mut product [4]u64) [2]u64 {
+	mut position := 255
+	for position >= 128 {
+		word := position / 64
+		bit := position & 63
+		if ((product[word] >> bit) & 1) != 0 {
+			product[word] &= ~(u64(1) << bit)
+			for offset in [0, 1, 2, 7] {
+				target := position - 128 + offset
+				product[target / 64] ^= u64(1) << (target & 63)
+			}
+		}
+		position--
+	}
+	mut result := [2]u64{}
+	result[0] = product[0]
+	result[1] = product[1]
+	return result
+}
+
+fn reverse_bits8(value u8) u8 {
+	mut reversed := u8(0)
+	for bit in 0 .. 8 {
+		reversed |= ((value >> bit) & 1) << (7 - bit)
+	}
+	return reversed
+}
+
+fn ghash_block_to_polynomial(block []u8) [2]u64 {
+	mut result := [2]u64{}
+	for i, value in block {
+		position := i * 8
+		reversed := reverse_bits8(value)
+		if position < 64 {
+			result[0] |= u64(reversed) << position
+		} else {
+			result[1] |= u64(reversed) << (position - 64)
+		}
+	}
+	return result
+}
+
+fn polynomial_to_ghash_block(value [2]u64) []u8 {
+	mut result := []u8{len: 16}
+	for i in 0 .. 16 {
+		position := i * 8
+		word := if position < 64 { value[0] } else { value[1] }
+		result[i] = reverse_bits8(u8(word >> (position & 63)))
+	}
+	return result
+}
+
+fn can_run_pclmul_test() bool {
+	mut ecx := u32(0)
+	asm amd64 {
+		mov eax, 1
+		cpuid
+		; =c (ecx)
+		; ; eax
+		  ebx
+		  edx
+	}
+	return (ecx & (u32(1) << 1)) != 0
+}
+
+fn test_raw_ghash_clmul_nist_vector() {
+	if !can_run_pclmul_test() {
+		return
+	}
+	x_bytes := hex.decode('0388dace60b6a392f328c2b971b2fe78')!
+	h_bytes := hex.decode('66e94bd4ef8a2c3b884cfa59ca342b2e')!
+	x := ghash_block_to_polynomial(x_bytes)
+	h := ghash_block_to_polynomial(h_bytes)
+	mut actual_product := raw_ghash_clmul_product(&x, &h)
+	expected_product := ghash_clmul_product_reference(x, h)
+	assert actual_product == expected_product
+	expected := hex.decode('5e2ec746917062882c85b0685353deb7')!
+	actual := polynomial_to_ghash_block(ghash_reduce_product(mut actual_product))
+	assert actual == expected
+}

--- a/vlib/v/slow_tests/assembly/asm_raw_simd_crypto_test.arm64.v
+++ b/vlib/v/slow_tests/assembly/asm_raw_simd_crypto_test.arm64.v
@@ -1,0 +1,255 @@
+import encoding.binary
+import encoding.hex
+import os
+
+// raw_chacha20_block_neon keeps one ChaCha state row in each NEON register.
+fn raw_chacha20_block_neon(state &[16]u32) [16]u32 {
+	mut output := [16]u32{}
+	// The raw block writes the fixed array through its first element.
+	output_ptr := unsafe { &output[0] }
+	asm arm64 raw {
+		"ldr q0, [%[state]]\n\t"
+		"ldr q1, [%[state], #16]\n\t"
+		"ldr q2, [%[state], #32]\n\t"
+		"ldr q3, [%[state], #48]\n\t"
+		"mov v8.16b, v0.16b\n\t"
+		"mov v9.16b, v1.16b\n\t"
+		"mov v10.16b, v2.16b\n\t"
+		"mov v11.16b, v3.16b\n\t"
+		".rept 10\n\t"
+
+		// Column quarter round.
+		"add v0.4s, v0.4s, v1.4s\n\t"
+		"eor v3.16b, v3.16b, v0.16b\n\t"
+		"mov v4.16b, v3.16b\n\t"
+		"shl v3.4s, v3.4s, #16\n\t"
+		"ushr v4.4s, v4.4s, #16\n\t"
+		"orr v3.16b, v3.16b, v4.16b\n\t"
+		"add v2.4s, v2.4s, v3.4s\n\t"
+		"eor v1.16b, v1.16b, v2.16b\n\t"
+		"mov v4.16b, v1.16b\n\t	"
+		"shl v1.4s, v1.4s, #12\n\t"
+		"ushr v4.4s, v4.4s, #20\n\t"
+		"orr v1.16b, v1.16b, v4.16b\n\t"
+		"add v0.4s, v0.4s, v1.4s\n\t"
+		"eor v3.16b, v3.16b, v0.16b\n\t"
+		"mov v4.16b, v3.16b\n\t"
+		"shl v3.4s, v3.4s, #8\n\t"
+		"ushr v4.4s, v4.4s, #24\n\t"
+		"orr v3.16b, v3.16b, v4.16b\n\t"
+		"add v2.4s, v2.4s, v3.4s\n\t"
+		"eor v1.16b, v1.16b, v2.16b\n\t"
+		"mov v4.16b, v1.16b\n\t"
+		"shl v1.4s, v1.4s, #7\n\t"
+		"ushr v4.4s, v4.4s, #25\n\t"
+		"orr v1.16b, v1.16b, v4.16b\n\t"
+
+		// Diagonal quarter round.
+		"ext v1.16b, v1.16b, v1.16b, #4\n\t"
+		"ext v2.16b, v2.16b, v2.16b, #8\n\t"
+		"ext v3.16b, v3.16b, v3.16b, #12\n\t"
+		"add v0.4s, v0.4s, v1.4s\n\t"
+		"eor v3.16b, v3.16b, v0.16b\n\t"
+		"mov v4.16b, v3.16b\n\t"
+		"shl v3.4s, v3.4s, #16\n\t"
+		"ushr v4.4s, v4.4s, #16\n\t"
+		"orr v3.16b, v3.16b, v4.16b\n\t"
+		"add v2.4s, v2.4s, v3.4s\n\t"
+		"eor v1.16b, v1.16b, v2.16b\n\t"
+		"mov v4.16b, v1.16b\n\t"
+		"shl v1.4s, v1.4s, #12\n\t"
+		"ushr v4.4s, v4.4s, #20\n\t"
+		"orr v1.16b, v1.16b, v4.16b\n\t"
+		"add v0.4s, v0.4s, v1.4s\n\t"
+		"eor v3.16b, v3.16b, v0.16b\n\t"
+		"mov v4.16b, v3.16b\n\t"
+		"shl v3.4s, v3.4s, #8\n\t"
+		"ushr v4.4s, v4.4s, #24\n\t"
+		"orr v3.16b, v3.16b, v4.16b\n\t"
+		"add v2.4s, v2.4s, v3.4s\n\t"
+		"eor v1.16b, v1.16b, v2.16b\n\t"
+		"mov v4.16b, v1.16b\n\t"
+		"shl v1.4s, v1.4s, #7\n\t"
+		"ushr v4.4s, v4.4s, #25\n\t"
+		"orr v1.16b, v1.16b, v4.16b\n\t"
+		"ext v1.16b, v1.16b, v1.16b, #12\n\t"
+		"ext v2.16b, v2.16b, v2.16b, #8\n\t"
+		"ext v3.16b, v3.16b, v3.16b, #4\n\t"
+		".endr\n\t"
+		"add v0.4s, v0.4s, v8.4s\n\t"
+		"add v1.4s, v1.4s, v9.4s\n\t"
+		"add v2.4s, v2.4s, v10.4s\n\t"
+		"add v3.4s, v3.4s, v11.4s\n\t"
+		"str q0, [%[output]]\n\t"
+		"str q1, [%[output], #16]\n\t"
+		"str q2, [%[output], #32]\n\t"
+		"str q3, [%[output], #48]"
+		;
+		; [state] "r" (state)
+		  [output] "r" (output_ptr)
+		; v0
+		  v1
+		  v2
+		  v3
+		  v4
+		  v8
+		  v9
+		  v10
+		  v11
+		  memory
+	}
+	return output
+}
+
+fn raw_ghash_pmull_product(x &[2]u64, h &[2]u64) [4]u64 {
+	mut output := [4]u64{}
+	// The raw block writes the fixed array through its first element.
+	output_ptr := unsafe { &output[0] }
+	asm arm64 raw {
+		"ldr q0, [%[x]]\n\t"
+		"ldr q1, [%[h]]\n\t"
+		"pmull v2.1q, v0.1d, v1.1d\n\t"
+		"pmull2 v3.1q, v0.2d, v1.2d\n\t"
+		"pmull v4.1q, v0.1d, v1.2d\n\t"
+		"pmull v5.1q, v0.2d, v1.1d\n\t"
+		"eor v4.16b, v4.16b, v5.16b\n\t"
+		"movi v6.2d, #0\n\t"
+		"movi v7.2d, #0\n\t"
+		"ins v6.d[1], v4.d[0]\n\t"
+		"ins v7.d[0], v4.d[1]\n\t"
+		"eor v2.16b, v2.16b, v6.16b\n\t"
+		"eor v3.16b, v3.16b, v7.16b\n\t"
+		"str q2, [%[output]]\n\t"
+		"str q3, [%[output], #16]"
+		;
+		; [x] "r" (x)
+		  [h] "r" (h)
+		  [output] "r" (output_ptr)
+		; v0
+		  v1
+		  v2
+		  v3
+		  v4
+		  v5
+		  v6
+		  v7
+		  memory
+	}
+	return output
+}
+
+fn arm64_chacha20_row_state() [16]u32 {
+	mut state := [16]u32{}
+	state[0] = 0x61707865
+	state[1] = 0x3320646e
+	state[2] = 0x79622d32
+	state[3] = 0x6b206574
+	state[4] = 0x03020100
+	state[5] = 0x07060504
+	state[6] = 0x0b0a0908
+	state[7] = 0x0f0e0d0c
+	state[8] = 0x13121110
+	state[9] = 0x17161514
+	state[10] = 0x1b1a1918
+	state[11] = 0x1f1e1d1c
+	state[12] = 1
+	state[13] = 0x09000000
+	state[14] = 0x4a000000
+	return state
+}
+
+fn arm64_chacha20_state_bytes(state [16]u32) []u8 {
+	mut result := []u8{len: 64}
+	for i, word in state {
+		binary.little_endian_put_u32(mut result[i * 4..i * 4 + 4], word)
+	}
+	return result
+}
+
+fn arm64_reverse_bits8(value u8) u8 {
+	mut reversed := u8(0)
+	for bit in 0 .. 8 {
+		reversed |= ((value >> bit) & 1) << (7 - bit)
+	}
+	return reversed
+}
+
+fn arm64_ghash_block_to_polynomial(block []u8) [2]u64 {
+	mut result := [2]u64{}
+	for i, value in block {
+		position := i * 8
+		reversed := arm64_reverse_bits8(value)
+		if position < 64 {
+			result[0] |= u64(reversed) << position
+		} else {
+			result[1] |= u64(reversed) << (position - 64)
+		}
+	}
+	return result
+}
+
+fn arm64_ghash_reduce_product(mut product [4]u64) [2]u64 {
+	mut position := 255
+	for position >= 128 {
+		word := position / 64
+		bit := position & 63
+		if ((product[word] >> bit) & 1) != 0 {
+			product[word] &= ~(u64(1) << bit)
+			for offset in [0, 1, 2, 7] {
+				target := position - 128 + offset
+				product[target / 64] ^= u64(1) << (target & 63)
+			}
+		}
+		position--
+	}
+	mut result := [2]u64{}
+	result[0] = product[0]
+	result[1] = product[1]
+	return result
+}
+
+fn arm64_polynomial_to_ghash_block(value [2]u64) []u8 {
+	mut result := []u8{len: 16}
+	for i in 0 .. 16 {
+		position := i * 8
+		word := if position < 64 { value[0] } else { value[1] }
+		result[i] = arm64_reverse_bits8(u8(word >> (position & 63)))
+	}
+	return result
+}
+
+fn can_run_pmull_test() bool {
+	$if linux {
+		cpuinfo := os.read_file('/proc/cpuinfo') or { return false }
+		return cpuinfo.contains('pmull')
+	} $else {
+		return true
+	}
+}
+
+fn test_raw_chacha20_neon_vector() {
+	state := arm64_chacha20_row_state()
+	actual_chacha := arm64_chacha20_state_bytes(raw_chacha20_block_neon(&state))
+	expected_chacha := hex.decode('10f1e7e4d13b5915500fdd1fa32071c4c7d1f4c733c068030422aa9ac3d46c4ed2826446079faa0914c2d705d98b02a2b5129cd1de164eb9cbd083e8a2503c4e')!
+	assert actual_chacha == expected_chacha
+}
+
+fn test_raw_ghash_pmull_vector() {
+	if !can_run_pmull_test() {
+		return
+	}
+	x_bytes := hex.decode('0388dace60b6a392f328c2b971b2fe78')!
+	h_bytes := hex.decode('66e94bd4ef8a2c3b884cfa59ca342b2e')!
+	x := arm64_ghash_block_to_polynomial(x_bytes)
+	h := arm64_ghash_block_to_polynomial(h_bytes)
+	mut product := raw_ghash_pmull_product(&x, &h)
+	mut expected_product := [4]u64{}
+	expected_product[0] = 967084790008197592
+	expected_product[1] = 8907455666260999920
+	expected_product[2] = 3863501629616998091
+	expected_product[3] = 3091736768428133317
+	assert product == expected_product
+	actual_ghash := arm64_polynomial_to_ghash_block(arm64_ghash_reduce_product(mut product))
+	expected_ghash := hex.decode('5e2ec746917062882c85b0685353deb7')!
+	assert actual_ghash == expected_ghash
+}

--- a/vlib/v/slow_tests/assembly/asm_raw_simd_pressure_test.amd64.v
+++ b/vlib/v/slow_tests/assembly/asm_raw_simd_pressure_test.amd64.v
@@ -1,0 +1,95 @@
+// vtest build: !msvc
+
+// raw_simd_pressure deliberately lists xmm6-xmm15 as clobbers. Those registers are
+// nonvolatile in the Win64 ABI, so GCC/Clang must preserve them around this block.
+fn raw_simd_pressure(seed f32, offset f64) f64 {
+	mut sum := f32(0)
+	asm amd64 raw {
+		"movss %[seed], %%xmm0\n\t"
+		"movss %[seed], %%xmm1\n\t"
+		"movss %[seed], %%xmm2\n\t"
+		"movss %[seed], %%xmm3\n\t"
+		"movss %[seed], %%xmm4\n\t"
+		"movss %[seed], %%xmm5\n\t"
+		"movss %[seed], %%xmm6\n\t"
+		"movss %[seed], %%xmm7\n\t"
+		"movss %[seed], %%xmm8\n\t"
+		"movss %[seed], %%xmm9\n\t"
+		"movss %[seed], %%xmm10\n\t"
+		"movss %[seed], %%xmm11\n\t"
+		"movss %[seed], %%xmm12\n\t"
+		"movss %[seed], %%xmm13\n\t"
+		"movss %[seed], %%xmm14\n\t"
+		"movss %[seed], %%xmm15\n\t"
+		"addss %%xmm0, %%xmm1\n\t"
+		"addss %%xmm1, %%xmm2\n\t"
+		"addss %%xmm2, %%xmm3\n\t"
+		"addss %%xmm3, %%xmm4\n\t"
+		"addss %%xmm4, %%xmm5\n\t"
+		"addss %%xmm5, %%xmm6\n\t"
+		"addss %%xmm6, %%xmm7\n\t"
+		"addss %%xmm7, %%xmm8\n\t"
+		"addss %%xmm8, %%xmm9\n\t"
+		"addss %%xmm9, %%xmm10\n\t"
+		"addss %%xmm10, %%xmm11\n\t"
+		"addss %%xmm11, %%xmm12\n\t"
+		"addss %%xmm12, %%xmm13\n\t"
+		"addss %%xmm13, %%xmm14\n\t"
+		"addss %%xmm14, %%xmm15\n\t"
+		"movss %%xmm15, %[sum]"
+		; [sum] "=m" (sum)
+		; [seed] "m" (seed)
+		; xmm0
+		  xmm1
+		  xmm2
+		  xmm3
+		  xmm4
+		  xmm5
+		  xmm6
+		  xmm7
+		  xmm8
+		  xmm9
+		  xmm10
+		  xmm11
+		  xmm12
+		  xmm13
+		  xmm14
+		  xmm15
+		  memory
+	}
+	left := offset + 1.5
+	right := offset * 2.0
+	return f64(sum) + left + right
+}
+
+fn raw_load_fixed_u32(input &[16]u8) u32 {
+	mut result := u32(0)
+	asm amd64 raw {
+		"movl 0(%[input]), %[result]"
+		; [result] "=r" (result)
+		; [input] "r" (input)
+		; memory
+	}
+	return result
+}
+
+fn raw_load_buffer_u32(input []u8) u32 {
+	mut result := u32(0)
+	asm amd64 raw {
+		"movzbl %[input], %[result]"
+		; [result] "=r" (result)
+		; [input] "m" (input[0])
+	}
+	return result
+}
+
+fn test_raw_simd_pressure_and_operand_binding() {
+	assert raw_simd_pressure(1.25, 2.5) == 29.0
+	mut input := [16]u8{}
+	input[0] = 0x78
+	input[1] = 0x56
+	input[2] = 0x34
+	input[3] = 0x12
+	assert raw_load_fixed_u32(&input) == u32(0x12345678)
+	assert raw_load_buffer_u32(input[..]) == 0x78
+}


### PR DESCRIPTION
Summary:
- Document SIMD operand binding, vector clobbers, Win64 XMM preservation, and optional CPU feature guards.
- Add amd64 SIMD register-pressure, ChaCha20 SSE2, and PCLMUL GHASH fixtures.
- Add arm64 NEON ChaCha20 and PMULL GHASH cross-target fixture.

Validation:
- GCC assembly suite: 11 passed, 11 skipped.
- Clang assembly suite: 11 passed, 11 skipped.
- TCC targeted fixtures: 3 passed via GCC fallback.
- arm64 cross code generation: passed.
- MSVC: new GNU fixtures skipped; existing naked_attr_test.amd64.v remains a pre-existing failure because MSVC x64 does not support inline assembly.
- check-md was attempted but the environment denied writes to the default VMODULES cache for unrelated mbedtls/SQLite examples.

