### PR TITLE
v3: preserve indexed optional fixed array wrappers

### DIFF
--- a/vlib/v3/tests/optional_fixed_array_assign_codegen_test.v
+++ b/vlib/v3/tests/optional_fixed_array_assign_codegen_test.v
@@ -43,3 +43,48 @@ fn main() {
 	run := os.execute(bin)
 	assert run.exit_code == 0, run.output
 }
+
+fn test_indexed_optional_fixed_array_assignment_keeps_the_option_wrapper() {
+	pid := os.getpid()
+	v3_bin := os.join_path(os.temp_dir(), 'v3_optional_fixed_array_index_assign_test_${pid}')
+	build :=
+		os.execute('${vexe} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+
+	src := os.join_path(os.temp_dir(), 'v3_optional_fixed_array_index_assign_input_${pid}.v')
+	os.write_file(src, 'struct Empty {}
+
+type Arr = [2]Empty
+
+struct IndexCounter {
+mut:
+	calls int
+}
+
+fn next_index(mut counter IndexCounter) int {
+	counter.calls++
+	return 0
+}
+
+fn main() {
+	mut values := []?Arr{len: 1}
+	mut counter := IndexCounter{}
+	values[next_index(mut counter)] = Arr{}
+	assert counter.calls == 1
+	assert values[0] != none
+	values[next_index(mut counter)] = ?Arr(none)
+	assert counter.calls == 2
+	assert values[0] == none
+	println("ok")
+}
+')!
+
+	bin := os.join_path(os.temp_dir(), 'v3_optional_fixed_array_index_assign_input_${pid}')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'ok', run.output
+}

--- a/vlib/v3/tests/optional_fixed_array_assign_codegen_test.v
+++ b/vlib/v3/tests/optional_fixed_array_assign_codegen_test.v
@@ -72,9 +72,11 @@ fn main() {
 	values[next_index(mut counter)] = Arr{}
 	assert counter.calls == 1
 	assert values[0] != none
+	assert values#[-1] != none
 	values[next_index(mut counter)] = ?Arr(none)
 	assert counter.calls == 2
 	assert values[0] == none
+	assert values#[-1] == none
 	println("ok")
 }
 ')!

--- a/vlib/v3/tests/optional_fixed_array_assign_codegen_test.v
+++ b/vlib/v3/tests/optional_fixed_array_assign_codegen_test.v
@@ -135,3 +135,34 @@ fn main() {
 	assert run.exit_code == 0, run.output
 	assert run.output.trim_space() == 'ok', run.output
 }
+
+fn test_smartcasted_optional_array_index_keeps_the_wrapper() {
+	pid := os.getpid()
+	v3_bin := os.join_path(os.temp_dir(), 'v3_smartcasted_optional_array_index_test_${pid}')
+	build :=
+		os.execute('${vexe} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+
+	src := os.join_path(os.temp_dir(), 'v3_smartcasted_optional_array_index_input_${pid}.v')
+	os.write_file(src, 'type OptionalInts = []?int
+
+type Values = OptionalInts | string
+
+fn main() {
+	x := Values(OptionalInts([?int(none)]))
+	if x is OptionalInts {
+		assert x[0] == none
+	}
+	println("ok")
+}
+')!
+
+	bin := os.join_path(os.temp_dir(), 'v3_smartcasted_optional_array_index_input_${pid}')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'ok', run.output
+}

--- a/vlib/v3/tests/optional_fixed_array_assign_codegen_test.v
+++ b/vlib/v3/tests/optional_fixed_array_assign_codegen_test.v
@@ -166,3 +166,39 @@ fn main() {
 	assert run.exit_code == 0, run.output
 	assert run.output.trim_space() == 'ok', run.output
 }
+
+fn test_nested_smartcasts_keep_optional_array_indexes_wrapped() {
+	pid := os.getpid()
+	v3_bin := os.join_path(os.temp_dir(), 'v3_nested_smartcasted_optional_array_index_test_${pid}')
+	build :=
+		os.execute('${vexe} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+
+	src := os.join_path(os.temp_dir(), 'v3_nested_smartcasted_optional_array_index_input_${pid}.v')
+	os.write_file(src, 'struct Foo {}
+
+struct Bar {}
+
+type Value = Bar | Foo
+
+fn main() {
+	mut values := []?Value{len: 1}
+	values[0] = Foo{}
+	if values[0] != none {
+		if values[0] is Foo {
+			assert values[0] != none
+		}
+	}
+	println("ok")
+}
+')!
+
+	bin := os.join_path(os.temp_dir(), 'v3_nested_smartcasted_optional_array_index_input_${pid}')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'ok', run.output
+}

--- a/vlib/v3/tests/optional_fixed_array_assign_codegen_test.v
+++ b/vlib/v3/tests/optional_fixed_array_assign_codegen_test.v
@@ -90,3 +90,48 @@ fn main() {
 	assert run.exit_code == 0, run.output
 	assert run.output.trim_space() == 'ok', run.output
 }
+
+fn test_optional_map_index_comparison_preserves_evaluation_order() {
+	pid := os.getpid()
+	v3_bin := os.join_path(os.temp_dir(), 'v3_optional_map_index_compare_test_${pid}')
+	build :=
+		os.execute('${vexe} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+
+	src := os.join_path(os.temp_dir(), 'v3_optional_map_index_compare_input_${pid}.v')
+	os.write_file(src, 'struct Trace {
+mut:
+	value int
+}
+
+fn make_map(mut trace Trace) map[string]?int {
+	trace.value = trace.value * 10 + 1
+	return map[string]?int{}
+}
+
+fn make_key(mut trace Trace) string {
+	trace.value = trace.value * 10 + 2
+	return "key"
+}
+
+fn main() {
+	mut trace := Trace{}
+	assert make_map(mut trace)[make_key(mut trace)] == none
+	assert trace.value == 12
+	println("ok")
+}
+')!
+
+	bin := os.join_path(os.temp_dir(), 'v3_optional_map_index_compare_input_${pid}')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+	c_code := os.read_file(bin + '.c')!
+	map_pos := c_code.index('map __in_lhs_') or { panic('missing map temporary') }
+	key_pos := c_code.index('string __map_key_') or { panic('missing map key temporary') }
+	assert map_pos < key_pos, c_code
+
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'ok', run.output
+}

--- a/vlib/v3/tests/optional_index_smartcast_restore_codegen_test.v
+++ b/vlib/v3/tests/optional_index_smartcast_restore_codegen_test.v
@@ -1,0 +1,60 @@
+import os
+
+const vexe = @VEXE
+const tests_dir = os.dir(@FILE)
+const v3_dir = os.dir(tests_dir)
+const vlib_dir = os.dir(v3_dir)
+const v3_src = os.join_path(v3_dir, 'v3.v')
+
+fn test_optional_index_keeps_smartcasts_recreated_after_ancestor_write() {
+	pid := os.getpid()
+	v3_bin := os.join_path(os.temp_dir(), 'v3_optional_index_smartcast_restore_test_${pid}')
+	build :=
+		os.execute('${vexe} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${v3_bin} ${v3_src}')
+	assert build.exit_code == 0, build.output
+
+	src := os.join_path(os.temp_dir(), 'v3_optional_index_smartcast_restore_input_${pid}.v')
+	os.write_file(src, 'struct Foo {
+	value int
+}
+
+struct Bar {}
+
+type Value = Bar | Foo
+
+struct Holder {
+mut:
+	value ?Value
+}
+
+fn main() {
+	mut h := Holder{}
+	h.value = Foo{
+		value: 1
+	}
+	if h.value != none {
+		h = Holder{}
+	}
+	h.value = Foo{
+		value: 2
+	}
+	opts := []?int{len: 1}
+	if h.value != none {
+		if h.value is Foo {
+			assert opts[0] == none
+			assert h.value.value == 2
+		}
+	}
+	println("ok")
+}
+')!
+
+	bin := os.join_path(os.temp_dir(), 'v3_optional_index_smartcast_restore_input_${pid}')
+	compile := os.execute('${v3_bin} ${src} -b c -o ${bin}')
+	assert compile.exit_code == 0, compile.output
+	assert !compile.output.contains('C compilation failed'), compile.output
+
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'ok', run.output
+}

--- a/vlib/v3/tests/optional_index_smartcast_restore_codegen_test.v
+++ b/vlib/v3/tests/optional_index_smartcast_restore_codegen_test.v
@@ -57,4 +57,47 @@ fn main() {
 	run := os.execute(bin)
 	assert run.exit_code == 0, run.output
 	assert run.output.trim_space() == 'ok', run.output
+
+	reassigned_src := os.join_path(os.temp_dir(), 'v3_optional_index_smartcast_reassignment_input_${pid}.v')
+	os.write_file(reassigned_src, 'struct Foo {
+	value int
+}
+
+struct Holder {
+mut:
+	value ?Foo
+}
+
+fn main() {
+	mut h := Holder{}
+	h.value = Foo{
+		value: 1
+	}
+	opts := []?int{len: 1}
+	if h.value != none {
+		assert opts[if true {
+			h.value = Foo{
+				value: 2
+			}
+			0
+		} else {
+			h.value = Foo{
+				value: 3
+			}
+			0
+		}] == none
+		assert h.value.value == 2
+	}
+	println("ok")
+}
+')!
+
+	reassigned_bin := os.join_path(os.temp_dir(), 'v3_optional_index_smartcast_reassignment_input_${pid}')
+	reassigned_compile := os.execute('${v3_bin} ${reassigned_src} -b c -o ${reassigned_bin}')
+	assert reassigned_compile.exit_code == 0, reassigned_compile.output
+	assert !reassigned_compile.output.contains('C compilation failed'), reassigned_compile.output
+
+	reassigned_run := os.execute(reassigned_bin)
+	assert reassigned_run.exit_code == 0, reassigned_run.output
+	assert reassigned_run.output.trim_space() == 'ok', reassigned_run.output
 }

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -2070,10 +2070,13 @@ fn (mut t Transformer) transform_optional_wrapper_expr(id flat.NodeId) flat.Node
 		}
 		source_id = base_id
 	}
-	raw_type := t.raw_expr_type_without_smartcast(source_id)
-	if t.is_optional_type_name(raw_type) && t.a.nodes[int(id)].kind in [.ident, .selector] {
+	mut raw_type := t.raw_expr_type_without_smartcast(source_id)
+	if !t.is_optional_type_name(raw_type) {
+		raw_type = t.optional_result_expr_type_name(source_id)
+	}
+	if t.is_optional_type_name(raw_type) && t.a.nodes[int(id)].kind in [.ident, .selector, .index] {
 		// `source_id` is already the wrapper expression with any redundant top-level
-		// payload selectors removed. Rebuilding a selector here would transform its
+		// payload selectors removed. Rebuilding it here would transform its
 		// base again and could apply the same assignment smartcast a second time
 		// (`foo?.field` becoming `foo.value.value.field`).
 		plain := source_id

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -2101,7 +2101,7 @@ fn (mut t Transformer) transform_optional_wrapper_expr(id flat.NodeId) flat.Node
 fn (mut t Transformer) transform_optional_wrapper_index_expr(id flat.NodeId, node flat.Node, raw_type string) flat.NodeId {
 	key := t.expr_key(id)
 	saved_smartcasts := t.smartcast_stack.clone()
-	saved_invalidation_events_len := t.smartcast_invalidation_events.len
+	saved_smartcast_event_id := t.smartcast_event_id
 	if key.len > 0 {
 		mut remaining_smartcasts := []SmartcastContext{cap: saved_smartcasts.len}
 		for smartcast in saved_smartcasts {
@@ -2113,8 +2113,7 @@ fn (mut t Transformer) transform_optional_wrapper_index_expr(id flat.NodeId, nod
 		t.smartcast_stack = remaining_smartcasts
 	}
 	transformed := t.transform_index_expr(id, node)
-	t.smartcast_stack = t.non_invalidated_smartcasts_since(saved_invalidation_events_len,
-		saved_smartcasts)
+	t.smartcast_stack = t.restore_smartcasts_since(saved_smartcast_event_id, saved_smartcasts)
 	return t.mark_optional_wrapper_expr(transformed, raw_type)
 }
 

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -2101,6 +2101,7 @@ fn (mut t Transformer) transform_optional_wrapper_expr(id flat.NodeId) flat.Node
 fn (mut t Transformer) transform_optional_wrapper_index_expr(id flat.NodeId, node flat.Node, raw_type string) flat.NodeId {
 	key := t.expr_key(id)
 	saved_smartcasts := t.smartcast_stack.clone()
+	saved_invalidated_smartcasts := t.invalidated_smartcasts.clone()
 	if key.len > 0 {
 		mut remaining_smartcasts := []SmartcastContext{cap: saved_smartcasts.len}
 		for smartcast in saved_smartcasts {
@@ -2112,7 +2113,13 @@ fn (mut t Transformer) transform_optional_wrapper_index_expr(id flat.NodeId, nod
 		t.smartcast_stack = remaining_smartcasts
 	}
 	transformed := t.transform_index_expr(id, node)
-	t.smartcast_stack = t.non_invalidated_smartcasts(saved_smartcasts)
+	mut index_invalidated_smartcasts := map[string]bool{}
+	for invalidated_key, invalidated in t.invalidated_smartcasts {
+		if invalidated && !(saved_invalidated_smartcasts[invalidated_key] or { false }) {
+			index_invalidated_smartcasts[invalidated_key] = true
+		}
+	}
+	t.smartcast_stack = t.non_invalidated_smartcasts_for(index_invalidated_smartcasts, saved_smartcasts)
 	return t.mark_optional_wrapper_expr(transformed, raw_type)
 }
 

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -2104,7 +2104,7 @@ fn (mut t Transformer) transform_optional_wrapper_index_expr(id flat.NodeId, nod
 	if key.len > 0 {
 		mut remaining_smartcasts := []SmartcastContext{cap: saved_smartcasts.len}
 		for smartcast in saved_smartcasts {
-			if smartcast.expr_name == key && smartcast.sum_type_name == option_unwrap_marker {
+			if smartcast.expr_name == key {
 				continue
 			}
 			remaining_smartcasts << smartcast

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -2074,6 +2074,14 @@ fn (mut t Transformer) transform_optional_wrapper_expr(id flat.NodeId) flat.Node
 	if !t.is_optional_type_name(raw_type) {
 		raw_type = t.optional_result_expr_type_name(source_id)
 	}
+	if t.is_optional_type_name(raw_type) {
+		source := t.a.nodes[int(source_id)]
+		if source.kind == .index && source.op == .gated_index {
+			if lowered := t.lower_gated_scalar_index(source) {
+				return t.transform_optional_wrapper_expr(lowered)
+			}
+		}
+	}
 	if t.is_optional_type_name(raw_type) && t.a.nodes[int(id)].kind in [.ident, .selector, .index] {
 		// `source_id` is already the wrapper expression with any redundant top-level
 		// payload selectors removed. Rebuilding it here would transform its

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -2101,7 +2101,7 @@ fn (mut t Transformer) transform_optional_wrapper_expr(id flat.NodeId) flat.Node
 fn (mut t Transformer) transform_optional_wrapper_index_expr(id flat.NodeId, node flat.Node, raw_type string) flat.NodeId {
 	key := t.expr_key(id)
 	saved_smartcasts := t.smartcast_stack.clone()
-	saved_invalidated_smartcasts := t.invalidated_smartcasts.clone()
+	saved_invalidation_events_len := t.smartcast_invalidation_events.len
 	if key.len > 0 {
 		mut remaining_smartcasts := []SmartcastContext{cap: saved_smartcasts.len}
 		for smartcast in saved_smartcasts {
@@ -2113,13 +2113,8 @@ fn (mut t Transformer) transform_optional_wrapper_index_expr(id flat.NodeId, nod
 		t.smartcast_stack = remaining_smartcasts
 	}
 	transformed := t.transform_index_expr(id, node)
-	mut index_invalidated_smartcasts := map[string]bool{}
-	for invalidated_key, invalidated in t.invalidated_smartcasts {
-		if invalidated && !(saved_invalidated_smartcasts[invalidated_key] or { false }) {
-			index_invalidated_smartcasts[invalidated_key] = true
-		}
-	}
-	t.smartcast_stack = t.non_invalidated_smartcasts_for(index_invalidated_smartcasts, saved_smartcasts)
+	t.smartcast_stack = t.non_invalidated_smartcasts_since(saved_invalidation_events_len,
+		saved_smartcasts)
 	return t.mark_optional_wrapper_expr(transformed, raw_type)
 }
 

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -2085,21 +2085,43 @@ fn (mut t Transformer) transform_optional_wrapper_expr(id flat.NodeId) flat.Node
 					return t.transform_optional_wrapper_expr(lowered)
 				}
 			}
+			return t.transform_optional_wrapper_index_expr(source_id, source, raw_type)
 		}
 	}
-	if t.is_optional_type_name(raw_type) && t.a.nodes[int(id)].kind in [.ident, .selector, .index] {
+	if t.is_optional_type_name(raw_type) && t.a.nodes[int(id)].kind in [.ident, .selector] {
 		// `source_id` is already the wrapper expression with any redundant top-level
 		// payload selectors removed. Rebuilding it here would transform its
 		// base again and could apply the same assignment smartcast a second time
 		// (`foo?.field` becoming `foo.value.value.field`).
-		plain := source_id
-		t.set_node_typ(int(plain), raw_type)
-		mut params := t.a.nodes[int(plain)].generic_params().clone()
-		params << optional_wrapper_access_marker
-		t.set_node_generic_params(int(plain), params)
-		return plain
+		return t.mark_optional_wrapper_expr(source_id, raw_type)
 	}
 	return t.transform_expr(id)
+}
+
+fn (mut t Transformer) transform_optional_wrapper_index_expr(id flat.NodeId, node flat.Node, raw_type string) flat.NodeId {
+	key := t.expr_key(id)
+	saved_smartcasts := t.smartcast_stack.clone()
+	if key.len > 0 {
+		mut remaining_smartcasts := []SmartcastContext{cap: saved_smartcasts.len}
+		for smartcast in saved_smartcasts {
+			if smartcast.expr_name == key && smartcast.sum_type_name == option_unwrap_marker {
+				continue
+			}
+			remaining_smartcasts << smartcast
+		}
+		t.smartcast_stack = remaining_smartcasts
+	}
+	transformed := t.transform_index_expr(id, node)
+	t.smartcast_stack = saved_smartcasts
+	return t.mark_optional_wrapper_expr(transformed, raw_type)
+}
+
+fn (mut t Transformer) mark_optional_wrapper_expr(id flat.NodeId, raw_type string) flat.NodeId {
+	t.set_node_typ(int(id), raw_type)
+	mut params := t.a.nodes[int(id)].generic_params().clone()
+	params << optional_wrapper_access_marker
+	t.set_node_generic_params(int(id), params)
+	return id
 }
 
 fn (mut t Transformer) stable_optional_wrapper_expr_for_reuse(id flat.NodeId, typ string, prefix string) flat.NodeId {

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -2112,7 +2112,7 @@ fn (mut t Transformer) transform_optional_wrapper_index_expr(id flat.NodeId, nod
 		t.smartcast_stack = remaining_smartcasts
 	}
 	transformed := t.transform_index_expr(id, node)
-	t.smartcast_stack = saved_smartcasts
+	t.smartcast_stack = t.non_invalidated_smartcasts(saved_smartcasts)
 	return t.mark_optional_wrapper_expr(transformed, raw_type)
 }
 

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -2076,9 +2076,14 @@ fn (mut t Transformer) transform_optional_wrapper_expr(id flat.NodeId) flat.Node
 	}
 	if t.is_optional_type_name(raw_type) {
 		source := t.a.nodes[int(source_id)]
-		if source.kind == .index && source.op == .gated_index {
-			if lowered := t.lower_gated_scalar_index(source) {
+		if source.kind == .index {
+			if lowered := t.try_lower_map_index_expr(source_id, source) {
 				return t.transform_optional_wrapper_expr(lowered)
+			}
+			if source.op == .gated_index {
+				if lowered := t.lower_gated_scalar_index(source) {
+					return t.transform_optional_wrapper_expr(lowered)
+				}
 			}
 		}
 	}

--- a/vlib/v3/transform/smartcast_invalidation_test.v
+++ b/vlib/v3/transform/smartcast_invalidation_test.v
@@ -1,0 +1,15 @@
+module transform
+
+fn test_repeated_smartcast_invalidation_is_new_event() {
+	mut t := Transformer{
+		smartcast_invalidation_events: ['h']
+	}
+	saved_smartcasts := [SmartcastContext{
+		expr_name: 'h.value'
+		variant_name: 'Value'
+		sum_type_name: option_unwrap_marker
+	}]
+	assert t.non_invalidated_smartcasts_since(1, saved_smartcasts).len == 1
+	t.smartcast_invalidation_events << 'h'
+	assert t.non_invalidated_smartcasts_since(1, saved_smartcasts).len == 0
+}

--- a/vlib/v3/transform/smartcast_invalidation_test.v
+++ b/vlib/v3/transform/smartcast_invalidation_test.v
@@ -2,14 +2,28 @@ module transform
 
 fn test_repeated_smartcast_invalidation_is_new_event() {
 	mut t := Transformer{
-		smartcast_invalidation_events: ['h']
+		smartcast_event_id: 1
+		smartcast_invalidation_event_ids: {
+			'h': 1
+		}
+		smartcast_reestablishment_event_ids: map[string]int{}
 	}
 	saved_smartcasts := [SmartcastContext{
 		expr_name: 'h.value'
 		variant_name: 'Value'
 		sum_type_name: option_unwrap_marker
 	}]
-	assert t.non_invalidated_smartcasts_since(1, saved_smartcasts).len == 1
-	t.smartcast_invalidation_events << 'h'
-	assert t.non_invalidated_smartcasts_since(1, saved_smartcasts).len == 0
+	assert t.restore_smartcasts_since(1, saved_smartcasts) == saved_smartcasts
+	t.smartcast_event_id++
+	t.smartcast_invalidation_event_ids['h'] = t.smartcast_event_id
+	assert t.restore_smartcasts_since(1, saved_smartcasts).len == 0
+	recreated := SmartcastContext{
+		expr_name: 'h.value'
+		variant_name: 'Foo'
+		sum_type_name: option_unwrap_marker
+	}
+	t.smartcast_stack << recreated
+	t.smartcast_event_id++
+	t.smartcast_reestablishment_event_ids['h.value'] = t.smartcast_event_id
+	assert t.restore_smartcasts_since(1, saved_smartcasts) == [recreated]
 }

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -109,6 +109,12 @@ pub:
 	sum_type_name string // the parent sum type name (e.g. "Expr")
 }
 
+enum SmartcastRestoreState {
+	unchanged
+	invalidated
+	reestablished
+}
+
 struct LocalClosureFieldCandidate {
 	source_id       int
 	owner_id        int
@@ -217,7 +223,9 @@ mut:
 	pending_stmts                   []flat.NodeId
 	smartcast_stack                 []SmartcastContext
 	invalidated_smartcasts          map[string]bool
-	smartcast_invalidation_events   []string
+	smartcast_event_id               int
+	smartcast_invalidation_event_ids map[string]int
+	smartcast_reestablishment_event_ids map[string]int
 	in_call_callee                  bool
 	in_monomorphize_scan            bool
 	validating_generic_spec         bool
@@ -3827,7 +3835,9 @@ fn (t &Transformer) fork_worker_config(ast &flat.FlatAst, wtc &types.TypeChecker
 	w.fixed_array_param_values = map[string]bool{}
 	w.smartcast_stack = []SmartcastContext{}
 	w.invalidated_smartcasts = map[string]bool{}
-	w.smartcast_invalidation_events = []string{}
+	w.smartcast_event_id = 0
+	w.smartcast_invalidation_event_ids = map[string]int{}
+	w.smartcast_reestablishment_event_ids = map[string]int{}
 	w.pending_stmts = []flat.NodeId{}
 	w.pointer_value_lvalues = map[string]bool{}
 	w.pointer_value_rvalues = map[string]bool{}
@@ -3951,7 +3961,9 @@ fn (t &Transformer) fork_scan_worker(wtc &types.TypeChecker) &Transformer {
 	w.fixed_array_param_values = map[string]bool{}
 	w.smartcast_stack = []SmartcastContext{}
 	w.invalidated_smartcasts = map[string]bool{}
-	w.smartcast_invalidation_events = []string{}
+	w.smartcast_event_id = 0
+	w.smartcast_invalidation_event_ids = map[string]int{}
+	w.smartcast_reestablishment_event_ids = map[string]int{}
 	w.pending_stmts = []flat.NodeId{}
 	w.pointer_value_lvalues = map[string]bool{}
 	w.pointer_value_rvalues = map[string]bool{}
@@ -4088,6 +4100,8 @@ fn (t &Transformer) fork_program_view(ast &flat.FlatAst, wtc &types.TypeChecker,
 		orm_initialized_fields: map[string][]string{}
 		sql_query_data_aliases: map[string][]string{}
 		invalidated_smartcasts: map[string]bool{}
+		smartcast_invalidation_event_ids: map[string]int{}
+		smartcast_reestablishment_event_ids: map[string]int{}
 		escaping_amp_ptrs: map[string]bool{}
 		escaping_amp_sources: map[string]bool{}
 		heaped_amp_locals: map[string]bool{}
@@ -8721,7 +8735,9 @@ fn (mut t Transformer) transform_fn_body(fn_idx int) {
 	t.cur_fn_variadic_param = ''
 	t.smartcast_stack.clear()
 	t.invalidated_smartcasts.clear()
-	t.smartcast_invalidation_events.clear()
+	t.smartcast_event_id = 0
+	t.smartcast_invalidation_event_ids.clear()
+	t.smartcast_reestablishment_event_ids.clear()
 	// Collect param types
 	mut param_idx := 0
 	mut source_mut_params := []string{}
@@ -8884,7 +8900,9 @@ fn (mut t Transformer) transform_fn_body(fn_idx int) {
 	}
 	t.smartcast_stack.clear()
 	t.invalidated_smartcasts.clear()
-	t.smartcast_invalidation_events.clear()
+	t.smartcast_event_id = 0
+	t.smartcast_invalidation_event_ids.clear()
+	t.smartcast_reestablishment_event_ids.clear()
 	t.cur_fn_is_generic = old_is_generic
 	t.cur_fn_manualfree = old_manualfree
 	t.cur_fn_receiver_name = old_receiver_name
@@ -9111,16 +9129,6 @@ fn (t &Transformer) non_invalidated_smartcasts(contexts []SmartcastContext) []Sm
 	return keep
 }
 
-fn (t &Transformer) non_invalidated_smartcasts_since(event_start int, contexts []SmartcastContext) []SmartcastContext {
-	mut keep := []SmartcastContext{cap: contexts.len}
-	for sc in contexts {
-		if !t.smartcast_context_invalidated_since(event_start, sc.expr_name) {
-			keep << sc
-		}
-	}
-	return keep
-}
-
 fn (t &Transformer) smartcast_context_invalidated(expr_name string) bool {
 	if expr_name.len == 0 || t.invalidated_smartcasts.len == 0 {
 		return false
@@ -9133,18 +9141,51 @@ fn (t &Transformer) smartcast_context_invalidated(expr_name string) bool {
 	return false
 }
 
-fn (t &Transformer) smartcast_context_invalidated_since(event_start int, expr_name string) bool {
-	if expr_name.len == 0 || event_start >= t.smartcast_invalidation_events.len {
-		return false
-	}
-	start := if event_start < 0 { 0 } else { event_start }
-	for i in start .. t.smartcast_invalidation_events.len {
-		key := t.smartcast_invalidation_events[i]
-		if expr_name == key || expr_name.starts_with('${key}.') {
-			return true
+fn (t &Transformer) restore_smartcasts_since(event_start int, saved []SmartcastContext) []SmartcastContext {
+	mut restored := []SmartcastContext{cap: saved.len}
+	mut replaced_exprs := map[string]bool{}
+	for smartcast in saved {
+		match t.smartcast_restore_state_since(event_start, smartcast.expr_name) {
+			.invalidated {
+				continue
+			}
+			.reestablished {
+				if smartcast.expr_name in replaced_exprs {
+					continue
+				}
+				replaced_exprs[smartcast.expr_name] = true
+				for current in t.smartcast_stack {
+					if current.expr_name == smartcast.expr_name {
+						restored << current
+					}
+				}
+			}
+			.unchanged {
+				restored << smartcast
+			}
 		}
 	}
-	return false
+	return restored
+}
+
+fn (t &Transformer) smartcast_restore_state_since(event_start int, expr_name string) SmartcastRestoreState {
+	if expr_name.len == 0 || event_start >= t.smartcast_event_id {
+		return .unchanged
+	}
+	mut latest_invalidation_id := 0
+	for key, event_id in t.smartcast_invalidation_event_ids {
+		if event_id > event_start && event_id > latest_invalidation_id
+			&& (expr_name == key || expr_name.starts_with('${key}.')) {
+			latest_invalidation_id = event_id
+		}
+	}
+	if latest_invalidation_id == 0 {
+		return .unchanged
+	}
+	if t.smartcast_reestablishment_event_ids[expr_name] or { 0 } > latest_invalidation_id {
+		return .reestablished
+	}
+	return .invalidated
 }
 
 fn (t &Transformer) is_multi_init_for_block(node flat.Node) bool {
@@ -12058,7 +12099,8 @@ fn (mut t Transformer) invalidate_smartcast_for_lvalue(id flat.NodeId) {
 	if key.len == 0 || t.smartcast_stack.len == 0 {
 		return
 	}
-	t.smartcast_invalidation_events << key
+	t.smartcast_event_id++
+	t.smartcast_invalidation_event_ids[key] = t.smartcast_event_id
 	t.invalidated_smartcasts[key] = true
 	prefix := '${key}.'
 	mut keep := []SmartcastContext{cap: t.smartcast_stack.len}
@@ -22239,11 +22281,14 @@ fn (mut t Transformer) make_if_with_ownership_drop_mode(cond flat.NodeId, then_b
 // push_smartcast updates push smartcast state for Transformer.
 pub fn (mut t Transformer) push_smartcast(expr_name string, variant string, sum_type string) {
 	t.invalidated_smartcasts.delete(expr_name)
-	t.smartcast_stack << SmartcastContext{
+	smartcast := SmartcastContext{
 		expr_name: expr_name
 		variant_name: variant
 		sum_type_name: sum_type
 	}
+	t.smartcast_stack << smartcast
+	t.smartcast_event_id++
+	t.smartcast_reestablishment_event_ids[expr_name] = t.smartcast_event_id
 }
 
 // pop_smartcast updates pop smartcast state for Transformer.

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -9097,9 +9097,13 @@ pub fn (mut t Transformer) transform_stmts(ids []flat.NodeId) []flat.NodeId {
 }
 
 fn (t &Transformer) non_invalidated_smartcasts(contexts []SmartcastContext) []SmartcastContext {
+	return t.non_invalidated_smartcasts_for(t.invalidated_smartcasts, contexts)
+}
+
+fn (t &Transformer) non_invalidated_smartcasts_for(invalidated map[string]bool, contexts []SmartcastContext) []SmartcastContext {
 	mut keep := []SmartcastContext{cap: contexts.len}
 	for sc in contexts {
-		if !t.smartcast_context_invalidated(sc.expr_name) {
+		if !t.smartcast_context_invalidated_for(invalidated, sc.expr_name) {
 			keep << sc
 		}
 	}
@@ -9107,10 +9111,14 @@ fn (t &Transformer) non_invalidated_smartcasts(contexts []SmartcastContext) []Sm
 }
 
 fn (t &Transformer) smartcast_context_invalidated(expr_name string) bool {
-	if expr_name.len == 0 || t.invalidated_smartcasts.len == 0 {
+	return t.smartcast_context_invalidated_for(t.invalidated_smartcasts, expr_name)
+}
+
+fn (t &Transformer) smartcast_context_invalidated_for(invalidated map[string]bool, expr_name string) bool {
+	if expr_name.len == 0 || invalidated.len == 0 {
 		return false
 	}
-	for key, _ in t.invalidated_smartcasts {
+	for key, _ in invalidated {
 		if expr_name == key || expr_name.starts_with('${key}.') {
 			return true
 		}

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -217,6 +217,7 @@ mut:
 	pending_stmts                   []flat.NodeId
 	smartcast_stack                 []SmartcastContext
 	invalidated_smartcasts          map[string]bool
+	smartcast_invalidation_events   []string
 	in_call_callee                  bool
 	in_monomorphize_scan            bool
 	validating_generic_spec         bool
@@ -3826,6 +3827,7 @@ fn (t &Transformer) fork_worker_config(ast &flat.FlatAst, wtc &types.TypeChecker
 	w.fixed_array_param_values = map[string]bool{}
 	w.smartcast_stack = []SmartcastContext{}
 	w.invalidated_smartcasts = map[string]bool{}
+	w.smartcast_invalidation_events = []string{}
 	w.pending_stmts = []flat.NodeId{}
 	w.pointer_value_lvalues = map[string]bool{}
 	w.pointer_value_rvalues = map[string]bool{}
@@ -3949,6 +3951,7 @@ fn (t &Transformer) fork_scan_worker(wtc &types.TypeChecker) &Transformer {
 	w.fixed_array_param_values = map[string]bool{}
 	w.smartcast_stack = []SmartcastContext{}
 	w.invalidated_smartcasts = map[string]bool{}
+	w.smartcast_invalidation_events = []string{}
 	w.pending_stmts = []flat.NodeId{}
 	w.pointer_value_lvalues = map[string]bool{}
 	w.pointer_value_rvalues = map[string]bool{}
@@ -8718,6 +8721,7 @@ fn (mut t Transformer) transform_fn_body(fn_idx int) {
 	t.cur_fn_variadic_param = ''
 	t.smartcast_stack.clear()
 	t.invalidated_smartcasts.clear()
+	t.smartcast_invalidation_events.clear()
 	// Collect param types
 	mut param_idx := 0
 	mut source_mut_params := []string{}
@@ -8880,6 +8884,7 @@ fn (mut t Transformer) transform_fn_body(fn_idx int) {
 	}
 	t.smartcast_stack.clear()
 	t.invalidated_smartcasts.clear()
+	t.smartcast_invalidation_events.clear()
 	t.cur_fn_is_generic = old_is_generic
 	t.cur_fn_manualfree = old_manualfree
 	t.cur_fn_receiver_name = old_receiver_name
@@ -9097,13 +9102,19 @@ pub fn (mut t Transformer) transform_stmts(ids []flat.NodeId) []flat.NodeId {
 }
 
 fn (t &Transformer) non_invalidated_smartcasts(contexts []SmartcastContext) []SmartcastContext {
-	return t.non_invalidated_smartcasts_for(t.invalidated_smartcasts, contexts)
-}
-
-fn (t &Transformer) non_invalidated_smartcasts_for(invalidated map[string]bool, contexts []SmartcastContext) []SmartcastContext {
 	mut keep := []SmartcastContext{cap: contexts.len}
 	for sc in contexts {
-		if !t.smartcast_context_invalidated_for(invalidated, sc.expr_name) {
+		if !t.smartcast_context_invalidated(sc.expr_name) {
+			keep << sc
+		}
+	}
+	return keep
+}
+
+fn (t &Transformer) non_invalidated_smartcasts_since(event_start int, contexts []SmartcastContext) []SmartcastContext {
+	mut keep := []SmartcastContext{cap: contexts.len}
+	for sc in contexts {
+		if !t.smartcast_context_invalidated_since(event_start, sc.expr_name) {
 			keep << sc
 		}
 	}
@@ -9111,14 +9122,24 @@ fn (t &Transformer) non_invalidated_smartcasts_for(invalidated map[string]bool, 
 }
 
 fn (t &Transformer) smartcast_context_invalidated(expr_name string) bool {
-	return t.smartcast_context_invalidated_for(t.invalidated_smartcasts, expr_name)
-}
-
-fn (t &Transformer) smartcast_context_invalidated_for(invalidated map[string]bool, expr_name string) bool {
-	if expr_name.len == 0 || invalidated.len == 0 {
+	if expr_name.len == 0 || t.invalidated_smartcasts.len == 0 {
 		return false
 	}
-	for key, _ in invalidated {
+	for key, _ in t.invalidated_smartcasts {
+		if expr_name == key || expr_name.starts_with('${key}.') {
+			return true
+		}
+	}
+	return false
+}
+
+fn (t &Transformer) smartcast_context_invalidated_since(event_start int, expr_name string) bool {
+	if expr_name.len == 0 || event_start >= t.smartcast_invalidation_events.len {
+		return false
+	}
+	start := if event_start < 0 { 0 } else { event_start }
+	for i in start .. t.smartcast_invalidation_events.len {
+		key := t.smartcast_invalidation_events[i]
 		if expr_name == key || expr_name.starts_with('${key}.') {
 			return true
 		}
@@ -12037,6 +12058,7 @@ fn (mut t Transformer) invalidate_smartcast_for_lvalue(id flat.NodeId) {
 	if key.len == 0 || t.smartcast_stack.len == 0 {
 		return
 	}
+	t.smartcast_invalidation_events << key
 	t.invalidated_smartcasts[key] = true
 	prefix := '${key}.'
 	mut keep := []SmartcastContext{cap: t.smartcast_stack.len}


### PR DESCRIPTION
## Summary
- preserve optional-wrapper typing for indexed expressions during `none` comparisons
- add an indexed optional fixed-array assignment regression test

## Tests
- `./vnew -silent test vlib/v3/tests/optional_fixed_array_assign_codegen_test.v`
- `./vnew -silent test vlib/v3/transform/` *(fails in existing `transform_parallel_test.v` assertions unrelated to this change)*