### PR TITLE
v3: support asm goto C lowering

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -9120,6 +9120,19 @@ asm amd64 raw {
 assert value == 42
 ```
 
+`asm goto` emits GNU `asm goto` and is available only with the C backend. Its fifth semicolon
+section lists the V labels that the assembly may branch to. Use the label name in a structured
+branch instruction; a `raw` template uses GNU's `%l[label]` form. Targets cannot enter or leave a
+V `lock` scope.
+
+```v ignore
+asm goto amd64 {
+    jne done
+    ; ; ; ; done
+}
+done:
+```
+
 Use `intel` for destination-first structured x86 assembly. V surrounds the generated template
 with `.intel_syntax noprefix` and `.att_syntax prefix`, and does not reorder its operands:
 

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -5,6 +5,7 @@ import strings
 import v3.flat
 import v3.gen.c.naming
 import v3.types
+import v3.util
 
 const direct_optional_forward_return_value = '__direct_optional_forward'
 const optional_success_return_value = '__optional_success_return'
@@ -3067,13 +3068,13 @@ fn (mut g FlatGen) gen_c_inline_asm_stmt(node flat.Node) {
 			g.writeln('"${template}"')
 			continue
 		}
-		lowered := if block.is_intel {
+		mut lowered := if block.is_intel {
 			lower_c_inline_asm_intel_template(template, aliases, is_extended)
 		} else {
 			lower_c_inline_asm_template(template, block.arch, aliases, is_extended)
 		}
 		if block.is_goto {
-			lowered = g.lower_c_inline_asm_goto_labels(lowered, block.labels)
+			lowered = g.lower_c_inline_asm_goto_branch_label(template, lowered, block.arch, aliases, block.labels)
 		}
 		g.writeln('"${c_escape(lowered + '\n\t')}"')
 	}
@@ -3290,28 +3291,46 @@ fn parse_c_inline_asm_block(source string) ?CInlineAsmBlock {
 	}
 }
 
-fn (mut g FlatGen) lower_c_inline_asm_goto_labels(template string, labels []string) string {
-	mut result := strings.new_builder(template.len)
-	mut i := 0
-	for i < template.len {
-		if !c_inline_asm_ident_start(template[i]) {
-			result.write_u8(template[i])
-			i++
-			continue
-		}
-		start := i
-		i++
-		for i < template.len && c_inline_asm_ident_char(template[i]) {
-			i++
-		}
-		word := template[start..i]
-		if word in labels && (i == template.len || template[i] != `:`) {
-			result.write_string('%l[${g.user_goto_c_label(word)}]')
-		} else {
-			result.write_string(word)
-		}
+fn (mut g FlatGen) lower_c_inline_asm_goto_branch_label(source string, lowered string, arch string, aliases map[string]bool, labels []string) string {
+	line := source.trim_space()
+	mut split := 0
+	for split < line.len && !line[split].is_space() {
+		split++
 	}
-	return result.str()
+	instruction := line[..split]
+	operands := split_c_inline_asm_operands(line[split..].trim_space())
+	label_index := c_inline_asm_goto_branch_label_operand_index(instruction, arch, operands.len)
+	if label_index < 0 {
+		return lowered
+	}
+	label := operands[label_index].trim_space()
+	if label !in labels || aliases[label] || label in util.asm_register_names(arch) {
+		return lowered
+	}
+	lowered_split := lowered.index_u8(` `)
+	if lowered_split < 0 {
+		return lowered
+	}
+	mut lowered_operands := split_c_inline_asm_operands(lowered[lowered_split + 1..])
+	if lowered_operands.len != operands.len {
+		return lowered
+	}
+	lowered_operands[label_index] = '%l[${g.user_goto_c_label(label)}]'
+	return lowered[..lowered_split + 1] + lowered_operands.join(', ')
+}
+
+fn c_inline_asm_goto_branch_label_operand_index(instruction string, arch string, operand_count int) int {
+	if operand_count == 0 {
+		return -1
+	}
+	if is_c_inline_asm_x86_arch(arch) {
+		return if instruction.starts_with('call') || instruction.starts_with('j') { 0 } else { -1 }
+	}
+	if arch in ['arm64', 'aarch64'] && (instruction == 'b' || instruction == 'bl'
+		|| instruction.starts_with('b.') || instruction.starts_with('cb') || instruction.starts_with('tb')) {
+		return operand_count - 1
+	}
+	return -1
 }
 
 // parse_c_inline_asm_raw_templates returns the verbatim text of every double-quoted

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -3318,12 +3318,14 @@ fn parse_c_inline_asm_block(source string) ?CInlineAsmBlock {
 
 fn (mut g FlatGen) lower_c_inline_asm_goto_branch_label(source string, lowered string, arch string, aliases map[string]bool, labels []string) string {
 	line := source.trim_space()
+	instruction_start := c_inline_asm_instruction_start(line)
+	instruction_line := line[instruction_start..]
 	mut split := 0
-	for split < line.len && !line[split].is_space() {
+	for split < instruction_line.len && !instruction_line[split].is_space() {
 		split++
 	}
-	instruction := line[..split]
-	operands := split_c_inline_asm_operands(line[split..].trim_space())
+	instruction := instruction_line[..split]
+	operands := split_c_inline_asm_operands(instruction_line[split..].trim_space())
 	label_index := c_inline_asm_goto_branch_label_operand_index(instruction, arch, operands.len)
 	if label_index < 0 {
 		return lowered
@@ -3332,16 +3334,18 @@ fn (mut g FlatGen) lower_c_inline_asm_goto_branch_label(source string, lowered s
 	if label !in labels || aliases[label] || label in util.asm_register_names(arch) {
 		return lowered
 	}
-	lowered_split := lowered.index_u8(` `)
+	lowered_instruction_start := c_inline_asm_instruction_start(lowered)
+	lowered_instruction := lowered[lowered_instruction_start..]
+	lowered_split := lowered_instruction.index_u8(` `)
 	if lowered_split < 0 {
 		return lowered
 	}
-	mut lowered_operands := split_c_inline_asm_operands(lowered[lowered_split + 1..])
+	mut lowered_operands := split_c_inline_asm_operands(lowered_instruction[lowered_split + 1..])
 	if lowered_operands.len != operands.len {
 		return lowered
 	}
 	lowered_operands[label_index] = '%l[${g.user_goto_c_label(label)}]'
-	return lowered[..lowered_split + 1] + lowered_operands.join(', ')
+	return lowered[..lowered_instruction_start + lowered_split + 1] + lowered_operands.join(', ')
 }
 
 fn (mut g FlatGen) lower_c_inline_asm_goto_raw_labels(template string, labels []string) string {
@@ -3596,12 +3600,14 @@ fn lower_c_inline_asm_template(source string, arch string, aliases map[string]bo
 	if line.len == 0 || line.ends_with(':') {
 		return line
 	}
+	instruction_start := c_inline_asm_instruction_start(line)
+	instruction_line := line[instruction_start..]
 	mut split := 0
-	for split < line.len && !line[split].is_space() {
+	for split < instruction_line.len && !instruction_line[split].is_space() {
 		split++
 	}
-	mut instruction := line[..split]
-	mut operands_source := line[split..].trim_space()
+	mut instruction := instruction_line[..split]
+	mut operands_source := instruction_line[split..].trim_space()
 	if is_c_inline_asm_x86_arch(arch) && instruction == 'lock' && operands_source.len > 0 {
 		mut next := 0
 		for next < operands_source.len && !operands_source[next].is_space() {
@@ -3611,7 +3617,7 @@ fn lower_c_inline_asm_template(source string, arch string, aliases map[string]bo
 		operands_source = operands_source[next..].trim_space()
 	}
 	if operands_source.len == 0 {
-		return instruction
+		return line[..instruction_start] + instruction
 	}
 	mut operands := split_c_inline_asm_operands(operands_source)
 	is_directive := instruction.starts_with('.')
@@ -3628,7 +3634,7 @@ fn lower_c_inline_asm_template(source string, arch string, aliases map[string]bo
 		}
 		lowered << lowered_operand
 	}
-	return instruction + ' ' + lowered.join(', ')
+	return line[..instruction_start] + instruction + ' ' + lowered.join(', ')
 }
 
 // lower_c_inline_asm_intel_template keeps V's destination-first structured syntax as
@@ -3639,12 +3645,14 @@ fn lower_c_inline_asm_intel_template(source string, aliases map[string]bool, is_
 	if line.len == 0 || line.ends_with(':') {
 		return line
 	}
+	instruction_start := c_inline_asm_instruction_start(line)
+	instruction_line := line[instruction_start..]
 	mut split := 0
-	for split < line.len && !line[split].is_space() {
+	for split < instruction_line.len && !instruction_line[split].is_space() {
 		split++
 	}
-	mut instruction := line[..split]
-	mut operands_source := line[split..].trim_space()
+	mut instruction := instruction_line[..split]
+	mut operands_source := instruction_line[split..].trim_space()
 	if instruction == 'lock' && operands_source.len > 0 {
 		mut next := 0
 		for next < operands_source.len && !operands_source[next].is_space() {
@@ -3654,14 +3662,37 @@ fn lower_c_inline_asm_intel_template(source string, aliases map[string]bool, is_
 		operands_source = operands_source[next..].trim_space()
 	}
 	if operands_source.len == 0 {
-		return instruction
+		return line[..instruction_start] + instruction
 	}
 	operands := split_c_inline_asm_operands(operands_source)
 	mut lowered := []string{cap: operands.len}
 	for operand in operands {
 		lowered << lower_c_inline_asm_intel_operand(operand, aliases, is_extended)
 	}
-	return instruction + ' ' + lowered.join(', ')
+	return line[..instruction_start] + instruction + ' ' + lowered.join(', ')
+}
+
+// c_inline_asm_instruction_start skips an optional local label before an instruction.
+fn c_inline_asm_instruction_start(line string) int {
+	mut i := 0
+	if i < line.len && line[i] == `.` {
+		i++
+	}
+	if i >= line.len || (!c_inline_asm_ident_start(line[i]) && !line[i].is_digit()) {
+		return 0
+	}
+	i++
+	for i < line.len && c_inline_asm_ident_char(line[i]) {
+		i++
+	}
+	if i >= line.len || line[i] != `:` {
+		return 0
+	}
+	i++
+	for i < line.len && line[i].is_space() {
+		i++
+	}
+	return i
 }
 
 fn lower_c_inline_asm_intel_operand(source string, aliases map[string]bool, is_extended bool) string {

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -23,6 +23,7 @@ struct CInlineAsmIO {
 
 struct CInlineAsmBlock {
 	arch          string
+	is_goto       bool
 	is_volatile   bool
 	is_raw        bool
 	is_intel      bool
@@ -30,6 +31,7 @@ struct CInlineAsmBlock {
 	output        []CInlineAsmIO
 	input         []CInlineAsmIO
 	clobbered     []string
+	labels        []string
 	section_count int
 }
 
@@ -3044,8 +3046,11 @@ fn (mut g FlatGen) gen_c_inline_asm_stmt(node flat.Node) {
 			aliases[io.alias] = true
 		}
 	}
-	is_extended := block.section_count > 1
+	is_extended := block.section_count > 1 || block.is_goto
 	g.write('__asm__')
+	if block.is_goto {
+		g.write(' goto')
+	}
 	if block.is_volatile {
 		g.write(' volatile')
 	}
@@ -3067,6 +3072,9 @@ fn (mut g FlatGen) gen_c_inline_asm_stmt(node flat.Node) {
 		} else {
 			lower_c_inline_asm_template(template, block.arch, aliases, is_extended)
 		}
+		if block.is_goto {
+			lowered = g.lower_c_inline_asm_goto_labels(lowered, block.labels)
+		}
 		g.writeln('"${c_escape(lowered + '\n\t')}"')
 	}
 	if block.is_intel {
@@ -3085,6 +3093,17 @@ fn (mut g FlatGen) gen_c_inline_asm_stmt(node flat.Node) {
 		for i, clobber in block.clobbered {
 			g.write('"${c_escape(clobber)}"')
 			if i + 1 < block.clobbered.len {
+				g.writeln(',')
+			} else {
+				g.writeln('')
+			}
+		}
+	}
+	if block.section_count > 4 {
+		g.write(': ')
+		for i, label in block.labels {
+			g.write(g.user_goto_c_label(label))
+			if i + 1 < block.labels.len {
 				g.writeln(',')
 			} else {
 				g.writeln('')
@@ -3199,6 +3218,7 @@ fn parse_c_inline_asm_block(source string) ?CInlineAsmBlock {
 	}
 	header := strip_c_inline_asm_comments(source[..open]).fields()
 	mut arch := ''
+	mut is_goto := false
 	mut is_volatile := false
 	mut is_raw := false
 	mut is_intel := false
@@ -3208,6 +3228,10 @@ fn parse_c_inline_asm_block(source string) ?CInlineAsmBlock {
 		}
 		if word == 'volatile' {
 			is_volatile = true
+			continue
+		}
+		if word == 'goto' {
+			is_goto = true
 			continue
 		}
 		if arch.len > 0 && word == 'raw' {
@@ -3245,8 +3269,15 @@ fn parse_c_inline_asm_block(source string) ?CInlineAsmBlock {
 			clobbered << name
 		}
 	}
+	mut labels := []string{}
+	if sections.len > 4 {
+		for label in sections[4].replace(',', ' ').fields() {
+			labels << label
+		}
+	}
 	return CInlineAsmBlock{
 		arch: arch
+		is_goto: is_goto
 		is_volatile: is_volatile
 		is_raw: is_raw
 		is_intel: is_intel
@@ -3254,8 +3285,33 @@ fn parse_c_inline_asm_block(source string) ?CInlineAsmBlock {
 		output: if sections.len > 1 { parse_c_inline_asm_ios(sections[1], true) } else { [] }
 		input: if sections.len > 2 { parse_c_inline_asm_ios(sections[2], false) } else { [] }
 		clobbered: clobbered
+		labels: labels
 		section_count: sections.len
 	}
+}
+
+fn (mut g FlatGen) lower_c_inline_asm_goto_labels(template string, labels []string) string {
+	mut result := strings.new_builder(template.len)
+	mut i := 0
+	for i < template.len {
+		if !c_inline_asm_ident_start(template[i]) {
+			result.write_u8(template[i])
+			i++
+			continue
+		}
+		start := i
+		i++
+		for i < template.len && c_inline_asm_ident_char(template[i]) {
+			i++
+		}
+		word := template[start..i]
+		if word in labels && (i == template.len || template[i] != `:`) {
+			result.write_string('%l[${g.user_goto_c_label(word)}]')
+		} else {
+			result.write_string(word)
+		}
+	}
+	return result.str()
 }
 
 // parse_c_inline_asm_raw_templates returns the verbatim text of every double-quoted

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -689,6 +689,22 @@ fn (g &FlatGen) goto_target_lock_scopes(label string) []int {
 	return g.goto_label_lock_scopes[label] or { []int{} }
 }
 
+fn (g &FlatGen) asm_goto_targets_stay_in_lock_scope(labels []string) bool {
+	active_scopes := g.active_lock_scope_ids()
+	for label in labels {
+		target_scopes := g.goto_target_lock_scopes(label)
+		if target_scopes.len != active_scopes.len {
+			return false
+		}
+		for i, target_scope in target_scopes {
+			if active_scopes[i] != target_scope {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 fn (mut g FlatGen) gen_goto_lock_leaves(label string) bool {
 	target_scopes := g.goto_target_lock_scopes(label)
 	active_scopes := g.active_lock_scope_ids()
@@ -3036,6 +3052,10 @@ fn (mut g FlatGen) gen_c_inline_asm_stmt(node flat.Node) {
 		&& block.clobbered.len == 0 && !block.is_volatile {
 		return
 	}
+	if block.is_goto && !g.asm_goto_targets_stay_in_lock_scope(block.labels) {
+		g.writeln('#error asm goto into or out of a lock scope is not supported')
+		return
+	}
 	mut aliases := map[string]bool{}
 	for io in block.output {
 		if io.alias.len > 0 {
@@ -3065,7 +3085,12 @@ fn (mut g FlatGen) gen_c_inline_asm_stmt(node flat.Node) {
 	}
 	for template in block.templates {
 		if block.is_raw {
-			g.writeln('"${template}"')
+			raw_template := if block.is_goto {
+				g.lower_c_inline_asm_goto_raw_labels(template, block.labels)
+			} else {
+				template
+			}
+			g.writeln('"${raw_template}"')
 			continue
 		}
 		mut lowered := if block.is_intel {
@@ -3319,12 +3344,25 @@ fn (mut g FlatGen) lower_c_inline_asm_goto_branch_label(source string, lowered s
 	return lowered[..lowered_split + 1] + lowered_operands.join(', ')
 }
 
+fn (mut g FlatGen) lower_c_inline_asm_goto_raw_labels(template string, labels []string) string {
+	mut lowered := template
+	for label in labels {
+		lowered = lowered.replace('%l[${label}]', '%l[${g.user_goto_c_label(label)}]')
+	}
+	return lowered
+}
+
 fn c_inline_asm_goto_branch_label_operand_index(instruction string, arch string, operand_count int) int {
 	if operand_count == 0 {
 		return -1
 	}
 	if is_c_inline_asm_x86_arch(arch) {
-		return if instruction.starts_with('call') || instruction.starts_with('j') { 0 } else { -1 }
+		return if instruction.starts_with('call') || instruction.starts_with('j')
+			|| instruction in ['loop', 'loope', 'loopne', 'loopz', 'loopnz'] {
+			0
+		} else {
+			-1
+		}
 	}
 	if arch in ['arm64', 'aarch64'] && (instruction == 'b' || instruction == 'bl'
 		|| instruction.starts_with('b.') || instruction.starts_with('cb') || instruction.starts_with('tb')) {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -8394,6 +8394,11 @@ fn (mut p Parser) validate_inline_asm_lock_instruction() {
 fn (mut p Parser) asm_stmt() flat.NodeId {
 	asm_pos := p.tok_pos
 	p.next() // skip 'asm'
+	mut is_goto := false
+	if p.tok == .key_goto {
+		is_goto = true
+		p.next()
+	}
 	// consume optional volatile keyword
 	if p.tok == .key_volatile || (p.tok == .name && p.lit == 'volatile') {
 		p.next()
@@ -8432,6 +8437,9 @@ fn (mut p Parser) asm_stmt() flat.NodeId {
 		p.next()
 	}
 	if !p.prefs.is_fmt {
+		if is_goto && p.prefs.backend != 'c' {
+			p.record_diagnostic('`asm goto` is only supported by the C backend', asm_pos)
+		}
 		if is_intel && pref.normalized_arch(asm_arch) !in ['amd64', 'x86'] {
 			p.record_diagnostic('the `intel` assembly modifier is only supported for i386 and amd64', asm_pos)
 		}

--- a/vlib/v3/tests/inline_asm_c_lowering_test.v
+++ b/vlib/v3/tests/inline_asm_c_lowering_test.v
@@ -306,10 +306,27 @@ fn test_asm_goto_reaches_c_lowering() {
 }
 ')
 	assert generate.exit_code == 0, generate.output
+	assert !generate.output.contains('label `over` defined and not used'), generate.output
 	assert c_source.contains('__asm__ goto ('), c_source
 	assert c_source.contains('"mov %%gs:(16), %%rax\\n\\t"'), c_source
 	assert c_source.contains('"jne %l[__v_user_goto_0]\\n\\t"'), c_source
 	assert c_source.contains(': __v_user_goto_0'), c_source
+}
+
+fn test_asm_goto_does_not_rewrite_non_branch_label_names() {
+	generate, c_source := generate_inline_asm_c('goto_register_label_program', 'fn main() {
+	asm goto amd64 {
+		mov rax, rax
+		jmp rax
+		; ; ; ; rax
+	}
+	rax:
+}
+')
+	assert generate.exit_code == 0, generate.output
+	assert c_source.contains('"mov %%rax, %%rax\\n\\t"'), c_source
+	assert c_source.contains('"jmp *%%rax\\n\\t"'), c_source
+	assert !c_source.contains('%l['), c_source
 }
 
 fn generate_inline_asm_c(name string, source string) (os.Result, string) {

--- a/vlib/v3/tests/inline_asm_c_lowering_test.v
+++ b/vlib/v3/tests/inline_asm_c_lowering_test.v
@@ -329,6 +329,54 @@ fn test_asm_goto_does_not_rewrite_non_branch_label_names() {
 	assert !c_source.contains('%l['), c_source
 }
 
+fn test_asm_goto_lowers_x86_loop_family_targets() {
+	generate, c_source := generate_inline_asm_c('goto_loop_program', 'fn main() {
+	asm goto amd64 {
+		loop done
+		; ; ; ; done
+	}
+	done:
+}
+')
+	assert generate.exit_code == 0, generate.output
+	assert c_source.contains('"loop %l[__v_user_goto_0]\\n\\t"'), c_source
+}
+
+fn test_raw_asm_goto_keeps_symbolic_label_references_valid() {
+	generate, c_source := generate_inline_asm_c('raw_goto_program', 'fn main() {
+	asm goto amd64 raw {
+		"jmp %l[done]\\n\\t"
+		; ; ; ; done
+	}
+	done:
+}
+')
+	assert generate.exit_code == 0, generate.output
+	assert c_source.contains('"jmp %l[__v_user_goto_0]\\n\\t"'), c_source
+	assert c_source.contains(': __v_user_goto_0'), c_source
+}
+
+fn test_asm_goto_across_lock_scope_is_rejected() {
+	generate, c_source := generate_inline_asm_c('goto_lock_scope_program', 'struct Counter {
+mut:
+	value int
+}
+
+fn main() {
+	shared counter := Counter{}
+	lock counter {
+		asm goto amd64 {
+			jmp done
+			; ; ; ; done
+		}
+	}
+	done:
+}
+')
+	assert generate.exit_code == 0, generate.output
+	assert c_source.contains('#error asm goto into or out of a lock scope is not supported'), c_source
+}
+
 fn generate_inline_asm_c(name string, source string) (os.Result, string) {
 	return generate_inline_asm_c_for_arch(name, source, 'amd64')
 }

--- a/vlib/v3/tests/inline_asm_c_lowering_test.v
+++ b/vlib/v3/tests/inline_asm_c_lowering_test.v
@@ -285,6 +285,7 @@ fn test_x86_inline_asm_segment_address_reaches_c_lowering() {
 		; +r (value)
 	}
 }
+
 ') or {
 		panic(err)
 	}
@@ -292,6 +293,23 @@ fn test_x86_inline_asm_segment_address_reaches_c_lowering() {
 	assert generate.exit_code == 0, generate.output
 	c_source := os.read_file(c_path) or { panic(err) }
 	assert c_source.contains('"mov %%fs:(%[value]), %[value]\\n\\t"'), c_source
+}
+
+fn test_asm_goto_reaches_c_lowering() {
+	generate, c_source := generate_inline_asm_c('asm_jump_program', 'fn main() {
+	asm goto amd64 {
+		mov rax, gs:[16]
+		jne over
+		; ; ; ; over
+	}
+	over:
+}
+')
+	assert generate.exit_code == 0, generate.output
+	assert c_source.contains('__asm__ goto ('), c_source
+	assert c_source.contains('"mov %%gs:(16), %%rax\\n\\t"'), c_source
+	assert c_source.contains('"jne %l[__v_user_goto_0]\\n\\t"'), c_source
+	assert c_source.contains(': __v_user_goto_0'), c_source
 }
 
 fn generate_inline_asm_c(name string, source string) (os.Result, string) {

--- a/vlib/v3/tests/inline_asm_c_lowering_test.v
+++ b/vlib/v3/tests/inline_asm_c_lowering_test.v
@@ -342,6 +342,19 @@ fn test_asm_goto_lowers_x86_loop_family_targets() {
 	assert c_source.contains('"loop %l[__v_user_goto_0]\\n\\t"'), c_source
 }
 
+fn test_asm_goto_lowers_branch_after_leading_local_label() {
+	generate, c_source := generate_inline_asm_c('goto_leading_label_program', 'fn main() {
+	asm goto amd64 {
+		retry: jne done
+		; ; ; ; done
+	}
+	done:
+}
+')
+	assert generate.exit_code == 0, generate.output
+	assert c_source.contains('"retry: jne %l[__v_user_goto_0]\\n\\t"'), c_source
+}
+
 fn test_raw_asm_goto_keeps_symbolic_label_references_valid() {
 	generate, c_source := generate_inline_asm_c('raw_goto_program', 'fn main() {
 	asm goto amd64 raw {

--- a/vlib/v3/types/checker_asm.v
+++ b/vlib/v3/types/checker_asm.v
@@ -92,6 +92,11 @@ fn (mut tc TypeChecker) check_inline_asm_block(id flat.NodeId, node flat.Node, s
 				}
 			}
 		}
+		if header.is_goto && sections.len > 4 {
+			for label in inline_asm_words(block, sections[4]) {
+				aliases[label.text] = true
+			}
+		}
 		tc.check_inline_asm_templates(id, node, block, start, sections[0], registers, aliases, header.arch, header.is_intel)
 	}
 }

--- a/vlib/v3/types/checker_asm.v
+++ b/vlib/v3/types/checker_asm.v
@@ -101,6 +101,27 @@ fn (mut tc TypeChecker) check_inline_asm_block(id flat.NodeId, node flat.Node, s
 	}
 }
 
+fn inline_asm_goto_labels(source string) []string {
+	block := inline_asm_mask_comments(source)
+	open := inline_asm_index_of(block, 0, block.len, `{`) or { return [] }
+	close := inline_asm_last_index_of(block, open, block.len, `}`) or { return [] }
+	header := util.parse_inline_asm_header(block[..open])
+	if !header.is_goto {
+		return []
+	}
+	sections := inline_asm_section_ranges(block, open + 1, close)
+	if sections.len <= 4 {
+		return []
+	}
+	mut labels := []string{}
+	for label in inline_asm_words(block, sections[4]) {
+		if label.text !in labels {
+			labels << label.text
+		}
+	}
+	return labels
+}
+
 fn (mut tc TypeChecker) check_inline_asm_output_lvalue(id flat.NodeId) {
 	if !tc.expr_can_take_address(id) {
 		tc.record_error_at(.assignment_mismatch, 'inline assembly output must be an lvalue', id, tc.a.node(id).pos)

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -68,7 +68,7 @@ fn interface_impl_index_chunk_thread(arg voidptr) voidptr {
 		}
 		results.items[i] = &InterfaceImplIndex{
 			names: impls
-			ids: stable_interface_type_ids(impls)
+			ids:   stable_interface_type_ids(impls)
 		}
 	}
 	return unsafe { nil }
@@ -101,15 +101,15 @@ fn (mut tc TypeChecker) prepare_interface_impl_indexes_parallel(iface_names []st
 		mut tasks := []workers.Task{cap: n_jobs}
 		for job in 0 .. n_jobs {
 			args << InterfaceImplChunkArgs{
-				checker: voidptr(checkers[job])
+				checker:     voidptr(checkers[job])
 				iface_names: unsafe { voidptr(&iface_names) }
-				results: voidptr(results)
-				start: iface_names.len * job / n_jobs
-				end: iface_names.len * (job + 1) / n_jobs
+				results:     voidptr(results)
+				start:       iface_names.len * job / n_jobs
+				end:         iface_names.len * (job + 1) / n_jobs
 			}
 			tasks << workers.Task{
-				run: interface_impl_index_chunk_thread
-				arg: unsafe { voidptr(&args[job]) }
+				run:        interface_impl_index_chunk_thread
+				arg:        unsafe { voidptr(&args[job]) }
 				force_sync: job == 0
 			}
 		}
@@ -126,7 +126,7 @@ fn (mut tc TypeChecker) prepare_interface_impl_indexes_parallel(iface_names []st
 				}
 				tc.interface_impl_indexes[iface_name] = &InterfaceImplIndex{
 					names: names
-					ids: stable_interface_type_ids(names)
+					ids:   stable_interface_type_ids(names)
 				}
 			}
 		}
@@ -195,28 +195,28 @@ fn (mut tc TypeChecker) prepare_collect_index_parallel(a &flat.FlatAst) bool {
 	tc.init_direct_parent_index(a)
 	mut args := [
 		CollectIndexPrepArgs{
-			tc: voidptr(tc)
-			a: a
+			tc:   voidptr(tc)
+			a:    a
 			kind: 0
 		},
 		CollectIndexPrepArgs{
-			tc: voidptr(tc)
-			a: a
+			tc:   voidptr(tc)
+			a:    a
 			kind: 1
 		},
 		CollectIndexPrepArgs{
-			tc: voidptr(tc)
-			a: a
+			tc:   voidptr(tc)
+			a:    a
 			kind: 2
-			n: a.nodes.len
+			n:    a.nodes.len
 		},
 	]
 	a.worker_pool.run([
 		workers.Task{ run: collect_index_prep_thread, arg: unsafe { voidptr(&args[0]) } },
 		workers.Task{ run: collect_index_prep_thread, arg: unsafe { voidptr(&args[1]) } },
 		workers.Task{
-			run: collect_index_prep_thread
-			arg: unsafe { voidptr(&args[2]) }
+			run:        collect_index_prep_thread
+			arg:        unsafe { voidptr(&args[2]) }
 			force_sync: true
 		},
 	])
@@ -235,18 +235,18 @@ fn (mut tc TypeChecker) prepare_collect_declaration_indexes_parallel(a &flat.Fla
 	}
 	mut args := [
 		CollectDeclarationIndexArgs{
-			tc: voidptr(tc)
-			a: a
+			tc:   voidptr(tc)
+			a:    a
 			kind: 0
 		},
 		CollectDeclarationIndexArgs{
-			tc: voidptr(tc)
-			a: a
+			tc:   voidptr(tc)
+			a:    a
 			kind: 1
 		},
 		CollectDeclarationIndexArgs{
-			tc: voidptr(tc)
-			a: a
+			tc:   voidptr(tc)
+			a:    a
 			kind: 2
 		},
 	]
@@ -260,8 +260,8 @@ fn (mut tc TypeChecker) prepare_collect_declaration_indexes_parallel(a &flat.Fla
 			arg: unsafe { voidptr(&args[1]) }
 		},
 		workers.Task{
-			run: collect_declaration_index_thread
-			arg: unsafe { voidptr(&args[2]) }
+			run:        collect_declaration_index_thread
+			arg:        unsafe { voidptr(&args[2]) }
 			force_sync: true
 		},
 	])
@@ -337,14 +337,14 @@ fn (mut tc TypeChecker) compute_pass2_fn_prep(node flat.Node) Pass2FnPrep {
 	ptypes = tc.fn_param_types_with_implicit_veb_ctx(node, ptypes)
 	shared_params = tc.fn_shared_params_with_implicit_veb_ctx(node, shared_params)
 	return Pass2FnPrep{
-		prepared: true
-		ret_type: ret_type
-		ptypes: ptypes
-		param_texts: param_texts
-		shared_params: shared_params
-		is_variadic: is_variadic
-		is_c_variadic: is_c_variadic
-		has_mut_receiver: has_mut_receiver
+		prepared:            true
+		ret_type:            ret_type
+		ptypes:              ptypes
+		param_texts:         param_texts
+		shared_params:       shared_params
+		is_variadic:         is_variadic
+		is_c_variadic:       is_c_variadic
+		has_mut_receiver:    has_mut_receiver
 		has_forwardable_ctx: has_forwardable_ctx
 	}
 }
@@ -423,19 +423,19 @@ fn (mut tc TypeChecker) collect_pass2_fn_preps_parallel() []Pass2FnPrep {
 		mut args := []Pass2PrepArgs{cap: n_jobs}
 		for ji in 0 .. n_jobs {
 			args << Pass2PrepArgs{
-				tc: voidptr(tc)
-				start: n * ji / n_jobs
-				end: n * (ji + 1) / n_jobs
-				file: ctx_files[ji]
+				tc:          voidptr(tc)
+				start:       n * ji / n_jobs
+				end:         n * (ji + 1) / n_jobs
+				file:        ctx_files[ji]
 				module_name: ctx_modules[ji]
-				preps: unsafe { voidptr(&preps) }
+				preps:       unsafe { voidptr(&preps) }
 			}
 		}
 		mut tasks := []workers.Task{cap: n_jobs}
 		for ji in 0 .. n_jobs {
 			tasks << workers.Task{
-				run: pass2_fn_prep_thread
-				arg: unsafe { voidptr(&args[ji]) }
+				run:        pass2_fn_prep_thread
+				arg:        unsafe { voidptr(&args[ji]) }
 				force_sync: ji == 0
 			}
 		}
@@ -465,14 +465,14 @@ fn (mut tc TypeChecker) finish_pass2_ancillary_registrations() {
 			mut tasks := []workers.Task{cap: 9}
 			for group in 0 .. 9 {
 				args << Pass2AncillaryArgs{
-					tc: voidptr(tc)
+					tc:    voidptr(tc)
 					group: group
 				}
 			}
 			for group in 0 .. 9 {
 				tasks << workers.Task{
-					run: pass2_ancillary_thread
-					arg: unsafe { voidptr(&args[group]) }
+					run:        pass2_ancillary_thread
+					arg:        unsafe { voidptr(&args[group]) }
 					force_sync: group == 0
 				}
 			}
@@ -515,7 +515,8 @@ fn (mut tc TypeChecker) apply_pass2_ancillary_group(group int) {
 		}
 	} else if group == 4 {
 		for registration in tc.fn_mut_receiver_registrations {
-			tc.register_mut_receiver_method_with_lowered(registration.name, registration.lowered_name)
+			tc.register_mut_receiver_method_with_lowered(registration.name,
+				registration.lowered_name)
 		}
 	} else if group == 5 {
 		for registration in tc.fn_ret_text_registrations {
@@ -523,7 +524,9 @@ fn (mut tc TypeChecker) apply_pass2_ancillary_group(group int) {
 		}
 	} else if group == 6 {
 		for registration in tc.visible_mutation_registrations {
-			tc.register_visible_mutation_fn_decl_with_lowered(registration.idx, registration.module_name, registration.qname, registration.source_name, registration.c_qname, registration.c_source_name)
+			tc.register_visible_mutation_fn_decl_with_lowered(registration.idx,
+				registration.module_name, registration.qname, registration.source_name,
+				registration.c_qname, registration.c_source_name)
 		}
 	} else if group == 7 {
 		for registration in tc.fn_ancillary_registrations {
@@ -825,12 +828,12 @@ pub fn (mut tc TypeChecker) check_semantics_reachable(selected map[string]bool) 
 					tc.check_decl_type_strings(node_id, node)
 					cost := i - prev_tl
 					items << CheckWorkItem{
-						fn_idx: i
+						fn_idx:   i
 						range_lo: prev_tl + 1
-						file: tc.cur_file
-						module: tc.cur_module
-						cost: cost
-						rank: i64(cost) * 1_000_000_000 - i64(i)
+						file:     tc.cur_file
+						module:   tc.cur_module
+						cost:     cost
+						rank:     i64(cost) * 1_000_000_000 - i64(i)
 					}
 				}
 			}
@@ -910,18 +913,18 @@ fn (mut tc TypeChecker) scan_unused_candidate_references(fn_keys map[string][]in
 		mut tasks := []workers.Task{cap: n_jobs}
 		for job in 0 .. n_jobs {
 			args << UnusedAliveScanArgs{
-				tc: voidptr(tc)
-				fn_keys: fn_keys
+				tc:         voidptr(tc)
+				fn_keys:    fn_keys
 				const_keys: const_keys
-				start: n_nodes * job / n_jobs
-				end: n_nodes * (job + 1) / n_jobs
-				alive: []bool{len: alive.len}
+				start:      n_nodes * job / n_jobs
+				end:        n_nodes * (job + 1) / n_jobs
+				alive:      []bool{len: alive.len}
 			}
 		}
 		for job in 0 .. n_jobs {
 			tasks << workers.Task{
-				run: unused_alive_scan_thread
-				arg: unsafe { voidptr(&args[job]) }
+				run:        unused_alive_scan_thread
+				arg:        unsafe { voidptr(&args[job]) }
 				force_sync: job == 0
 			}
 		}
@@ -1020,12 +1023,12 @@ fn (mut tc TypeChecker) collect_parallel_check_items() []CheckWorkItem {
 					span
 				}
 				items << CheckWorkItem{
-					fn_idx: i
+					fn_idx:   i
 					range_lo: prev_tl + 1
-					file: tc.cur_file
-					module: tc.cur_module
-					cost: cost
-					rank: i64(cost) * 1_000_000_000 - i64(i)
+					file:     tc.cur_file
+					module:   tc.cur_module
+					cost:     cost
+					rank:     i64(cost) * 1_000_000_000 - i64(i)
 				}
 			}
 			else {}
@@ -1083,7 +1086,9 @@ fn (mut tc TypeChecker) check_top_level_declarations_filtered(do_values bool, do
 				node_id := flat.NodeId(i)
 				if do_signatures {
 					if comma_attr_text_has(node.typ, 'typedef') && !node.value.starts_with('C.') {
-						tc.record_error_at(.assignment_mismatch, '`typedef` attribute can only be used with C structs', node_id, tc.declaration_keyword_name_pos(node_id, 'struct'))
+						tc.record_error_at(.assignment_mismatch,
+							'`typedef` attribute can only be used with C structs', node_id, tc.declaration_keyword_name_pos(node_id,
+							'struct'))
 					}
 					tc.check_decl_type_strings(flat.NodeId(i), node)
 				}
@@ -1105,7 +1110,9 @@ fn (mut tc TypeChecker) check_top_level_declarations_filtered(do_values bool, do
 					} else {
 						'alias'
 					}
-					tc.record_error_at(.duplicate_decl, 'cannot register ${kind} `${node.value}`, another type with this name exists', node_id, tc.declaration_keyword_name_pos(node_id, 'type'))
+					tc.record_error_at(.duplicate_decl,
+						'cannot register ${kind} `${node.value}`, another type with this name exists',
+						node_id, tc.declaration_keyword_name_pos(node_id, 'type'))
 				}
 				tc.check_decl_type_strings(flat.NodeId(i), node)
 			}
@@ -1122,7 +1129,9 @@ fn (mut tc TypeChecker) check_top_level_declarations_filtered(do_values bool, do
 			.global_decl {
 				if do_values {
 					if !tc.enable_globals && !tc.has_globals_files[tc.cur_file] {
-						tc.record_error_at(.duplicate_decl, 'use `v -enable-globals ...` to enable globals', flat.NodeId(i), node.pos)
+						tc.record_error_at(.duplicate_decl,
+							'use `v -enable-globals ...` to enable globals', flat.NodeId(i),
+							node.pos)
 					}
 					tc.check_const_global_initializers(node)
 				}
@@ -1205,11 +1214,11 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 		fail := os.getenv('V3_TEST_PTHREAD_CREATE_FAIL')
 		dynamic_dispatch := tc.scope_parallel_check_workers && tc.building_v_fast && fail.len == 0
 		mut dynamic_chunks := [][]CheckWorkItem{}
-		mut chunk_queue := chan int{ cap: 1 }
+		mut chunk_queue := chan int{cap: 1}
 		if dynamic_dispatch {
 			dynamic_target := int_min(items.len, chunk_count * dynamic_check_chunks_per_job)
 			dynamic_chunks = split_check_items(items, dynamic_target)
-			chunk_queue = chan int{ cap: dynamic_chunks.len }
+			chunk_queue = chan int{cap: dynamic_chunks.len}
 			for ci in 0 .. dynamic_chunks.len {
 				chunk_queue <- ci
 			}
@@ -1239,12 +1248,12 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 				worker = checker_workers[ci - 1]
 			}
 			args << CheckChunkArgs{
-				worker: worker
-				items_ptr: unsafe { voidptr(&chunks[ci]) }
+				worker:        worker
+				items_ptr:     unsafe { voidptr(&chunks[ci]) }
 				dynamic_items: dynamic_items_ptr
-				chunk_queue: chunk_queue
+				chunk_queue:   chunk_queue
 				scope_enabled: tc.scope_parallel_check_workers
-				index: ci
+				index:         ci
 			}
 		}
 		// The master checks its own chunk under the same range discipline as the
@@ -1261,14 +1270,14 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 		for ci in 0 .. chunk_count {
 			helper_idx := ci - 1
 			tasks << workers.Task{
-				run: check_chunk_thread
-				arg: unsafe { voidptr(&args[ci]) }
+				run:        check_chunk_thread
+				arg:        unsafe { voidptr(&args[ci]) }
 				force_sync: ci == 0 || fail == 'checker:all' || fail == 'checker:${helper_idx}'
 			}
 		}
 		tasks << workers.Task{
-			run: check_top_level_decl_signatures_thread
-			arg: voidptr(tc)
+			run:        check_top_level_decl_signatures_thread
+			arg:        voidptr(tc)
 			force_sync: true
 		}
 		check_worker_scope_leave(setup_scope)
@@ -1293,16 +1302,16 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 			mg_t0 := time.sys_mono_now()
 			for ci in 0 .. chunk_count {
 				clone_args << CheckCloneChunkArgs{
-					tc: voidptr(tc)
+					tc:        voidptr(tc)
 					items_ptr: unsafe { voidptr(&chunks[ci]) }
-					miss: []int{cap: 1024}
+					miss:      []int{cap: 1024}
 				}
 			}
 			mut ctasks := []workers.Task{cap: chunk_count}
 			for ci in 0 .. chunk_count {
 				ctasks << workers.Task{
-					run: check_clone_chunk_thread
-					arg: unsafe { voidptr(&clone_args[ci]) }
+					run:        check_clone_chunk_thread
+					arg:        unsafe { voidptr(&clone_args[ci]) }
 					force_sync: ci == 0
 				}
 			}
@@ -1569,7 +1578,9 @@ fn (mut tc TypeChecker) check_fn_decl_semantics(fn_idx int, node flat.Node, file
 	if !fast_valid_build && module_name in ['', 'main'] && !node.value.contains('.') {
 		if visibility := tc.declaration_visibility['builtin.${node.value}'] {
 			if visibility.is_pub {
-				tc.record_error_at(.duplicate_decl, 'cannot redefine builtin public function `${node.value}`', flat.NodeId(fn_idx), tc.fn_declaration_diagnostic_pos(node))
+				tc.record_error_at(.duplicate_decl,
+					'cannot redefine builtin public function `${node.value}`', flat.NodeId(fn_idx),
+					tc.fn_declaration_diagnostic_pos(node))
 				tc.fn_context = saved_fn_context
 				return
 			}
@@ -1606,7 +1617,8 @@ fn (mut tc TypeChecker) check_fn_decl_semantics(fn_idx int, node flat.Node, file
 		&& node.children_count > 0 {
 		receiver := tc.a.child_node(&node, 0)
 		if receiver.kind == .param && receiver.typ.trim_left('&').starts_with('[]') {
-			tc.record_error_at(.call_arg_mismatch, 'method overrides built-in array method', flat.NodeId(fn_idx), tc.fn_declaration_diagnostic_pos(node))
+			tc.record_error_at(.call_arg_mismatch, 'method overrides built-in array method',
+				flat.NodeId(fn_idx), tc.fn_declaration_diagnostic_pos(node))
 		}
 	}
 	mut duplicate_parameter_ids := map[int]bool{}
@@ -1618,7 +1630,9 @@ fn (mut tc TypeChecker) check_fn_decl_semantics(fn_idx int, node flat.Node, file
 			if param.kind == .param {
 				if param.value.len > 0 && param.value != '_' {
 					if parameter_names[param.value] {
-						tc.record_error_at(.duplicate_decl, 'redefinition of parameter `${param.value}`', param_id, tc.node_value_diagnostic_pos(param_id))
+						tc.record_error_at(.duplicate_decl,
+							'redefinition of parameter `${param.value}`', param_id,
+							tc.node_value_diagnostic_pos(param_id))
 						duplicate_parameter_ids[int(param_id)] = true
 					} else {
 						parameter_names[param.value] = true
@@ -1633,17 +1647,22 @@ fn (mut tc TypeChecker) check_fn_decl_semantics(fn_idx int, node flat.Node, file
 					}
 					raw_param_type := tc.parse_scope_param_type(diagnostic_type_text)
 					if tc.is_params_struct_type(raw_param_type) {
-						tc.record_error_at(.call_arg_mismatch, 'declaring a mutable parameter that accepts a struct with the `@[params]` attribute is not allowed', param_id, tc.type_diagnostic_pos(param_id, diagnostic_type_text))
+						tc.record_error_at(.call_arg_mismatch,
+							'declaring a mutable parameter that accepts a struct with the `@[params]` attribute is not allowed',
+							param_id, tc.type_diagnostic_pos(param_id, diagnostic_type_text))
 					}
 					param_type := unalias_type(raw_param_type)
 					if !is_specialized && !mut_param_type_is_allowed(raw_param_type) {
 						type_name := param_type.name()
-						tc.record_error_at(.call_arg_mismatch, 'mutable arguments are only allowed for arrays, interfaces, maps, pointers, structs or their aliases\nreturn values instead: `fn foo(mut n ${type_name}) {` => `fn foo(n ${type_name}) ${type_name} {`', param_id, tc.type_diagnostic_pos(param_id, diagnostic_type_text))
+						tc.record_error_at(.call_arg_mismatch,
+							'mutable arguments are only allowed for arrays, interfaces, maps, pointers, structs or their aliases\nreturn values instead: `fn foo(mut n ${type_name}) {` => `fn foo(n ${type_name}) ${type_name} {`',
+							param_id, tc.type_diagnostic_pos(param_id, diagnostic_type_text))
 					}
 				}
 				tc.check_reserved_parameter_name(param_id)
 				if param.op == .dot {
-					tc.check_import_symbol_conflict_at(param_id, param.value, tc.fn_receiver_param_diagnostic_pos(node, param.value))
+					tc.check_import_symbol_conflict_at(param_id, param.value, tc.fn_receiver_param_diagnostic_pos(node,
+						param.value))
 				} else {
 					tc.check_import_symbol_conflict(param_id, param.value)
 				}
@@ -1652,7 +1671,8 @@ fn (mut tc TypeChecker) check_fn_decl_semantics(fn_idx int, node flat.Node, file
 		}
 	}
 	if !fast_valid_build && !node.value.contains('.') && tc.has_active_import(node.value) {
-		tc.record_error_at(.duplicate_decl, 'duplicate of an import symbol `${node.value}`', flat.NodeId(fn_idx), tc.fn_declaration_diagnostic_pos(node))
+		tc.record_error_at(.duplicate_decl, 'duplicate of an import symbol `${node.value}`',
+			flat.NodeId(fn_idx), tc.fn_declaration_diagnostic_pos(node))
 	}
 	for pi in 0 .. node.children_count {
 		param_id := tc.a.child(&node, pi)
@@ -1709,7 +1729,8 @@ fn (mut tc TypeChecker) check_fn_decl_semantics(fn_idx int, node flat.Node, file
 			&& !tc.fn_body_definitely_returns(node) && !is_disabled_stub
 			&& !has_deferred_generic_return && tc.should_diagnose(flat.NodeId(fn_idx)) {
 			message := 'missing return at end of function `${node.value.all_after_last('.')}`'
-			tc.record_error_at(.return_mismatch, message, flat.NodeId(fn_idx), tc.fn_declaration_diagnostic_pos(node))
+			tc.record_error_at(.return_mismatch, message, flat.NodeId(fn_idx),
+				tc.fn_declaration_diagnostic_pos(node))
 		}
 	}
 	tc.fn_context.node_id = -1
@@ -1727,24 +1748,31 @@ fn (mut tc TypeChecker) check_fn_receiver_and_operator_return(node flat.Node, id
 		receiver := tc.a.node(receiver_id)
 		if receiver.kind == .param && receiver.op == .dot
 			&& unalias_type(tc.parse_type(receiver.typ)) is MultiReturn {
-			tc.record_error_at(.call_arg_mismatch, 'cannot define method on multi-value', receiver_id, tc.type_diagnostic_pos(receiver_id, receiver.typ))
+			tc.record_error_at(.call_arg_mismatch, 'cannot define method on multi-value',
+				receiver_id, tc.type_diagnostic_pos(receiver_id, receiver.typ))
 		}
 	}
 	raw_return_type := node.typ.trim_space()
 	if raw_return_type.starts_with('!?') || raw_return_type.starts_with('?!') {
-		tc.record_error_at(.return_mismatch, 'the type must be Option or Result', id, tc.nested_option_result_marker_pos(node))
+		tc.record_error_at(.return_mismatch, 'the type must be Option or Result', id,
+			tc.nested_option_result_marker_pos(node))
 	}
 	if raw_return_type == '?void' {
-		tc.record_error_at(.return_mismatch, 'use `?` instead of `?void`', id, tc.option_void_payload_diagnostic_pos(node))
+		tc.record_error_at(.return_mismatch, 'use `?` instead of `?void`', id,
+			tc.option_void_payload_diagnostic_pos(node))
 	}
 	if raw_return_type.ends_with('?') && !raw_return_type.starts_with('?') {
-		tc.record_error_at(.return_mismatch, 'wrong syntax, it must be ?${raw_return_type.trim_right('?')}, not ${raw_return_type}', id, tc.suffix_option_return_type_diagnostic_pos(node))
+		tc.record_error_at(.return_mismatch,
+			'wrong syntax, it must be ?${raw_return_type.trim_right('?')}, not ${raw_return_type}',
+			id, tc.suffix_option_return_type_diagnostic_pos(node))
 	}
 	signature_return_type := unalias_type(tc.parse_type(node.typ))
 	if signature_return_type is MultiReturn {
 		for typ in signature_return_type.types {
 			if is_ierror_type(unalias_type(typ)) {
-				tc.record_error_at(.return_mismatch, 'type `IError` cannot be used in multi-return, return an Option instead', id, tc.fn_return_type_diagnostic_pos(node))
+				tc.record_error_at(.return_mismatch,
+					'type `IError` cannot be used in multi-return, return an Option instead', id,
+					tc.fn_return_type_diagnostic_pos(node))
 				break
 			}
 		}
@@ -1756,11 +1784,14 @@ fn (mut tc TypeChecker) check_fn_receiver_and_operator_return(node flat.Node, id
 			receiver_type := unalias_type(tc.parse_type(receiver.typ))
 			if receiver_type is Interface
 				&& node.value.all_after_last('.') in tc.interface_abstract_method_names(receiver_type.name) {
-				tc.record_error_at(.duplicate_decl, 'interface `${receiver_type.name}` cannot implement its own interface method `${node.value.all_after_last('.')}`', id, tc.fn_declaration_diagnostic_pos(node))
+				tc.record_error_at(.duplicate_decl,
+					'interface `${receiver_type.name}` cannot implement its own interface method `${node.value.all_after_last('.')}`',
+					id, tc.fn_declaration_diagnostic_pos(node))
 			}
 			if receiver_type is OptionType || receiver.typ.contains('?')
 				|| receiver_name.starts_with('?') {
-				tc.record_error_at(.call_arg_mismatch, 'option types cannot have methods', id, tc.fn_option_receiver_diagnostic_pos(node, receiver.value))
+				tc.record_error_at(.call_arg_mismatch, 'option types cannot have methods', id, tc.fn_option_receiver_diagnostic_pos(node,
+					receiver.value))
 			}
 		}
 	}
@@ -1770,13 +1801,14 @@ fn (mut tc TypeChecker) check_fn_receiver_and_operator_return(node flat.Node, id
 			tc.type_aliases[tc.qualify_name(alias_name)] or { '' }
 		}
 		if alias_target.starts_with('?') {
-			tc.record_error_at(.return_mismatch, 'the fn returns type `${raw_return_type}`, but type `${alias_name}` is an Option alias, you can not mix them', id, tc.fn_return_type_diagnostic_pos(node))
+			tc.record_error_at(.return_mismatch,
+				'the fn returns type `${raw_return_type}`, but type `${alias_name}` is an Option alias, you can not mix them',
+				id, tc.fn_return_type_diagnostic_pos(node))
 		}
 	}
 	operator := node.value.all_after_last('.')
 	if !node.value.contains('.')
-		|| operator !in ['+', '-', '*', '/', '%', '==', '!=', '<', '<=', '>', '>=', '<<', '>>',
-			'&', '|', '^'] {
+		|| operator !in ['+', '-', '*', '/', '%', '==', '!=', '<', '<=', '>', '>=', '<<', '>>', '&', '|', '^'] {
 		return
 	}
 	mut param_ids := []flat.NodeId{}
@@ -1787,20 +1819,25 @@ fn (mut tc TypeChecker) check_fn_receiver_and_operator_return(node flat.Node, id
 		}
 	}
 	if param_ids.len != 2 {
-		tc.record_error_at(.call_arg_mismatch, 'operator methods should have exactly 1 argument', id, tc.fn_declaration_diagnostic_pos(node))
+		tc.record_error_at(.call_arg_mismatch, 'operator methods should have exactly 1 argument',
+			id, tc.fn_declaration_diagnostic_pos(node))
 	}
 	mut operator_params_match := param_ids.len == 2
 	if param_ids.len > 0 {
 		receiver_id := param_ids[0]
 		receiver := tc.a.node(receiver_id)
 		if receiver.is_mut {
-			tc.record_error_at(.call_arg_mismatch, 'receiver cannot be `mut` for operator overloading', receiver_id, tc.operator_receiver_without_mut_pos(node))
+			tc.record_error_at(.call_arg_mismatch,
+				'receiver cannot be `mut` for operator overloading', receiver_id,
+				tc.operator_receiver_without_mut_pos(node))
 		}
 		if param_ids.len > 1 {
 			param_id := param_ids[1]
 			param := tc.a.node(param_id)
 			if param.is_mut {
-				tc.record_error_at(.call_arg_mismatch, 'argument cannot be `mut` for operator overloading', id, tc.fn_declaration_diagnostic_pos(node))
+				tc.record_error_at(.call_arg_mismatch,
+					'argument cannot be `mut` for operator overloading', id,
+					tc.fn_declaration_diagnostic_pos(node))
 			}
 			raw_receiver_type := tc.parse_type(receiver.typ)
 			raw_param_type := tc.parse_type(param.typ)
@@ -1809,18 +1846,23 @@ fn (mut tc TypeChecker) check_fn_receiver_and_operator_return(node flat.Node, id
 			if !receiver.is_mut && !param.is_mut && receiver_type.name() == param_type.name()
 				&& raw_receiver_type.name() != raw_param_type.name() {
 				operator_params_match = false
-				tc.record_error_at(.call_arg_mismatch, 'the receiver type `${receiver.typ}` should be the same type as the operand `${param.typ}`', id, tc.fn_declaration_diagnostic_pos(node))
+				tc.record_error_at(.call_arg_mismatch,
+					'the receiver type `${receiver.typ}` should be the same type as the operand `${param.typ}`',
+					id, tc.fn_declaration_diagnostic_pos(node))
 			}
 			if receiver_type.name() != param_type.name() && param_type !is FnType {
 				operator_params_match = false
-				tc.record_error_at(.call_arg_mismatch, 'expected `${receiver_type.name()}` not `${param_type.name()}` - both operands must be the same type for operator overloading', param_id, tc.type_diagnostic_pos(param_id, param_type.name()))
+				tc.record_error_at(.call_arg_mismatch,
+					'expected `${receiver_type.name()}` not `${param_type.name()}` - both operands must be the same type for operator overloading',
+					param_id, tc.type_diagnostic_pos(param_id, param_type.name()))
 			}
 		}
 	}
 	parsed_return_type := tc.parse_type(node.typ)
 	return_type := unalias_type(parsed_return_type)
 	if return_type is OptionType || return_type is ResultType {
-		tc.record_error_at(.return_mismatch, 'return type cannot be Option or Result', id, tc.fn_return_type_diagnostic_pos(node))
+		tc.record_error_at(.return_mismatch, 'return type cannot be Option or Result', id,
+			tc.fn_return_type_diagnostic_pos(node))
 	}
 	if node.children_count > 0 && operator in ['+', '-', '*', '/', '%', '<<', '>>', '&', '|', '^'] {
 		receiver := tc.a.child_node(&node, 0)
@@ -1828,7 +1870,9 @@ fn (mut tc TypeChecker) check_fn_receiver_and_operator_return(node flat.Node, id
 		if receiver_type is Alias && (infix_power_type_is_numeric(receiver_type.base_type)
 			|| unalias_type(receiver_type.base_type) is String)
 			&& parsed_return_type.name() != receiver_type.name && operator_params_match {
-			tc.record_error_at(.return_mismatch, 'operator `${operator}` methods on primitive aliases should return `${receiver_type.name}`', id, tc.fn_return_type_diagnostic_pos(node))
+			tc.record_error_at(.return_mismatch,
+				'operator `${operator}` methods on primitive aliases should return `${receiver_type.name}`',
+				id, tc.fn_return_type_diagnostic_pos(node))
 		}
 	}
 }
@@ -1882,7 +1926,7 @@ fn (mut tc TypeChecker) record_unused_fn_vars(node flat.Node) {
 					flat.empty_node
 				}
 				candidates << UnusedFnVarCandidate{
-					name: lhs.value
+					name:   lhs.value
 					lhs_id: lhs_id
 					rhs_id: rhs_id
 				}
@@ -1905,7 +1949,8 @@ fn (mut tc TypeChecker) record_unused_fn_vars(node flat.Node) {
 			&& !tc.expr_subtree_allows_unused_warning(candidate.rhs_id) {
 			continue
 		}
-		tc.record_warning_at(.unknown_ident, 'unused variable: `${candidate.name}`', candidate.lhs_id, tc.node_value_diagnostic_pos(candidate.lhs_id))
+		tc.record_warning_at(.unknown_ident, 'unused variable: `${candidate.name}`',
+			candidate.lhs_id, tc.node_value_diagnostic_pos(candidate.lhs_id))
 	}
 }
 
@@ -1962,12 +2007,14 @@ fn (mut tc TypeChecker) record_lambda_capture_errors(fn_node flat.Node) {
 				capture_pos := tc.node_value_diagnostic_pos(capture_id)
 				if !tc.errors.any(it.msg == undefined_message && it.pos.id == capture_pos.id
 					&& it.pos.offset == capture_pos.offset && it.pos.end == capture_pos.end) {
-					tc.errors << tc.make_type_error_at(.unknown_ident, undefined_message, capture_id, capture_pos)
+					tc.errors << tc.make_type_error_at(.unknown_ident, undefined_message,
+						capture_id, capture_pos)
 				}
 				value_message := '`${capture.value}` used as value'
 				if !tc.errors.any(it.msg == value_message && it.pos.id == node.pos.id
 					&& it.pos.offset == node.pos.offset && it.pos.end == node.pos.end) {
-					tc.errors << tc.make_type_error_at(.return_mismatch, value_message, id, node.pos)
+					tc.errors << tc.make_type_error_at(.return_mismatch, value_message, id,
+						node.pos)
 				}
 			}
 		}
@@ -2023,12 +2070,13 @@ fn (mut tc TypeChecker) record_unused_top_level_vars(node flat.Node) {
 			rhs := tc.a.node(rhs_id)
 			generic_interface_cast := rhs.kind == .cast_expr
 				&& (rhs.value in tc.interface_generic_params
-					|| tc.qualify_name(rhs.value) in tc.interface_generic_params)
+				|| tc.qualify_name(rhs.value) in tc.interface_generic_params)
 			if tc.expr_subtree_has_error(rhs_id) && !tc.expr_contains_nil_deref(rhs_id)
 				&& !generic_interface_cast {
 				continue
 			}
-			tc.record_warning_at(.unknown_ident, 'unused variable: `${lhs.value}`', lhs_id, tc.node_value_diagnostic_pos(lhs_id))
+			tc.record_warning_at(.unknown_ident, 'unused variable: `${lhs.value}`', lhs_id,
+				tc.node_value_diagnostic_pos(lhs_id))
 		}
 	}
 }
@@ -2121,7 +2169,7 @@ fn (tc &TypeChecker) expr_subtree_has_undefined_ident_error(id flat.NodeId) bool
 	for diagnostic in tc.errors {
 		if diagnostic.kind != .unknown_ident
 			|| (!diagnostic.msg.starts_with('undefined variable:')
-				&& !diagnostic.msg.starts_with('undefined ident:')) {
+			&& !diagnostic.msg.starts_with('undefined ident:')) {
 			continue
 		}
 		if diagnostic.node == id {
@@ -2158,7 +2206,7 @@ fn (tc &TypeChecker) expr_subtree_has_no_value_error(id flat.NodeId) bool {
 	root := tc.a.node(id)
 	return tc.errors.any(it.msg.contains('does not return a value') && (it.node == id
 		|| (it.pos.id == root.pos.id && it.pos.offset >= root.pos.offset
-			&& it.pos.end <= root.pos.end)))
+		&& it.pos.end <= root.pos.end)))
 }
 
 fn (tc &TypeChecker) expr_subtree_has_error_except(id flat.NodeId, ignored TypeErrorKind) bool {
@@ -2224,7 +2272,7 @@ fn (tc &TypeChecker) expr_subtree_allows_unused_warning(id flat.NodeId) bool {
 		|| it.msg.starts_with('invalid map value: expected ')
 		|| (it.msg.starts_with('type mismatch, `') && it.msg.ends_with('` must return a bool'))
 		|| (it.msg.contains('` is a generic fn, you should pass its concrete types, e.g. ')
-			&& it.msg.ends_with('[int]')) || (it.msg.starts_with('generic struct `')
+		&& it.msg.ends_with('[int]')) || (it.msg.starts_with('generic struct `')
 		&& it.msg.contains('` must specify type parameter'))))
 }
 
@@ -2275,7 +2323,7 @@ fn (tc &TypeChecker) fn_body_read_names(node flat.Node, candidate_names map[stri
 				}
 				if (current.kind == .sql_expr && sql_text_contains_ident(current.value, name))
 					|| (current.kind == .comptime_if
-						&& type_text_contains_symbol(current.value, name)) {
+					&& type_text_contains_symbol(current.value, name)) {
 					used_names[name] = true
 					continue
 				}
@@ -2347,7 +2395,8 @@ fn (mut tc TypeChecker) record_unused_fn_params(node flat.Node) {
 		if has_param_error {
 			continue
 		}
-		tc.record_notice_at(.unknown_ident, 'unused parameter: `${param.value}`', param_id, tc.node_value_diagnostic_pos(param_id))
+		tc.record_notice_at(.unknown_ident, 'unused parameter: `${param.value}`', param_id,
+			tc.node_value_diagnostic_pos(param_id))
 	}
 }
 
@@ -2408,7 +2457,8 @@ fn (mut tc TypeChecker) record_unused_fn_labels(node flat.Node) {
 			continue
 		}
 		if !used[label.value] {
-			tc.record_warning_at(.unknown_ident, 'label `${label.value}` defined and not used', label_id, tc.a.node(label_id).pos)
+			tc.record_warning_at(.unknown_ident, 'label `${label.value}` defined and not used',
+				label_id, tc.a.node(label_id).pos)
 		}
 	}
 }
@@ -2575,7 +2625,7 @@ fn (mut tc TypeChecker) install_type_cache_overlay() {
 	}
 	tc.prewarm_shared_type_cache()
 	tc.type_cache = &TypeCache{
-		base: tc.type_cache
+		base:          tc.type_cache
 		parse_enabled: tc.type_cache.parse_enabled
 	}
 	if !isnil(tc.resolution_type_views) {
@@ -2648,10 +2698,10 @@ fn (tc &TypeChecker) fork_for_parallel_check() &TypeChecker {
 	// worker (and each disposable scoped batch) owns mutable result/miss maps while
 	// sharing the declaration index that collect completed before checking starts.
 	w.visible_mutation_cache = &VisibleMutationCache{
-		decls: tc.visible_mutation_cache.decls
-		decl_misses: map[string]bool{}
-		results: map[u64]bool{}
-		rebind_results: map[u64]bool{}
+		decls:            tc.visible_mutation_cache.decls
+		decl_misses:      map[string]bool{}
+		results:          map[u64]bool{}
+		rebind_results:   map[u64]bool{}
 		decl_index_ready: tc.visible_mutation_cache.decl_index_ready
 	}
 	w.scope_parallel_check_workers = tc.scope_parallel_check_workers
@@ -2685,55 +2735,55 @@ fn (tc &TypeChecker) fork_for_parallel_check() &TypeChecker {
 	w.type_cache = &TypeCache{
 		// The master's frozen pre-region cache (the overlay's base) is shared
 		// read-only across all forks; each fork writes to its own maps.
-		base: if tc.type_cache != unsafe { nil } {
+		base:                        if tc.type_cache != unsafe { nil } {
 			tc.type_cache.base
 		} else {
 			&TypeCache(unsafe { nil })
 		}
-		parse_enabled: if tc.type_cache != unsafe { nil } {
+		parse_enabled:               if tc.type_cache != unsafe { nil } {
 			tc.type_cache.parse_enabled
 		} else {
 			false
 		}
-		parse_entries: map[u64]ParseTypeCacheEntry{}
-		c_entries: map[TypeId]string{}
-		struct_field_entries: map[string]Type{}
-		struct_field_misses: map[string]bool{}
+		parse_entries:               map[u64]ParseTypeCacheEntry{}
+		c_entries:                   map[TypeId]string{}
+		struct_field_entries:        map[string]Type{}
+		struct_field_misses:         map[string]bool{}
 		sum_variant_pattern_entries: map[string]string{}
-		lexical_smartcast_entries: map[int]Type{}
-		lexical_smartcast_misses: map[int]bool{}
-		short_type_name_index: if isnil(precomputed)
+		lexical_smartcast_entries:   map[int]Type{}
+		lexical_smartcast_misses:    map[int]bool{}
+		short_type_name_index:       if isnil(precomputed)
 			|| !precomputed.short_type_name_index_built {
 			map[string]string{}
 		} else {
 			precomputed.short_type_name_index
 		}
 		short_type_name_index_built: !isnil(precomputed) && precomputed.short_type_name_index_built
-		local_fn_decl_index: if isnil(precomputed)
+		local_fn_decl_index:         if isnil(precomputed)
 			|| precomputed.local_fn_decl_indexed_len == 0 {
 			map[string]bool{}
 		} else {
 			precomputed.local_fn_decl_index
 		}
-		local_fn_decl_indexed_len: if isnil(precomputed) {
+		local_fn_decl_indexed_len:   if isnil(precomputed) {
 			0
 		} else {
 			precomputed.local_fn_decl_indexed_len
 		}
-		local_fn_decl_last_module: if isnil(precomputed) {
+		local_fn_decl_last_module:   if isnil(precomputed) {
 			''
 		} else {
 			precomputed.local_fn_decl_last_module
 		}
-		ierror_compat_entries: map[string]int{}
-		source_error_embed_entries: if isnil(precomputed)
+		ierror_compat_entries:       map[string]int{}
+		source_error_embed_entries:  if isnil(precomputed)
 			|| !precomputed.source_error_embed_indexed {
 			map[string]int{}
 		} else {
 			precomputed.source_error_embed_entries
 		}
-		source_error_embed_indexed: !isnil(precomputed) && precomputed.source_error_embed_indexed
-		source_error_embed_shared: !isnil(precomputed) && precomputed.source_error_embed_indexed
+		source_error_embed_indexed:  !isnil(precomputed) && precomputed.source_error_embed_indexed
+		source_error_embed_shared:   !isnil(precomputed) && precomputed.source_error_embed_indexed
 	}
 	if tc.scope_parallel_check_workers {
 		// Shared interner growth from a helper arena would leave compilation-wide
@@ -2838,31 +2888,31 @@ fn clone_parallel_type_error(err TypeError) TypeError {
 		details << detail.clone()
 	}
 	return TypeError{
-		msg: err.msg.clone()
-		kind: err.kind
-		node: err.node
-		file: err.file.clone()
-		node_kind: err.node_kind.clone()
+		msg:        err.msg.clone()
+		kind:       err.kind
+		node:       err.node
+		file:       err.file.clone()
+		node_kind:  err.node_kind.clone()
 		node_value: err.node_value.clone()
-		node_pos: err.node_pos.clone()
-		pos: err.pos
-		details: details
-		severity: err.severity.clone()
+		node_pos:   err.node_pos.clone()
+		pos:        err.pos
+		details:    details
+		severity:   err.severity.clone()
 	}
 }
 
 fn clone_parallel_call_info(info CallInfo) CallInfo {
 	return CallInfo{
-		name: info.name.clone()
-		params: clone_owned_types(info.params)
-		shared_params: info.shared_params.clone()
-		return_type: clone_owned_type(info.return_type)
-		has_receiver: info.has_receiver
-		is_variadic: info.is_variadic
-		is_c_variadic: info.is_c_variadic
-		params_known: info.params_known
+		name:                 info.name.clone()
+		params:               clone_owned_types(info.params)
+		shared_params:        info.shared_params.clone()
+		return_type:          clone_owned_type(info.return_type)
+		has_receiver:         info.has_receiver
+		is_variadic:          info.is_variadic
+		is_c_variadic:        info.is_c_variadic
+		params_known:         info.params_known
 		has_implicit_veb_ctx: info.has_implicit_veb_ctx
-		arg_offset: info.arg_offset
+		arg_offset:           info.arg_offset
 	}
 }
 
@@ -2893,7 +2943,7 @@ fn (mut tc TypeChecker) merge_parallel_check_worker_scoped(w &TypeChecker, scope
 	for pending in w.pending_ierror_errors {
 		tc.pending_ierror_errors << if scoped {
 			PendingIerrorError{
-				err: clone_parallel_type_error(pending.err)
+				err:      clone_parallel_type_error(pending.err)
 				fn_qname: pending.fn_qname.clone()
 			}
 		} else {

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -68,7 +68,7 @@ fn interface_impl_index_chunk_thread(arg voidptr) voidptr {
 		}
 		results.items[i] = &InterfaceImplIndex{
 			names: impls
-			ids:   stable_interface_type_ids(impls)
+			ids: stable_interface_type_ids(impls)
 		}
 	}
 	return unsafe { nil }
@@ -101,15 +101,15 @@ fn (mut tc TypeChecker) prepare_interface_impl_indexes_parallel(iface_names []st
 		mut tasks := []workers.Task{cap: n_jobs}
 		for job in 0 .. n_jobs {
 			args << InterfaceImplChunkArgs{
-				checker:     voidptr(checkers[job])
+				checker: voidptr(checkers[job])
 				iface_names: unsafe { voidptr(&iface_names) }
-				results:     voidptr(results)
-				start:       iface_names.len * job / n_jobs
-				end:         iface_names.len * (job + 1) / n_jobs
+				results: voidptr(results)
+				start: iface_names.len * job / n_jobs
+				end: iface_names.len * (job + 1) / n_jobs
 			}
 			tasks << workers.Task{
-				run:        interface_impl_index_chunk_thread
-				arg:        unsafe { voidptr(&args[job]) }
+				run: interface_impl_index_chunk_thread
+				arg: unsafe { voidptr(&args[job]) }
 				force_sync: job == 0
 			}
 		}
@@ -126,7 +126,7 @@ fn (mut tc TypeChecker) prepare_interface_impl_indexes_parallel(iface_names []st
 				}
 				tc.interface_impl_indexes[iface_name] = &InterfaceImplIndex{
 					names: names
-					ids:   stable_interface_type_ids(names)
+					ids: stable_interface_type_ids(names)
 				}
 			}
 		}
@@ -195,28 +195,28 @@ fn (mut tc TypeChecker) prepare_collect_index_parallel(a &flat.FlatAst) bool {
 	tc.init_direct_parent_index(a)
 	mut args := [
 		CollectIndexPrepArgs{
-			tc:   voidptr(tc)
-			a:    a
+			tc: voidptr(tc)
+			a: a
 			kind: 0
 		},
 		CollectIndexPrepArgs{
-			tc:   voidptr(tc)
-			a:    a
+			tc: voidptr(tc)
+			a: a
 			kind: 1
 		},
 		CollectIndexPrepArgs{
-			tc:   voidptr(tc)
-			a:    a
+			tc: voidptr(tc)
+			a: a
 			kind: 2
-			n:    a.nodes.len
+			n: a.nodes.len
 		},
 	]
 	a.worker_pool.run([
 		workers.Task{ run: collect_index_prep_thread, arg: unsafe { voidptr(&args[0]) } },
 		workers.Task{ run: collect_index_prep_thread, arg: unsafe { voidptr(&args[1]) } },
 		workers.Task{
-			run:        collect_index_prep_thread
-			arg:        unsafe { voidptr(&args[2]) }
+			run: collect_index_prep_thread
+			arg: unsafe { voidptr(&args[2]) }
 			force_sync: true
 		},
 	])
@@ -235,18 +235,18 @@ fn (mut tc TypeChecker) prepare_collect_declaration_indexes_parallel(a &flat.Fla
 	}
 	mut args := [
 		CollectDeclarationIndexArgs{
-			tc:   voidptr(tc)
-			a:    a
+			tc: voidptr(tc)
+			a: a
 			kind: 0
 		},
 		CollectDeclarationIndexArgs{
-			tc:   voidptr(tc)
-			a:    a
+			tc: voidptr(tc)
+			a: a
 			kind: 1
 		},
 		CollectDeclarationIndexArgs{
-			tc:   voidptr(tc)
-			a:    a
+			tc: voidptr(tc)
+			a: a
 			kind: 2
 		},
 	]
@@ -260,8 +260,8 @@ fn (mut tc TypeChecker) prepare_collect_declaration_indexes_parallel(a &flat.Fla
 			arg: unsafe { voidptr(&args[1]) }
 		},
 		workers.Task{
-			run:        collect_declaration_index_thread
-			arg:        unsafe { voidptr(&args[2]) }
+			run: collect_declaration_index_thread
+			arg: unsafe { voidptr(&args[2]) }
 			force_sync: true
 		},
 	])
@@ -337,14 +337,14 @@ fn (mut tc TypeChecker) compute_pass2_fn_prep(node flat.Node) Pass2FnPrep {
 	ptypes = tc.fn_param_types_with_implicit_veb_ctx(node, ptypes)
 	shared_params = tc.fn_shared_params_with_implicit_veb_ctx(node, shared_params)
 	return Pass2FnPrep{
-		prepared:            true
-		ret_type:            ret_type
-		ptypes:              ptypes
-		param_texts:         param_texts
-		shared_params:       shared_params
-		is_variadic:         is_variadic
-		is_c_variadic:       is_c_variadic
-		has_mut_receiver:    has_mut_receiver
+		prepared: true
+		ret_type: ret_type
+		ptypes: ptypes
+		param_texts: param_texts
+		shared_params: shared_params
+		is_variadic: is_variadic
+		is_c_variadic: is_c_variadic
+		has_mut_receiver: has_mut_receiver
 		has_forwardable_ctx: has_forwardable_ctx
 	}
 }
@@ -423,19 +423,19 @@ fn (mut tc TypeChecker) collect_pass2_fn_preps_parallel() []Pass2FnPrep {
 		mut args := []Pass2PrepArgs{cap: n_jobs}
 		for ji in 0 .. n_jobs {
 			args << Pass2PrepArgs{
-				tc:          voidptr(tc)
-				start:       n * ji / n_jobs
-				end:         n * (ji + 1) / n_jobs
-				file:        ctx_files[ji]
+				tc: voidptr(tc)
+				start: n * ji / n_jobs
+				end: n * (ji + 1) / n_jobs
+				file: ctx_files[ji]
 				module_name: ctx_modules[ji]
-				preps:       unsafe { voidptr(&preps) }
+				preps: unsafe { voidptr(&preps) }
 			}
 		}
 		mut tasks := []workers.Task{cap: n_jobs}
 		for ji in 0 .. n_jobs {
 			tasks << workers.Task{
-				run:        pass2_fn_prep_thread
-				arg:        unsafe { voidptr(&args[ji]) }
+				run: pass2_fn_prep_thread
+				arg: unsafe { voidptr(&args[ji]) }
 				force_sync: ji == 0
 			}
 		}
@@ -465,14 +465,14 @@ fn (mut tc TypeChecker) finish_pass2_ancillary_registrations() {
 			mut tasks := []workers.Task{cap: 9}
 			for group in 0 .. 9 {
 				args << Pass2AncillaryArgs{
-					tc:    voidptr(tc)
+					tc: voidptr(tc)
 					group: group
 				}
 			}
 			for group in 0 .. 9 {
 				tasks << workers.Task{
-					run:        pass2_ancillary_thread
-					arg:        unsafe { voidptr(&args[group]) }
+					run: pass2_ancillary_thread
+					arg: unsafe { voidptr(&args[group]) }
 					force_sync: group == 0
 				}
 			}
@@ -515,8 +515,7 @@ fn (mut tc TypeChecker) apply_pass2_ancillary_group(group int) {
 		}
 	} else if group == 4 {
 		for registration in tc.fn_mut_receiver_registrations {
-			tc.register_mut_receiver_method_with_lowered(registration.name,
-				registration.lowered_name)
+			tc.register_mut_receiver_method_with_lowered(registration.name, registration.lowered_name)
 		}
 	} else if group == 5 {
 		for registration in tc.fn_ret_text_registrations {
@@ -524,9 +523,7 @@ fn (mut tc TypeChecker) apply_pass2_ancillary_group(group int) {
 		}
 	} else if group == 6 {
 		for registration in tc.visible_mutation_registrations {
-			tc.register_visible_mutation_fn_decl_with_lowered(registration.idx,
-				registration.module_name, registration.qname, registration.source_name,
-				registration.c_qname, registration.c_source_name)
+			tc.register_visible_mutation_fn_decl_with_lowered(registration.idx, registration.module_name, registration.qname, registration.source_name, registration.c_qname, registration.c_source_name)
 		}
 	} else if group == 7 {
 		for registration in tc.fn_ancillary_registrations {
@@ -828,12 +825,12 @@ pub fn (mut tc TypeChecker) check_semantics_reachable(selected map[string]bool) 
 					tc.check_decl_type_strings(node_id, node)
 					cost := i - prev_tl
 					items << CheckWorkItem{
-						fn_idx:   i
+						fn_idx: i
 						range_lo: prev_tl + 1
-						file:     tc.cur_file
-						module:   tc.cur_module
-						cost:     cost
-						rank:     i64(cost) * 1_000_000_000 - i64(i)
+						file: tc.cur_file
+						module: tc.cur_module
+						cost: cost
+						rank: i64(cost) * 1_000_000_000 - i64(i)
 					}
 				}
 			}
@@ -913,18 +910,18 @@ fn (mut tc TypeChecker) scan_unused_candidate_references(fn_keys map[string][]in
 		mut tasks := []workers.Task{cap: n_jobs}
 		for job in 0 .. n_jobs {
 			args << UnusedAliveScanArgs{
-				tc:         voidptr(tc)
-				fn_keys:    fn_keys
+				tc: voidptr(tc)
+				fn_keys: fn_keys
 				const_keys: const_keys
-				start:      n_nodes * job / n_jobs
-				end:        n_nodes * (job + 1) / n_jobs
-				alive:      []bool{len: alive.len}
+				start: n_nodes * job / n_jobs
+				end: n_nodes * (job + 1) / n_jobs
+				alive: []bool{len: alive.len}
 			}
 		}
 		for job in 0 .. n_jobs {
 			tasks << workers.Task{
-				run:        unused_alive_scan_thread
-				arg:        unsafe { voidptr(&args[job]) }
+				run: unused_alive_scan_thread
+				arg: unsafe { voidptr(&args[job]) }
 				force_sync: job == 0
 			}
 		}
@@ -1023,12 +1020,12 @@ fn (mut tc TypeChecker) collect_parallel_check_items() []CheckWorkItem {
 					span
 				}
 				items << CheckWorkItem{
-					fn_idx:   i
+					fn_idx: i
 					range_lo: prev_tl + 1
-					file:     tc.cur_file
-					module:   tc.cur_module
-					cost:     cost
-					rank:     i64(cost) * 1_000_000_000 - i64(i)
+					file: tc.cur_file
+					module: tc.cur_module
+					cost: cost
+					rank: i64(cost) * 1_000_000_000 - i64(i)
 				}
 			}
 			else {}
@@ -1086,9 +1083,7 @@ fn (mut tc TypeChecker) check_top_level_declarations_filtered(do_values bool, do
 				node_id := flat.NodeId(i)
 				if do_signatures {
 					if comma_attr_text_has(node.typ, 'typedef') && !node.value.starts_with('C.') {
-						tc.record_error_at(.assignment_mismatch,
-							'`typedef` attribute can only be used with C structs', node_id, tc.declaration_keyword_name_pos(node_id,
-							'struct'))
+						tc.record_error_at(.assignment_mismatch, '`typedef` attribute can only be used with C structs', node_id, tc.declaration_keyword_name_pos(node_id, 'struct'))
 					}
 					tc.check_decl_type_strings(flat.NodeId(i), node)
 				}
@@ -1110,9 +1105,7 @@ fn (mut tc TypeChecker) check_top_level_declarations_filtered(do_values bool, do
 					} else {
 						'alias'
 					}
-					tc.record_error_at(.duplicate_decl,
-						'cannot register ${kind} `${node.value}`, another type with this name exists',
-						node_id, tc.declaration_keyword_name_pos(node_id, 'type'))
+					tc.record_error_at(.duplicate_decl, 'cannot register ${kind} `${node.value}`, another type with this name exists', node_id, tc.declaration_keyword_name_pos(node_id, 'type'))
 				}
 				tc.check_decl_type_strings(flat.NodeId(i), node)
 			}
@@ -1129,9 +1122,7 @@ fn (mut tc TypeChecker) check_top_level_declarations_filtered(do_values bool, do
 			.global_decl {
 				if do_values {
 					if !tc.enable_globals && !tc.has_globals_files[tc.cur_file] {
-						tc.record_error_at(.duplicate_decl,
-							'use `v -enable-globals ...` to enable globals', flat.NodeId(i),
-							node.pos)
+						tc.record_error_at(.duplicate_decl, 'use `v -enable-globals ...` to enable globals', flat.NodeId(i), node.pos)
 					}
 					tc.check_const_global_initializers(node)
 				}
@@ -1214,11 +1205,11 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 		fail := os.getenv('V3_TEST_PTHREAD_CREATE_FAIL')
 		dynamic_dispatch := tc.scope_parallel_check_workers && tc.building_v_fast && fail.len == 0
 		mut dynamic_chunks := [][]CheckWorkItem{}
-		mut chunk_queue := chan int{cap: 1}
+		mut chunk_queue := chan int{ cap: 1 }
 		if dynamic_dispatch {
 			dynamic_target := int_min(items.len, chunk_count * dynamic_check_chunks_per_job)
 			dynamic_chunks = split_check_items(items, dynamic_target)
-			chunk_queue = chan int{cap: dynamic_chunks.len}
+			chunk_queue = chan int{ cap: dynamic_chunks.len }
 			for ci in 0 .. dynamic_chunks.len {
 				chunk_queue <- ci
 			}
@@ -1248,12 +1239,12 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 				worker = checker_workers[ci - 1]
 			}
 			args << CheckChunkArgs{
-				worker:        worker
-				items_ptr:     unsafe { voidptr(&chunks[ci]) }
+				worker: worker
+				items_ptr: unsafe { voidptr(&chunks[ci]) }
 				dynamic_items: dynamic_items_ptr
-				chunk_queue:   chunk_queue
+				chunk_queue: chunk_queue
 				scope_enabled: tc.scope_parallel_check_workers
-				index:         ci
+				index: ci
 			}
 		}
 		// The master checks its own chunk under the same range discipline as the
@@ -1270,14 +1261,14 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 		for ci in 0 .. chunk_count {
 			helper_idx := ci - 1
 			tasks << workers.Task{
-				run:        check_chunk_thread
-				arg:        unsafe { voidptr(&args[ci]) }
+				run: check_chunk_thread
+				arg: unsafe { voidptr(&args[ci]) }
 				force_sync: ci == 0 || fail == 'checker:all' || fail == 'checker:${helper_idx}'
 			}
 		}
 		tasks << workers.Task{
-			run:        check_top_level_decl_signatures_thread
-			arg:        voidptr(tc)
+			run: check_top_level_decl_signatures_thread
+			arg: voidptr(tc)
 			force_sync: true
 		}
 		check_worker_scope_leave(setup_scope)
@@ -1302,16 +1293,16 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 			mg_t0 := time.sys_mono_now()
 			for ci in 0 .. chunk_count {
 				clone_args << CheckCloneChunkArgs{
-					tc:        voidptr(tc)
+					tc: voidptr(tc)
 					items_ptr: unsafe { voidptr(&chunks[ci]) }
-					miss:      []int{cap: 1024}
+					miss: []int{cap: 1024}
 				}
 			}
 			mut ctasks := []workers.Task{cap: chunk_count}
 			for ci in 0 .. chunk_count {
 				ctasks << workers.Task{
-					run:        check_clone_chunk_thread
-					arg:        unsafe { voidptr(&clone_args[ci]) }
+					run: check_clone_chunk_thread
+					arg: unsafe { voidptr(&clone_args[ci]) }
 					force_sync: ci == 0
 				}
 			}
@@ -1578,9 +1569,7 @@ fn (mut tc TypeChecker) check_fn_decl_semantics(fn_idx int, node flat.Node, file
 	if !fast_valid_build && module_name in ['', 'main'] && !node.value.contains('.') {
 		if visibility := tc.declaration_visibility['builtin.${node.value}'] {
 			if visibility.is_pub {
-				tc.record_error_at(.duplicate_decl,
-					'cannot redefine builtin public function `${node.value}`', flat.NodeId(fn_idx),
-					tc.fn_declaration_diagnostic_pos(node))
+				tc.record_error_at(.duplicate_decl, 'cannot redefine builtin public function `${node.value}`', flat.NodeId(fn_idx), tc.fn_declaration_diagnostic_pos(node))
 				tc.fn_context = saved_fn_context
 				return
 			}
@@ -1617,8 +1606,7 @@ fn (mut tc TypeChecker) check_fn_decl_semantics(fn_idx int, node flat.Node, file
 		&& node.children_count > 0 {
 		receiver := tc.a.child_node(&node, 0)
 		if receiver.kind == .param && receiver.typ.trim_left('&').starts_with('[]') {
-			tc.record_error_at(.call_arg_mismatch, 'method overrides built-in array method',
-				flat.NodeId(fn_idx), tc.fn_declaration_diagnostic_pos(node))
+			tc.record_error_at(.call_arg_mismatch, 'method overrides built-in array method', flat.NodeId(fn_idx), tc.fn_declaration_diagnostic_pos(node))
 		}
 	}
 	mut duplicate_parameter_ids := map[int]bool{}
@@ -1630,9 +1618,7 @@ fn (mut tc TypeChecker) check_fn_decl_semantics(fn_idx int, node flat.Node, file
 			if param.kind == .param {
 				if param.value.len > 0 && param.value != '_' {
 					if parameter_names[param.value] {
-						tc.record_error_at(.duplicate_decl,
-							'redefinition of parameter `${param.value}`', param_id,
-							tc.node_value_diagnostic_pos(param_id))
+						tc.record_error_at(.duplicate_decl, 'redefinition of parameter `${param.value}`', param_id, tc.node_value_diagnostic_pos(param_id))
 						duplicate_parameter_ids[int(param_id)] = true
 					} else {
 						parameter_names[param.value] = true
@@ -1647,22 +1633,17 @@ fn (mut tc TypeChecker) check_fn_decl_semantics(fn_idx int, node flat.Node, file
 					}
 					raw_param_type := tc.parse_scope_param_type(diagnostic_type_text)
 					if tc.is_params_struct_type(raw_param_type) {
-						tc.record_error_at(.call_arg_mismatch,
-							'declaring a mutable parameter that accepts a struct with the `@[params]` attribute is not allowed',
-							param_id, tc.type_diagnostic_pos(param_id, diagnostic_type_text))
+						tc.record_error_at(.call_arg_mismatch, 'declaring a mutable parameter that accepts a struct with the `@[params]` attribute is not allowed', param_id, tc.type_diagnostic_pos(param_id, diagnostic_type_text))
 					}
 					param_type := unalias_type(raw_param_type)
 					if !is_specialized && !mut_param_type_is_allowed(raw_param_type) {
 						type_name := param_type.name()
-						tc.record_error_at(.call_arg_mismatch,
-							'mutable arguments are only allowed for arrays, interfaces, maps, pointers, structs or their aliases\nreturn values instead: `fn foo(mut n ${type_name}) {` => `fn foo(n ${type_name}) ${type_name} {`',
-							param_id, tc.type_diagnostic_pos(param_id, diagnostic_type_text))
+						tc.record_error_at(.call_arg_mismatch, 'mutable arguments are only allowed for arrays, interfaces, maps, pointers, structs or their aliases\nreturn values instead: `fn foo(mut n ${type_name}) {` => `fn foo(n ${type_name}) ${type_name} {`', param_id, tc.type_diagnostic_pos(param_id, diagnostic_type_text))
 					}
 				}
 				tc.check_reserved_parameter_name(param_id)
 				if param.op == .dot {
-					tc.check_import_symbol_conflict_at(param_id, param.value, tc.fn_receiver_param_diagnostic_pos(node,
-						param.value))
+					tc.check_import_symbol_conflict_at(param_id, param.value, tc.fn_receiver_param_diagnostic_pos(node, param.value))
 				} else {
 					tc.check_import_symbol_conflict(param_id, param.value)
 				}
@@ -1671,8 +1652,7 @@ fn (mut tc TypeChecker) check_fn_decl_semantics(fn_idx int, node flat.Node, file
 		}
 	}
 	if !fast_valid_build && !node.value.contains('.') && tc.has_active_import(node.value) {
-		tc.record_error_at(.duplicate_decl, 'duplicate of an import symbol `${node.value}`',
-			flat.NodeId(fn_idx), tc.fn_declaration_diagnostic_pos(node))
+		tc.record_error_at(.duplicate_decl, 'duplicate of an import symbol `${node.value}`', flat.NodeId(fn_idx), tc.fn_declaration_diagnostic_pos(node))
 	}
 	for pi in 0 .. node.children_count {
 		param_id := tc.a.child(&node, pi)
@@ -1729,8 +1709,7 @@ fn (mut tc TypeChecker) check_fn_decl_semantics(fn_idx int, node flat.Node, file
 			&& !tc.fn_body_definitely_returns(node) && !is_disabled_stub
 			&& !has_deferred_generic_return && tc.should_diagnose(flat.NodeId(fn_idx)) {
 			message := 'missing return at end of function `${node.value.all_after_last('.')}`'
-			tc.record_error_at(.return_mismatch, message, flat.NodeId(fn_idx),
-				tc.fn_declaration_diagnostic_pos(node))
+			tc.record_error_at(.return_mismatch, message, flat.NodeId(fn_idx), tc.fn_declaration_diagnostic_pos(node))
 		}
 	}
 	tc.fn_context.node_id = -1
@@ -1748,31 +1727,24 @@ fn (mut tc TypeChecker) check_fn_receiver_and_operator_return(node flat.Node, id
 		receiver := tc.a.node(receiver_id)
 		if receiver.kind == .param && receiver.op == .dot
 			&& unalias_type(tc.parse_type(receiver.typ)) is MultiReturn {
-			tc.record_error_at(.call_arg_mismatch, 'cannot define method on multi-value',
-				receiver_id, tc.type_diagnostic_pos(receiver_id, receiver.typ))
+			tc.record_error_at(.call_arg_mismatch, 'cannot define method on multi-value', receiver_id, tc.type_diagnostic_pos(receiver_id, receiver.typ))
 		}
 	}
 	raw_return_type := node.typ.trim_space()
 	if raw_return_type.starts_with('!?') || raw_return_type.starts_with('?!') {
-		tc.record_error_at(.return_mismatch, 'the type must be Option or Result', id,
-			tc.nested_option_result_marker_pos(node))
+		tc.record_error_at(.return_mismatch, 'the type must be Option or Result', id, tc.nested_option_result_marker_pos(node))
 	}
 	if raw_return_type == '?void' {
-		tc.record_error_at(.return_mismatch, 'use `?` instead of `?void`', id,
-			tc.option_void_payload_diagnostic_pos(node))
+		tc.record_error_at(.return_mismatch, 'use `?` instead of `?void`', id, tc.option_void_payload_diagnostic_pos(node))
 	}
 	if raw_return_type.ends_with('?') && !raw_return_type.starts_with('?') {
-		tc.record_error_at(.return_mismatch,
-			'wrong syntax, it must be ?${raw_return_type.trim_right('?')}, not ${raw_return_type}',
-			id, tc.suffix_option_return_type_diagnostic_pos(node))
+		tc.record_error_at(.return_mismatch, 'wrong syntax, it must be ?${raw_return_type.trim_right('?')}, not ${raw_return_type}', id, tc.suffix_option_return_type_diagnostic_pos(node))
 	}
 	signature_return_type := unalias_type(tc.parse_type(node.typ))
 	if signature_return_type is MultiReturn {
 		for typ in signature_return_type.types {
 			if is_ierror_type(unalias_type(typ)) {
-				tc.record_error_at(.return_mismatch,
-					'type `IError` cannot be used in multi-return, return an Option instead', id,
-					tc.fn_return_type_diagnostic_pos(node))
+				tc.record_error_at(.return_mismatch, 'type `IError` cannot be used in multi-return, return an Option instead', id, tc.fn_return_type_diagnostic_pos(node))
 				break
 			}
 		}
@@ -1784,14 +1756,11 @@ fn (mut tc TypeChecker) check_fn_receiver_and_operator_return(node flat.Node, id
 			receiver_type := unalias_type(tc.parse_type(receiver.typ))
 			if receiver_type is Interface
 				&& node.value.all_after_last('.') in tc.interface_abstract_method_names(receiver_type.name) {
-				tc.record_error_at(.duplicate_decl,
-					'interface `${receiver_type.name}` cannot implement its own interface method `${node.value.all_after_last('.')}`',
-					id, tc.fn_declaration_diagnostic_pos(node))
+				tc.record_error_at(.duplicate_decl, 'interface `${receiver_type.name}` cannot implement its own interface method `${node.value.all_after_last('.')}`', id, tc.fn_declaration_diagnostic_pos(node))
 			}
 			if receiver_type is OptionType || receiver.typ.contains('?')
 				|| receiver_name.starts_with('?') {
-				tc.record_error_at(.call_arg_mismatch, 'option types cannot have methods', id, tc.fn_option_receiver_diagnostic_pos(node,
-					receiver.value))
+				tc.record_error_at(.call_arg_mismatch, 'option types cannot have methods', id, tc.fn_option_receiver_diagnostic_pos(node, receiver.value))
 			}
 		}
 	}
@@ -1801,14 +1770,13 @@ fn (mut tc TypeChecker) check_fn_receiver_and_operator_return(node flat.Node, id
 			tc.type_aliases[tc.qualify_name(alias_name)] or { '' }
 		}
 		if alias_target.starts_with('?') {
-			tc.record_error_at(.return_mismatch,
-				'the fn returns type `${raw_return_type}`, but type `${alias_name}` is an Option alias, you can not mix them',
-				id, tc.fn_return_type_diagnostic_pos(node))
+			tc.record_error_at(.return_mismatch, 'the fn returns type `${raw_return_type}`, but type `${alias_name}` is an Option alias, you can not mix them', id, tc.fn_return_type_diagnostic_pos(node))
 		}
 	}
 	operator := node.value.all_after_last('.')
 	if !node.value.contains('.')
-		|| operator !in ['+', '-', '*', '/', '%', '==', '!=', '<', '<=', '>', '>=', '<<', '>>', '&', '|', '^'] {
+		|| operator !in ['+', '-', '*', '/', '%', '==', '!=', '<', '<=', '>', '>=', '<<', '>>',
+			'&', '|', '^'] {
 		return
 	}
 	mut param_ids := []flat.NodeId{}
@@ -1819,25 +1787,20 @@ fn (mut tc TypeChecker) check_fn_receiver_and_operator_return(node flat.Node, id
 		}
 	}
 	if param_ids.len != 2 {
-		tc.record_error_at(.call_arg_mismatch, 'operator methods should have exactly 1 argument',
-			id, tc.fn_declaration_diagnostic_pos(node))
+		tc.record_error_at(.call_arg_mismatch, 'operator methods should have exactly 1 argument', id, tc.fn_declaration_diagnostic_pos(node))
 	}
 	mut operator_params_match := param_ids.len == 2
 	if param_ids.len > 0 {
 		receiver_id := param_ids[0]
 		receiver := tc.a.node(receiver_id)
 		if receiver.is_mut {
-			tc.record_error_at(.call_arg_mismatch,
-				'receiver cannot be `mut` for operator overloading', receiver_id,
-				tc.operator_receiver_without_mut_pos(node))
+			tc.record_error_at(.call_arg_mismatch, 'receiver cannot be `mut` for operator overloading', receiver_id, tc.operator_receiver_without_mut_pos(node))
 		}
 		if param_ids.len > 1 {
 			param_id := param_ids[1]
 			param := tc.a.node(param_id)
 			if param.is_mut {
-				tc.record_error_at(.call_arg_mismatch,
-					'argument cannot be `mut` for operator overloading', id,
-					tc.fn_declaration_diagnostic_pos(node))
+				tc.record_error_at(.call_arg_mismatch, 'argument cannot be `mut` for operator overloading', id, tc.fn_declaration_diagnostic_pos(node))
 			}
 			raw_receiver_type := tc.parse_type(receiver.typ)
 			raw_param_type := tc.parse_type(param.typ)
@@ -1846,23 +1809,18 @@ fn (mut tc TypeChecker) check_fn_receiver_and_operator_return(node flat.Node, id
 			if !receiver.is_mut && !param.is_mut && receiver_type.name() == param_type.name()
 				&& raw_receiver_type.name() != raw_param_type.name() {
 				operator_params_match = false
-				tc.record_error_at(.call_arg_mismatch,
-					'the receiver type `${receiver.typ}` should be the same type as the operand `${param.typ}`',
-					id, tc.fn_declaration_diagnostic_pos(node))
+				tc.record_error_at(.call_arg_mismatch, 'the receiver type `${receiver.typ}` should be the same type as the operand `${param.typ}`', id, tc.fn_declaration_diagnostic_pos(node))
 			}
 			if receiver_type.name() != param_type.name() && param_type !is FnType {
 				operator_params_match = false
-				tc.record_error_at(.call_arg_mismatch,
-					'expected `${receiver_type.name()}` not `${param_type.name()}` - both operands must be the same type for operator overloading',
-					param_id, tc.type_diagnostic_pos(param_id, param_type.name()))
+				tc.record_error_at(.call_arg_mismatch, 'expected `${receiver_type.name()}` not `${param_type.name()}` - both operands must be the same type for operator overloading', param_id, tc.type_diagnostic_pos(param_id, param_type.name()))
 			}
 		}
 	}
 	parsed_return_type := tc.parse_type(node.typ)
 	return_type := unalias_type(parsed_return_type)
 	if return_type is OptionType || return_type is ResultType {
-		tc.record_error_at(.return_mismatch, 'return type cannot be Option or Result', id,
-			tc.fn_return_type_diagnostic_pos(node))
+		tc.record_error_at(.return_mismatch, 'return type cannot be Option or Result', id, tc.fn_return_type_diagnostic_pos(node))
 	}
 	if node.children_count > 0 && operator in ['+', '-', '*', '/', '%', '<<', '>>', '&', '|', '^'] {
 		receiver := tc.a.child_node(&node, 0)
@@ -1870,9 +1828,7 @@ fn (mut tc TypeChecker) check_fn_receiver_and_operator_return(node flat.Node, id
 		if receiver_type is Alias && (infix_power_type_is_numeric(receiver_type.base_type)
 			|| unalias_type(receiver_type.base_type) is String)
 			&& parsed_return_type.name() != receiver_type.name && operator_params_match {
-			tc.record_error_at(.return_mismatch,
-				'operator `${operator}` methods on primitive aliases should return `${receiver_type.name}`',
-				id, tc.fn_return_type_diagnostic_pos(node))
+			tc.record_error_at(.return_mismatch, 'operator `${operator}` methods on primitive aliases should return `${receiver_type.name}`', id, tc.fn_return_type_diagnostic_pos(node))
 		}
 	}
 }
@@ -1926,7 +1882,7 @@ fn (mut tc TypeChecker) record_unused_fn_vars(node flat.Node) {
 					flat.empty_node
 				}
 				candidates << UnusedFnVarCandidate{
-					name:   lhs.value
+					name: lhs.value
 					lhs_id: lhs_id
 					rhs_id: rhs_id
 				}
@@ -1949,8 +1905,7 @@ fn (mut tc TypeChecker) record_unused_fn_vars(node flat.Node) {
 			&& !tc.expr_subtree_allows_unused_warning(candidate.rhs_id) {
 			continue
 		}
-		tc.record_warning_at(.unknown_ident, 'unused variable: `${candidate.name}`',
-			candidate.lhs_id, tc.node_value_diagnostic_pos(candidate.lhs_id))
+		tc.record_warning_at(.unknown_ident, 'unused variable: `${candidate.name}`', candidate.lhs_id, tc.node_value_diagnostic_pos(candidate.lhs_id))
 	}
 }
 
@@ -2007,14 +1962,12 @@ fn (mut tc TypeChecker) record_lambda_capture_errors(fn_node flat.Node) {
 				capture_pos := tc.node_value_diagnostic_pos(capture_id)
 				if !tc.errors.any(it.msg == undefined_message && it.pos.id == capture_pos.id
 					&& it.pos.offset == capture_pos.offset && it.pos.end == capture_pos.end) {
-					tc.errors << tc.make_type_error_at(.unknown_ident, undefined_message,
-						capture_id, capture_pos)
+					tc.errors << tc.make_type_error_at(.unknown_ident, undefined_message, capture_id, capture_pos)
 				}
 				value_message := '`${capture.value}` used as value'
 				if !tc.errors.any(it.msg == value_message && it.pos.id == node.pos.id
 					&& it.pos.offset == node.pos.offset && it.pos.end == node.pos.end) {
-					tc.errors << tc.make_type_error_at(.return_mismatch, value_message, id,
-						node.pos)
+					tc.errors << tc.make_type_error_at(.return_mismatch, value_message, id, node.pos)
 				}
 			}
 		}
@@ -2070,13 +2023,12 @@ fn (mut tc TypeChecker) record_unused_top_level_vars(node flat.Node) {
 			rhs := tc.a.node(rhs_id)
 			generic_interface_cast := rhs.kind == .cast_expr
 				&& (rhs.value in tc.interface_generic_params
-				|| tc.qualify_name(rhs.value) in tc.interface_generic_params)
+					|| tc.qualify_name(rhs.value) in tc.interface_generic_params)
 			if tc.expr_subtree_has_error(rhs_id) && !tc.expr_contains_nil_deref(rhs_id)
 				&& !generic_interface_cast {
 				continue
 			}
-			tc.record_warning_at(.unknown_ident, 'unused variable: `${lhs.value}`', lhs_id,
-				tc.node_value_diagnostic_pos(lhs_id))
+			tc.record_warning_at(.unknown_ident, 'unused variable: `${lhs.value}`', lhs_id, tc.node_value_diagnostic_pos(lhs_id))
 		}
 	}
 }
@@ -2169,7 +2121,7 @@ fn (tc &TypeChecker) expr_subtree_has_undefined_ident_error(id flat.NodeId) bool
 	for diagnostic in tc.errors {
 		if diagnostic.kind != .unknown_ident
 			|| (!diagnostic.msg.starts_with('undefined variable:')
-			&& !diagnostic.msg.starts_with('undefined ident:')) {
+				&& !diagnostic.msg.starts_with('undefined ident:')) {
 			continue
 		}
 		if diagnostic.node == id {
@@ -2206,7 +2158,7 @@ fn (tc &TypeChecker) expr_subtree_has_no_value_error(id flat.NodeId) bool {
 	root := tc.a.node(id)
 	return tc.errors.any(it.msg.contains('does not return a value') && (it.node == id
 		|| (it.pos.id == root.pos.id && it.pos.offset >= root.pos.offset
-		&& it.pos.end <= root.pos.end)))
+			&& it.pos.end <= root.pos.end)))
 }
 
 fn (tc &TypeChecker) expr_subtree_has_error_except(id flat.NodeId, ignored TypeErrorKind) bool {
@@ -2272,7 +2224,7 @@ fn (tc &TypeChecker) expr_subtree_allows_unused_warning(id flat.NodeId) bool {
 		|| it.msg.starts_with('invalid map value: expected ')
 		|| (it.msg.starts_with('type mismatch, `') && it.msg.ends_with('` must return a bool'))
 		|| (it.msg.contains('` is a generic fn, you should pass its concrete types, e.g. ')
-		&& it.msg.ends_with('[int]')) || (it.msg.starts_with('generic struct `')
+			&& it.msg.ends_with('[int]')) || (it.msg.starts_with('generic struct `')
 		&& it.msg.contains('` must specify type parameter'))))
 }
 
@@ -2323,7 +2275,7 @@ fn (tc &TypeChecker) fn_body_read_names(node flat.Node, candidate_names map[stri
 				}
 				if (current.kind == .sql_expr && sql_text_contains_ident(current.value, name))
 					|| (current.kind == .comptime_if
-					&& type_text_contains_symbol(current.value, name)) {
+						&& type_text_contains_symbol(current.value, name)) {
 					used_names[name] = true
 					continue
 				}
@@ -2395,8 +2347,7 @@ fn (mut tc TypeChecker) record_unused_fn_params(node flat.Node) {
 		if has_param_error {
 			continue
 		}
-		tc.record_notice_at(.unknown_ident, 'unused parameter: `${param.value}`', param_id,
-			tc.node_value_diagnostic_pos(param_id))
+		tc.record_notice_at(.unknown_ident, 'unused parameter: `${param.value}`', param_id, tc.node_value_diagnostic_pos(param_id))
 	}
 }
 
@@ -2441,6 +2392,10 @@ fn (mut tc TypeChecker) record_unused_fn_labels(node flat.Node) {
 			labels << id
 		} else if current.kind == .goto_stmt {
 			used[current.value] = true
+		} else if current.kind == .asm_stmt {
+			for label in inline_asm_goto_labels(current.value) {
+				used[label] = true
+			}
 		}
 		for i in 0 .. current.children_count {
 			stack << tc.a.child(current, i)
@@ -2453,8 +2408,7 @@ fn (mut tc TypeChecker) record_unused_fn_labels(node flat.Node) {
 			continue
 		}
 		if !used[label.value] {
-			tc.record_warning_at(.unknown_ident, 'label `${label.value}` defined and not used',
-				label_id, tc.a.node(label_id).pos)
+			tc.record_warning_at(.unknown_ident, 'label `${label.value}` defined and not used', label_id, tc.a.node(label_id).pos)
 		}
 	}
 }
@@ -2621,7 +2575,7 @@ fn (mut tc TypeChecker) install_type_cache_overlay() {
 	}
 	tc.prewarm_shared_type_cache()
 	tc.type_cache = &TypeCache{
-		base:          tc.type_cache
+		base: tc.type_cache
 		parse_enabled: tc.type_cache.parse_enabled
 	}
 	if !isnil(tc.resolution_type_views) {
@@ -2694,10 +2648,10 @@ fn (tc &TypeChecker) fork_for_parallel_check() &TypeChecker {
 	// worker (and each disposable scoped batch) owns mutable result/miss maps while
 	// sharing the declaration index that collect completed before checking starts.
 	w.visible_mutation_cache = &VisibleMutationCache{
-		decls:            tc.visible_mutation_cache.decls
-		decl_misses:      map[string]bool{}
-		results:          map[u64]bool{}
-		rebind_results:   map[u64]bool{}
+		decls: tc.visible_mutation_cache.decls
+		decl_misses: map[string]bool{}
+		results: map[u64]bool{}
+		rebind_results: map[u64]bool{}
 		decl_index_ready: tc.visible_mutation_cache.decl_index_ready
 	}
 	w.scope_parallel_check_workers = tc.scope_parallel_check_workers
@@ -2731,55 +2685,55 @@ fn (tc &TypeChecker) fork_for_parallel_check() &TypeChecker {
 	w.type_cache = &TypeCache{
 		// The master's frozen pre-region cache (the overlay's base) is shared
 		// read-only across all forks; each fork writes to its own maps.
-		base:                        if tc.type_cache != unsafe { nil } {
+		base: if tc.type_cache != unsafe { nil } {
 			tc.type_cache.base
 		} else {
 			&TypeCache(unsafe { nil })
 		}
-		parse_enabled:               if tc.type_cache != unsafe { nil } {
+		parse_enabled: if tc.type_cache != unsafe { nil } {
 			tc.type_cache.parse_enabled
 		} else {
 			false
 		}
-		parse_entries:               map[u64]ParseTypeCacheEntry{}
-		c_entries:                   map[TypeId]string{}
-		struct_field_entries:        map[string]Type{}
-		struct_field_misses:         map[string]bool{}
+		parse_entries: map[u64]ParseTypeCacheEntry{}
+		c_entries: map[TypeId]string{}
+		struct_field_entries: map[string]Type{}
+		struct_field_misses: map[string]bool{}
 		sum_variant_pattern_entries: map[string]string{}
-		lexical_smartcast_entries:   map[int]Type{}
-		lexical_smartcast_misses:    map[int]bool{}
-		short_type_name_index:       if isnil(precomputed)
+		lexical_smartcast_entries: map[int]Type{}
+		lexical_smartcast_misses: map[int]bool{}
+		short_type_name_index: if isnil(precomputed)
 			|| !precomputed.short_type_name_index_built {
 			map[string]string{}
 		} else {
 			precomputed.short_type_name_index
 		}
 		short_type_name_index_built: !isnil(precomputed) && precomputed.short_type_name_index_built
-		local_fn_decl_index:         if isnil(precomputed)
+		local_fn_decl_index: if isnil(precomputed)
 			|| precomputed.local_fn_decl_indexed_len == 0 {
 			map[string]bool{}
 		} else {
 			precomputed.local_fn_decl_index
 		}
-		local_fn_decl_indexed_len:   if isnil(precomputed) {
+		local_fn_decl_indexed_len: if isnil(precomputed) {
 			0
 		} else {
 			precomputed.local_fn_decl_indexed_len
 		}
-		local_fn_decl_last_module:   if isnil(precomputed) {
+		local_fn_decl_last_module: if isnil(precomputed) {
 			''
 		} else {
 			precomputed.local_fn_decl_last_module
 		}
-		ierror_compat_entries:       map[string]int{}
-		source_error_embed_entries:  if isnil(precomputed)
+		ierror_compat_entries: map[string]int{}
+		source_error_embed_entries: if isnil(precomputed)
 			|| !precomputed.source_error_embed_indexed {
 			map[string]int{}
 		} else {
 			precomputed.source_error_embed_entries
 		}
-		source_error_embed_indexed:  !isnil(precomputed) && precomputed.source_error_embed_indexed
-		source_error_embed_shared:   !isnil(precomputed) && precomputed.source_error_embed_indexed
+		source_error_embed_indexed: !isnil(precomputed) && precomputed.source_error_embed_indexed
+		source_error_embed_shared: !isnil(precomputed) && precomputed.source_error_embed_indexed
 	}
 	if tc.scope_parallel_check_workers {
 		// Shared interner growth from a helper arena would leave compilation-wide
@@ -2884,31 +2838,31 @@ fn clone_parallel_type_error(err TypeError) TypeError {
 		details << detail.clone()
 	}
 	return TypeError{
-		msg:        err.msg.clone()
-		kind:       err.kind
-		node:       err.node
-		file:       err.file.clone()
-		node_kind:  err.node_kind.clone()
+		msg: err.msg.clone()
+		kind: err.kind
+		node: err.node
+		file: err.file.clone()
+		node_kind: err.node_kind.clone()
 		node_value: err.node_value.clone()
-		node_pos:   err.node_pos.clone()
-		pos:        err.pos
-		details:    details
-		severity:   err.severity.clone()
+		node_pos: err.node_pos.clone()
+		pos: err.pos
+		details: details
+		severity: err.severity.clone()
 	}
 }
 
 fn clone_parallel_call_info(info CallInfo) CallInfo {
 	return CallInfo{
-		name:                 info.name.clone()
-		params:               clone_owned_types(info.params)
-		shared_params:        info.shared_params.clone()
-		return_type:          clone_owned_type(info.return_type)
-		has_receiver:         info.has_receiver
-		is_variadic:          info.is_variadic
-		is_c_variadic:        info.is_c_variadic
-		params_known:         info.params_known
+		name: info.name.clone()
+		params: clone_owned_types(info.params)
+		shared_params: info.shared_params.clone()
+		return_type: clone_owned_type(info.return_type)
+		has_receiver: info.has_receiver
+		is_variadic: info.is_variadic
+		is_c_variadic: info.is_c_variadic
+		params_known: info.params_known
 		has_implicit_veb_ctx: info.has_implicit_veb_ctx
-		arg_offset:           info.arg_offset
+		arg_offset: info.arg_offset
 	}
 }
 
@@ -2939,7 +2893,7 @@ fn (mut tc TypeChecker) merge_parallel_check_worker_scoped(w &TypeChecker, scope
 	for pending in w.pending_ierror_errors {
 		tc.pending_ierror_errors << if scoped {
 			PendingIerrorError{
-				err:      clone_parallel_type_error(pending.err)
+				err: clone_parallel_type_error(pending.err)
 				fn_qname: pending.fn_qname.clone()
 			}
 		} else {

--- a/vlib/v3/util/inline_asm.v
+++ b/vlib/v3/util/inline_asm.v
@@ -7,6 +7,7 @@ import strings
 pub struct InlineAsmHeader {
 pub:
 	arch        string
+	is_goto     bool
 	is_volatile bool
 	is_raw      bool
 	is_intel    bool
@@ -16,6 +17,7 @@ pub:
 // text preceding an assembly block's opening brace.
 pub fn parse_inline_asm_header(source string) InlineAsmHeader {
 	mut arch := ''
+	mut is_goto := false
 	mut is_volatile := false
 	mut is_raw := false
 	mut is_intel := false
@@ -25,6 +27,10 @@ pub fn parse_inline_asm_header(source string) InlineAsmHeader {
 		}
 		if word == 'volatile' {
 			is_volatile = true
+			continue
+		}
+		if word == 'goto' {
+			is_goto = true
 			continue
 		}
 		// The instruction set always comes first, so a leading `raw` or `intel` would
@@ -43,6 +49,7 @@ pub fn parse_inline_asm_header(source string) InlineAsmHeader {
 	}
 	return InlineAsmHeader{
 		arch: arch
+		is_goto: is_goto
 		is_volatile: is_volatile
 		is_raw: is_raw
 		is_intel: is_intel

--- a/vlib/v3/util/util_test.v
+++ b/vlib/v3/util/util_test.v
@@ -30,12 +30,17 @@ fn test_parse_inline_asm_header_reads_arch_and_modifiers() {
 	assert !plain.is_raw
 	assert !plain.is_intel
 	assert !plain.is_volatile
+	assert !plain.is_goto
 
 	modified := parse_inline_asm_header('asm volatile amd64 raw intel ')
 	assert modified.arch == 'amd64'
 	assert modified.is_volatile
 	assert modified.is_raw
 	assert modified.is_intel
+
+	goto_header := parse_inline_asm_header('asm goto amd64 ')
+	assert goto_header.arch == 'amd64'
+	assert goto_header.is_goto
 }
 
 fn test_asm_register_names_cover_the_supported_architectures() {


### PR DESCRIPTION
V3 interpreted `goto` as the assembly architecture, so `asm goto amd64` could not lower through the C backend. This adds GNU C `asm goto` emission, label operand lowering, and regression coverage.