### PR TITLE
v3: find parent v.mod for relative inputs

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -22,6 +22,7 @@ import v3.tempname
 import v3.token as v3token
 import v3.transform
 import v3.types
+import v3.util
 import v3.workers
 import v.build_constraint
 import v.vmod
@@ -14135,18 +14136,7 @@ fn project_root_for_files(files []string) string {
 }
 
 fn nearest_vmod_root_for_file(path string) string {
-	mut dir := if os.is_dir(path) { path } else { os.dir(path) }
-	for _ in 0 .. 32 {
-		if os.exists(os.join_path_single(dir, 'v.mod')) {
-			return dir
-		}
-		parent := os.dir(dir)
-		if parent == dir {
-			break
-		}
-		dir = parent
-	}
-	return ''
+	return util.nearest_vmod_root(path) or { '' }
 }
 
 // resolve_vroot_for_input resolves the V repo root for the compiler being built.

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -9948,17 +9948,7 @@ fn c_vmod_root_for_file(source_file string) string {
 	if dir.len == 0 {
 		dir = os.getwd()
 	}
-	for {
-		if os.exists(os.join_path(dir, 'v.mod')) {
-			return os.real_path(dir)
-		}
-		parent := os.dir(dir)
-		if parent == dir || parent.len == 0 {
-			return os.real_path(dir)
-		}
-		dir = parent
-	}
-	return os.real_path(dir)
+	return util.nearest_vmod_root(source_file) or { os.real_path(dir) }
 }
 
 fn c_pkgconfig_flags(raw string) []string {

--- a/vlib/v3/gen/fastc/source.v
+++ b/vlib/v3/gen/fastc/source.v
@@ -6,24 +6,14 @@ import time
 import v3.pref
 import v3.scanner
 import v3.token
+import v3.util
 
 fn fastc_vmod_root_for_file(source_file string) string {
 	mut dir := if source_file.len > 0 { os.dir(source_file) } else { os.getwd() }
 	if dir.len == 0 {
 		dir = os.getwd()
 	}
-	original_dir := dir
-	for {
-		if os.exists(os.join_path(dir, 'v.mod')) {
-			return os.real_path(dir)
-		}
-		parent := os.dir(dir)
-		if parent == dir || parent.len == 0 {
-			return os.real_path(original_dir)
-		}
-		dir = parent
-	}
-	return os.real_path(original_dir)
+	return util.nearest_vmod_root(source_file) or { os.real_path(dir) }
 }
 
 fn fastc_resolve_c_pseudo_paths(raw string, vroot string, source_file string) string {

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -713,18 +713,7 @@ fn vmod_root_for_file(path string) string {
 	if dir.len == 0 {
 		dir = os.getwd()
 	}
-	original_dir := dir
-	for {
-		if os.exists(os.join_path(dir, 'v.mod')) {
-			return dir
-		}
-		parent := os.dir(dir)
-		if parent == dir || parent.len == 0 {
-			return original_dir
-		}
-		dir = parent
-	}
-	return dir
+	return util.nearest_vmod_root(path) or { os.real_path(dir) }
 }
 
 fn vmod_hash_for_file(path string) !string {

--- a/vlib/v3/tests/driver_cli_test.v
+++ b/vlib/v3/tests/driver_cli_test.v
@@ -1393,6 +1393,53 @@ fn main() {
 	assert_driver_cli_failure(v3_bin, ['-d', 'feature', '-silent', '-no-parallel', invalid_source], 'i64 literal expected, found "true"')
 }
 
+fn test_driver_finds_parent_vmod_and_git_from_relative_input() {
+	root := os.join_path(os.vtmp_dir(), 'v3_driver_parent_vmod_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	project := os.join_path(root, 'project')
+	work_dir := os.join_path(project, 'nested')
+	support_dir := os.join_path(project, 'support')
+	git_refs := os.join_path(project, '.git', 'refs', 'heads')
+	os.mkdir_all(work_dir) or { panic(err) }
+	os.mkdir_all(support_dir) or { panic(err) }
+	os.mkdir_all(git_refs) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	v3_bin := build_driver_cli_v3(root)
+	os.write_file(os.join_path(project, 'v.mod'), "Module { name: 'parent_vmod' }\n")!
+	os.write_file(os.join_path(project, '.git', 'HEAD'), 'ref: refs/heads/main\n')!
+	os.write_file(os.join_path(git_refs, 'main'), '0123456789abcdef0123456789abcdef01234567\n')!
+	os.write_file(os.join_path(project, 'api.h'), '#ifndef V3_PARENT_VMOD_API_H\n#define V3_PARENT_VMOD_API_H\nstatic inline int parent_answer(void) { return 42; }\n#endif\n')!
+	os.write_file(os.join_path(work_dir, 'main.c.v'), 'module main
+
+import support
+
+#flag -I @VMODROOT
+#include "api.h"
+
+fn C.parent_answer() int
+
+fn main() {
+	println(@VMODROOT)
+	println(@VMODHASH)
+	println(support.answer() + C.parent_answer())
+}
+')!
+	os.write_file(os.join_path(support_dir, 'support.v'), 'module support
+
+pub fn answer() int {
+	return 42
+}
+')!
+	output := os.join_path(root, 'parent_vmod')
+	compile := cmdexec.run_in(v3_bin, ['-silent', '-no-parallel', '-o', output, 'main.c.v'], work_dir)
+	assert compile.exit_code == 0, compile.output
+	run := cmdexec.run(output, [])
+	assert run.exit_code == 0, run.output
+	assert run.output == '${os.real_path(project)}\n0123456\n84\n', run.output
+}
+
 fn test_delegated_driver_preserves_invoking_vroot() {
 	root := os.join_path(os.vtmp_dir(), 'v3_driver_invoking_vroot_${os.getpid()}')
 	os.rmdir_all(root) or {}

--- a/vlib/v3/transform/comptime.v
+++ b/vlib/v3/transform/comptime.v
@@ -5,6 +5,7 @@ import strconv
 import strings
 import v3.flat
 import v3.types
+import v3.util
 
 const comptime_unsupported_late_generic_call = '__v3_comptime_unsupported_late_generic_call'
 const comptime_method_selector_marker = '__v3_comptime_method_selector'
@@ -16,17 +17,7 @@ fn (t &Transformer) vmod_root() string {
 	if dir.len == 0 {
 		dir = os.getwd()
 	}
-	for {
-		if os.exists(os.join_path(dir, 'v.mod')) {
-			return dir
-		}
-		parent := os.dir(dir)
-		if parent == dir || parent.len == 0 {
-			return if t.cur_file.len > 0 { os.dir(t.cur_file) } else { os.getwd() }
-		}
-		dir = parent
-	}
-	return dir
+	return util.nearest_vmod_root(t.cur_file) or { os.real_path(dir) }
 }
 
 // Compile-time reflection: `$for field in T.fields { ... }`.

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -2734,18 +2734,10 @@ fn (tc &TypeChecker) resolve_insert_path(target string, file string) string {
 
 fn checker_vmod_root_for_file(file string) string {
 	mut dir := if file.len > 0 { os.dir(file) } else { os.getwd() }
-	original := dir
-	for {
-		if os.exists(os.join_path_single(dir, 'v.mod')) {
-			return os.real_path(dir)
-		}
-		parent := os.dir(dir)
-		if parent == dir || parent.len == 0 {
-			return os.real_path(original)
-		}
-		dir = parent
+	if dir.len == 0 {
+		dir = os.getwd()
 	}
-	return os.real_path(original)
+	return util.nearest_vmod_root(file) or { os.real_path(dir) }
 }
 
 fn checker_flag_include_dir(raw string) ?string {

--- a/vlib/v3/util/util.v
+++ b/vlib/v3/util/util.v
@@ -63,6 +63,32 @@ pub fn tokenize_c_flag(value string) []string {
 	return tokens
 }
 
+// nearest_vmod_root returns the closest directory containing a v.mod for path.
+pub fn nearest_vmod_root(path string) ?string {
+	mut dir := if path.len == 0 {
+		os.getwd()
+	} else if os.is_dir(path) {
+		path
+	} else {
+		os.dir(path)
+	}
+	if dir.len == 0 {
+		dir = os.getwd()
+	}
+	dir = os.real_path(dir)
+	for dir.len > 0 {
+		if os.is_file(os.join_path_single(dir, 'v.mod')) {
+			return dir
+		}
+		parent := os.dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return none
+}
+
 // githash returns the current seven-character Git commit hash for path.
 pub fn githash(path string) !string {
 	head_file := os.join_path(path, '.git', 'HEAD')


### PR DESCRIPTION
## Summary

- canonicalize the starting directory before walking parent directories for v.mod
- share the lookup across the v3 driver, parser, checker, transformer, C backend, and FastC backend
- add a nested CLI regression covering project imports, @VMODROOT, @VMODHASH, and parent-rooted C directives

## Tests

- ./vnew -silent test -run-only test_driver_finds_parent_vmod_and_git_from_relative_input vlib/v3/tests/driver_cli_test.v
- ./vnew -silent test -run-only *vmod* vlib/v3/gen/fastc/fastc_test.v
- ./vnew -silent test -run-only *vmod* vlib/v3/tests/transformer_parity_test.v
- ./vnew -silent test -run-only *vmod* vlib/v3/modulecache/modulecache_test.v
- VFLAGS=-old-compiler ./vnew -silent vlib/v/compiler_errors_test.v (1707 passed, 1 skipped)

The broader default-v3 legacy diagnostic and C-output suites still have unrelated existing parity failures.