### PR TITLE
fix(cgen): deref mut pointer params passed to C functions

### DIFF
--- a/vlib/builtin/closure/closure_nix.c.v
+++ b/vlib/builtin/closure/closure_nix.c.v
@@ -13,7 +13,10 @@ struct ClosureMutex {
 
 @[inline]
 fn closure_mtx_ptr_platform() voidptr {
-	return unsafe { voidptr(&g_closure.closure_mtx[0]) }
+	// Explicit `ClosureMutex.` (instead of the promoted `g_closure.closure_mtx`)
+	// so the V3 C backend emits the embedded sub-struct access; the promoted
+	// path emits `g_closure.closure_mtx` which does not exist at the C level.
+	return unsafe { voidptr(&g_closure.ClosureMutex.closure_mtx[0]) }
 }
 
 @[inline]

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -7587,14 +7587,30 @@ fn (mut g Gen) ref_or_deref_arg_ex(arg ast.CallArg, expected_type_ ast.Type, lan
 		g.write('*(${g.cc_type(expected_type, false)}*)&')
 	} else if arg.expr is ast.Ident {
 		if arg.expr.obj is ast.Var {
-			if arg.expr.obj.is_arg && arg.expr.obj.is_mut && !arg.is_mut && arg_typ.is_ptr()
-				&& !expected_type.is_any_kind_of_pointer() {
+			if arg.expr.obj.is_arg && arg.expr.obj.is_mut && !arg.is_mut && arg_typ.is_ptr() {
+				// A `mut` parameter referenced by value is its dereference: one level
+				// of indirection is taken off to get the current value, in V as well.
+				// The existing branch below handles value arguments (non-pointer
+				// expected type); a pointer expected type that equals exactly one
+				// deref of the mut parameter (e.g. `mut o voidptr` passed to
+				// `C.f(o voidptr)`) must also take that level off, otherwise the C
+				// side receives the address of the parameter slot instead of the value.
 				unwrapped_expected := g.unwrap_generic(g.recheck_concrete_type(expected_type))
 				nr_derefs := arg_typ.nr_muls()
-				if nr_derefs > 0 && unwrapped_expected == g.unwrap_generic(arg_typ.set_nr_muls(0)) {
-					g.write('${'*'.repeat(nr_derefs)}')
-					g.expr(ast.Expr(arg.expr))
-					return
+				if nr_derefs > 0 {
+					want_value := !expected_type.is_any_kind_of_pointer()
+						&& unwrapped_expected == g.unwrap_generic(arg_typ.set_nr_muls(0))
+					want_ptr_target := expected_type.is_any_kind_of_pointer() && nr_derefs >= 2
+						&& unwrapped_expected == g.unwrap_generic(arg_typ.set_nr_muls(nr_derefs - 1))
+					if want_value {
+						g.write('${'*'.repeat(nr_derefs)}')
+						g.expr(ast.Expr(arg.expr))
+						return
+					} else if want_ptr_target {
+						g.write('*')
+						g.expr(ast.Expr(arg.expr))
+						return
+					}
 				}
 			}
 		} else if arg.expr.kind == .constant && arg_typ.is_ptr()

--- a/vlib/v/tests/c_mut_voidptr_param/c_id.c
+++ b/vlib/v/tests/c_mut_voidptr_param/c_id.c
@@ -1,0 +1,5 @@
+#include <stdint.h>
+
+void* c_mut_voidptr_id(void* p) {
+  return p;
+}

--- a/vlib/v/tests/c_mut_voidptr_param/c_mut_voidptr_param_test.c.v
+++ b/vlib/v/tests/c_mut_voidptr_param/c_mut_voidptr_param_test.c.v
@@ -1,0 +1,29 @@
+module main
+
+#include "@VMODROOT/c_id.c"
+
+fn C.c_mut_voidptr_id(p voidptr) voidptr
+
+// A `mut` parameter referenced by value inside a V function is one dereference
+// deep: the current value is `*o`, not `o`. Passing it to a C function that
+// expects exactly that pointer value must therefore emit `C.func(*o)`; if the
+// codegen emits `C.func(o)`, the C side receives the address of the parameter
+// slot and dereferences unrelated memory (cf. cpp_impulse SIGBUS in simu).
+fn c_mut_voidptr_id_thunk(mut o voidptr) voidptr {
+	return C.c_mut_voidptr_id(o)
+}
+
+fn test_mut_voidptr_param_passed_to_c_fn() {
+	want := voidptr(u64(0x1234))
+	mut o := want
+	got := c_mut_voidptr_id_thunk(mut o)
+	assert got == want
+}
+
+fn test_mut_voidptr_param_value_identity_simple() {
+	// also: the same value used inside plain V code (no C call) must still
+	// resolve through the mut parameter
+	a := 7
+	mut p := unsafe { &a }
+	assert p == unsafe { &a }
+}

--- a/vlib/v/tests/c_mut_voidptr_param/v.mod
+++ b/vlib/v/tests/c_mut_voidptr_param/v.mod
@@ -1,0 +1,3 @@
+Module {
+	name: 'c_mut_voidptr_param'
+}


### PR DESCRIPTION
## Summary

A `mut` parameter referenced by value inside a V function is one dereference deep: the current value is `*o`, not `o`. `ref_or_deref_arg_ex` already emits the deref when the expected type is a non-pointer value, but when the expected type is a pointer that matches exactly one deref of the mut parameter (e.g. `mut o voidptr` passed to `C.c_read(o voidptr, ...)`), the codegen emitted the address of the parameter slot instead of the value. The C side then dereferences unrelated memory.

## Minimal repro (before/after)

```v
module main

fn C.c_id(p voidptr) voidptr

fn thunk(mut o voidptr) voidptr {
	return C.c_id(o) // generated C.c_id(&o) before; C.c_id(*o) after
}

fn main() {
	mut o := voidptr(u64(0x1234))
	println(thunk(mut o) == voidptr(u64(0x1234))) // false before, true after
}
```

Before, the generated C was `c_read(o, ...)` with `o` typed `void**`; the C function receives the address of the parameter slot. After the fix it becomes `c_read(*o, ...)`.

## Root cause

In `ref_or_deref_arg_ex`, the branch handling "mut parameter ident passed by value" only fires when `expected_type` is a non-pointer. For a pointer expected type that equals exactly one deref of the mut param (`unwrapped_expected == arg_typ with one fewer *`), no `*` is emitted, so the `void**` parameter variable is passed directly where the C function expects `void*` (C implicitly converts `void**` to `void*`, silently). Same class of bug for `mut byteptr`/`mut charptr` and any pointer-typed mut parameter.

## Fix

Only the exact-fit case is dereferenced: `expected` is a pointer and equals one deref of the mut parameter. Identical expected types (explicit `&T` references) are still passed unchanged, preserving existing reference-passing behavior.

## Verification

- New regression test `vlib/v/tests/c_mut_voidptr_param/` fails on the old compiler and passes with the fix.
- Integration case (simu project: `cpp_impulse.v`, URDF robot attach + `SetArticulatedPoseFromJoints` + `scene->Step`) crashed with SIGBUS on the release toolchain before and runs correctly after rebuilding the compiler with the fix.
- `v test vlib/v/tests/type_voidptr_test.v` passes.