### PR TITLE
v3: fix libbacktrace callback ABI

### DIFF
--- a/vlib/builtin/builtin_d_use_libbacktrace.c.v
+++ b/vlib/builtin/builtin_d_use_libbacktrace.c.v
@@ -11,6 +11,7 @@ $if openbsd {
 	fn eprint_libbacktrace(frames_to_skip int) {
 	}
 } $else $if !tinyc {
+
 	// full libbacktrace implementation for gcc/clang (TCC can't compile libbacktrace's C code)
 	#flag -I@VEXEROOT/thirdparty/libbacktrace
 	#flag @VEXEROOT/thirdparty/libbacktrace/backtrace.o
@@ -21,13 +22,13 @@ $if openbsd {
 		// filename &char
 	}
 
-	type BacktraceErrorCallback = fn (data voidptr, msg &char, errnum int)
+	type BacktraceErrorCallback = fn (data voidptr, const_msg &char, errnum i32)
 
-	type BacktraceFullCallback = fn (data voidptr, pc voidptr, filename &char, lineno int, func &char) int
+	type BacktraceFullCallback = fn (data voidptr, pc usize, const_filename &char, lineno i32, const_func &char) i32
 
 	fn C.backtrace_create_state(filename &char, threaded i32, error_callback BacktraceErrorCallback, data voidptr) &C.backtrace_state
 	fn C.backtrace_full(state &C.backtrace_state, skip i32, cb BacktraceFullCallback, err_cb BacktraceErrorCallback,
-	data voidptr) i32
+		data voidptr) i32
 
 	__global bt_state = init_bt_state()
 
@@ -46,7 +47,7 @@ $if openbsd {
 		stdin bool = true
 	}
 
-	fn bt_print_callback(data_ptr voidptr, pc voidptr, filename_ptr &char, line int, fn_name_ptr &char) int {
+	fn bt_print_callback(data_ptr voidptr, pc usize, filename_ptr &char, line i32, fn_name_ptr &char) i32 {
 		data := unsafe { &BacktraceOptions(data_ptr) }
 		filename := if filename_ptr == unsafe { nil } {
 			'???'
@@ -69,7 +70,7 @@ $if openbsd {
 		return 0
 	}
 
-	fn bt_error_callback(data voidptr, msg_ptr &char, errnum int) {
+	fn bt_error_callback(data voidptr, msg_ptr &char, errnum i32) {
 		// if data != unsafe { nil } && data.state != unsafe { nil } && data.state.filename != unsafe { nil } {
 		// 	filename := unsafe{ data.state.filename.vstring() }
 		// 	eprint('${filename}: ')
@@ -85,7 +86,7 @@ $if openbsd {
 	}
 
 	// for backtrace_create_state only
-	fn bt_error_handler(data voidptr, msg &char, errnum int) {
+	fn bt_error_handler(data voidptr, msg &char, errnum i32) {
 		eprint('libbacktrace: ')
 		eprint(unsafe { msg.vstring() })
 		if errnum > 0 {
@@ -115,6 +116,7 @@ $if openbsd {
 		C.backtrace_full(bt_state, frames_to_skip, bt_print_callback, bt_error_callback, data)
 	}
 } $else {
+
 	// no-op stubs for TCC (TCC can't compile libbacktrace's C code, and
 	// it has its own built-in backtrace via tcc_backtrace instead)
 	fn print_libbacktrace(frames_to_skip int) {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -13111,9 +13111,7 @@ fn (mut g FlatGen) c_call_callback_abi_thunk(arg_id flat.NodeId, expected types.
 		return none
 	}
 	actual_fn := g.callback_fn_value_type(actual_name) or { return none }
-	encoded := g.tc.c_abi_fn_ptr_type_for_type_text(expected.name()) or {
-		g.c_extern_fn_ptr_encoded(expected_fn)
-	}
+	encoded := g.c_extern_fn_ptr_encoded_for_type(expected, expected_fn)
 	return g.ensure_callback_userdata_wrapper(actual_name, actual_fn, expected_fn, encoded)
 }
 
@@ -13332,10 +13330,15 @@ fn (mut g FlatGen) ensure_callback_userdata_wrapper(actual_name string, actual t
 	}
 	actual_ret_ct := g.callback_c_type(actual.return_type)
 	expected_ret_ct := g.callback_expected_return_c_type(expected.return_type, expected_c_abi)
-	if actual_ret_ct != expected_ret_ct {
-		return none
-	}
 	mut needs_wrapper := false
+	mut cast_return := false
+	if actual_ret_ct != expected_ret_ct {
+		if !callback_can_cast_scalar_int_param(actual_ret_ct, expected_ret_ct) {
+			return none
+		}
+		needs_wrapper = true
+		cast_return = true
+	}
 	mut param_decls := []string{}
 	mut call_args := []string{}
 	mut setup_lines := []string{}
@@ -13393,11 +13396,12 @@ fn (mut g FlatGen) ensure_callback_userdata_wrapper(actual_name string, actual t
 	g.callback_wrapper_names[key] = name
 	params := if param_decls.len == 0 { 'void' } else { param_decls.join(', ') }
 	call := '${actual_c_name}(${call_args.join(', ')})'
+	return_expr := if cast_return { '(${expected_ret_ct})(${call})' } else { call }
 	setup := if setup_lines.len == 0 { '' } else { setup_lines.join(' ') + ' ' }
 	body := if expected_ret_ct == 'void' {
 		'static void ${name}(${params}) { ${setup}${call}; }'
 	} else {
-		'static ${expected_ret_ct} ${name}(${params}) { ${setup}return ${call}; }'
+		'static ${expected_ret_ct} ${name}(${params}) { ${setup}return ${return_expr}; }'
 	}
 	g.add_callback_wrapper_def(body)
 	return name
@@ -17890,8 +17894,10 @@ fn (mut g FlatGen) c_extern_interop_type_name(t types.Type) ?string {
 	if t is types.Alias {
 		// A `type Cb = fn (int)` alias over a function type must still keep C `int`
 		// inside the C ABI; alias-over-`int` likewise. Non-interop bases return none.
-		if encoded := g.tc.c_abi_fn_ptr_type_for_type_text(t.name) {
-			return g.resolve_fn_ptr_type(encoded)
+		if _ := g.tc.c_abi_fn_ptr_type_for_type_text(t.name) {
+			if fn_type := fn_type_from(t) {
+				return g.resolve_fn_ptr_type(g.c_extern_fn_ptr_encoded_for_type(t, fn_type))
+			}
 		}
 		return g.c_extern_interop_type_name(t.base_type)
 	}
@@ -17929,6 +17935,38 @@ fn (mut g FlatGen) c_extern_fn_ptr_encoded(t types.FnType) string {
 		params << (g.c_extern_interop_type_name(pt) or { g.tc.c_type(pt) })
 	}
 	return 'fn_ptr:${ret}|${params.join(', ')}'
+}
+
+// c_extern_fn_ptr_encoded_for_type merges source-retained callback ABI details,
+// such as `const_` pointer parameters, into the C-extern encoding. Positions that
+// have no retained override keep the extern lowering, notably V `int` as C `int`.
+fn (mut g FlatGen) c_extern_fn_ptr_encoded_for_type(t types.Type, fn_type types.FnType) string {
+	extern_encoded := g.c_extern_fn_ptr_encoded(fn_type)
+	retained_encoded := g.tc.c_abi_fn_ptr_type_for_type_text(t.name()) or {
+		return extern_encoded
+	}
+	ordinary_encoded := g.fn_ptr_type_key(fn_type)
+	return merge_retained_fn_ptr_c_abi(extern_encoded, retained_encoded, ordinary_encoded)
+}
+
+fn merge_retained_fn_ptr_c_abi(extern_encoded string, retained_encoded string, ordinary_encoded string) string {
+	extern_ret, _ := fn_ptr_typedef_parts(extern_encoded)
+	retained_ret, _ := fn_ptr_typedef_parts(retained_encoded)
+	ordinary_ret, _ := fn_ptr_typedef_parts(ordinary_encoded)
+	mut extern_params := callback_fn_ptr_param_c_types(extern_encoded)
+	retained_params := callback_fn_ptr_param_c_types(retained_encoded)
+	ordinary_params := callback_fn_ptr_param_c_types(ordinary_encoded)
+	if extern_params.len != retained_params.len || retained_params.len != ordinary_params.len {
+		return extern_encoded
+	}
+	for i, retained_param in retained_params {
+		if retained_param != ordinary_params[i] {
+			extern_params[i] = retained_param
+		}
+	}
+	ret := if retained_ret != ordinary_ret { retained_ret } else { extern_ret }
+	params := if extern_params.len == 0 { 'void' } else { extern_params.join(', ') }
+	return 'fn_ptr:${ret}|${params}'
 }
 
 // c_call_arg_cabi_cast returns the C spelling to cast a C-call argument to so it

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -13102,8 +13102,8 @@ fn (mut g FlatGen) gen_callback_fn_value_for_expected_c_abi(arg_id flat.NodeId, 
 // when no adapter is needed (widths already match) or the argument is not a directly
 // resolvable V function (a forwarded/dynamic fn-pointer value falls through to the
 // plain C-ABI cast).
-fn (mut g FlatGen) c_call_callback_abi_thunk(arg_id flat.NodeId, expected_fn types.FnType) ?string {
-	expected := types.Type(expected_fn)
+fn (mut g FlatGen) c_call_callback_abi_thunk(arg_id flat.NodeId, expected types.Type) ?string {
+	expected_fn := fn_type_from(expected) or { return none }
 	actual_name := g.callback_fn_value_name(arg_id, expected) or {
 		g.direct_callback_ident_name(arg_id) or { return none }
 	}
@@ -13111,7 +13111,9 @@ fn (mut g FlatGen) c_call_callback_abi_thunk(arg_id flat.NodeId, expected_fn typ
 		return none
 	}
 	actual_fn := g.callback_fn_value_type(actual_name) or { return none }
-	encoded := g.c_extern_fn_ptr_encoded(expected_fn)
+	encoded := g.tc.c_abi_fn_ptr_type_for_type_text(expected.name()) or {
+		g.c_extern_fn_ptr_encoded(expected_fn)
+	}
 	return g.ensure_callback_userdata_wrapper(actual_name, actual_fn, expected_fn, encoded)
 }
 
@@ -15505,9 +15507,9 @@ fn (mut g FlatGen) gen_call_args(fn_name string, node flat.Node, start int) {
 			// functions already have their exact ABI in the included header, including
 			// qualifiers that cannot be expressed by their `fn C.` declarations.
 			if arg_idx >= 0 && arg_idx < typed_param_count {
-				if cb_fn := fn_type_from(param_types[arg_idx]) {
+				if _ := fn_type_from(param_types[arg_idx]) {
 					if !g.is_c_extern_fn_name_arg(arg_id) {
-						if thunk := g.c_call_callback_abi_thunk(arg_id, cb_fn) {
+						if thunk := g.c_call_callback_abi_thunk(arg_id, param_types[arg_idx]) {
 							g.write(thunk)
 							continue
 						}
@@ -17888,6 +17890,9 @@ fn (mut g FlatGen) c_extern_interop_type_name(t types.Type) ?string {
 	if t is types.Alias {
 		// A `type Cb = fn (int)` alias over a function type must still keep C `int`
 		// inside the C ABI; alias-over-`int` likewise. Non-interop bases return none.
+		if encoded := g.tc.c_abi_fn_ptr_type_for_type_text(t.name) {
+			return g.resolve_fn_ptr_type(encoded)
+		}
 		return g.c_extern_interop_type_name(t.base_type)
 	}
 	if t is types.FnType {

--- a/vlib/v3/tests/c_extern_fn_callback_arg_codegen_test.v
+++ b/vlib/v3/tests/c_extern_fn_callback_arg_codegen_test.v
@@ -28,8 +28,16 @@ fn C.native_register(fn (voidptr, &u8, usize) i32) i32
 fn C.native_send_int(voidptr, &u8, int) i32
 fn C.native_register_int(fn (voidptr, &u8, int) i32) i32
 
+type NativeConstIntCallback = fn (const_buf &u8, len int) int
+
+fn C.native_register_const_int(NativeConstIntCallback) int
+
 fn v_send(ctx voidptr, buf &u8, len usize) i32 {
 	return i32(len) + i32(unsafe { buf[0] }) + i32(ctx != unsafe { nil })
+}
+
+fn v_send_int(buf &u8, len int) int {
+	return int(unsafe { buf[0] }) + len
 }
 
 fn main() {
@@ -39,6 +47,7 @@ fn main() {
 	println(C.native_register(v_send))
 	println(C.native_register_int(C.native_send_int))
 	println(C.native_register_int((C.native_send_int)))
+	println(C.native_register_const_int(v_send_int))
 }
 ') or { panic(err) }
 	return src
@@ -75,4 +84,10 @@ fn test_c_extern_fn_callback_arg_is_not_cast() {
 	assert compact.contains('native_register_int(native_send_int)'), c_code
 	assert compact.contains('native_register_int((native_send_int))'), c_code
 	assert !compact.contains('__v3_callback_wrap_native_send_int'), c_code
+	// Retained `const_` pointer qualifiers must be merged into the C-extern ABI,
+	// without replacing its C `int` parameter and return widths with V i64.
+	assert c_code.contains('const u8* arg0, int arg1'), c_code
+	assert c_code.contains('static int v_send_int_callback_adapter_'), c_code
+	assert c_code.contains('return (int)(v_send_int((u8*)arg0, (i64)arg1));'), c_code
+	assert compact.contains('native_register_const_int(v_send_int_callback_adapter_'), c_code
 }

--- a/vlib/v3/tests/libbacktrace_callback_codegen_test.v
+++ b/vlib/v3/tests/libbacktrace_callback_codegen_test.v
@@ -38,6 +38,6 @@ fn test_libbacktrace_callback_codegen_matches_header() {
 		'incompatible-pointer-types'
 	}
 	include_dir := os.join_path(vroot, 'thirdparty', 'libbacktrace')
-	check := os.execute('${os.quoted_path(cc)} -w -Werror=${pointer_warning} -fsyntax-only -I${os.quoted_path(include_dir)} ${os.quoted_path(c_path)}')
+	check := os.execute('${os.quoted_path(cc)} -Werror=${pointer_warning} -fsyntax-only -I${os.quoted_path(include_dir)} ${os.quoted_path(c_path)}')
 	assert check.exit_code == 0, check.output
 }

--- a/vlib/v3/tests/libbacktrace_callback_codegen_test.v
+++ b/vlib/v3/tests/libbacktrace_callback_codegen_test.v
@@ -1,0 +1,43 @@
+import os
+
+fn test_libbacktrace_callback_codegen_matches_header() {
+	$if !linux && !macos {
+		return
+	}
+	vroot := @VEXEROOT
+	v3_dir := os.join_path(vroot, 'vlib', 'v3')
+	vlib_dir := os.join_path(vroot, 'vlib')
+	temp_dir := os.join_path(os.vtmp_dir(), 'v3_libbacktrace_callback_${os.getpid()}')
+	os.rmdir_all(temp_dir) or {}
+	os.mkdir_all(temp_dir) or { panic(err) }
+	defer {
+		os.rmdir_all(temp_dir) or {}
+	}
+
+	v3_bin := os.join_path(temp_dir, 'v3')
+	build := os.execute('${os.quoted_path(@VEXE)} -gc none -path "${vlib_dir}|@vlib|@vmodules" -o ${os.quoted_path(v3_bin)} ${os.quoted_path(os.join_path(v3_dir, 'v3.v'))}')
+	assert build.exit_code == 0, build.output
+
+	source := os.join_path(temp_dir, 'main.v')
+	os.write_file(source, "fn main() {\n\tpanic('boom')\n}\n") or { panic(err) }
+	c_path := os.join_path(temp_dir, 'main.c')
+	generate := os.execute('${os.quoted_path(v3_bin)} -d use_libbacktrace -b c -o ${os.quoted_path(c_path)} ${os.quoted_path(source)}')
+	assert generate.exit_code == 0, generate.output
+
+	c_source := os.read_file(c_path) or { panic(err) }
+	assert c_source.contains('size_t arg1, const char* arg2, i32 arg3, const char* arg4'), c_source
+	assert c_source.contains('void* arg0, const char* arg1, i32 arg2'), c_source
+	assert c_source.contains('backtrace_full(bt_state, frames_to_skip, bt_print_callback_callback_adapter_'), c_source
+	assert c_source.contains('backtrace_create_state(filename, 1, bt_error_handler_callback_adapter_'), c_source
+
+	cc := os.find_abs_path_of_executable('cc') or { return }
+	cc_version := os.execute('${os.quoted_path(cc)} --version').output.to_lower_ascii()
+	pointer_warning := if cc_version.contains('clang') {
+		'incompatible-function-pointer-types'
+	} else {
+		'incompatible-pointer-types'
+	}
+	include_dir := os.join_path(vroot, 'thirdparty', 'libbacktrace')
+	check := os.execute('${os.quoted_path(cc)} -w -Werror=${pointer_warning} -fsyntax-only -I${os.quoted_path(include_dir)} ${os.quoted_path(c_path)}')
+	assert check.exit_code == 0, check.output
+}

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -14465,7 +14465,9 @@ fn (tc &TypeChecker) c_abi_fn_ptr_type_from_text(typ string) ?string {
 	return 'fn_ptr:${ret_ct}|${params_ct}'
 }
 
-fn (tc &TypeChecker) c_abi_fn_ptr_type_for_type_text(typ string) ?string {
+// c_abi_fn_ptr_type_for_type_text returns the C ABI function-pointer encoding retained
+// by a source function type or alias, including `const_` pointer parameters.
+pub fn (tc &TypeChecker) c_abi_fn_ptr_type_for_type_text(typ string) ?string {
 	mut seen := map[string]bool{}
 	return tc.c_abi_fn_ptr_type_for_type_text_inner(trimmed_space(typ), mut seen)
 }


### PR DESCRIPTION
## Summary

- align builtin libbacktrace callback declarations with the bundled C header
- preserve retained C ABI qualifiers for V3 callback aliases passed to C functions
- add an end-to-end regression that compiles generated backtrace C with strict callback pointer diagnostics

## Tests

- `./vnew vlib/v3/tests/libbacktrace_callback_codegen_test.v`
- `./vnew vlib/v3/tests/c_extern_fn_callback_arg_codegen_test.v`
- `./vnew -silent test vlib/v3/gen/c/` (19/19 passed)
- strict Clang syntax check of V3-generated libbacktrace C with incompatible function pointer diagnostics promoted to errors

Additional broad checks encountered unrelated existing failures: two storage-source assertions in `vlib/v3/types/`, and legacy V1 diagnostic fixtures that are not currently compatible with the V3-backed compiler.