### PR TITLE
builtin: reduce map header to pointer size

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -299,7 +299,7 @@ fn __new_array_with_array_default(mylen int, cap int, elm_size int, val array, d
 	return arr
 }
 
-fn __new_array_with_map_default(mylen int, cap int, elm_size int, val map) array {
+fn __new_array_with_map_default(mylen int, cap int, elm_size int, val map, free_seed bool) array {
 	panic_on_negative_len(mylen)
 	panic_on_negative_cap(cap)
 	cap_ := if cap < mylen { mylen } else { cap }
@@ -321,6 +321,9 @@ fn __new_array_with_map_default(mylen int, cap int, elm_size int, val map) array
 				eptr += arr.element_size
 			}
 		}
+	}
+	if free_seed {
+		unsafe { val.free() }
 	}
 	return arr
 }

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -230,7 +230,7 @@ mut:
 	data &VMapData = unsafe { nil }
 }
 
-// map_empty_data keeps explicitly freed maps readable without retaining their allocated header.
+// map_empty_data keeps freed and moved-from maps readable without retaining their allocated header.
 __global map_empty_data = VMapData{
 	metas: unsafe { nil }
 }
@@ -391,14 +391,11 @@ fn new_map_update_init(update &map, n int, key_bytes int, value_bytes int, keys 
 	return out
 }
 
-// move moves the map to a new location in memory.
-// It does this by copying to a new location, then setting the
-// old location to all `0` with `vmemset`
+// move moves the map to a new location in memory and resets the old location
+// to an empty map.
 pub fn (mut m map) move() map {
 	r := *m
-	unsafe {
-		vmemset(m, 0, int(sizeof(map)))
-	}
+	m.data = &map_empty_data
 	return r
 }
 

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -193,8 +193,8 @@ type MapCloneFn = fn (voidptr, voidptr)
 
 type MapFreeFn = fn (voidptr)
 
-// map is the internal representation of a V `map` type.
-pub struct map {
+// VMapData contains the internal state of a V `map` type.
+struct VMapData {
 	// Number of bytes of a key
 	key_bytes int
 	// Number of bytes of a value
@@ -220,9 +220,19 @@ mut:
 	key_eq_fn       MapEqFn
 	clone_fn        MapCloneFn
 	free_fn         MapFreeFn
-pub mut:
 	// Number of key-values currently in the hashmap
-	len int
+	count int
+}
+
+// map is the pointer-sized internal representation of a V `map` type.
+pub struct map {
+mut:
+	data &VMapData = unsafe { nil }
+}
+
+// map_empty_data keeps explicitly freed maps readable without retaining their allocated header.
+__global map_empty_data = VMapData{
+	metas: unsafe { nil }
 }
 
 @[inline]
@@ -253,20 +263,20 @@ fn map_eq_int_8(a voidptr, b voidptr) bool {
 // map_map_eq compares two maps for equality.
 // Returns true if both maps have the same keys and associated values.
 fn map_map_eq(a map, b map) bool {
-	if a.len != b.len {
+	if a.data.count != b.data.count {
 		return false
 	}
-	for i := 0; i < a.key_values.len; i++ {
-		if !a.key_values.has_index(i) {
+	for i := 0; i < a.data.key_values.len; i++ {
+		if !a.data.key_values.has_index(i) {
 			continue
 		}
-		k := a.key_values.key(i)
-		if !b.exists(k) {
+		k := a.data.key_values.key(i)
+		if !b.data.exists(k) {
 			return false
 		}
-		va := a.key_values.value(i)
-		vb := b.get(k, va)
-		if unsafe { vmemcmp(va, vb, a.value_bytes) } != 0 {
+		va := a.data.key_values.value(i)
+		vb := b.data.get(k, va)
+		if unsafe { vmemcmp(va, vb, a.data.value_bytes) } != 0 {
 			return false
 		}
 	}
@@ -323,12 +333,11 @@ fn map_free_string(pkey voidptr) {
 fn map_free_nop(_ voidptr) {
 }
 
-fn new_map(key_bytes int, value_bytes int, hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn, free_fn MapFreeFn) map {
+fn new_map_data(key_bytes int, value_bytes int, hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn,
+	free_fn MapFreeFn) &VMapData {
 	// for now assume anything bigger than a pointer is a string
 	has_string_keys := key_bytes > int(sizeof(voidptr))
-	// Keep this as a local before returning it. Alpine's x86_64 TCC can leave fields
-	// uninitialized when this large nested struct is returned as a compound literal.
-	result := map{
+	return &VMapData{
 		key_bytes: key_bytes
 		value_bytes: value_bytes
 		even_index: init_even_index
@@ -337,14 +346,19 @@ fn new_map(key_bytes int, value_bytes int, hash_fn MapHashFn, key_eq_fn MapEqFn,
 		key_values: DenseArray{ key_bytes: key_bytes, value_bytes: value_bytes }
 		metas: unsafe { nil }
 		extra_metas: extra_metas_inc
-		len: 0
+		count: 0
 		has_string_keys: has_string_keys
 		hash_fn: hash_fn
 		key_eq_fn: key_eq_fn
 		clone_fn: clone_fn
 		free_fn: free_fn
 	}
-	return result
+}
+
+fn new_map(key_bytes int, value_bytes int, hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn, free_fn MapFreeFn) map {
+	return map{
+		data: new_map_data(key_bytes, value_bytes, hash_fn, key_eq_fn, clone_fn, free_fn)
+	}
 }
 
 fn new_map_init(hash_fn MapHashFn, key_eq_fn MapEqFn, clone_fn MapCloneFn, free_fn MapFreeFn, n int, key_bytes int,
@@ -392,6 +406,10 @@ pub fn (mut m map) move() map {
 // It does it by setting the map length to `0`
 // Example: mut m := {'abc': 'xyz', 'def': 'aaa'}; m.clear(); assert m.len == 0
 pub fn (mut m map) clear() {
+	m.data.clear()
+}
+
+fn (mut m VMapData) clear() {
 	if m.metas == unsafe { nil } {
 		return
 	}
@@ -408,11 +426,11 @@ pub fn (mut m map) clear() {
 	m.even_index = init_even_index
 	m.cached_hashbits = max_cached_hashbits
 	m.shift = init_log_capicity
-	m.len = 0
+	m.count = 0
 }
 
 @[inline]
-fn (m &map) key_to_index(pkey voidptr) (u32, u32) {
+fn (m &VMapData) key_to_index(pkey voidptr) (u32, u32) {
 	if voidptr(m.hash_fn) == unsafe { nil } {
 		unsafe {
 			p := &u64(m)
@@ -428,7 +446,7 @@ fn (m &map) key_to_index(pkey voidptr) (u32, u32) {
 }
 
 @[inline]
-fn (m &map) meta_less(_index u32, _metas u32) (u32, u32) {
+fn (m &VMapData) meta_less(_index u32, _metas u32) (u32, u32) {
 	mut index := _index
 	mut meta := _metas
 	for meta < unsafe { m.metas[index] } {
@@ -439,7 +457,7 @@ fn (m &map) meta_less(_index u32, _metas u32) (u32, u32) {
 }
 
 @[inline]
-fn (mut m map) meta_greater(_index u32, _metas u32, kvi u32) {
+fn (mut m VMapData) meta_greater(_index u32, _metas u32, kvi u32) {
 	mut meta := _metas
 	mut index := _index
 	mut kv_index := kvi
@@ -469,7 +487,7 @@ fn (mut m map) meta_greater(_index u32, _metas u32, kvi u32) {
 	m.ensure_extra_metas(probe_count)
 }
 
-fn (mut m map) ensure_extra_metas_grow() {
+fn (mut m VMapData) ensure_extra_metas_grow() {
 	size_of_u32 := sizeof(u32)
 	old_mem_size := (m.even_index + 2 + m.extra_metas)
 	m.extra_metas += extra_metas_inc
@@ -482,7 +500,7 @@ fn (mut m map) ensure_extra_metas_grow() {
 }
 
 @[inline]
-fn (mut m map) ensure_extra_metas(probe_count u32) {
+fn (mut m VMapData) ensure_extra_metas(probe_count u32) {
 	if (probe_count << 1) == m.extra_metas {
 		size_of_u32 := sizeof(u32)
 		old_mem_size := (m.even_index + 2 + m.extra_metas)
@@ -504,6 +522,10 @@ fn (mut m map) ensure_extra_metas(probe_count u32) {
 // not equivalent to the key of any other element already in the container.
 // If the key already exists, its value is changed to the value of the new element.
 fn (mut m map) set(key voidptr, value voidptr) {
+	m.data.set(key, value)
+}
+
+fn (mut m VMapData) set(key voidptr, value voidptr) {
 	if m.metas == unsafe { nil } {
 		// Most compiler bookkeeping maps remain empty. Allocate backing storage
 		// only on the first insertion or an explicit reservation.
@@ -512,7 +534,7 @@ fn (mut m map) set(key voidptr, value voidptr) {
 	}
 	// Integer-based load factor check: equivalent to (2*len)/even_index > 0.8
 	// which simplifies to 5*len > 2*even_index (avoids float ops broken in ARM64 backend)
-	if u32(5) * u32(m.len) > u32(2) * m.even_index {
+	if u32(5) * u32(m.count) > u32(2) * m.even_index {
 		m.expand()
 	}
 	mut index, mut meta := m.key_to_index(key)
@@ -539,11 +561,11 @@ fn (mut m map) set(key voidptr, value voidptr) {
 		vmemcpy(pvalue, value, m.value_bytes)
 	}
 	m.meta_greater(index, meta, u32(kv_index))
-	m.len++
+	m.count++
 }
 
 // Doubles the size of the hashmap
-fn (mut m map) expand() {
+fn (mut m VMapData) expand() {
 	old_cap := m.even_index
 	m.even_index = ((m.even_index + 2) << 1) - 2
 	// Check if any hashbits are left
@@ -562,12 +584,12 @@ fn (mut m map) expand() {
 // to their hash value into the newly sized key-value container.
 // Rehashes are performed when the load_factor is going to surpass
 // the max_load_factor in an operation.
-fn (mut m map) rehash() {
+fn (mut m VMapData) rehash() {
 	meta_bytes := sizeof(u32) * (m.even_index + 2 + m.extra_metas)
 	m.reserve_metas(meta_bytes)
 }
 
-fn (mut m map) reserve_metas(meta_bytes u32) {
+fn (mut m VMapData) reserve_metas(meta_bytes u32) {
 	unsafe {
 		// TODO: use realloc_data here too
 		x := v_realloc(byteptr(m.metas), int(meta_bytes))
@@ -587,7 +609,11 @@ fn (mut m map) reserve_metas(meta_bytes u32) {
 
 // reserve ensures that the map can store at least `n` entries without rehashing.
 pub fn (mut m map) reserve(n u32) {
-	if m.len == 0 {
+	m.data.reserve(n)
+}
+
+fn (mut m VMapData) reserve(n u32) {
+	if m.count == 0 {
 		old_index := m.even_index
 		for u64(n) * 5 > u64(m.even_index) * 2 {
 			m.even_index = ((m.even_index + 2) << 1) - 2
@@ -626,7 +652,7 @@ pub fn (mut m map) reserve(n u32) {
 
 // cached_rehashd works like rehash. However, instead of rehashing the
 // key completely, it uses the bits cached in `metas`.
-fn (mut m map) cached_rehash(old_cap u32) {
+fn (mut m VMapData) cached_rehash(old_cap u32) {
 	old_metas := m.metas
 	metasize := int(sizeof(u32) * (m.even_index + 2 + m.extra_metas))
 	m.metas = unsafe { &u32(vcalloc(metasize)) }
@@ -651,6 +677,10 @@ fn (mut m map) cached_rehash(old_cap u32) {
 // does not exist in the map, it's added to the map along with the zero/default value.
 // If the key exists, its respective value is returned.
 fn (mut m map) get_and_set(key voidptr, zero voidptr) voidptr {
+	return m.data.get_and_set(key, zero)
+}
+
+fn (mut m VMapData) get_and_set(key voidptr, zero voidptr) voidptr {
 	if m.metas == unsafe { nil } {
 		m.set(key, zero)
 	}
@@ -681,7 +711,11 @@ fn (mut m map) get_and_set(key voidptr, zero voidptr) voidptr {
 // the method returns a reference to its mapped value.
 // If not, a zero/default value is returned.
 fn (m &map) get(key voidptr, zero voidptr) voidptr {
-	if m.len == 0 {
+	return m.data.get(key, zero)
+}
+
+fn (m &VMapData) get(key voidptr, zero voidptr) voidptr {
+	if m.count == 0 {
 		return zero
 	}
 	mut index, mut meta := m.key_to_index(key)
@@ -708,7 +742,11 @@ fn (m &map) get(key voidptr, zero voidptr) voidptr {
 // If not, a zero pointer is returned.
 // This is used in `x := m['key'] or { ... }`
 fn (m &map) get_check(key voidptr) voidptr {
-	if m.len == 0 {
+	return m.data.get_check(key)
+}
+
+fn (m &VMapData) get_check(key voidptr) voidptr {
+	if m.count == 0 {
 		return 0
 	}
 	mut index, mut meta := m.key_to_index(key)
@@ -734,7 +772,11 @@ fn (m &map) get_check(key voidptr) voidptr {
 // the method returns a reference to the stored key.
 // If not, a zero pointer is returned.
 fn (m &map) get_key_check(key voidptr) voidptr {
-	if m.len == 0 {
+	return m.data.get_key_check(key)
+}
+
+fn (m &VMapData) get_key_check(key voidptr) voidptr {
+	if m.count == 0 {
 		return 0
 	}
 	mut index, mut meta := m.key_to_index(key)
@@ -757,7 +799,11 @@ fn (m &map) get_key_check(key voidptr) voidptr {
 
 // Checks whether a particular key exists in the map.
 fn (m &map) exists(key voidptr) bool {
-	if m.len == 0 {
+	return m.data.exists(key)
+}
+
+fn (m &VMapData) exists(key voidptr) bool {
+	if m.count == 0 {
 		return false
 	}
 	mut index, mut meta := m.key_to_index(key)
@@ -797,7 +843,12 @@ fn (mut d DenseArray) delete(i int) {
 // delete removes the mapping of a particular key from the map.
 @[unsafe]
 pub fn (mut m map) delete(key voidptr) {
-	if m.len == 0 {
+	unsafe { m.data.delete(key) }
+}
+
+@[unsafe]
+fn (mut m VMapData) delete(key voidptr) {
+	if m.count == 0 {
 		return
 	}
 	mut index, mut meta := m.key_to_index(key)
@@ -814,7 +865,7 @@ pub fn (mut m map) delete(key voidptr) {
 				}
 				index += 2
 			}
-			m.len--
+			m.count--
 			m.key_values.delete(kv_index)
 			unsafe {
 				m.metas[index] = 0
@@ -839,7 +890,11 @@ pub fn (mut m map) delete(key voidptr) {
 
 // keys returns all keys in the map.
 pub fn (m &map) keys() array {
-	mut keys := __new_array(m.len, 0, m.key_bytes)
+	return m.data.keys()
+}
+
+fn (m &VMapData) keys() array {
+	mut keys := __new_array(m.count, 0, m.key_bytes)
 	mut item := unsafe { &u8(keys.data) }
 	if m.key_values.deletes == 0 {
 		for i := 0; i < m.key_values.len; i++ {
@@ -866,8 +921,12 @@ pub fn (m &map) keys() array {
 
 // values returns all values in the map.
 pub fn (m &map) values() array {
-	mut values := __new_array(m.len, 0, m.value_bytes)
-	if m.len == 0 {
+	return m.data.values()
+}
+
+fn (m &VMapData) values() array {
+	mut values := __new_array(m.count, 0, m.value_bytes)
+	if m.count == 0 {
 		return values
 	}
 	mut item := unsafe { &u8(values.data) }
@@ -918,11 +977,23 @@ fn (d &DenseArray) clone() DenseArray {
 // clone returns a clone of the `map`.
 @[unsafe]
 pub fn (m &map) clone() map {
+	if m.data == unsafe { nil } || m.data == &map_empty_data {
+		return map{
+			data: &map_empty_data
+		}
+	}
+	return map{
+		data: unsafe { m.data.clone() }
+	}
+}
+
+@[unsafe]
+fn (m &VMapData) clone() &VMapData {
 	if m.metas == unsafe { nil } {
-		return new_map(m.key_bytes, m.value_bytes, m.hash_fn, m.key_eq_fn, m.clone_fn, m.free_fn)
+		return new_map_data(m.key_bytes, m.value_bytes, m.hash_fn, m.key_eq_fn, m.clone_fn, m.free_fn)
 	}
 	metasize := int(sizeof(u32) * (m.even_index + 2 + m.extra_metas))
-	res := map{
+	res := &VMapData{
 		key_bytes: m.key_bytes
 		value_bytes: m.value_bytes
 		even_index: m.even_index
@@ -931,7 +1002,7 @@ pub fn (m &map) clone() map {
 		key_values: unsafe { m.key_values.clone() }
 		metas: unsafe { &u32(malloc_noscan(metasize)) }
 		extra_metas: m.extra_metas
-		len: m.len
+		count: m.count
 		has_string_keys: m.has_string_keys
 		hash_fn: m.hash_fn
 		key_eq_fn: m.key_eq_fn
@@ -955,6 +1026,20 @@ pub fn (m &map) clone() map {
 // free releases all memory resources occupied by the `map`.
 @[unsafe]
 pub fn (m &map) free() {
+	if m.data == unsafe { nil } || m.data == &map_empty_data {
+		return
+	}
+	data := m.data
+	mut target := unsafe { &map(m) }
+	target.data = &map_empty_data
+	unsafe {
+		data.free()
+		free(data)
+	}
+}
+
+@[unsafe]
+fn (m &VMapData) free() {
 	unsafe { free(m.metas) }
 	unsafe {
 		m.metas = nil
@@ -1006,6 +1091,6 @@ pub fn (m &map) free() {
 		m.shift = 0
 		m.extra_metas = 0
 		m.has_string_keys = false
-		m.len = 0
+		m.count = 0
 	}
 }

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -230,7 +230,7 @@ mut:
 	data &VMapData = unsafe { nil }
 }
 
-// map_empty_data keeps freed and moved-from maps readable without retaining their allocated header.
+// map_empty_data keeps freed maps readable without retaining their allocated header.
 __global map_empty_data = VMapData{
 	metas: unsafe { nil }
 }
@@ -395,7 +395,11 @@ fn new_map_update_init(update &map, n int, key_bytes int, value_bytes int, keys 
 // to an empty map.
 pub fn (mut m map) move() map {
 	r := *m
-	m.data = &map_empty_data
+	if m.data == unsafe { nil } || m.data == &map_empty_data {
+		m.data = &map_empty_data
+	} else {
+		m.data = new_map_data(m.data.key_bytes, m.data.value_bytes, m.data.hash_fn, m.data.key_eq_fn, m.data.clone_fn, m.data.free_fn)
+	}
 	return r
 }
 

--- a/vlib/builtin/map_d_gcboehm_opt.v
+++ b/vlib/builtin/map_d_gcboehm_opt.v
@@ -35,20 +35,22 @@ fn new_map_noscan_key(key_bytes int, value_bytes int, hash_fn MapHashFn, key_eq_
 	// for now assume anything bigger than a pointer is a string
 	has_string_keys := key_bytes > sizeof(voidptr)
 	return map{
-		key_bytes:       key_bytes
-		value_bytes:     value_bytes
-		even_index:      init_even_index
-		cached_hashbits: max_cached_hashbits
-		shift:           init_log_capicity
-		key_values:      new_dense_array_noscan(key_bytes, true, value_bytes, false)
-		metas:           unsafe { &u32(vcalloc_noscan(metasize)) }
-		extra_metas:     extra_metas_inc
-		len:             0
-		has_string_keys: has_string_keys
-		hash_fn:         hash_fn
-		key_eq_fn:       key_eq_fn
-		clone_fn:        clone_fn
-		free_fn:         free_fn
+		data: &VMapData{
+			key_bytes:       key_bytes
+			value_bytes:     value_bytes
+			even_index:      init_even_index
+			cached_hashbits: max_cached_hashbits
+			shift:           init_log_capicity
+			key_values:      new_dense_array_noscan(key_bytes, true, value_bytes, false)
+			metas:           unsafe { &u32(vcalloc_noscan(metasize)) }
+			extra_metas:     extra_metas_inc
+			count:           0
+			has_string_keys: has_string_keys
+			hash_fn:         hash_fn
+			key_eq_fn:       key_eq_fn
+			clone_fn:        clone_fn
+			free_fn:         free_fn
+		}
 	}
 }
 
@@ -58,20 +60,22 @@ fn new_map_noscan_value(key_bytes int, value_bytes int, hash_fn MapHashFn, key_e
 	// for now assume anything bigger than a pointer is a string
 	has_string_keys := key_bytes > sizeof(voidptr)
 	return map{
-		key_bytes:       key_bytes
-		value_bytes:     value_bytes
-		even_index:      init_even_index
-		cached_hashbits: max_cached_hashbits
-		shift:           init_log_capicity
-		key_values:      new_dense_array_noscan(key_bytes, false, value_bytes, true)
-		metas:           unsafe { &u32(vcalloc_noscan(metasize)) }
-		extra_metas:     extra_metas_inc
-		len:             0
-		has_string_keys: has_string_keys
-		hash_fn:         hash_fn
-		key_eq_fn:       key_eq_fn
-		clone_fn:        clone_fn
-		free_fn:         free_fn
+		data: &VMapData{
+			key_bytes:       key_bytes
+			value_bytes:     value_bytes
+			even_index:      init_even_index
+			cached_hashbits: max_cached_hashbits
+			shift:           init_log_capicity
+			key_values:      new_dense_array_noscan(key_bytes, false, value_bytes, true)
+			metas:           unsafe { &u32(vcalloc_noscan(metasize)) }
+			extra_metas:     extra_metas_inc
+			count:           0
+			has_string_keys: has_string_keys
+			hash_fn:         hash_fn
+			key_eq_fn:       key_eq_fn
+			clone_fn:        clone_fn
+			free_fn:         free_fn
+		}
 	}
 }
 
@@ -81,20 +85,22 @@ fn new_map_noscan_key_value(key_bytes int, value_bytes int, hash_fn MapHashFn, k
 	// for now assume anything bigger than a pointer is a string
 	has_string_keys := key_bytes > sizeof(voidptr)
 	return map{
-		key_bytes:       key_bytes
-		value_bytes:     value_bytes
-		even_index:      init_even_index
-		cached_hashbits: max_cached_hashbits
-		shift:           init_log_capicity
-		key_values:      new_dense_array_noscan(key_bytes, true, value_bytes, true)
-		metas:           unsafe { &u32(vcalloc_noscan(metasize)) }
-		extra_metas:     extra_metas_inc
-		len:             0
-		has_string_keys: has_string_keys
-		hash_fn:         hash_fn
-		key_eq_fn:       key_eq_fn
-		clone_fn:        clone_fn
-		free_fn:         free_fn
+		data: &VMapData{
+			key_bytes:       key_bytes
+			value_bytes:     value_bytes
+			even_index:      init_even_index
+			cached_hashbits: max_cached_hashbits
+			shift:           init_log_capicity
+			key_values:      new_dense_array_noscan(key_bytes, true, value_bytes, true)
+			metas:           unsafe { &u32(vcalloc_noscan(metasize)) }
+			extra_metas:     extra_metas_inc
+			count:           0
+			has_string_keys: has_string_keys
+			hash_fn:         hash_fn
+			key_eq_fn:       key_eq_fn
+			clone_fn:        clone_fn
+			free_fn:         free_fn
+		}
 	}
 }
 

--- a/vlib/builtin/map_delete_reclaim_test.v
+++ b/vlib/builtin/map_delete_reclaim_test.v
@@ -10,7 +10,7 @@ mut:
 	values      &u8 = unsafe { nil }
 }
 
-struct MapLayoutForTest {
+struct MapDataLayoutForTest {
 	key_bytes   int
 	value_bytes int
 mut:
@@ -26,12 +26,17 @@ mut:
 	clone_fn        voidptr
 	free_fn         voidptr
 pub mut:
-	len int
+	count int
+}
+
+struct MapLayoutForTest {
+mut:
+	data &MapDataLayoutForTest = unsafe { nil }
 }
 
 fn test_map_delete_reclaims_dense_array_tail() {
 	mut m := map[string]string{}
-	raw := unsafe { &MapLayoutForTest(&m) }
+	raw := unsafe { (&MapLayoutForTest(&m)).data }
 	// Establish backing storage before checking repeated insertion/deletion.
 	m['first'] = 'first'
 	m.delete('first')
@@ -53,7 +58,7 @@ fn test_empty_map_defers_storage_until_first_write() {
 	// initializer. Under gcboehm_opt, pointer-free storage uses eager no-scan
 	// allocations by design.
 	mut m := map[string]string{}
-	raw := unsafe { &MapLayoutForTest(&m) }
+	raw := unsafe { (&MapLayoutForTest(&m)).data }
 	assert raw.metas == unsafe { nil }
 	assert raw.key_values.keys == unsafe { nil }
 	assert raw.key_values.values == unsafe { nil }
@@ -118,7 +123,7 @@ fn test_lazy_map_small_reservations_and_nested_first_writes() {
 
 fn test_map_reserve_preallocates_dense_array() {
 	mut m := map[string]int{}
-	raw := unsafe { &MapLayoutForTest(&m) }
+	raw := unsafe { (&MapLayoutForTest(&m)).data }
 	m.reserve(1000)
 	assert raw.key_values.cap >= 1000
 	keys := raw.key_values.keys
@@ -139,8 +144,8 @@ fn test_empty_map_reserve_matches_populated_map_hash_state() {
 		}
 		empty.reserve(u32(n))
 		populated.reserve(u32(n))
-		e := unsafe { &MapLayoutForTest(&empty) }
-		p := unsafe { &MapLayoutForTest(&populated) }
+		e := unsafe { (&MapLayoutForTest(&empty)).data }
+		p := unsafe { (&MapLayoutForTest(&populated)).data }
 		assert e.even_index == p.even_index
 		assert e.cached_hashbits == p.cached_hashbits
 		assert e.shift == p.shift

--- a/vlib/builtin/map_size_test.v
+++ b/vlib/builtin/map_size_test.v
@@ -1,0 +1,16 @@
+interface MapLength {
+	len int
+}
+
+fn test_map_header_is_pointer_sized() {
+	assert sizeof(map[int]int) == sizeof(voidptr)
+}
+
+fn test_map_len_interface_uses_map_data() {
+	m := {
+		'one': 1
+		'two': 2
+	}
+	length := MapLength(m)
+	assert length.len == 2
+}

--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -587,6 +587,18 @@ fn test_map_reserve_keeps_empty_map_valid() {
 	unsafe { moved.free() }
 }
 
+fn test_map_move_leaves_source_empty() {
+	mut original := {
+		'abc': 42
+	}
+	moved := original.move()
+	assert moved.len == 1
+	assert original.len == 0
+	assert 'abc' !in original
+	original.clear()
+	assert original.len == 0
+}
+
 struct MValue {
 	name string
 	misc map[string]string

--- a/vlib/builtin/map_test.v
+++ b/vlib/builtin/map_test.v
@@ -597,6 +597,14 @@ fn test_map_move_leaves_source_empty() {
 	assert 'abc' !in original
 	original.clear()
 	assert original.len == 0
+	original.reserve(32)
+	original['def'] = 24
+	assert original == {
+		'def': 24
+	}
+	assert moved == {
+		'abc': 42
+	}
 }
 
 struct MValue {

--- a/vlib/v/ast/table.v
+++ b/vlib/v/ast/table.v
@@ -1090,6 +1090,15 @@ pub fn (t &Table) struct_fields(sym &TypeSymbol) []StructField {
 pub fn (t &Table) find_field(s &TypeSymbol, name string) !StructField {
 	mut ts := unsafe { s }
 	for {
+		if ts.kind == .map && name == 'len' {
+			return StructField{
+				name:          'len'
+				typ:           int_type
+				unaliased_typ: int_type
+				is_pub:        true
+				is_mut:        true
+			}
+		}
 		match mut ts.info {
 			Struct {
 				if field := ts.info.find_field(name) {
@@ -2761,7 +2770,8 @@ pub fn (mut t Table) complete_interface_check() {
 	}
 	for tk, mut tsym in t.type_symbols {
 		tk_typ := idx_to_type(tk)
-		if tsym.kind != .struct {
+		// VMapData is private storage behind map and cannot be an interface value.
+		if tsym.kind != .struct || (tsym.mod == 'builtin' && tsym.name == 'VMapData') {
 			continue
 		}
 		for _, mut idecl in t.interfaces {

--- a/vlib/v/ast/types.v
+++ b/vlib/v/ast/types.v
@@ -1503,13 +1503,8 @@ pub fn (t &Table) type_size(typ Type) (int, int) {
 			size = info.size * elem_size
 			align = elem_align
 		}
-		// TODO: hardcoded:
 		.map {
-			size = if t.pointer_size == 8 {
-				$if new_int ? && x64 { 144 } $else { 120 }
-			} else {
-				80
-			}
+			size = t.pointer_size
 			align = t.pointer_size
 		}
 		.array {

--- a/vlib/v/checker/checker.v
+++ b/vlib/v/checker/checker.v
@@ -3148,7 +3148,7 @@ fn (mut c Checker) selector_expr(mut node ast.SelectorExpr) ast.Type {
 	field_name := node.field_name
 	mut sym := c.table.final_sym(typ)
 	mut final_sym := c.table.final_sym(typ)
-	if (typ.has_flag(.variadic) || final_sym.kind == .array_fixed) && field_name == 'len' {
+	if (typ.has_flag(.variadic) || final_sym.kind in [.array_fixed, .map]) && field_name == 'len' {
 		node.typ = ast.int_type
 		return ast.int_type
 	}

--- a/vlib/v/gen/c/array.v
+++ b/vlib/v/gen/c/array.v
@@ -681,7 +681,9 @@ fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp
 	elem_styp := g.styp(elem_type.typ)
 	noscan := g.check_noscan(elem_type.typ)
 	is_default_array := elem_type.unaliased_sym.kind == .array && node.has_init
-	is_default_map := elem_type.unaliased_sym.kind == .map && node.has_init
+	// An indexed initializer overwrites every element itself, so it does not need a
+	// cloned map seed. All other map initializers use the map-aware clone helper.
+	is_default_map := elem_type.unaliased_sym.kind == .map && !node.has_index
 	needs_more_defaults := node.has_len && (g.struct_has_array_or_map_field(elem_type.typ)
 		|| elem_type.unaliased_sym.kind in [.array, .map])
 	if node.has_index {
@@ -731,7 +733,7 @@ fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp
 		} else if node.has_len && elem_type.typ == ast.string_type {
 			g.write2('&(${elem_styp}[]){', '_S("")')
 			g.write('})')
-		} else if node.has_len && elem_type.unaliased_sym.kind in [.array, .map] {
+		} else if node.has_len && elem_type.unaliased_sym.kind == .array {
 			g.write2('(voidptr)&(${elem_styp}[]){', g.type_default(elem_type.typ))
 			g.write('}[0])')
 		} else {
@@ -800,8 +802,13 @@ fn (mut g Gen) array_init_with_fields(node ast.ArrayInit, elem_type Type, is_amp
 		g.write('}[0], ${depth})')
 	} else if is_default_map {
 		g.write('(${elem_styp}[]){')
-		g.expr(node.init_expr)
-		g.write('}[0])')
+		if node.has_init {
+			g.expr(node.init_expr)
+			g.write('}[0], false)')
+		} else {
+			g.write(g.type_default(elem_type.typ))
+			g.write('}[0], true)')
+		}
 	} else if needs_more_defaults {
 		tmp := g.new_tmp_var()
 		line := g.go_before_last_stmt().trim_space()

--- a/vlib/v/gen/c/assign.v
+++ b/vlib/v/gen/c/assign.v
@@ -2592,8 +2592,14 @@ fn (mut g Gen) gen_cross_var_assign(node &ast.AssignStmt) {
 				} else if sym.kind == .map {
 					info := sym.info as ast.Map
 					styp := g.styp(info.value_type)
+					val_sym := g.table.final_sym(info.value_type)
+					if val_sym.kind == .map {
+						g.write('${styp} _var_${left.pos.pos} = ')
+						g.gen_map_value_lookup(left, info.key_type, info.value_type, styp, left.left_type.is_ptr(), false, false, false)
+						g.writeln(';')
+						continue
+					}
 					zero := g.type_default(info.value_type)
-					val_sym := g.table.sym(info.value_type)
 					if val_sym.kind == .function {
 						left_type := node.left_types[i]
 						left_sym := g.table.sym(left_type)

--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -558,6 +558,10 @@ fn (mut g Gen) gen_map_equality_fn(left_type ast.Type) string {
 
 	mut fn_builder := strings.new_builder(512)
 	fn_builder.writeln('${g.static_non_parallel}inline bool ${ptr_styp}_map_eq(${ptr_styp} a, ${ptr_styp} b) {')
+	if left.typ.has_flag(.option) {
+		fn_builder.writeln('\tif (a.state != b.state) return false;')
+		fn_builder.writeln('\tif (a.state == 2 && a.state == b.state) return true;')
+	}
 	fn_builder.writeln('\tif (${left_len} != ${right_len}) {')
 	fn_builder.writeln('\t\treturn false;')
 	fn_builder.writeln('\t}')

--- a/vlib/v/gen/c/auto_eq_methods.v
+++ b/vlib/v/gen/c/auto_eq_methods.v
@@ -549,9 +549,9 @@ fn (mut g Gen) gen_map_equality_fn(left_type ast.Type) string {
 	ptr_value_styp := g.styp(value.typ)
 	g.definitions.writeln('${g.static_non_parallel}bool ${ptr_styp}_map_eq(${ptr_styp} a, ${ptr_styp} b);')
 
-	left_len := g.read_map_field_from_option(left.typ, 'len', 'a')
-	right_len := g.read_map_field_from_option(left.typ, 'len', 'b')
-	key_values := g.read_map_field_from_option(left.typ, 'key_values', 'a')
+	left_len := g.read_map_field_from_option(left.typ, 'data->count', 'a')
+	right_len := g.read_map_field_from_option(left.typ, 'data->count', 'b')
+	key_values := g.read_map_field_from_option(left.typ, 'data->key_values', 'a')
 
 	a := if left.typ.has_flag(.option) { g.read_map_from_option(left.typ, 'a') } else { '&a' }
 	b := if left.typ.has_flag(.option) { g.read_map_from_option(left.typ, 'b') } else { '&b' }

--- a/vlib/v/gen/c/auto_str_methods.v
+++ b/vlib/v/gen/c/auto_str_methods.v
@@ -1004,20 +1004,20 @@ fn (mut g Gen) gen_str_for_map(info ast.Map, styp string, str_fn_name string) {
 	g.auto_str_funcs.writeln('${g.static_non_parallel}string ${str_fn_name}(${styp} m) { return indent_${str_fn_name}(m, 0);}')
 	g.definitions.writeln('${g.static_non_parallel}string indent_${str_fn_name}(${styp} m, ${ast.int_type_name} indent_count);')
 	g.auto_str_funcs.writeln('${g.static_non_parallel}string indent_${str_fn_name}(${styp} m, ${ast.int_type_name} indent_count) { /* gen_str_for_map */')
-	g.auto_str_funcs.writeln('\tstrings__Builder sb = strings__new_builder(2 + m.key_values.len * 10);')
+	g.auto_str_funcs.writeln('\tstrings__Builder sb = strings__new_builder(2 + m.data->key_values.len * 10);')
 	g.auto_str_funcs.writeln('\tstrings__Builder_write_string(&sb, _S("{"));')
 	g.auto_str_funcs.writeln('\tbool is_first = true;')
-	g.auto_str_funcs.writeln('\tfor (${ast.int_type_name} i = 0; i < m.key_values.len; ++i) {')
-	g.auto_str_funcs.writeln('\t\tif (!builtin__DenseArray_has_index(&m.key_values, i)) { continue; }')
+	g.auto_str_funcs.writeln('\tfor (${ast.int_type_name} i = 0; i < m.data->key_values.len; ++i) {')
+	g.auto_str_funcs.writeln('\t\tif (!builtin__DenseArray_has_index(&m.data->key_values, i)) { continue; }')
 	g.auto_str_funcs.writeln('\t\telse if (!is_first) { strings__Builder_write_string(&sb, _S(", ")); }')
 
 	if key_sym.kind == .string {
-		g.auto_str_funcs.writeln('\t\tstring key = *(string*)builtin__DenseArray_key(&m.key_values, i);')
+		g.auto_str_funcs.writeln('\t\tstring key = *(string*)builtin__DenseArray_key(&m.data->key_values, i);')
 	} else if key_sym.kind == .array_fixed {
 		g.auto_str_funcs.writeln('\t\t${key_styp} key;')
-		g.auto_str_funcs.writeln('\t\tmemcpy(key, builtin__DenseArray_key(&m.key_values, i), sizeof(${key_styp}));')
+		g.auto_str_funcs.writeln('\t\tmemcpy(key, builtin__DenseArray_key(&m.data->key_values, i), sizeof(${key_styp}));')
 	} else {
-		g.auto_str_funcs.writeln('\t\t${key_styp} key = *(${key_styp}*)builtin__DenseArray_key(&m.key_values, i);')
+		g.auto_str_funcs.writeln('\t\t${key_styp} key = *(${key_styp}*)builtin__DenseArray_key(&m.data->key_values, i);')
 	}
 	if key_sym.kind == .string {
 		g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${str_intp_sq('key')});')
@@ -1038,9 +1038,9 @@ fn (mut g Gen) gen_str_for_map(info ast.Map, styp string, str_fn_name string) {
 	} else if val_sym.kind == .string {
 		if val_typ.has_flag(.option) {
 			func := g.get_str_fn(val_typ)
-			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${func}(*(${val_styp}*)builtin__DenseArray_value(&m.key_values, i)));')
+			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${func}(*(${val_styp}*)builtin__DenseArray_value(&m.data->key_values, i)));')
 		} else {
-			tmp_str := str_intp_sq('*(${val_styp}*)builtin__DenseArray_value(&m.key_values, i)')
+			tmp_str := str_intp_sq('*(${val_styp}*)builtin__DenseArray_value(&m.data->key_values, i)')
 			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${tmp_str});')
 		}
 	} else if should_use_indent_func(val_sym.kind) && fn_str.name != 'str' {
@@ -1049,11 +1049,11 @@ fn (mut g Gen) gen_str_for_map(info ast.Map, styp string, str_fn_name string) {
 		} else {
 			'*'.repeat(val_typ.nr_muls() + 1)
 		}
-		g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, indent_${elem_str_fn_name}(${deref}(${val_styp}*)builtin__DenseArray_value(&m.key_values, i), indent_count));')
+		g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, indent_${elem_str_fn_name}(${deref}(${val_styp}*)builtin__DenseArray_value(&m.data->key_values, i), indent_count));')
 	} else if val_sym.kind in [.f32, .f64] {
-		tmp_val := '*(${val_styp}*)builtin__DenseArray_value(&m.key_values, i)'
+		tmp_val := '*(${val_styp}*)builtin__DenseArray_value(&m.data->key_values, i)'
 		if val_typ.has_flag(.option) {
-			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${g.get_str_fn(val_typ)}(*(${val_styp}*)builtin__DenseArray_value(&m.key_values, i)));')
+			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${g.get_str_fn(val_typ)}(*(${val_styp}*)builtin__DenseArray_value(&m.data->key_values, i)));')
 		} else {
 			if val_sym.kind == .f32 {
 				g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${str_intp_g32(tmp_val)});')
@@ -1063,16 +1063,16 @@ fn (mut g Gen) gen_str_for_map(info ast.Map, styp string, str_fn_name string) {
 		}
 	} else if val_sym.kind == .rune {
 		tmp_str :=
-			str_intp_rune('${elem_str_fn_name}(*(${val_styp}*)builtin__DenseArray_value(&m.key_values, i))')
+			str_intp_rune('${elem_str_fn_name}(*(${val_styp}*)builtin__DenseArray_value(&m.data->key_values, i))')
 		g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${tmp_str});')
 	} else {
 		deref := '*'.repeat(val_typ.nr_muls())
 		if val_typ.has_flag(.option) {
-			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${g.get_str_fn(val_typ)}(*${deref}(${val_styp}*)builtin__DenseArray_value(&m.key_values, i)));')
+			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${g.get_str_fn(val_typ)}(*${deref}(${val_styp}*)builtin__DenseArray_value(&m.data->key_values, i)));')
 		} else if receiver_is_ptr {
-			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${elem_str_fn_name}(${deref}(${val_styp}*)builtin__DenseArray_value(&m.key_values, i)));')
+			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${elem_str_fn_name}(${deref}(${val_styp}*)builtin__DenseArray_value(&m.data->key_values, i)));')
 		} else {
-			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${elem_str_fn_name}(*${deref}(${val_styp}*)builtin__DenseArray_value(&m.key_values, i)));')
+			g.auto_str_funcs.writeln('\t\tstrings__Builder_write_string(&sb, ${elem_str_fn_name}(*${deref}(${val_styp}*)builtin__DenseArray_value(&m.data->key_values, i)));')
 		}
 	}
 	g.auto_str_funcs.writeln('\t\tis_first = false;')

--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -8075,7 +8075,15 @@ fn (mut g Gen) selector_expr(node ast.SelectorExpr) {
 	}
 	unwrapped_expr_type := g.unwrap_generic(lhs_expr_type)
 	sym := g.table.sym(unwrapped_expr_type)
-	field_name := if sym.language == .v { c_name(node.field_name) } else { node.field_name }
+	is_map_len := g.table.final_sym(unwrapped_expr_type).kind == .map
+		&& node.field_name == 'len'
+	field_name := if is_map_len {
+		'data->count'
+	} else if sym.language == .v {
+		c_name(node.field_name)
+	} else {
+		node.field_name
+	}
 	resolved_selector_expr_type := if lhs_expr_type.has_flag(.generic)
 		|| g.type_has_unresolved_generic_parts(lhs_expr_type) {
 		unwrapped_expr_type
@@ -14469,6 +14477,9 @@ fn (mut g Gen) interface_field_ptr_expr(st ast.Type, cctype string, field ast.St
 	cname := c_name(field.name)
 	field_styp := g.styp(field.typ)
 	resolved_st_sym := g.table.final_sym(st)
+	if resolved_st_sym.kind == .map && field.name == 'len' {
+		return '(${field_styp}*)(&x->data->count)'
+	}
 	if _ := g.table.find_field(resolved_st_sym, field.name) {
 		return '(${field_styp}*)((char*)x + __offsetof_ptr(x, ${cctype}, ${cname}))'
 	}

--- a/vlib/v/gen/c/coutput_test.v
+++ b/vlib/v/gen/c/coutput_test.v
@@ -283,6 +283,9 @@ fn test_addressable_map_fallback_does_not_allocate_carrier() {
 	ensure_compilation_succeeded(compilation, cmd)
 	assert !generated_c_uses_v3_codegen(compilation.output)
 	assert compilation.output.contains('Map_string_main__Entry _t')
+	assert compilation.output.contains('*ADDR(Map_string_main__Entry, ({')
+	assert compilation.output.contains('*((Map_string_main__Entry*)')
+	assert !compilation.output.contains('} (Map_string_main__Entry*)')
 	assert !compilation.output.contains('builtin__memdup(ADDR(Map_string_main__Entry')
 }
 

--- a/vlib/v/gen/c/coutput_test.v
+++ b/vlib/v/gen/c/coutput_test.v
@@ -275,6 +275,17 @@ fn test_map_guard_without_observed_error_does_not_allocate_error() {
 	assert !body.contains('builtin___v_error(')
 }
 
+fn test_addressable_map_fallback_does_not_allocate_carrier() {
+	os.chdir(vroot) or {}
+	path := os.join_path(testdata_folder, 'map_value_lookup_lazy_default.vv')
+	cmd := '${os.quoted_path(vexe)} -old-compiler -o - ${os.quoted_path(path)}'
+	compilation := os.execute(cmd)
+	ensure_compilation_succeeded(compilation, cmd)
+	assert !generated_c_uses_v3_codegen(compilation.output)
+	assert compilation.output.contains('Map_string_main__Entry _t')
+	assert !compilation.output.contains('builtin__memdup(ADDR(Map_string_main__Entry')
+}
+
 fn test_or_block_err_var_collision_does_not_emit_self_referential_err() {
 	os.chdir(vroot) or {}
 	path := os.join_path(testdata_folder, 'or_block_err_var_collision.vv')

--- a/vlib/v/gen/c/for.v
+++ b/vlib/v/gen/c/for.v
@@ -990,20 +990,21 @@ fn (mut g Gen) for_in_stmt(node_ ast.ForInStmt) {
 			'++${idx}'
 		}
 		map_len := g.new_tmp_var()
+		key_values := '${cond_var}${dot_or_ptr}data->key_values'
 		g.empty_line = true
-		g.writeln('${ast.int_type_name} ${map_len} = ${cond_var}${dot_or_ptr}key_values.len;')
+		g.writeln('${ast.int_type_name} ${map_len} = ${key_values}.len;')
 		g.writeln('for (${ast.int_type_name} ${idx} = 0; ${idx} < ${map_len}; ${plus_plus_idx} ) {')
 		// TODO: don't have this check when the map has no deleted elements
 		g.indent++
 		diff := g.new_tmp_var()
-		g.writeln('${ast.int_type_name} ${diff} = ${cond_var}${dot_or_ptr}key_values.len - ${map_len};')
-		g.writeln('${map_len} = ${cond_var}${dot_or_ptr}key_values.len;')
+		g.writeln('${ast.int_type_name} ${diff} = ${key_values}.len - ${map_len};')
+		g.writeln('${map_len} = ${key_values}.len;')
 		// TODO: optimize this
 		g.writeln('if (${diff} < 0) {')
 		g.writeln('\t${idx} = -1;')
 		g.writeln('\tcontinue;')
 		g.writeln('}')
-		g.writeln('if (!builtin__DenseArray_has_index(&${cond_var}${dot_or_ptr}key_values, ${idx})) {continue;}')
+		g.writeln('if (!builtin__DenseArray_has_index(&${key_values}, ${idx})) {continue;}')
 		if node.cond is ast.Ident {
 			cond_ident := node.cond as ast.Ident
 			resolved_key_type := g.resolve_current_fn_generic_param_key_type(cond_ident.name)
@@ -1026,9 +1027,9 @@ fn (mut g Gen) for_in_stmt(node_ ast.ForInStmt) {
 			key := c_name(node.key_var)
 			if g.table.final_sym(node.key_type).kind == .array_fixed {
 				g.writeln('${key_styp} ${key};')
-				g.writeln('memcpy(${key}, builtin__DenseArray_key(&${cond_var}${dot_or_ptr}key_values, ${idx}), sizeof(${key_styp}));')
+				g.writeln('memcpy(${key}, builtin__DenseArray_key(&${key_values}, ${idx}), sizeof(${key_styp}));')
 			} else {
-				g.writeln('${key_styp} ${key} = *(${key_styp}*)builtin__DenseArray_key(&${cond_var}${dot_or_ptr}key_values, ${idx});')
+				g.writeln('${key_styp} ${key} = *(${key_styp}*)builtin__DenseArray_key(&${key_values}, ${idx});')
 			}
 			// TODO: analyze whether node.key_type has a .clone() method and call .clone() for all types:
 			if node.key_type == ast.string_type {
@@ -1041,11 +1042,11 @@ fn (mut g Gen) for_in_stmt(node_ ast.ForInStmt) {
 				tcc_bug := c_name(node.val_var)
 				g.write_fn_ptr_decl(&val_sym.info, tcc_bug)
 				g.write(' = (*(voidptr*)')
-				g.writeln('builtin__DenseArray_value(&${cond_var}${dot_or_ptr}key_values, ${idx}));')
+				g.writeln('builtin__DenseArray_value(&${key_values}, ${idx}));')
 			} else if val_sym.kind == .array_fixed && !node.val_is_mut {
 				val_styp := g.styp(node.val_type)
 				g.writeln('${val_styp} ${c_name(node.val_var)};')
-				g.writeln('memcpy(*(${val_styp}*)${c_name(node.val_var)}, (byte*)builtin__DenseArray_value(&${cond_var}${dot_or_ptr}key_values, ${idx}), sizeof(${val_styp}));')
+				g.writeln('memcpy(*(${val_styp}*)${c_name(node.val_var)}, (byte*)builtin__DenseArray_value(&${key_values}, ${idx}), sizeof(${val_styp}));')
 			} else {
 				val_styp := g.styp(node.val_type)
 				if node.val_is_mut || node.val_is_ref {
@@ -1057,7 +1058,7 @@ fn (mut g Gen) for_in_stmt(node_ ast.ForInStmt) {
 				} else {
 					g.write('${val_styp} ${c_name(node.val_var)} = (*(${val_styp}*)')
 				}
-				g.writeln('builtin__DenseArray_value(&${cond_var}${dot_or_ptr}key_values, ${idx}));')
+				g.writeln('builtin__DenseArray_value(&${key_values}, ${idx}));')
 			}
 		}
 		g.indent--

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -845,6 +845,11 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 	} else if !gen_or && (g.inside_map_postfix || g.inside_map_infix
 		|| g.inside_map_index || g.inside_array_index || g.inside_left_shift
 		|| (g.is_assign_lhs && !g.is_arraymap_set && get_and_set_types)) {
+		if val_sym.kind == .map {
+			is_mutable_lookup := use_get_and_set || (g.is_assign_lhs && g.inside_map_index)
+			g.gen_map_value_lookup(node, key_type, val_type, val_type_str, left_is_ptr, left_is_shared, is_mutable_lookup, true)
+			return
+		}
 		zero := g.type_default(val_type)
 		if use_get_and_set {
 			g.write('(*(${val_type_str}*)builtin__map_get_and_set((map*)')
@@ -865,6 +870,10 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 		g.is_assign_lhs = old_is_assign_lhs
 		g.write(', &(${val_type_str}[]){ ${zero} }))')
 	} else {
+		if !gen_or && val_sym.kind == .map {
+			g.gen_map_value_lookup(node, key_type, val_type, val_type_str, left_is_ptr, left_is_shared, false, false)
+			return
+		}
 		zero := g.type_default(val_type)
 		is_gen_or_and_assign_rhs := gen_or && !g.discard_or_result
 		cur_line := if is_gen_or_and_assign_rhs {
@@ -998,5 +1007,61 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 				}
 			}
 		}
+	}
+}
+
+// gen_map_value_lookup emits a lookup whose empty map fallback is constructed only
+// when the key is absent. A map default owns a heap-allocated header, so passing it
+// eagerly to map_get would leak the discarded header for every successful lookup.
+fn (mut g Gen) gen_map_value_lookup(node ast.IndexExpr, key_type ast.Type, val_type ast.Type, val_type_str string, left_is_ptr bool, left_is_shared bool, insert_if_missing bool, addressable bool) {
+	map_tmp := g.new_tmp_var()
+	key_tmp := g.new_tmp_var()
+	value_tmp := g.new_tmp_var()
+	if insert_if_missing || addressable {
+		g.write('(*({ map* ${map_tmp} = (map*)')
+	} else {
+		g.write('({ map* ${map_tmp} = (map*)')
+	}
+	if insert_if_missing {
+		// Mutating lookups must retain the address of the original map.
+		if !left_is_ptr || left_is_shared {
+			g.write('&')
+		}
+		g.expr(node.left)
+		if left_is_shared {
+			g.write('->val')
+		}
+	} else {
+		// ADDR also gives value-returning map expressions a stable address.
+		if !left_is_ptr || left_is_shared {
+			g.write('ADDR(map, ')
+			g.expr(node.left)
+			g.write(')')
+		} else {
+			g.write('(')
+			g.expr(node.left)
+			g.write(')')
+		}
+		if left_is_shared {
+			if left_is_ptr {
+				g.write('->val')
+			} else {
+				g.write('.val')
+			}
+		}
+	}
+	g.write('; void* ${key_tmp} = ')
+	old_is_assign_lhs := g.is_assign_lhs
+	g.is_assign_lhs = false
+	g.write_map_key_arg(node.index, key_type)
+	g.is_assign_lhs = old_is_assign_lhs
+	g.write('; void* ${value_tmp} = builtin__map_get_check(${map_tmp}, ${key_tmp}); ')
+	zero := g.type_default(val_type)
+	if insert_if_missing {
+		g.write('if (!${value_tmp}) { ${value_tmp} = builtin__map_get_and_set(${map_tmp}, ${key_tmp}, &(${val_type_str}[]){ ${zero} }); } (${val_type_str}*)${value_tmp}; }))')
+	} else if addressable {
+		g.write('if (!${value_tmp}) { ${value_tmp} = builtin__memdup(ADDR(${val_type_str}, ${zero}), sizeof(${val_type_str})); } (${val_type_str}*)${value_tmp}; }))')
+	} else {
+		g.write('${value_tmp} ? *((${val_type_str}*)${value_tmp}) : ${zero}; })')
 	}
 }

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -1017,8 +1017,11 @@ fn (mut g Gen) gen_map_value_lookup(node ast.IndexExpr, key_type ast.Type, val_t
 	map_tmp := g.new_tmp_var()
 	key_tmp := g.new_tmp_var()
 	value_tmp := g.new_tmp_var()
-	if insert_if_missing || addressable {
+	if insert_if_missing {
 		g.write('(*({ map* ${map_tmp} = (map*)')
+	} else if addressable {
+		// The outer ADDR carrier keeps the copied value alive after the statement expression ends.
+		g.write('(*ADDR(${val_type_str}, ({ map* ${map_tmp} = (map*)')
 	} else {
 		g.write('({ map* ${map_tmp} = (map*)')
 	}
@@ -1036,18 +1039,19 @@ fn (mut g Gen) gen_map_value_lookup(node ast.IndexExpr, key_type ast.Type, val_t
 		if !left_is_ptr || left_is_shared {
 			g.write('ADDR(map, ')
 			g.expr(node.left)
+			if left_is_shared {
+				// Project the shared value before ADDR closes so it receives a map expression.
+				if left_is_ptr {
+					g.write('->val')
+				} else {
+					g.write('.val')
+				}
+			}
 			g.write(')')
 		} else {
 			g.write('(')
 			g.expr(node.left)
 			g.write(')')
-		}
-		if left_is_shared {
-			if left_is_ptr {
-				g.write('->val')
-			} else {
-				g.write('.val')
-			}
 		}
 	}
 	g.write('; void* ${key_tmp} = ')
@@ -1061,7 +1065,7 @@ fn (mut g Gen) gen_map_value_lookup(node ast.IndexExpr, key_type ast.Type, val_t
 		g.write('if (!${value_tmp}) { ${value_tmp} = builtin__map_get_and_set(${map_tmp}, ${key_tmp}, &(${val_type_str}[]){ ${zero} }); } (${val_type_str}*)${value_tmp}; }))')
 	} else if addressable {
 		zero_tmp := g.new_tmp_var()
-		g.write('${val_type_str} ${zero_tmp}; if (!${value_tmp}) { ${zero_tmp} = ${zero}; ${value_tmp} = &${zero_tmp}; } (${val_type_str}*)${value_tmp}; }))')
+		g.write('${val_type_str} ${zero_tmp}; if (!${value_tmp}) { ${zero_tmp} = ${zero}; ${value_tmp} = &${zero_tmp}; } *((${val_type_str}*)${value_tmp}); })))')
 	} else {
 		g.write('${value_tmp} ? *((${val_type_str}*)${value_tmp}) : ${zero}; })')
 	}

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -1060,7 +1060,8 @@ fn (mut g Gen) gen_map_value_lookup(node ast.IndexExpr, key_type ast.Type, val_t
 	if insert_if_missing {
 		g.write('if (!${value_tmp}) { ${value_tmp} = builtin__map_get_and_set(${map_tmp}, ${key_tmp}, &(${val_type_str}[]){ ${zero} }); } (${val_type_str}*)${value_tmp}; }))')
 	} else if addressable {
-		g.write('if (!${value_tmp}) { ${value_tmp} = builtin__memdup(ADDR(${val_type_str}, ${zero}), sizeof(${val_type_str})); } (${val_type_str}*)${value_tmp}; }))')
+		zero_tmp := g.new_tmp_var()
+		g.write('${val_type_str} ${zero_tmp}; if (!${value_tmp}) { ${zero_tmp} = ${zero}; ${value_tmp} = &${zero_tmp}; } (${val_type_str}*)${value_tmp}; }))')
 	} else {
 		g.write('${value_tmp} ? *((${val_type_str}*)${value_tmp}) : ${zero}; })')
 	}

--- a/vlib/v/gen/c/json.v
+++ b/vlib/v/gen/c/json.v
@@ -1368,7 +1368,6 @@ fn (mut g Gen) encode_map(utyp ast.Type, key_type ast.Type, value_type ast.Type)
 	key_array_type := ast.idx_to_type(g.table.find_or_register_array(key_type))
 	key_array_styp := g.styp(key_array_type)
 	fn_name_v := js_enc_name(styp_v)
-	zero := g.type_default(value_type)
 	keys_tmp := g.new_tmp_var()
 	mut key := 'string key = '
 	if key_type.is_string() {
@@ -1383,7 +1382,7 @@ fn (mut g Gen) encode_map(utyp ast.Type, key_type ast.Type, value_type ast.Type)
 		${key_array_styp} ${keys_tmp} = builtin__map_keys((map*)val.data);
 		for (${ast.int_type_name} i = 0; i < ${keys_tmp}.len; ++i) {
 			${key}
-			cJSON_AddItemToObject(o, (char*) key.str, ${fn_name_v} ( *(${styp_v}*) builtin__map_get((map*)val.data, &key, &(${styp_v}[]) { ${zero} } ) ) );
+			cJSON_AddItemToObject(o, (char*) key.str, ${fn_name_v} ( *(${styp_v}*) builtin__map_get_check((map*)val.data, &key) ) );
 		}
 		builtin__array_free(&${keys_tmp});
 '
@@ -1394,7 +1393,7 @@ fn (mut g Gen) encode_map(utyp ast.Type, key_type ast.Type, value_type ast.Type)
 		${key_array_styp} ${keys_tmp} = builtin__map_keys(${ref}val);
 		for (${ast.int_type_name} i = 0; i < ${keys_tmp}.len; ++i) {
 			${key}
-			cJSON_AddItemToObject(o, (char*) key.str, ${fn_name_v} ( *(${styp_v}*) builtin__map_get(${ref}val, &key, &(${styp_v}[]) { ${zero} } ) ) );
+			cJSON_AddItemToObject(o, (char*) key.str, ${fn_name_v} ( *(${styp_v}*) builtin__map_get_check(${ref}val, &key) ) );
 		}
 		builtin__array_free(&${keys_tmp});
 '

--- a/vlib/v/gen/c/testdata/map_value_lookup_lazy_default.c.must_have
+++ b/vlib/v/gen/c/testdata/map_value_lookup_lazy_default.c.must_have
@@ -1,2 +1,6 @@
 builtin__map_get_check(_t2, _t3); _t4 ? *((Map_string_int*)_t4) : builtin__new_map
 if (!_t3) { _t3 = builtin__map_get_and_set(_t1, _t2, &(Map_string_int[]){ builtin__new_map
+Map_string_main__Entry _t
+builtin____new_array_with_map_default(2, 0, sizeof(Map_string_int)
+}[0], true)
+}[0], false)

--- a/vlib/v/gen/c/testdata/map_value_lookup_lazy_default.c.must_have
+++ b/vlib/v/gen/c/testdata/map_value_lookup_lazy_default.c.must_have
@@ -1,0 +1,2 @@
+builtin__map_get_check(_t2, _t3); _t4 ? *((Map_string_int*)_t4) : builtin__new_map
+if (!_t3) { _t3 = builtin__map_get_and_set(_t1, _t2, &(Map_string_int[]){ builtin__new_map

--- a/vlib/v/gen/c/testdata/map_value_lookup_lazy_default.vv
+++ b/vlib/v/gen/c/testdata/map_value_lookup_lazy_default.vv
@@ -1,0 +1,22 @@
+// vtest vflags: -old-compiler
+
+fn read_present(values map[string]map[string]int) int {
+	return values['present'].len
+}
+
+fn set_nested(mut values map[string]map[string]int) {
+	values['created']['answer'] = 42
+}
+
+fn main() {
+	mut values := {
+		'present': {
+			'answer': 7
+		}
+	}
+	for _ in 0 .. 100 {
+		assert read_present(values) == 1
+	}
+	set_nested(mut values)
+	assert values['created']['answer'] == 42
+}

--- a/vlib/v/gen/c/testdata/map_value_lookup_lazy_default.vv
+++ b/vlib/v/gen/c/testdata/map_value_lookup_lazy_default.vv
@@ -8,6 +8,15 @@ fn set_nested(mut values map[string]map[string]int) {
 	values['created']['answer'] = 42
 }
 
+struct Entry {
+mut:
+	answer int
+}
+
+fn set_field_on_missing_nested_map(mut values map[string]map[string]Entry) {
+	values['missing']['child'].answer = 42
+}
+
 fn main() {
 	mut values := {
 		'present': {
@@ -19,4 +28,27 @@ fn main() {
 	}
 	set_nested(mut values)
 	assert values['created']['answer'] == 42
+
+	mut missing := map[string]map[string]Entry{}
+	set_field_on_missing_nested_map(mut missing)
+	assert missing.len == 0
+
+	mut defaults := []map[string]int{len: 2}
+	defaults[0]['changed'] = 1
+	assert defaults[1].len == 0
+
+	mut seed := {
+		'present': 1
+	}
+	initialized := []map[string]int{len: 2, init: seed}
+	seed['still_valid'] = 2
+	assert seed.len == 2
+	assert initialized[0].len == 1
+	assert initialized[1].len == 1
+
+	indexed := []map[string]int{len: 2, init: {
+		'index': index
+	}}
+	assert indexed[0]['index'] == 0
+	assert indexed[1]['index'] == 1
 }

--- a/vlib/v/tests/builtin_maps/map_pointer_sized_value_equality_test.v
+++ b/vlib/v/tests/builtin_maps/map_pointer_sized_value_equality_test.v
@@ -1,0 +1,65 @@
+fn test_map_pointer_sized_scalar_values_compare_without_map_dispatch() {
+	i64_left := {
+		'value': i64(17)
+	}
+	i64_right := {
+		'value': i64(17)
+	}
+	i64_different := {
+		'value': i64(18)
+	}
+	assert i64_left == i64_right
+	assert i64_left != i64_different
+
+	u64_left := {
+		'value': u64(17)
+	}
+	u64_right := {
+		'value': u64(17)
+	}
+	assert u64_left == u64_right
+
+	f64_left := {
+		'value': f64(17.5)
+	}
+	f64_right := {
+		'value': f64(17.5)
+	}
+	assert f64_left == f64_right
+	positive_zero := {
+		'value': f64(0.0)
+	}
+	negative_zero := {
+		'value': -f64(0.0)
+	}
+	assert positive_zero == negative_zero
+
+	value := 17
+	pointer_left := {
+		'value': voidptr(&value)
+	}
+	pointer_right := {
+		'value': voidptr(&value)
+	}
+	assert pointer_left == pointer_right
+}
+
+fn test_nested_map_values_use_semantic_equality() {
+	left := {
+		'outer': {
+			'inner': 17
+		}
+	}
+	right := {
+		'outer': {
+			'inner': 17
+		}
+	}
+	different := {
+		'outer': {
+			'inner': 18
+		}
+	}
+	assert left == right
+	assert left != different
+}

--- a/vlib/v/tests/nested_map_shared_lookup_test.v
+++ b/vlib/v/tests/nested_map_shared_lookup_test.v
@@ -1,0 +1,40 @@
+fn test_missing_nested_map_lookup() {
+	outer := map[string]map[string]int{}
+	assert outer['missing']['child'] == 0
+}
+
+struct NestedMapEntry {
+mut:
+	value int
+}
+
+fn test_addressable_missing_nested_map_lookup() {
+	mut outer := map[string]map[string]NestedMapEntry{}
+	outer['missing']['child'].value = 42
+	assert outer.len == 0
+}
+
+fn test_shared_map_value_lookup() {
+	shared outer := {
+		'present': {
+			'answer': 42
+		}
+	}
+	rlock outer {
+		assert outer['present'].len == 1
+		assert outer['present']['answer'] == 42
+		assert outer['missing'].len == 0
+	}
+}
+
+fn test_shared_map_pointer_value_lookup() {
+	shared outer := &{
+		'present': {
+			'answer': 42
+		}
+	}
+	rlock outer {
+		assert outer['present'].len == 1
+		assert outer['present']['answer'] == 42
+	}
+}

--- a/vlib/v/tests/options/option_map_container_equality_test.v
+++ b/vlib/v/tests/options/option_map_container_equality_test.v
@@ -1,0 +1,21 @@
+fn test_array_of_optional_map_equality() {
+	none_map := ?map[string]int(none)
+	some_map := ?map[string]int({
+		'answer': 42
+	})
+
+	assert [none_map] == [none_map]
+	assert [none_map] != [some_map]
+	assert [some_map] == [some_map]
+}
+
+fn test_fixed_array_of_optional_map_equality() {
+	none_map := ?map[string]int(none)
+	some_map := ?map[string]int({
+		'answer': 42
+	})
+
+	assert [none_map]! == [none_map]!
+	assert [none_map]! != [some_map]!
+	assert [some_map]! == [some_map]!
+}

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -15082,6 +15082,20 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			} else if base_type is types.Map {
 				c_key := g.map_key_temp_c_type(base_type.key_type)
 				c_val := g.value_c_type(base_type.value_type)
+				if default_init_unalias_type(base_type.value_type) is types.Map {
+					map_tmp := g.tmp_name()
+					value_tmp := g.tmp_name()
+					zero_tmp := g.tmp_name()
+					// Keep the allocating map default behind the missing-key branch.
+					g.write('(*({ map* ${map_tmp} = &((map[]){')
+					g.gen_expr(base_id)
+					g.write('}[0]); void* ${value_tmp} = map__get_check(${map_tmp}, &(${c_key}[]){')
+					g.gen_expr(g.a.child(node, 1))
+					g.write('}); ${c_val} ${zero_tmp}; if (!${value_tmp}) { ${zero_tmp} = ')
+					g.gen_default_value_for_type(base_type.value_type)
+					g.write('; ${value_tmp} = &${zero_tmp}; } (${c_val}*)${value_tmp}; }))')
+					return
+				}
 				// The map expression may be a value-returning call. Put it in a compound
 				// literal so C can take a stable address for the duration of map__get.
 				g.write('(*(${c_val}*)map__get(&((map[]){')
@@ -16209,14 +16223,9 @@ fn (mut g FlatGen) gen_map_infix_eq(node flat.Node, lhs_id flat.NodeId, rhs_id f
 	if clean_lhs !is types.Map || map_str_clean_type(rhs_type) !is types.Map {
 		return false
 	}
-	// v3_map_map_eq compares value payloads it does not recognize bytewise. That
-	// is wrong whenever a value's semantic equality differs from its bytes — a
-	// struct/sum type/fixed array holding strings, arrays or maps. The
-	// transformer lowers those maps directly to element-wise comparisons; only
-	// fall back to the raw helper for value types it compares correctly (its
-	// size dispatch handles primitives, pointers, strings, and dynamic maps and
-	// arrays of those). Otherwise leave the comparison unlowered rather than
-	// emit a silently incorrect result.
+	// The runtime helper has no semantic type descriptor. The transformer lowers
+	// strings and containers to typed comparisons; only bytewise scalar values
+	// may reach this fallback.
 	if !g.map_value_bytewise_eq_safe((clean_lhs as types.Map).value_type) {
 		return false
 	}
@@ -16231,38 +16240,25 @@ fn (mut g FlatGen) gen_map_infix_eq(node flat.Node, lhs_id flat.NodeId, rhs_id f
 	return true
 }
 
-// map_value_bytewise_eq_safe reports whether v3_map_map_eq compares a map value
-// of this type correctly. Its size dispatch handles primitive/pointer/string
-// values and recurses through dynamic maps and arrays of such values, but
-// falls back to a raw memcmp for anything else (structs, sum types, fixed
-// arrays, interfaces, options), which breaks semantic equality.
+// map_value_bytewise_eq_safe reports whether v3_map_map_eq can compare a map
+// value without semantic type information. Container and string values are
+// lowered to typed comparisons by the transformer; the runtime fallback must
+// never infer their type from a byte count.
 fn (g &FlatGen) map_value_bytewise_eq_safe(value_type types.Type) bool {
 	clean := default_init_unalias_type(value_type)
-	if clean is types.Map {
-		// v3_map_map_eq recurses into map values through itself, so a nested map
-		// is safe as long as its own value type is.
-		return g.map_value_bytewise_eq_safe(clean.value_type)
-	}
-	if clean is types.Array {
-		// The runtime helper's Array case only compares string elements
-		// (array_eq_string) or primitive/pointer elements (array_eq_raw)
-		// correctly; arrays of maps, structs, or nested arrays fall through to a
-		// bytewise element compare of their descriptors. Only flat element types
-		// are safe here — anything else is left to the transform's element-wise
-		// path.
-		return g.map_scalar_bytewise_eq_safe(clean.elem_type)
-	}
 	return g.map_scalar_bytewise_eq_safe(clean)
 }
 
 // map_scalar_bytewise_eq_safe reports whether a bytewise (memcmp/array_eq_raw)
 // comparison of a single value of this type matches its semantic equality.
-// True only for types with no indirection to follow: primitives, enums,
-// pointers (compared by address), and strings (which v3_map_map_eq / array
-// helpers special-case).
+// True only for types with no indirection or representation-level equality
+// differences: integer/boolean primitives, enums, pointers, and nil.
 fn (g &FlatGen) map_scalar_bytewise_eq_safe(t types.Type) bool {
 	clean := default_init_unalias_type(t)
-	return clean is types.Primitive || clean is types.Char || clean is types.Rune || clean is types.ISize || clean is types.USize || clean is types.Enum || clean is types.Pointer || clean is types.String || clean is types.Nil
+	if clean is types.Primitive {
+		return clean.props.has(.boolean) || clean.props.has(.integer)
+	}
+	return clean is types.Char || clean is types.Rune || clean is types.ISize || clean is types.USize || clean is types.Enum || clean is types.Pointer || clean is types.Nil
 }
 
 fn (mut g FlatGen) gen_array_infix_eq(node flat.Node, lhs_id flat.NodeId, rhs_id flat.NodeId, lhs_type types.Type, rhs_type types.Type) bool {
@@ -19230,6 +19226,11 @@ fn (mut g FlatGen) heap_tracking_fallback_decls() {
 	}
 }
 
+fn (mut g FlatGen) map_equality_fallback_decls() {
+	g.writeln('static inline bool v3_map_value_eq(void* a, void* b, int value_bytes) { return memcmp(a, b, value_bytes) == 0; }')
+	g.writeln('static inline bool v3_map_map_eq(map a, map b) { if (a.data->count != b.data->count) return false; for (int i = 0; i < a.data->key_values.len; ++i) { if (a.data->key_values.deletes != 0 && a.data->key_values.all_deleted != 0 && a.data->key_values.all_deleted[i] != 0) continue; void* ak = (void*)(a.data->key_values.keys + i * a.data->key_values.key_bytes); if (!map__exists(&b, ak)) return false; void* av = (void*)(a.data->key_values.values + i * a.data->key_values.value_bytes); void* bv = map__get(&b, ak, av); if (!v3_map_value_eq(av, bv, a.data->value_bytes)) return false; } return true; }')
+}
+
 fn (mut g FlatGen) builtin_abi_decls() {
 	if !g.has_builtins {
 		return
@@ -19414,9 +19415,7 @@ fn (mut g FlatGen) builtin_abi_decls() {
 	g.writeln('static inline bool array_eq_array(Array a, Array b, int depth) { if (a.len != b.len || a.element_size != b.element_size) return false; if (depth <= 1 || a.element_size != sizeof(Array)) { if (a.element_size == sizeof(string)) return array_eq_string(a, b); return array_eq_raw(a, b, a.element_size); } Array* ad = (Array*)a.data; Array* bd = (Array*)b.data; for (int i = 0; i < a.len; i++) { if (!array_eq_array(ad[i], bd[i], depth - 1)) return false; } return true; }')
 	g.writeln('void* map__get(map* m, void* key, void* zero);')
 	g.writeln('bool map__exists(map* m, void* key);')
-	g.writeln('static inline bool v3_map_map_eq(map a, map b);')
-	g.writeln('static inline bool v3_map_value_eq(void* a, void* b, int value_bytes) { if (value_bytes == sizeof(string)) { string sa = *(string*)a; string sb = *(string*)b; return sa.len == sb.len && (sa.len == 0 || memcmp(sa.str, sb.str, sa.len) == 0); } if (value_bytes == sizeof(map)) { return v3_map_map_eq(*(map*)a, *(map*)b); } if (value_bytes == sizeof(string) + sizeof(map)) { string sa = *(string*)a; string sb = *(string*)b; if (!(sa.len == sb.len && (sa.len == 0 || memcmp(sa.str, sb.str, sa.len) == 0))) return false; map ma = *(map*)((u8*)a + sizeof(string)); map mb = *(map*)((u8*)b + sizeof(string)); return v3_map_map_eq(ma, mb); } if (value_bytes == sizeof(Array)) { Array aa = *(Array*)a; Array bb = *(Array*)b; if (aa.element_size != bb.element_size) return false; if (aa.element_size == sizeof(string)) return array_eq_string(aa, bb); if (aa.element_size == sizeof(Array)) return array_eq_array(aa, bb, 8); return array_eq_raw(aa, bb, aa.element_size); } return memcmp(a, b, value_bytes) == 0; }')
-	g.writeln('static inline bool v3_map_map_eq(map a, map b) { if (a.data->count != b.data->count) return false; for (int i = 0; i < a.data->key_values.len; ++i) { if (a.data->key_values.deletes != 0 && a.data->key_values.all_deleted != 0 && a.data->key_values.all_deleted[i] != 0) continue; void* ak = (void*)(a.data->key_values.keys + i * a.data->key_values.key_bytes); if (!map__exists(&b, ak)) return false; void* av = (void*)(a.data->key_values.values + i * a.data->key_values.value_bytes); void* bv = map__get(&b, ak, av); if (!v3_map_value_eq(av, bv, a.data->value_bytes)) return false; } return true; }')
+	g.map_equality_fallback_decls()
 	g.writeln('static inline bool fixed_array_contains_string(const string* a, int len, string val) { for (int i = 0; i < len; i++) if (a[i].len == val.len && memcmp(a[i].str, val.str, val.len) == 0) return true; return false; }')
 	g.writeln('static inline bool fixed_array_contains_u8(const u8* a, int len, u8 val) { for (int i = 0; i < len; i++) if (a[i] == val) return true; return false; }')
 	g.writeln('static inline bool fixed_array_contains_int(const ${g.int_ct}* a, int len, ${g.int_ct} val) { for (int i = 0; i < len; i++) if (a[i] == val) return true; return false; }')

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -14813,10 +14813,23 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 					g.write(')')
 				}
 				g.write('.len')
-			} else if node.value == 'len' && (base_type_clean is types.Array || base_type_clean is types.Map || (base_type_clean is types.Struct && base_type_clean.name in [
-				'array',
-				'map',
-			])) {
+			} else if node.value == 'len' && (base_type_clean is types.Map
+				|| (base_type_clean is types.Struct && base_type_clean.name == 'map')) {
+				needs_paren := base.kind !in [.ident, .selector]
+				if needs_paren {
+					g.write('(')
+				}
+				g.gen_expr(base_id)
+				if needs_paren {
+					g.write(')')
+				}
+				if base_type0 is types.Pointer {
+					g.write('->data->count')
+				} else {
+					g.write('.data->count')
+				}
+			} else if node.value == 'len' && (base_type_clean is types.Array
+				|| (base_type_clean is types.Struct && base_type_clean.name == 'array')) {
 				// Array accessors such as `last()` are calls in the flat tree, but
 				// emit a dereference expression in C. Parenthesize that value before
 				// selecting `.len`, otherwise the member access binds inside `array_get`.
@@ -19374,14 +19387,14 @@ fn (mut g FlatGen) builtin_abi_decls() {
 	g.writeln('}')
 	g.writeln('static inline string v3_map_str(map m, int key_kind, int val_kind, int val_fixed_len) {')
 	g.writeln('\tstring out = v3_c_lit("{", 1); bool first = true;')
-	g.writeln('\tfor (int i = 0; i < m.key_values.len; ++i) {')
-	g.writeln('\t\tif (m.key_values.deletes != 0 && m.key_values.all_deleted != 0 && m.key_values.all_deleted[i] != 0) continue;')
+	g.writeln('\tfor (int i = 0; i < m.data->key_values.len; ++i) {')
+	g.writeln('\t\tif (m.data->key_values.deletes != 0 && m.data->key_values.all_deleted != 0 && m.data->key_values.all_deleted[i] != 0) continue;')
 	g.writeln('\t\tif (!first) out = string__plus(out, v3_c_lit(", ", 2));')
-	g.writeln('\t\tvoid* key = (void*)(m.key_values.keys + i * m.key_values.key_bytes);')
-	g.writeln('\t\tvoid* val = (void*)(m.key_values.values + i * m.key_values.value_bytes);')
-	g.writeln('\t\tout = string__plus(out, v3_map_str_piece(key, key_kind, m.key_values.key_bytes, 0));')
+	g.writeln('\t\tvoid* key = (void*)(m.data->key_values.keys + i * m.data->key_values.key_bytes);')
+	g.writeln('\t\tvoid* val = (void*)(m.data->key_values.values + i * m.data->key_values.value_bytes);')
+	g.writeln('\t\tout = string__plus(out, v3_map_str_piece(key, key_kind, m.data->key_values.key_bytes, 0));')
 	g.writeln('\t\tout = string__plus(out, v3_c_lit(": ", 2));')
-	g.writeln('\t\tout = string__plus(out, v3_map_str_piece(val, val_kind, m.value_bytes, val_fixed_len));')
+	g.writeln('\t\tout = string__plus(out, v3_map_str_piece(val, val_kind, m.data->value_bytes, val_fixed_len));')
 	g.writeln('\t\tfirst = false;')
 	g.writeln('\t}')
 	g.writeln('\treturn string__plus(out, v3_c_lit("}", 1));')
@@ -19403,7 +19416,7 @@ fn (mut g FlatGen) builtin_abi_decls() {
 	g.writeln('bool map__exists(map* m, void* key);')
 	g.writeln('static inline bool v3_map_map_eq(map a, map b);')
 	g.writeln('static inline bool v3_map_value_eq(void* a, void* b, int value_bytes) { if (value_bytes == sizeof(string)) { string sa = *(string*)a; string sb = *(string*)b; return sa.len == sb.len && (sa.len == 0 || memcmp(sa.str, sb.str, sa.len) == 0); } if (value_bytes == sizeof(map)) { return v3_map_map_eq(*(map*)a, *(map*)b); } if (value_bytes == sizeof(string) + sizeof(map)) { string sa = *(string*)a; string sb = *(string*)b; if (!(sa.len == sb.len && (sa.len == 0 || memcmp(sa.str, sb.str, sa.len) == 0))) return false; map ma = *(map*)((u8*)a + sizeof(string)); map mb = *(map*)((u8*)b + sizeof(string)); return v3_map_map_eq(ma, mb); } if (value_bytes == sizeof(Array)) { Array aa = *(Array*)a; Array bb = *(Array*)b; if (aa.element_size != bb.element_size) return false; if (aa.element_size == sizeof(string)) return array_eq_string(aa, bb); if (aa.element_size == sizeof(Array)) return array_eq_array(aa, bb, 8); return array_eq_raw(aa, bb, aa.element_size); } return memcmp(a, b, value_bytes) == 0; }')
-	g.writeln('static inline bool v3_map_map_eq(map a, map b) { if (a.len != b.len) return false; for (int i = 0; i < a.key_values.len; ++i) { if (a.key_values.deletes != 0 && a.key_values.all_deleted != 0 && a.key_values.all_deleted[i] != 0) continue; void* ak = (void*)(a.key_values.keys + i * a.key_values.key_bytes); if (!map__exists(&b, ak)) return false; void* av = (void*)(a.key_values.values + i * a.key_values.value_bytes); void* bv = map__get(&b, ak, av); if (!v3_map_value_eq(av, bv, a.value_bytes)) return false; } return true; }')
+	g.writeln('static inline bool v3_map_map_eq(map a, map b) { if (a.data->count != b.data->count) return false; for (int i = 0; i < a.data->key_values.len; ++i) { if (a.data->key_values.deletes != 0 && a.data->key_values.all_deleted != 0 && a.data->key_values.all_deleted[i] != 0) continue; void* ak = (void*)(a.data->key_values.keys + i * a.data->key_values.key_bytes); if (!map__exists(&b, ak)) return false; void* av = (void*)(a.data->key_values.values + i * a.data->key_values.value_bytes); void* bv = map__get(&b, ak, av); if (!v3_map_value_eq(av, bv, a.data->value_bytes)) return false; } return true; }')
 	g.writeln('static inline bool fixed_array_contains_string(const string* a, int len, string val) { for (int i = 0; i < len; i++) if (a[i].len == val.len && memcmp(a[i].str, val.str, val.len) == 0) return true; return false; }')
 	g.writeln('static inline bool fixed_array_contains_u8(const u8* a, int len, u8 val) { for (int i = 0; i < len; i++) if (a[i] == val) return true; return false; }')
 	g.writeln('static inline bool fixed_array_contains_int(const ${g.int_ct}* a, int len, ${g.int_ct} val) { for (int i = 0; i < len; i++) if (a[i] == val) return true; return false; }')

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -9596,7 +9596,7 @@ fn (mut g FlatGen) json_encode_value_c_expr_inner(typ types.Type, expr string, s
 		encoded := g.json_encode_value_c_expr_inner(clean.value_type, '(*${value_name})', seen) or {
 			return none
 		}
-		return '({ map ${map_name} = ${expr}; string ${out_name} = v3_c_lit("{", 1); bool ${out_name}_first = true; for (int ${idx_name} = 0; ${idx_name} < ${map_name}.key_values.len; ++${idx_name}) { if (${map_name}.key_values.deletes != 0 && ${map_name}.key_values.all_deleted != 0 && ${map_name}.key_values.all_deleted[${idx_name}] != 0) continue; if (!${out_name}_first) ${out_name} = string__plus(${out_name}, v3_c_lit(",", 1)); string* ${key_name} = (string*)(${map_name}.key_values.keys + ${idx_name} * ${map_name}.key_values.key_bytes); ${value_ct}* ${value_name} = (${value_ct}*)(${map_name}.key_values.values + ${idx_name} * ${map_name}.key_values.value_bytes); ${out_name} = string__plus(string__plus(string__plus(${out_name}, v3_json_encode_string(*${key_name})), v3_c_lit(":", 1)), ${encoded}); ${out_name}_first = false; } string__plus(${out_name}, v3_c_lit("}", 1)); })'
+		return '({ map ${map_name} = ${expr}; string ${out_name} = v3_c_lit("{", 1); bool ${out_name}_first = true; for (int ${idx_name} = 0; ${idx_name} < ${map_name}.data->key_values.len; ++${idx_name}) { if (${map_name}.data->key_values.deletes != 0 && ${map_name}.data->key_values.all_deleted != 0 && ${map_name}.data->key_values.all_deleted[${idx_name}] != 0) continue; if (!${out_name}_first) ${out_name} = string__plus(${out_name}, v3_c_lit(",", 1)); string* ${key_name} = (string*)(${map_name}.data->key_values.keys + ${idx_name} * ${map_name}.data->key_values.key_bytes); ${value_ct}* ${value_name} = (${value_ct}*)(${map_name}.data->key_values.values + ${idx_name} * ${map_name}.data->key_values.value_bytes); ${out_name} = string__plus(string__plus(string__plus(${out_name}, v3_json_encode_string(*${key_name})), v3_c_lit(":", 1)), ${encoded}); ${out_name}_first = false; } string__plus(${out_name}, v3_c_lit("}", 1)); })'
 	}
 	if clean is types.Primitive {
 		if clean.props.has(.boolean) {
@@ -9742,7 +9742,7 @@ fn (mut g FlatGen) json_encode_value_c_expr_inner(typ types.Type, expr string, s
 		colon := g.intern_string(':')
 		empty := g.intern_string('')
 		value_expr := g.json_encode_value_c_expr_inner(clean.value_type, '(*(${value_ct}*)${value_name})', seen) or { return none }
-		return '({ map ${map_name} = ${expr}; string ${out_name} = _str_${open}; int ${count_name} = 0; for (int ${idx_name} = 0; ${idx_name} < ${map_name}.key_values.len; ++${idx_name}) { if (${map_name}.key_values.deletes != 0 && ${map_name}.key_values.all_deleted != 0 && ${map_name}.key_values.all_deleted[${idx_name}] != 0) continue; string ${key_name} = *(string*)(${map_name}.key_values.keys + ${idx_name} * ${map_name}.key_values.key_bytes); void* ${value_name} = (void*)(${map_name}.key_values.values + ${idx_name} * ${map_name}.key_values.value_bytes); ${out_name} = string__plus(${out_name}, ${count_name} == 0 ? _str_${empty} : _str_${comma}); ${out_name} = string__plus(${out_name}, v3_json_encode_string(${key_name})); ${out_name} = string__plus(${out_name}, _str_${colon}); ${out_name} = string__plus(${out_name}, ${value_expr}); ${count_name}++; } string__plus(${out_name}, _str_${close}); })'
+		return '({ map ${map_name} = ${expr}; string ${out_name} = _str_${open}; int ${count_name} = 0; for (int ${idx_name} = 0; ${idx_name} < ${map_name}.data->key_values.len; ++${idx_name}) { if (${map_name}.data->key_values.deletes != 0 && ${map_name}.data->key_values.all_deleted != 0 && ${map_name}.data->key_values.all_deleted[${idx_name}] != 0) continue; string ${key_name} = *(string*)(${map_name}.data->key_values.keys + ${idx_name} * ${map_name}.data->key_values.key_bytes); void* ${value_name} = (void*)(${map_name}.data->key_values.values + ${idx_name} * ${map_name}.data->key_values.value_bytes); ${out_name} = string__plus(${out_name}, ${count_name} == 0 ? _str_${empty} : _str_${comma}); ${out_name} = string__plus(${out_name}, v3_json_encode_string(${key_name})); ${out_name} = string__plus(${out_name}, _str_${colon}); ${out_name} = string__plus(${out_name}, ${value_expr}); ${count_name}++; } string__plus(${out_name}, _str_${close}); })'
 	}
 	return none
 }
@@ -9879,7 +9879,7 @@ fn (mut g FlatGen) json_encode_equal_c_expr(typ types.Type, left string, right s
 		left_value := g.tmp_name()
 		right_value := g.tmp_name()
 		value_equal := g.json_encode_equal_c_expr(clean.value_type, '(*${left_value})', '(*${right_value})', seen) or { return none }
-		return '({ map ${left_name} = ${left}; map ${right_name} = ${right}; bool ${equal_name} = ${left_name}.len == ${right_name}.len; for (int ${index_name} = 0; ${equal_name} && ${index_name} < ${left_name}.key_values.len; ++${index_name}) { if (${left_name}.key_values.deletes != 0 && ${left_name}.key_values.all_deleted != 0 && ${left_name}.key_values.all_deleted[${index_name}] != 0) continue; string* ${key_name} = (string*)(${left_name}.key_values.keys + ${index_name} * ${left_name}.key_values.key_bytes); ${value_ct}* ${left_value} = (${value_ct}*)(${left_name}.key_values.values + ${index_name} * ${left_name}.key_values.value_bytes); if (!map__exists(&${right_name}, ${key_name})) { ${equal_name} = false; break; } ${value_ct}* ${right_value} = (${value_ct}*)map__get(&${right_name}, ${key_name}, ${left_value}); if (!(${value_equal})) ${equal_name} = false; } ${equal_name}; })'
+		return '({ map ${left_name} = ${left}; map ${right_name} = ${right}; bool ${equal_name} = ${left_name}.data->count == ${right_name}.data->count; for (int ${index_name} = 0; ${equal_name} && ${index_name} < ${left_name}.data->key_values.len; ++${index_name}) { if (${left_name}.data->key_values.deletes != 0 && ${left_name}.data->key_values.all_deleted != 0 && ${left_name}.data->key_values.all_deleted[${index_name}] != 0) continue; string* ${key_name} = (string*)(${left_name}.data->key_values.keys + ${index_name} * ${left_name}.data->key_values.key_bytes); ${value_ct}* ${left_value} = (${value_ct}*)(${left_name}.data->key_values.values + ${index_name} * ${left_name}.data->key_values.value_bytes); if (!map__exists(&${right_name}, ${key_name})) { ${equal_name} = false; break; } ${value_ct}* ${right_value} = (${value_ct}*)map__get(&${right_name}, ${key_name}, ${left_value}); if (!(${value_equal})) ${equal_name} = false; } ${equal_name}; })'
 	}
 	if clean is types.Struct {
 		if clean.name in seen {
@@ -11752,6 +11752,9 @@ fn (mut g FlatGen) gen_embedded_interface_receiver_from_expr(base_expr string, b
 }
 
 fn (g &FlatGen) interface_impl_field_access_suffix(impl_name string, field_name string) string {
+	if field_name == 'len' && types.unalias_type(g.tc.parse_type(impl_name)) is types.Map {
+		return '->data->count'
+	}
 	if g.direct_struct_field_exists(impl_name, field_name) {
 		return '->${g.cname(field_name)}'
 	}

--- a/vlib/v3/gen/c/for.v
+++ b/vlib/v3/gen/c/for.v
@@ -299,10 +299,10 @@ fn (mut g FlatGen) gen_for_in(node flat.Node) {
 						g.writeln('map ${map_src} = ${container_str};')
 						g.writeln('map ${map_snapshot_var} = map__clone(&${map_src});')
 					}
-					'${map_snapshot_var}.key_values'
+					'${map_snapshot_var}.data->key_values'
 				} else {
 					access := if container_storage_is_pointer { '->' } else { '.' }
-					'(${container_str})${access}key_values'
+					'(${container_str})${access}data->key_values'
 				}
 				g.writeln('for (int ${iter_var} = 0; ${iter_var} < ${key_values}.len; ${iter_var}++) {')
 				g.indent++
@@ -666,7 +666,7 @@ fn (g &FlatGen) node_contains_delete_call(id flat.NodeId, container_key string) 
 
 fn (mut g FlatGen) gen_map_loop_copyback_dirty_checks(map_ptr_expr string, key_ptr_expr string) {
 	for guard in g.map_loop_copyback_guards {
-		g.writeln('if (!${guard.dirty_var} && (${map_ptr_expr}) == (${guard.map_ref}) && (${guard.map_ref})->key_eq_fn(${key_ptr_expr}, ${guard.key_ref})) ${guard.dirty_var} = true;')
+		g.writeln('if (!${guard.dirty_var} && (${map_ptr_expr}) == (${guard.map_ref}) && (${guard.map_ref})->data->key_eq_fn(${key_ptr_expr}, ${guard.key_ref})) ${guard.dirty_var} = true;')
 	}
 }
 

--- a/vlib/v3/gen/c/interface.v
+++ b/vlib/v3/gen/c/interface.v
@@ -2685,8 +2685,8 @@ fn (mut g FlatGen) interface_map_str_expr(map_type types.Map, expr string, mut s
 	tmp := g.interface_tmp('iface_str_map')
 	out := g.interface_tmp('iface_str_out')
 	idx := g.interface_tmp('iface_str_i')
-	key := '*(${key_ct}*)((u8*)${tmp}.key_values.keys + ${idx} * ${tmp}.key_values.key_bytes)'
-	value := '*(${value_ct}*)((u8*)${tmp}.key_values.values + ${idx} * ${tmp}.key_values.value_bytes)'
+	key := '*(${key_ct}*)((u8*)${tmp}.data->key_values.keys + ${idx} * ${tmp}.data->key_values.key_bytes)'
+	value := '*(${value_ct}*)((u8*)${tmp}.data->key_values.values + ${idx} * ${tmp}.data->key_values.value_bytes)'
 	mut key_str := g.interface_implicit_str_expr(map_type.key_type, key, true, mut stack) or {
 		g.interface_str_lit('<map key>')
 	}
@@ -2695,7 +2695,7 @@ fn (mut g FlatGen) interface_map_str_expr(map_type types.Map, expr string, mut s
 	}
 	key_str = 'v3_indent_multiline(${key_str})'
 	value_str = 'v3_indent_multiline(${value_str})'
-	return '({ map ${tmp} = ${expr}; string ${out} = ${g.interface_str_lit('{')}; bool first = true; for (int ${idx} = 0; ${idx} < ${tmp}.key_values.len; ++${idx}) { if (${tmp}.key_values.deletes != 0 && ${tmp}.key_values.all_deleted != 0 && ${tmp}.key_values.all_deleted[${idx}] != 0) continue; if (!first) ${out} = ${g.interface_str_plus(out,
+	return '({ map ${tmp} = ${expr}; string ${out} = ${g.interface_str_lit('{')}; bool first = true; for (int ${idx} = 0; ${idx} < ${tmp}.data->key_values.len; ++${idx}) { if (${tmp}.data->key_values.deletes != 0 && ${tmp}.data->key_values.all_deleted != 0 && ${tmp}.data->key_values.all_deleted[${idx}] != 0) continue; if (!first) ${out} = ${g.interface_str_plus(out,
 		g.interface_str_lit(', '))}; ${out} = ${g.interface_str_plus(out, key_str)}; ${out} = ${g.interface_str_plus(out,
 		g.interface_str_lit(': '))}; ${out} = ${g.interface_str_plus(out, value_str)}; first = false; } ${g.interface_str_plus(out,
 		g.interface_str_lit('}'))}; })'

--- a/vlib/v3/gen/c/preamble_test.v
+++ b/vlib/v3/gen/c/preamble_test.v
@@ -178,6 +178,15 @@ fn test_builtin_abi_decls_reuse_tcc_x64_stdatomic_fence_declaration() {
 	assert !c_code.contains('extern void __atomic_thread_fence(int order);')
 }
 
+fn test_map_equality_fallback_does_not_infer_value_type_from_size() {
+	mut g := FlatGen.new()
+	g.map_equality_fallback_decls()
+	c_code := g.sb.str()
+	assert c_code.contains('v3_map_value_eq(void* a, void* b, int value_bytes) { return memcmp(a, b, value_bytes) == 0; }')
+	assert !c_code.contains('value_bytes == sizeof(map)')
+	assert !c_code.contains('value_bytes == sizeof(string)')
+}
+
 fn test_builtin_heap_tracking_fallbacks_do_not_redefine_user_hooks() {
 	mut fallback := FlatGen.new()
 	fallback.heap_tracking_fallback_decls()

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -1338,7 +1338,7 @@ fn (mut g FlatGen) gen_ownership_drop_value_inner(typ types.Type, expr string, d
 			}
 		}
 		types.Map {
-			key_values := '(${expr}).key_values'
+			key_values := '(${expr}).data->key_values'
 			if g.ownership_type_requires_destruction(typ.key_type, depth + 1)
 				|| g.ownership_type_requires_destruction(typ.value_type, depth + 1) {
 				idx := g.tmp_count
@@ -2314,7 +2314,7 @@ fn (mut g FlatGen) gen_select_receive_map_value(expr string, actual types.Type, 
 	g.gen_select_receive_value(source_key, actual_key, expected_key)
 	g.write('; ${expected_value_ct} ${value} = ')
 	g.gen_select_receive_value(source_value, actual_value, expected_value)
-	g.write('; map__set(&${out}, &${key}, &${value}); ${source}.free_fn(&${source_key}); } ')
+	g.write('; map__set(&${out}, &${key}, &${value}); ${source}.data->free_fn(&${source_key}); } ')
 	g.write('array__free(&${keys}); map__free(&${source}); ${out}; })')
 	return true
 }

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -36,6 +36,22 @@ struct CInlineAsmBlock {
 fn gen_map_index_lvalue(mut g FlatGen, node flat.Node, base_id flat.NodeId, map_type types.Map, base_is_pointer bool) {
 	c_key := g.map_key_temp_c_type(map_type.key_type)
 	c_val := g.tc.c_type(map_type.value_type)
+	if default_init_unalias_type(map_type.value_type) is types.Map {
+		map_tmp := g.tmp_name()
+		key_tmp := g.tmp_name()
+		value_tmp := g.tmp_name()
+		g.write('(*({ map* ${map_tmp} = ')
+		if !base_is_pointer {
+			g.write('&')
+		}
+		g.gen_expr(base_id)
+		g.write('; void* ${key_tmp} = &(${c_key}[]){')
+		g.gen_expr(g.a.child(&node, 1))
+		g.write('}; void* ${value_tmp} = map__get_check(${map_tmp}, ${key_tmp}); if (!${value_tmp}) { ${value_tmp} = map__get_or_set(${map_tmp}, ${key_tmp}, ')
+		g.gen_default_value_addr_for_type(map_type.value_type)
+		g.write('); } (${c_val}*)${value_tmp}; }))')
+		return
+	}
 	g.write('(*(${c_val}*)map__get_or_set(')
 	if !base_is_pointer {
 		g.write('&')

--- a/vlib/v3/gen/fastc/array.v
+++ b/vlib/v3/gen/fastc/array.v
@@ -767,6 +767,11 @@ fn (g &Parser) render_raw_expression_tokens(tokens []FastcExpressionToken) ?stri
 	mut previous_module_separator := false
 	for i, item in tokens {
 		mut piece := item.lit
+		map_length_receiver_type := if item.tok == .dot {
+			g.map_length_receiver_type(tokens, i) or { '' }
+		} else {
+			''
+		}
 		if item.tok == .right_shift_unsigned {
 			// V's logical right shift `>>>` has no C spelling; on the unsigned operand it is
 			// always applied to (V code casts to an unsigned type first, e.g. `u64(x) >>> n`)
@@ -863,7 +868,10 @@ fn (g &Parser) render_raw_expression_tokens(tokens []FastcExpressionToken) ?stri
 			piece = '(Option){.state=2}'
 		} else if item.tok == .name {
 			previous := if i == 0 { token.Token.unknown } else { tokens[i - 1].tok }
-			piece = if previous == .dot && i + 1 < tokens.len && tokens[i + 1].tok == .lpar {
+			piece = if previous == .dot && item.lit == 'len'
+				&& g.map_length_receiver_type(tokens, i - 1) != none {
+				'count'
+			} else if previous == .dot && i + 1 < tokens.len && tokens[i + 1].tok == .lpar {
 				item.lit
 			} else if previous == .dot && previous_module_separator {
 				// The module prefix already makes a qualified keyword-named constant safe
@@ -880,6 +888,8 @@ fn (g &Parser) render_raw_expression_tokens(tokens []FastcExpressionToken) ?stri
 			} else {
 				g.resolved_expression_name(item.lit, previous)
 			}
+		} else if item.tok == .dot && map_length_receiver_type != '' {
+			piece = if map_length_receiver_type.ends_with('*') { '->data->' } else { '.data->' }
 		} else if item.tok == .dot && i > 0 && tokens[i - 1].tok == .name && tokens[i - 1].lit in g.imports && tokens[i - 1].lit !in g.locals && (i < 2 || tokens[i - 2].tok != .dot) {
 			// An imported module name qualifies only at the start of a chain; `v.pref.os.str()`
 			// accesses the field `os`, not the `os` module, even when that module is imported. A

--- a/vlib/v3/gen/fastc/expr.v
+++ b/vlib/v3/gen/fastc/expr.v
@@ -2098,6 +2098,17 @@ fn (mut g Parser) read_expression_with_prefix_mode_impl(prefix string, stops []t
 		g.validate_expression_stream_token(expression_tokens, stops, allow_mutation_statement, allow_declaration_guard, paren_depth, bracket_depth, brace_depth, unsafe_expression_depth, source_token_count, mut operator_state)!
 		streamed := g.render_expression_stream_token(mut expression_tokens, stops, previous_token, previous_lit, previous_module_separator, shared_is_struct_field, spawn_is_field_name, keyword_is_field_name, brace_depth, previous_was_pointer_cast, next_token_is_mut_argument, source_token_count)!
 		mut piece := streamed.piece
+		if g.tok == .dot {
+			mut selector_lookahead := g.s
+			if selector_lookahead.scan() == .name && selector_lookahead.lit == 'len' {
+				if receiver_type := g.map_receiver_type_before_dot(expression_tokens, expression_tokens.len - 1) {
+					piece = if receiver_type.ends_with('*') { '->data->' } else { '.data->' }
+				}
+			}
+		} else if g.tok == .name && g.lit == 'len' && previous_token == .dot
+			&& g.map_length_receiver_type(expression_tokens, expression_tokens.len - 2) != none {
+			piece = 'count'
+		}
 		if previous_module_separator && expression_tokens.len >= 3
 			&& expression_tokens.last().tok == .name {
 			mut call_lookahead := g.s

--- a/vlib/v3/gen/fastc/fastc.v
+++ b/vlib/v3/gen/fastc/fastc.v
@@ -40,7 +40,38 @@ typedef unsigned char *byteptr;
 typedef char *charptr;
 typedef void *chan;
 typedef struct { void *data; int offset; int len; int cap; int flags; } array;
-typedef struct { void *data; int len; } map;
+/* Keep these private map-header declarations in sync with builtin/map.v. */
+typedef struct {
+	int key_bytes;
+	int value_bytes;
+	int cap;
+	int len;
+	u32 deletes;
+	u8 *all_deleted;
+	u8 *keys;
+	u8 *values;
+} DenseArray;
+typedef u64 (*MapHashFn)(voidptr);
+typedef bool (*MapEqFn)(voidptr, voidptr);
+typedef void (*MapCloneFn)(voidptr, voidptr);
+typedef void (*MapFreeFn)(voidptr);
+typedef struct VMapData {
+	int key_bytes;
+	int value_bytes;
+	u32 even_index;
+	u8 cached_hashbits;
+	u8 shift;
+	DenseArray key_values;
+	u32 *metas;
+	u32 extra_metas;
+	bool has_string_keys;
+	MapHashFn hash_fn;
+	MapEqFn key_eq_fn;
+	MapCloneFn clone_fn;
+	MapFreeFn free_fn;
+	int count;
+} VMapData;
+typedef struct { VMapData *data; } map;
 typedef struct { void *data; void *err; unsigned char state; } Option;
 /* One multi-return component. Values up to 32 bytes are stored inline; larger
    ones are boxed and referenced through `ptr`, so no component size can

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -2762,6 +2762,35 @@ fn test_real_builtin_path_inferred_enum_keyed_map() {
 	assert source.contains('Map_Block_string'), source
 }
 
+fn test_map_layout_and_length_selector_use_runtime_header() {
+	prefs := pref.new_preferences()
+	c_source := generate('module main
+
+struct Holder {
+	values map[string]int
+}
+
+fn map_len(values map[string]int) int {
+	return values.len + 1
+}
+
+fn map_nonempty(values map[string]int) bool {
+	return values.len > 0
+}
+
+fn map_field_len(holder Holder) int {
+	return holder.values.len
+}
+
+fn main() {}
+', 'map_length_selector.v', prefs) or { panic(err) }
+	assert c_source.contains('typedef struct { VMapData *data; } map;'), c_source
+	assert c_source.contains('return values.data->count+1;'), c_source
+	assert c_source.contains('values.data->count>0'), c_source
+	assert c_source.contains('return holder.values.data->count;'), c_source
+	assert !c_source.contains('typedef struct { void *data; int len; } map;'), c_source
+}
+
 fn test_selfhost_inferred_map_enum_value_shorthand_uses_first_value_type() {
 	mut prefs := pref.new_preferences()
 	prefs.building_v = true

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -2791,6 +2791,27 @@ fn main() {}
 	assert !c_source.contains('typedef struct { void *data; int len; } map;'), c_source
 }
 
+fn test_map_valued_lookup_uses_valid_lazy_fallback() {
+	mut prefs := pref.new_preferences()
+	prefs.building_v = true
+	c_source := generate('module main
+
+fn missing_map_len(values map[string]map[string]int) int {
+	inner := values["missing"]
+	return inner.len
+}
+
+fn main() {
+	values := map[string]map[string]int{}
+	_ := missing_map_len(values)
+}
+', 'map_value_lookup.v', prefs) or { panic(err) }
+	assert c_source.contains('__vf_ml.state ? (Map_string_int)builtin__new_map(sizeof(string), sizeof(int)'), c_source
+	assert c_source.contains('return inner.data->count;'), c_source
+	assert !c_source.contains('Map_string_int){0}'), c_source
+	assert !c_source.contains('__vf_map_zero'), c_source
+}
+
 fn test_selfhost_inferred_map_enum_value_shorthand_uses_first_value_type() {
 	mut prefs := pref.new_preferences()
 	prefs.building_v = true

--- a/vlib/v3/gen/fastc/render.v
+++ b/vlib/v3/gen/fastc/render.v
@@ -110,8 +110,9 @@ fn (g &Parser) render_map_expression(tokens []FastcExpressionToken) ?FastcRender
 		// The Option temp uses the reserved `__vf_` prefix, NOT a plain name like `lookup`: a
 		// source variable of that name used in the key (`m[lookup]`) would otherwise be shadowed by
 		// this declaration and read uninitialized inside its own initializer.
+		missing_value := g.map_lookup_missing_value_expression(lookup.typ)
 		return FastcRenderedExpression{
-			source: '({ Option __vf_ml = (${lookup.source}); __vf_ml.state ? (${lookup.typ}){0} : *((${lookup.typ} *)__vf_ml.data); })'
+			source: '({ Option __vf_ml = (${lookup.source}); __vf_ml.state ? ${missing_value} : *((${lookup.typ} *)__vf_ml.data); })'
 			typ: lookup.typ
 		}
 	}
@@ -206,8 +207,9 @@ fn (g &Parser) render_map_expression(tokens []FastcExpressionToken) ?FastcRender
 		global_key := fastc_global_key(g.module_name, tokens[0].lit)
 		map_source := g.globals[global_key] or { tokens[0].lit }
 		map_address := if map_type.ends_with('*') { map_source } else { '&${map_source}' }
+		missing_value := g.map_lookup_missing_value_expression(value_type)
 		return FastcRenderedExpression{
-			source: '({ ${key_type} __vf_k = (${key_source}); ${value_type} __vf_map_zero = (${value_type}){0}; *((${value_type} *)builtin__map_get((map *)${map_address}, &__vf_k, &__vf_map_zero)); })'
+			source: '({ ${key_type} __vf_k = (${key_source}); ${value_type} *__vf_map_value = (${value_type} *)builtin__map_get_check((map *)${map_address}, &__vf_k); __vf_map_value == NULL ? ${missing_value} : *__vf_map_value; })'
 			typ: value_type
 		}
 	}
@@ -3957,6 +3959,23 @@ fn (g &Parser) map_runtime_functions(key_type string) (string, string, string, s
 		resolved_type = if g.enum_flags[enum_key] { 'u64' } else { 'int' }
 	}
 	return fastc_map_runtime_functions(resolved_type, g.prefs.target.pointer_bits)
+}
+
+// map_lookup_missing_value_expression gives map values a usable empty runtime header and uses
+// the ordinary C zero value for every other lookup value type.
+fn (g &Parser) map_lookup_missing_value_expression(value_type string) string {
+	zero := '(${value_type}){0}'
+	normalized := fastc_normalize_inferred_type(value_type)
+	if normalized.ends_with('*') {
+		return zero
+	}
+	map_type := g.underlying_alias_type(normalized)
+	if map_type.ends_with('*') {
+		return zero
+	}
+	key_type, nested_value_type := g.map_key_value_types(map_type) or { return zero }
+	hash_fn, eq_fn, clone_fn, free_fn := g.map_runtime_functions(key_type)
+	return '(${value_type})builtin__new_map(sizeof(${fastc_runtime_c_type(key_type)}), sizeof(${fastc_runtime_c_type(nested_value_type)}), &${hash_fn}, &${eq_fn}, &${clone_fn}, &${free_fn})'
 }
 
 fn (g &Parser) render_explicit_generic_call_expression(tokens []FastcExpressionToken) ?FastcRenderedExpression {

--- a/vlib/v3/gen/fastc/render.v
+++ b/vlib/v3/gen/fastc/render.v
@@ -4890,6 +4890,14 @@ fn (g &Parser) render_member_receiver(tokens []FastcExpressionToken) ?string {
 				continue
 			}
 		}
+		if tokens[i + 1].lit == 'len' && g.is_map_type(current_type) {
+			separator := if current_type.ends_with('*') { '->' } else { '.' }
+			source += '${separator}data->count'
+			current_type = 'int'
+			member_path += '.len'
+			i += 2
+			continue
+		}
 		field := g.struct_field_metadata(current_type, tokens[i + 1].lit) or { return none }
 		for storage_name in field.storage_path {
 			separator := if current_type.ends_with('*') { '->' } else { '.' }

--- a/vlib/v3/gen/fastc/render_calls.v
+++ b/vlib/v3/gen/fastc/render_calls.v
@@ -762,11 +762,7 @@ fn (g &Parser) render_mutable_map_value_pointer(tokens []FastcExpressionToken) ?
 		}
 		map_address = if map_type.ends_with('*') { map_source } else { '&(${map_source})' }
 	}
-	mut empty_value := '(${value_type}){0}'
-	if nested_key_type, nested_value_type := g.map_key_value_types(value_type) {
-		hash_fn, eq_fn, clone_fn, free_fn := g.map_runtime_functions(nested_key_type)
-		empty_value = '(${value_type})builtin__new_map(sizeof(${fastc_runtime_c_type(nested_key_type)}), sizeof(${fastc_runtime_c_type(nested_value_type)}), &${hash_fn}, &${eq_fn}, &${clone_fn}, &${free_fn})'
-	}
+	empty_value := g.map_lookup_missing_value_expression(value_type)
 	return FastcRenderedExpression{
 		source: '({ ${key_type} __vf_nested_map_key = (${key_source}); ${value_type} *__vf_nested_map_value = (${value_type} *)builtin__map_get_check((map *)(${map_address}), &__vf_nested_map_key); if (__vf_nested_map_value == NULL) { ${value_type} __vf_nested_map_empty = ${empty_value}; builtin__map_set((map *)(${map_address}), &__vf_nested_map_key, &__vf_nested_map_empty); __vf_nested_map_value = (${value_type} *)builtin__map_get_check((map *)(${map_address}), &__vf_nested_map_key); } __vf_nested_map_value; })'
 		typ: value_type

--- a/vlib/v3/gen/fastc/signatures.v
+++ b/vlib/v3/gen/fastc/signatures.v
@@ -1463,6 +1463,11 @@ fn (g &Parser) map_key_value_types(typ string) ?(string, string) {
 	return fastc_declared_map_key_value_types(typ, g.declared_kinds)
 }
 
+fn (g &Parser) is_map_type(typ string) bool {
+	base := fastc_trim_pointer_suffix(g.underlying_alias_type(fastc_normalize_inferred_type(typ)))
+	return base == 'map' || g.map_key_value_types(base) != none
+}
+
 fn fastc_register_composite_type(typ string, mut composite_types map[string]bool) {
 	base := typ.trim_right('*')
 	if base.starts_with('Array_') || base.starts_with('Map_') {

--- a/vlib/v3/gen/fastc/types.v
+++ b/vlib/v3/gen/fastc/types.v
@@ -153,6 +153,25 @@ fn fastc_method_receiver_start_after(tokens []FastcExpressionToken, dot int, low
 	return lower_bound
 }
 
+fn (g &Parser) map_receiver_type_before_dot(tokens []FastcExpressionToken, dot int) ?string {
+	if dot <= 0 || dot >= tokens.len || tokens[dot].tok != .dot {
+		return none
+	}
+	receiver_start := fastc_method_receiver_start(tokens, dot)
+	receiver_type := g.infer_expression_type(tokens[receiver_start..dot]) or { return none }
+	if !g.is_map_type(receiver_type) {
+		return none
+	}
+	return receiver_type
+}
+
+fn (g &Parser) map_length_receiver_type(tokens []FastcExpressionToken, dot int) ?string {
+	if dot + 1 >= tokens.len || tokens[dot + 1].tok != .name || tokens[dot + 1].lit != 'len' {
+		return none
+	}
+	return g.map_receiver_type_before_dot(tokens, dot)
+}
+
 fn fastc_call_arguments(tokens []FastcExpressionToken, open int, close int) ![][]FastcExpressionToken {
 	if open + 1 == close {
 		return [][]FastcExpressionToken{}

--- a/vlib/v3/gen/fastc/validate.v
+++ b/vlib/v3/gen/fastc/validate.v
@@ -824,6 +824,9 @@ fn (g &Parser) validate_expression_mutation_lvalue(tokens []FastcExpressionToken
 }
 
 fn (g &Parser) struct_direct_member_type(receiver_type string, field_name string) string {
+	if field_name == 'len' && g.is_map_type(receiver_type) {
+		return 'int'
+	}
 	mut layout_type := fastc_trim_pointer_suffix(receiver_type)
 	if layout_type.starts_with('Array_') {
 		layout_type = 'array'

--- a/vlib/v3/tests/review_transform_regressions_test.v
+++ b/vlib/v3/tests/review_transform_regressions_test.v
@@ -4365,6 +4365,26 @@ fn test_nested_map_equality_uses_declared_value_type() {
 	assert out == 'true\ntrue'
 }
 
+fn test_map_value_lookup_constructs_default_only_for_missing_key() {
+	v3_bin := build_v3_review_transform()
+	source := "fn read_present(values map[string]map[string]int) int {\n\treturn values['present'].len\n}\n\nfn set_nested(mut values map[string]map[string]int) {\n\tvalues['created']['answer'] = 42\n}\n\nfn main() {\n\tmut values := {\n\t\t'present': {'answer': 7}\n\t}\n\tfor _ in 0 .. 100 {\n\t\tassert read_present(values) == 1\n\t}\n\tset_nested(mut values)\n\tprintln(int_str(values['created']['answer']))\n}\n"
+	c_source := gen_c_from_source(v3_bin, 'map_value_lookup_lazy_default_c', source)
+	read_body := c_fn_body(c_source, 'i64 read_present(map values) {')
+	read_check := read_body.index('map__get_check') or { -1 }
+	read_default := read_body.index('new_map(') or { -1 }
+	assert read_check >= 0, read_body
+	assert read_default > read_check, read_body
+	assert read_body[read_check..read_default].contains('?'), read_body
+	set_body := c_fn_body(c_source, 'void set_nested(map* values) {')
+	set_check := set_body.index('map__get_check') or { -1 }
+	set_default := set_body.index('new_map(') or { -1 }
+	assert set_check >= 0, set_body
+	assert set_default > set_check, set_body
+	set_guard := set_body[set_check..set_default]
+	assert set_guard.contains('?') || set_guard.contains('if (!'), set_body
+	assert run_good(v3_bin, 'map_value_lookup_lazy_default', source) == '42'
+}
+
 fn test_pointer_array_equality_uses_pointer_identity() {
 	v3_bin := build_v3_review_transform()
 	out := run_good(v3_bin, 'pointer_array_equality', 'struct Node {\n\tvalue int\n}\n\nfn main() {\n\tleft_node := Node{\n\t\tvalue: 5\n\t}\n\tright_node := Node{\n\t\tvalue: 5\n\t}\n\tleft_ptr := &left_node\n\tright_ptr := &right_node\n\tleft := [left_ptr]\n\tright := [right_ptr]\n\tsame := [left_ptr]\n\tprintln(left == right)\n\tprintln(left != right)\n\tprintln(left == same)\n\tprintln(right_ptr in left)\n\tprintln(int_str(left.index(right_ptr)))\n}\n')

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -3322,6 +3322,11 @@ fn (t &Transformer) map_value_needs_element_eq(value_type string) bool {
 		return false
 	}
 	clean := t.membership_container_type(value_type)
+	// Float equality is semantic: +0.0 and -0.0 compare equal even though their
+	// representations differ, so the raw map equality helper cannot compare them.
+	if clean in ['f32', 'f64'] {
+		return true
+	}
 	if t.is_fixed_array_type(clean) {
 		return true
 	}
@@ -3452,24 +3457,21 @@ fn (mut t Transformer) make_map_elementwise_eq_call_with_seen(lhs flat.NodeId, r
 	lhs_value := t.stable_transformed_expr_for_reuse(lhs, map_type, 'map_eq_lhs')
 	rhs_value := t.stable_transformed_expr_for_reuse(rhs, map_type, 'map_eq_rhs')
 	result_name := t.new_temp('map_eq')
-	zero_name := t.new_temp('map_eq_zero')
 	key_name := t.new_temp('map_eq_key')
 	lhs_val_name := t.new_temp('map_eq_val')
 	len_eq := t.make_infix(.eq, t.make_selector(lhs_value, 'len', 'int'), t.make_selector(rhs_value,
 		'len', 'int'))
 	t.pending_stmts << t.make_decl_assign_typed(result_name, len_eq, 'bool')
-	t.pending_stmts << t.make_decl_assign_typed(zero_name, t.zero_value_for_type(value_type),
-		value_type)
 	t.set_var_type(key_name, t.map_key_storage_type(key_type))
 	t.set_var_type(lhs_val_name, value_type)
 	key_ident := t.make_ident(key_name)
 	val_ident := t.make_ident(lhs_val_name)
 	rhs_exists := t.make_map_exists_expr(rhs_value, map_type, key_name)
-	rhs_val := t.make_map_get_expr(rhs_value, map_type, key_name, zero_name, value_type)
+	mut body := []flat.NodeId{}
+	rhs_val := t.make_map_lookup_value(rhs_value, map_type, key_name, value_type, mut body)
 	pending_start := t.pending_stmts.len
-	value_eq := t.make_membership_eq_expr_with_seen(t.make_ident(lhs_val_name), rhs_val,
-		value_type, seen)
-	mut body := t.pending_stmts[pending_start..].clone()
+	value_eq := t.make_membership_eq_expr_with_seen(t.make_ident(lhs_val_name), rhs_val, value_type, seen)
+	body << t.pending_stmts[pending_start..].clone()
 	t.pending_stmts = t.pending_stmts[..pending_start].clone()
 	missing := t.make_prefix(.not, t.make_paren(rhs_exists))
 	value_diff := t.make_prefix(.not, t.make_paren(value_eq))

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -8523,7 +8523,6 @@ fn (mut t Transformer) lower_typed_map_str(map_expr flat.NodeId, map_type string
 	keys_name := t.new_temp('map_str_keys')
 	idx_name := t.new_temp('map_str_idx')
 	key_name := t.new_temp('map_str_key')
-	zero_name := t.new_temp('map_str_zero')
 	value_name := t.new_temp('map_str_value')
 	key_kind := t.map_str_kind_for_type(key_type)
 	value_kind := t.map_str_kind_for_type(value_type)
@@ -8537,12 +8536,10 @@ fn (mut t Transformer) lower_typed_map_str(map_expr flat.NodeId, map_type string
 	post := t.make_expr_stmt(t.make_postfix(t.make_ident(idx_name), .inc))
 	key_expr := t.array_get_value(t.make_ident(keys_name), t.make_ident(idx_name), key_storage_type)
 	key_decl := t.make_decl_assign_typed(key_name, key_expr, key_storage_type)
-	zero_decl := t.make_decl_assign_typed(zero_name, t.zero_value_for_type(value_type), value_type)
-	value_expr := t.make_map_get_expr(base, map_type, key_name, zero_name, value_type)
-	value_decl := t.make_decl_assign_typed(value_name, value_expr, value_type)
 	mut loop_body := []flat.NodeId{}
 	loop_body << key_decl
-	loop_body << zero_decl
+	value_expr := t.make_map_lookup_value(base, map_type, key_name, value_type, mut loop_body)
+	value_decl := t.make_decl_assign_typed(value_name, value_expr, value_type)
 	loop_body << value_decl
 	sep_cond := t.make_infix(.gt, t.make_ident(idx_name), t.make_int_literal(0))
 	sep_stmt := t.append_string(result_name, t.make_string_literal(', '))

--- a/vlib/v3/transform/map.v
+++ b/vlib/v3/transform/map.v
@@ -1732,6 +1732,32 @@ fn (mut t Transformer) make_map_get_expr(map_expr flat.NodeId, base_type string,
 	return result
 }
 
+// make_map_lookup_value builds a map lookup and appends its setup. Map defaults
+// allocate their runtime header, so map-valued lookups construct one only for a missing key.
+fn (mut t Transformer) make_map_lookup_value(map_expr flat.NodeId, base_type string, key_name string, value_type string, mut prelude []flat.NodeId) flat.NodeId {
+	if t.clean_map_type(value_type).starts_with('map[') {
+		ptr_name := t.new_temp('map_value_ptr')
+		prelude << t.make_decl_assign_typed(ptr_name, t.make_map_get_check_expr(map_expr, base_type, key_name), 'voidptr')
+		clean_value_type := t.normalize_type_alias(value_type)
+		found := t.make_prefix(.mul, t.make_cast('&${clean_value_type}', t.make_ident(ptr_name), '&${clean_value_type}'))
+		cond := t.make_infix(.ne, t.make_ident(ptr_name), t.a.add(.nil_literal))
+		then_block := t.make_block([t.make_expr_stmt(found)])
+		else_block := t.make_block([
+			t.make_expr_stmt(t.zero_value_for_type(value_type)),
+		])
+		value := t.make_if(cond, then_block, else_block)
+		t.set_node_typ(int(value), value_type)
+		// Nested indexing needs an addressable map base. Materializing the lazy
+		// conditional also keeps the checked pointer from escaping its setup.
+		result_name := t.new_temp('map_value')
+		prelude << t.make_decl_assign_typed(result_name, value, value_type)
+		return t.make_ident(result_name)
+	}
+	zero_name := t.new_temp('map_zero')
+	prelude << t.make_decl_assign_typed(zero_name, t.zero_value_for_type(value_type), value_type)
+	return t.make_map_get_expr(map_expr, base_type, key_name, zero_name, value_type)
+}
+
 fn (t &Transformer) fixed_array_type_contains_map(typ string) bool {
 	clean := t.normalize_type_alias(typ).trim_space()
 	if clean.starts_with('map[') {
@@ -1912,10 +1938,7 @@ fn (mut t Transformer) try_lower_map_index_expr(id flat.NodeId, node flat.Node) 
 		}
 		return result
 	}
-	zero_name := t.new_temp('map_zero')
-	t.pending_stmts << t.make_decl_assign_typed(zero_name, t.zero_value_for_type(value_type),
-		value_type)
-	value := t.make_map_get_expr(map_expr, base_type, key_name, zero_name, value_type)
+	value := t.make_map_lookup_value(map_expr, base_type, key_name, value_type, mut t.pending_stmts)
 	if cleanup_key || source_is_owned_temporary {
 		result_name := t.new_temp('map_index_value')
 		t.pending_stmts << t.make_decl_assign_typed(result_name, value, value_type)
@@ -2838,11 +2861,8 @@ fn map_compound_to_infix_op(op flat.Op) ?flat.Op {
 
 // load_map_index_current reads load map index current input for transform.
 fn (mut t Transformer) load_map_index_current(info MapIndexInfo, map_expr flat.NodeId, key_name string, mut result []flat.NodeId) string {
-	zero_name := t.new_temp('map_zero')
 	current_name := t.new_temp('map_val')
-	result << t.make_decl_assign_typed(zero_name, t.zero_value_for_type(info.value_type),
-		info.value_type)
-	get_expr := t.make_map_get_expr(map_expr, info.base_type, key_name, zero_name, info.value_type)
+	get_expr := t.make_map_lookup_value(map_expr, info.base_type, key_name, info.value_type, mut result)
 	result << t.make_decl_assign_typed(current_name, get_expr, info.value_type)
 	return current_name
 }

--- a/vlib/v3/transform/return.v
+++ b/vlib/v3/transform/return.v
@@ -779,7 +779,6 @@ fn (mut t Transformer) convert_forwarded_map(value_id flat.NodeId, actual_type t
 	idx_name := t.new_temp('return_map_idx')
 	source_key_name := t.new_temp('return_map_source_key')
 	key_name := t.new_temp('return_map_key')
-	zero_name := t.new_temp('return_map_zero')
 	source_value_name := t.new_temp('return_map_source_value')
 	value_name := t.new_temp('return_map_value')
 	keys_type := '[]${actual_key_storage}'
@@ -795,10 +794,7 @@ fn (mut t Transformer) convert_forwarded_map(value_id flat.NodeId, actual_type t
 		actual_key_storage)
 	mut body := []flat.NodeId{}
 	body << t.make_decl_assign_typed(source_key_name, source_key, actual_key_storage)
-	body << t.make_decl_assign_typed(zero_name, t.zero_value_for_type(actual_value_type),
-		actual_value_type)
-	source_value := t.make_map_get_expr(base, actual_map_type, source_key_name, zero_name,
-		actual_value_type)
+	source_value := t.make_map_lookup_value(base, actual_map_type, source_key_name, actual_value_type, mut body)
 	body << t.make_decl_assign_typed(source_value_name, source_value, actual_value_type)
 	body_pending_start := t.pending_stmts.len
 	logical_source_key := if actual_key_storage == actual_key_type {

--- a/vlib/v3/types/checker_comptime.v
+++ b/vlib/v3/types/checker_comptime.v
@@ -4730,6 +4730,13 @@ fn (tc &TypeChecker) interface_diagnostic_type_name(typ Type, alias_module strin
 }
 
 fn (tc &TypeChecker) interface_actual_field(concrete_name string, field_name string) ?StructField {
+	if field_name == 'len' && unalias_type(tc.parse_type(concrete_name)) is Map {
+		return StructField{
+			name:   'len'
+			typ:    Type(int_)
+			is_mut: true
+		}
+	}
 	mut candidates := [concrete_name]
 	if !concrete_name.contains('.') {
 		qname := tc.qualify_name(concrete_name)

--- a/vlib/v3/types/checker_scoped_transform_test.v
+++ b/vlib/v3/types/checker_scoped_transform_test.v
@@ -72,7 +72,7 @@ mut:
 	values      &u8 = unsafe { nil }
 }
 
-struct SignatureMapLayoutForTest {
+struct SignatureMapDataLayoutForTest {
 	key_bytes   int
 	value_bytes int
 mut:
@@ -88,10 +88,15 @@ mut:
 	clone_fn        voidptr
 	free_fn         voidptr
 pub mut:
-	len int
+	count int
 }
 
-fn signature_map_storage_owned_by_scope(scope voidptr, layout &SignatureMapLayoutForTest) bool {
+struct SignatureMapLayoutForTest {
+mut:
+	data &SignatureMapDataLayoutForTest = unsafe { nil }
+}
+
+fn signature_map_storage_owned_by_scope(scope voidptr, layout &SignatureMapDataLayoutForTest) bool {
 	$if prealloc {
 		return unsafe { prealloc_scope_owns(scope, layout.key_values.keys) }
 			|| unsafe { prealloc_scope_owns(scope, layout.key_values.values) }
@@ -137,11 +142,13 @@ fn test_rebuild_scoped_transform_signatures_and_suffix_index_after_growth() {
 			tc.fn_variadic[name] = false
 			tc.specialized_generic_fns[name] = true
 		}
-		ret_scoped := unsafe { &SignatureMapLayoutForTest(&tc.fn_ret_types) }
-		params_scoped := unsafe { &SignatureMapLayoutForTest(&tc.fn_param_types) }
-		variadic_scoped := unsafe { &SignatureMapLayoutForTest(&tc.fn_variadic) }
-		specialized_scoped := unsafe { &SignatureMapLayoutForTest(&tc.specialized_generic_fns) }
-		suffix_scoped := unsafe { &SignatureMapLayoutForTest(&tc.receiver_method_suffix_index) }
+		ret_scoped := unsafe { (&SignatureMapLayoutForTest(&tc.fn_ret_types)).data }
+		params_scoped := unsafe { (&SignatureMapLayoutForTest(&tc.fn_param_types)).data }
+		variadic_scoped := unsafe { (&SignatureMapLayoutForTest(&tc.fn_variadic)).data }
+		specialized_scoped := unsafe {
+			(&SignatureMapLayoutForTest(&tc.specialized_generic_fns)).data
+		}
+		suffix_scoped := unsafe { (&SignatureMapLayoutForTest(&tc.receiver_method_suffix_index)).data }
 		assert signature_map_storage_owned_by_scope(scope, ret_scoped)
 		assert signature_map_storage_owned_by_scope(scope, params_scoped)
 		assert signature_map_storage_owned_by_scope(scope, variadic_scoped)
@@ -152,11 +159,13 @@ fn test_rebuild_scoped_transform_signatures_and_suffix_index_after_growth() {
 		tc.rebuild_scoped_transform_signature_maps()
 		tc.rebuild_fn_param_suffix_index()
 		assert tc.transform_signature_names_log.len == 0
-		ret_rebuilt := unsafe { &SignatureMapLayoutForTest(&tc.fn_ret_types) }
-		params_rebuilt := unsafe { &SignatureMapLayoutForTest(&tc.fn_param_types) }
-		variadic_rebuilt := unsafe { &SignatureMapLayoutForTest(&tc.fn_variadic) }
-		specialized_rebuilt := unsafe { &SignatureMapLayoutForTest(&tc.specialized_generic_fns) }
-		suffix_rebuilt := unsafe { &SignatureMapLayoutForTest(&tc.receiver_method_suffix_index) }
+		ret_rebuilt := unsafe { (&SignatureMapLayoutForTest(&tc.fn_ret_types)).data }
+		params_rebuilt := unsafe { (&SignatureMapLayoutForTest(&tc.fn_param_types)).data }
+		variadic_rebuilt := unsafe { (&SignatureMapLayoutForTest(&tc.fn_variadic)).data }
+		specialized_rebuilt := unsafe {
+			(&SignatureMapLayoutForTest(&tc.specialized_generic_fns)).data
+		}
+		suffix_rebuilt := unsafe { (&SignatureMapLayoutForTest(&tc.receiver_method_suffix_index)).data }
 		assert !signature_map_storage_owned_by_scope(scope, ret_rebuilt)
 		assert !signature_map_storage_owned_by_scope(scope, params_rebuilt)
 		assert !signature_map_storage_owned_by_scope(scope, variadic_rebuilt)

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -9242,6 +9242,18 @@ fn (tc &TypeChecker) type_implements_interface(actual Type, expected Interface) 
 		}
 		return true
 	}
+	if clean is Map {
+		if tc.interface_abstract_method_names(expected.name).len > 0 {
+			return false
+		}
+		for field in tc.interface_field_list(expected.name) {
+			if field.name != 'len' || !tc.type_compatible(Type(int_), field.typ)
+				|| !tc.type_compatible(field.typ, Type(int_)) {
+				return false
+			}
+		}
+		return true
+	}
 	concrete_name := method_type_name(clean)
 	if concrete_name.len == 0 {
 		return false
@@ -9652,7 +9664,11 @@ fn (tc &TypeChecker) interface_impl_candidate_names() map[string]bool {
 		candidates[name] = true
 	}
 	for name, _ in tc.structs {
-		candidates[interface_impl_candidate_name(name)] = true
+		candidate := interface_impl_candidate_name(name)
+		// builtin.VMapData is private map storage and cannot be an interface value.
+		if name != 'VMapData' || tc.struct_modules[name] != 'builtin' {
+			candidates[candidate] = true
+		}
 	}
 	for name, _ in tc.enum_names {
 		candidates[interface_impl_candidate_name(name)] = true
@@ -9684,7 +9700,10 @@ fn (tc &TypeChecker) interface_impl_names_uncached_after(iface_name string, excl
 		}
 	}
 	for name, _ in tc.structs {
-		add_interface_impl_candidate(mut candidate_set, interface_impl_candidate_name(name), excluded)
+		candidate := interface_impl_candidate_name(name)
+		if name != 'VMapData' || tc.struct_modules[name] != 'builtin' {
+			add_interface_impl_candidate(mut candidate_set, candidate, excluded)
+		}
 	}
 	if has_no_requirements || accepts_implicit_str {
 		for name, _ in tc.enum_names {


### PR DESCRIPTION
## Summary

- store builtin map metadata in a heap-allocated internal header so each map value is one pointer
- preserve map `.len`, structural interface fields, iteration, equality, string conversion, JSON, and ownership behavior in V1 and V3
- reclaim the allocated header in `map.free()` and add a pointer-size regression test

On 64-bit targets this reduces `sizeof(map[int]int)` from 144 bytes to 8 bytes, matching the size of a Go map value.

## Testing

- `./v1_fallback -silent vlib/v/compiler_errors_test.v` — 1707 passed, 1 skipped
- V1 and V3 `vlib/builtin/map_size_test.v`
- V1 and V3 `vlib/builtin/map_test.v`
- V1 and V3 `vlib/builtin/map_delete_reclaim_test.v`
- V1 and V3 strict Clang builds of `map_size_test.v`
- V1 and V3 no-GC map tests
- V3 map iteration, range, pointer-lvalue, ownership, and interface regression tests
- broad `vlib/v/` run — 2353 passed, 30 skipped, with 10 unrelated existing/environment failures