### PR TITLE
tools: avoid repeated rebuilds in v up

### DIFF
--- a/cmd/tools/vup.v
+++ b/cmd/tools/vup.v
@@ -24,11 +24,11 @@ const args = arguments()
 
 fn new_app() App {
 	return App{
-		is_verbose:   '-v' in args
-		is_prod:      '-prod' in args
-		vexe:         vexe
-		vroot:        vroot
-		skip_v_self:  '-skip_v_self' in args
+		is_verbose: '-v' in args
+		is_prod: '-prod' in args
+		vexe: vexe
+		vroot: vroot
+		skip_v_self: '-skip_v_self' in args
 		skip_current: '-skip_current' in args
 	}
 }
@@ -45,9 +45,9 @@ fn main() {
 		eprintln('Try running `${get_tcc_update_cmd()}` .')
 		exit(1)
 	}
-	hash_when_vup_was_compiled := @VCURRENTHASH
-	current_hash_from_filesystem := version.githash(vroot) or { hash_when_vup_was_compiled }
-	if !app.skip_current && hash_when_vup_was_compiled == current_hash_from_filesystem {
+	current_v_hash := app.current_v_hash() or { @VCURRENTHASH }
+	current_hash_from_filesystem := version.githash(vroot) or { current_v_hash }
+	if !app.skip_current && current_v_hash == current_hash_from_filesystem {
 		println('V is already updated.')
 		if !os.exists(app.current_vexe_path()) {
 			eprintln('`${app.vexe}` is missing, trying `${get_make_cmd_name()}` to restore it...')
@@ -214,6 +214,28 @@ fn (app App) show_current_v_version() {
 	}
 }
 
+fn (app App) current_v_hash() ?string {
+	vexe_path := app.current_vexe_path()
+	if !os.exists(vexe_path) {
+		return none
+	}
+	vout := os.execute('${os.quoted_path(vexe_path)} version')
+	if vout.exit_code != 0 {
+		return none
+	}
+	for line in vout.output.split_into_lines() {
+		fields := line.trim_space().fields()
+		if fields.len != 3 || fields[0] != 'V' {
+			continue
+		}
+		hash := fields[2].all_after_last('.')
+		if hash.len >= 7 && hash[..7].bytes().all(it.is_hex_digit()) {
+			return hash[..7]
+		}
+	}
+	return none
+}
+
 fn (app App) current_vexe_name() string {
 	vexe_name := os.file_name(app.vexe)
 	if vexe_name == '' {
@@ -229,6 +251,19 @@ fn (app App) current_vbackup_name() string {
 }
 
 fn (app App) current_vexe_path() string {
+	// The V3 dispatcher delegates building `vup` to `v1_fallback`. In that case
+	// @VEXE identifies the fallback, but `v up` must inspect and rebuild the main
+	// compiler next to it.
+	if os.file_name(app.vexe) in ['v1_fallback', 'v1_fallback.exe'] {
+		primary_vexe := os.join_path_single(app.vroot, if os.user_os() == 'windows' {
+			'v.exe'
+		} else {
+			'v'
+		})
+		if os.exists(primary_vexe) {
+			return primary_vexe
+		}
+	}
 	if os.exists(app.vexe) {
 		return app.vexe
 	}

--- a/cmd/tools/vup.v
+++ b/cmd/tools/vup.v
@@ -49,8 +49,9 @@ fn main() {
 	current_hash_from_filesystem := version.githash(vroot) or { current_v_hash }
 	if !app.skip_current && current_v_hash == current_hash_from_filesystem {
 		println('V is already updated.')
-		if !os.exists(app.current_vexe_path()) {
-			eprintln('`${app.vexe}` is missing, trying `${get_make_cmd_name()}` to restore it...')
+		current_vexe_path := app.current_vexe_path()
+		if !os.exists(current_vexe_path) {
+			eprintln('`${current_vexe_path}` is missing, trying `${get_make_cmd_name()}` to restore it...')
 			if !app.make('') {
 				app.show_current_v_version()
 				eprintln('Recompiling V *failed*.')
@@ -197,7 +198,7 @@ fn (app App) make(_vself string) bool {
 fn (app App) show_current_v_version() {
 	vexe_path := app.current_vexe_path()
 	if !os.exists(vexe_path) {
-		println('Current V version: unavailable (`${app.vexe}` is missing).')
+		println('Current V version: unavailable (`${vexe_path}` is missing).')
 		return
 	}
 	vout := os.execute('${os.quoted_path(vexe_path)} version')
@@ -260,9 +261,7 @@ fn (app App) current_vexe_path() string {
 		} else {
 			'v'
 		})
-		if os.exists(primary_vexe) {
-			return primary_vexe
-		}
+		return primary_vexe
 	}
 	if os.exists(app.vexe) {
 		return app.vexe

--- a/cmd/tools/vup_test.v
+++ b/cmd/tools/vup_test.v
@@ -44,3 +44,47 @@ fn test_vup_checks_primary_compiler_when_built_by_v1_fallback() ! {
 	assert !compiler_calls.contains('fallback'), compiler_calls
 	assert compiler_calls.trim_space().split_into_lines() == ['version', 'version'], compiler_calls
 }
+
+fn test_vup_restores_missing_primary_compiler_when_built_by_v1_fallback() ! {
+	$if windows {
+		return
+	}
+	test_root := os.join_path(os.vtmp_dir(), 'vup_missing_primary_compiler_${os.getpid()}')
+	os.rmdir_all(test_root) or {}
+	os.mkdir_all(test_root)!
+	defer {
+		os.rmdir_all(test_root) or {}
+	}
+
+	// Give the test tool a known embedded hash so the fallback and checkout can
+	// appear current while the primary compiler is missing.
+	vup_source := os.read_file(os.join_path(vroot, 'cmd', 'tools', 'vup.v'))!
+	assert vup_source.count('@VCURRENTHASH') == 1
+	test_source := os.join_path(test_root, 'vup.v')
+	os.write_file(test_source, vup_source.replace('@VCURRENTHASH', "'abcdef0'"))!
+	tool := os.join_path(test_root, 'vup')
+	build := os.execute('${os.quoted_path(vexe)} -o ${os.quoted_path(tool)} ${os.quoted_path(test_source)}')
+	assert build.exit_code == 0, build.output
+
+	git_refs := os.join_path(test_root, '.git', 'refs', 'heads')
+	os.mkdir_all(git_refs)!
+	os.write_file(os.join_path(test_root, '.git', 'HEAD'), 'ref: refs/heads/master\n')!
+	os.write_file(os.join_path(git_refs, 'master'), 'abcdef0123456789abcdef0123456789abcdef01\n')!
+
+	bin_dir := os.join_path(test_root, 'bin')
+	os.mkdir_all(bin_dir)!
+	make_log := os.join_path(test_root, 'make.log')
+	fallback_log := os.join_path(test_root, 'fallback.log')
+	write_executable(os.join_path(test_root, 'v1_fallback'), '#!/bin/sh\n' + 'printf "%s\\n" "\$*" >> ${os.quoted_path(fallback_log)}\n' + 'if [ "\$1" = "version" ]; then\n' + '  echo "V 0.5.2 abcdef0"\n' + '  exit 0\n' + 'fi\n' + 'exit 1\n')!
+	write_executable(os.join_path(bin_dir, 'git'), '#!/bin/sh\n' + 'if [ "\$1" = "pull" ]; then\n' + '  echo "Already up to date."\n' + 'fi\n' + 'exit 0\n')!
+	write_executable(os.join_path(bin_dir, 'make'), '#!/bin/sh\n' + 'printf "make:%s\\n" "\$*" >> ${os.quoted_path(make_log)}\n' + 'exit 0\n')!
+
+	path := '${bin_dir}:${os.getenv('PATH')}'
+	primary_vexe := os.join_path(os.real_path(test_root), 'v')
+	result := os.execute('PATH=${os.quoted_path(path)} VEXE=${os.quoted_path(os.join_path(test_root, 'v1_fallback'))} ${os.quoted_path(tool)}')
+	assert result.exit_code == 0, result.output
+	assert result.output.contains('`${primary_vexe}` is missing, trying `make` to restore it...'), result.output
+	make_calls := os.read_file(make_log)!
+	assert make_calls.trim_space().split_into_lines() == ['make:latest_tcc', 'make:'], make_calls
+	assert !os.exists(fallback_log), os.read_file(fallback_log) or { '' }
+}

--- a/cmd/tools/vup_test.v
+++ b/cmd/tools/vup_test.v
@@ -1,0 +1,46 @@
+import os
+
+const vexe = @VEXE
+const vroot = os.dir(vexe)
+
+fn write_executable(path string, content string) ! {
+	os.write_file(path, content)!
+	os.chmod(path, 0o755)!
+}
+
+fn test_vup_checks_primary_compiler_when_built_by_v1_fallback() ! {
+	$if windows {
+		return
+	}
+	test_root := os.join_path(os.vtmp_dir(), 'vup_primary_compiler_${os.getpid()}')
+	os.rmdir_all(test_root) or {}
+	os.mkdir_all(test_root)!
+	defer {
+		os.rmdir_all(test_root) or {}
+	}
+
+	tool := os.join_path(test_root, 'vup')
+	build := os.execute('${os.quoted_path(vexe)} -o ${os.quoted_path(tool)} ${os.quoted_path(os.join_path(vroot, 'cmd', 'tools', 'vup.v'))}')
+	assert build.exit_code == 0, build.output
+
+	git_refs := os.join_path(test_root, '.git', 'refs', 'heads')
+	os.mkdir_all(git_refs)!
+	os.write_file(os.join_path(test_root, '.git', 'HEAD'), 'ref: refs/heads/master\n')!
+	os.write_file(os.join_path(git_refs, 'master'), 'abcdef0123456789abcdef0123456789abcdef01\n')!
+
+	bin_dir := os.join_path(test_root, 'bin')
+	os.mkdir_all(bin_dir)!
+	log_file := os.join_path(test_root, 'compiler.log')
+	write_executable(os.join_path(test_root, 'v'), '#!/bin/sh\n' + 'printf "%s\\n" "\$*" >> ${os.quoted_path(log_file)}\n' + 'if [ "\$1" = "version" ]; then\n' + '  echo "V 0.5.2 abcdef0"\n' + '  exit 0\n' + 'fi\n' + 'exit 1\n')!
+	write_executable(os.join_path(test_root, 'v1_fallback'), '#!/bin/sh\n' + 'printf "fallback %s\\n" "\$*" >> ${os.quoted_path(log_file)}\n' + 'exit 1\n')!
+	write_executable(os.join_path(bin_dir, 'git'), '#!/bin/sh\n' + 'if [ "\$1" = "pull" ]; then\n' + '  echo "Already up to date."\n' + 'fi\n' + 'exit 0\n')!
+	write_executable(os.join_path(bin_dir, 'make'), '#!/bin/sh\nexit 0\n')!
+
+	path := '${bin_dir}:${os.getenv('PATH')}'
+	result := os.execute('PATH=${os.quoted_path(path)} VEXE=${os.quoted_path(os.join_path(test_root, 'v1_fallback'))} ${os.quoted_path(tool)}')
+	assert result.exit_code == 0, result.output
+	assert result.output.contains('V is already updated.'), result.output
+	compiler_calls := os.read_file(log_file)!
+	assert !compiler_calls.contains('fallback'), compiler_calls
+	assert compiler_calls.trim_space().split_into_lines() == ['version', 'version'], compiler_calls
+}


### PR DESCRIPTION
## Summary

- resolve the primary V executable when vup was compiled through v1_fallback
- compare the installed compiler hash with the checkout instead of the helper embedded hash
- add a regression test for an up-to-date checkout with a stale fallback compiler

## Testing

- ./vnew -silent test cmd/tools/vup_test.v
- ./vnew -g -gc none cmd/tools/vup.v
- reproduced the consecutive-run scenario and confirmed the second invocation reports V is already updated without self-compiling