### PR TITLE
cgen: fix generic interface pointer arg specialization

### DIFF
--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -7213,16 +7213,20 @@ fn (mut g Gen) ref_or_deref_arg_ex(arg ast.CallArg, expected_type_ ast.Type, lan
 				arg_typ = resolved_param_type
 			}
 		}
-		if in_generic_context {
-			resolved_scope_type := g.resolved_scope_var_type_uncached(arg.expr)
-			if resolved_scope_type != 0 {
-				resolved_arg_type := g.unwrap_generic(g.recheck_concrete_type(resolved_scope_type))
-				skip_inherited_option_storage_type := arg.expr.obj is ast.Var
-					&& arg.expr.obj.is_inherited && !expected_type.has_option_or_result()
-					&& arg_typ != 0 && !arg_typ.has_option_or_result()
-					&& resolved_arg_type.has_option_or_result()
-				if !skip_inherited_option_storage_type {
-					arg_typ = resolved_arg_type
+		if in_generic_context && arg.expr.obj is ast.Var {
+			if scope_var := arg.expr.scope.find_var(arg.expr.name) {
+				if scope_var.pos.pos == arg.expr.obj.pos.pos {
+					resolved_scope_type := g.resolved_scope_var_type_uncached(arg.expr)
+					if resolved_scope_type != 0 {
+						resolved_arg_type := g.unwrap_generic(g.recheck_concrete_type(resolved_scope_type))
+						skip_inherited_option_storage_type := arg.expr.obj.is_inherited
+							&& !expected_type.has_option_or_result() && arg_typ != 0
+							&& !arg_typ.has_option_or_result()
+							&& resolved_arg_type.has_option_or_result()
+						if !skip_inherited_option_storage_type {
+							arg_typ = resolved_arg_type
+						}
+					}
 				}
 			}
 		}

--- a/vlib/v/gen/c/fn.v
+++ b/vlib/v/gen/c/fn.v
@@ -7213,6 +7213,19 @@ fn (mut g Gen) ref_or_deref_arg_ex(arg ast.CallArg, expected_type_ ast.Type, lan
 				arg_typ = resolved_param_type
 			}
 		}
+		if in_generic_context {
+			resolved_scope_type := g.resolved_scope_var_type_uncached(arg.expr)
+			if resolved_scope_type != 0 {
+				resolved_arg_type := g.unwrap_generic(g.recheck_concrete_type(resolved_scope_type))
+				skip_inherited_option_storage_type := arg.expr.obj is ast.Var
+					&& arg.expr.obj.is_inherited && !expected_type.has_option_or_result()
+					&& arg_typ != 0 && !arg_typ.has_option_or_result()
+					&& resolved_arg_type.has_option_or_result()
+				if !skip_inherited_option_storage_type {
+					arg_typ = resolved_arg_type
+				}
+			}
+		}
 	}
 	needs_resolved_expr_type := arg.expr is ast.SelectorExpr
 		|| arg.expr is ast.IndexExpr || arg.expr is ast.ComptimeSelector

--- a/vlib/v/tests/generics/generic_interface_pointer_specialization_recheck_test.v
+++ b/vlib/v/tests/generics/generic_interface_pointer_specialization_recheck_test.v
@@ -1,0 +1,110 @@
+interface Issue28471Speaker {
+mut:
+	speak() string
+}
+
+struct Issue28471Dog {
+mut:
+	n int
+}
+
+fn (mut d Issue28471Dog) speak() string {
+	d.n++
+	return 'woof'
+}
+
+struct Issue28471Box[T] {
+	item T
+}
+
+fn issue28471_apply_one_interface_then_pointer[T](b Issue28471Box[T], f fn (mut T) string) string {
+	mut it := b.item
+	return f(mut it)
+}
+
+fn issue28471_apply_one_pointer_then_interface[T](b Issue28471Box[T], f fn (mut T) string) string {
+	mut it := b.item
+	return f(mut it)
+}
+
+fn issue28471_apply_two_interface_then_pointer[T, R](b Issue28471Box[T], f fn (mut T) R) R {
+	mut it := b.item
+	return f(mut it)
+}
+
+fn issue28471_apply_two_pointer_then_interface[T, R](b Issue28471Box[T], f fn (mut T) R) R {
+	mut it := b.item
+	return f(mut it)
+}
+
+fn test_generic_interface_then_pointer_specializations_keep_mutation_target() {
+	mut d := Issue28471Dog{}
+	speaker_box := Issue28471Box[Issue28471Speaker]{
+		item: Issue28471Speaker(&d)
+	}
+	dog_box := Issue28471Box[&Issue28471Dog]{
+		item: &d
+	}
+
+	assert issue28471_apply_one_interface_then_pointer[Issue28471Speaker](speaker_box, fn (mut it Issue28471Speaker) string {
+		return it.speak()
+	}) == 'woof'
+	assert issue28471_apply_one_interface_then_pointer[&Issue28471Dog](dog_box, fn (mut it &Issue28471Dog) string {
+		return it.speak()
+	}) == 'woof'
+	assert d.n == 2
+}
+
+fn test_generic_pointer_then_interface_specializations_keep_mutation_target() {
+	mut d := Issue28471Dog{}
+	speaker_box := Issue28471Box[Issue28471Speaker]{
+		item: Issue28471Speaker(&d)
+	}
+	dog_box := Issue28471Box[&Issue28471Dog]{
+		item: &d
+	}
+
+	assert issue28471_apply_one_pointer_then_interface[&Issue28471Dog](dog_box, fn (mut it &Issue28471Dog) string {
+		return it.speak()
+	}) == 'woof'
+	assert issue28471_apply_one_pointer_then_interface[Issue28471Speaker](speaker_box, fn (mut it Issue28471Speaker) string {
+		return it.speak()
+	}) == 'woof'
+	assert d.n == 2
+}
+
+fn test_generic_two_param_interface_then_pointer_specializations_keep_mutation_target() {
+	mut d := Issue28471Dog{}
+	speaker_box := Issue28471Box[Issue28471Speaker]{
+		item: Issue28471Speaker(&d)
+	}
+	dog_box := Issue28471Box[&Issue28471Dog]{
+		item: &d
+	}
+
+	assert issue28471_apply_two_interface_then_pointer[Issue28471Speaker, string](speaker_box, fn (mut it Issue28471Speaker) string {
+		return it.speak()
+	}) == 'woof'
+	assert issue28471_apply_two_interface_then_pointer[&Issue28471Dog, string](dog_box, fn (mut it &Issue28471Dog) string {
+		return it.speak()
+	}) == 'woof'
+	assert d.n == 2
+}
+
+fn test_generic_two_param_pointer_then_interface_specializations_keep_mutation_target() {
+	mut d := Issue28471Dog{}
+	speaker_box := Issue28471Box[Issue28471Speaker]{
+		item: Issue28471Speaker(&d)
+	}
+	dog_box := Issue28471Box[&Issue28471Dog]{
+		item: &d
+	}
+
+	assert issue28471_apply_two_pointer_then_interface[&Issue28471Dog, string](dog_box, fn (mut it &Issue28471Dog) string {
+		return it.speak()
+	}) == 'woof'
+	assert issue28471_apply_two_pointer_then_interface[Issue28471Speaker, string](speaker_box, fn (mut it Issue28471Speaker) string {
+		return it.speak()
+	}) == 'woof'
+	assert d.n == 2
+}


### PR DESCRIPTION
Fixes #28471.

This PR fixes old C generator argument lowering for generic function specializations where the same generic call path is instantiated with both interface and pointer argument types.

`ref_or_deref_arg_ex()` could use the stale `CallArg.typ` stored on the shared generic AST. In cases like `T = Interface` followed by `T = &Struct`, that could make cgen emit an invalid interface conversion for an already interface argument.
 
This PR also refreshes identifier argument types from the current generic specialization scope before ref/deref/interface conversion. The refresh is guarded so it only applies when the scope lookup resolves to the same bound variable declaration as the identifier, avoiding accidental replacement from same name shadowing declarations.

A regression test covers one and two generic-parameter call paths in both interface first and pointer first specialization order.

## Tests

- [x] make
- [x] v test vlib/v/tests/generics/generic_interface_pointer_specialization_recheck_test.v
