### PR TITLE
v3: enable by default on BSD

### DIFF
--- a/.github/workflows/freebsd_ci.yml
+++ b/.github/workflows/freebsd_ci.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - master
     paths-ignore:
-      - 'vlib/v3/**'
       - '**.md'
       - '**.yml'
       - 'cmd/tools/**'
@@ -45,6 +44,7 @@ on:
       - 'vlib/time/**'
       - 'vlib/toml/**'
       - 'vlib/v/**'
+      - 'vlib/v3/**'
       # build-examples / DB / Sokol deps exercised by ci/freebsd_ci.vsh
       - 'examples/**'
       - 'vlib/compress/**'
@@ -90,7 +90,8 @@ jobs:
         with:
           operating_system: freebsd
           version: '15.1'
-          memory: 4G
+          memory: 8G
+          cpu_count: 2
           shell: sh
           sync_files: runner-to-vm
 
@@ -131,7 +132,8 @@ jobs:
         with:
           operating_system: freebsd
           version: '15.1'
-          memory: 4G
+          memory: 8G
+          cpu_count: 2
           shell: sh
           sync_files: runner-to-vm
 
@@ -172,7 +174,8 @@ jobs:
         with:
           operating_system: freebsd
           version: '15.1'
-          memory: 4G
+          memory: 8G
+          cpu_count: 2
           shell: sh
           sync_files: runner-to-vm
 

--- a/.github/workflows/openbsd_ci.yml
+++ b/.github/workflows/openbsd_ci.yml
@@ -7,7 +7,6 @@ on:
       - master
     paths:
       - '**'
-      - '!vlib/v3/**'
       - '!**.md'
       - '!**.yml'
       - '!cmd/tools/**'
@@ -47,6 +46,7 @@ on:
       - 'vlib/time/**'
       - 'vlib/toml/**'
       - 'vlib/v/**'
+      - 'vlib/v3/**'
       # build-examples / DB / Sokol deps exercised by ci/openbsd_ci.vsh
       - 'vlib/compress/**'
       - 'vlib/crypto/rand/**'
@@ -91,7 +91,8 @@ jobs:
         with:
           operating_system: openbsd
           version: '7.8'
-          memory: 4G
+          memory: 8G
+          cpu_count: 2
           sync_files: runner-to-vm
 
       - name: Tests on OpenBSD with tcc
@@ -129,7 +130,8 @@ jobs:
         with:
           operating_system: openbsd
           version: '7.8'
-          memory: 4G
+          memory: 8G
+          cpu_count: 2
           sync_files: runner-to-vm
 
       - name: Tests on OpenBSD with clang

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -8,7 +8,7 @@ VC     ?= ./vc
 VEXE   ?= ./v
 V1_FALLBACK_EXE := $(dir $(VEXE))v1_fallback
 # Portable VC snapshots do not embed V3. Keep their v1 executable on the full
-# compatibility compiler path even when the generated C is built on macOS/Linux.
+# compatibility compiler path even when the generated C is built on a V3 host.
 VC_BOOTSTRAP_DEFINE := -DCUSTOM_DEFINE_v1_fallback
 VCREPO ?= https://github.com/vlang/vc
 TCCREPO ?= https://github.com/vlang/tccbin
@@ -75,19 +75,26 @@ endif
 endif
 
 ifeq ($(_SYS),FreeBSD)
+V1_FALLBACK_BUILD := 1
 TCCOS := freebsd
 LDFLAGS += -lexecinfo
 endif
 
 ifeq ($(_SYS),NetBSD)
 NETBSD := 1
+V1_FALLBACK_BUILD := 1
 TCCOS := netbsd
 LDFLAGS += -lexecinfo
 endif
 
 ifeq ($(_SYS),OpenBSD)
+V1_FALLBACK_BUILD := 1
 TCCOS := openbsd
 LDFLAGS += -lexecinfo
+endif
+
+ifeq ($(_SYS),DragonFly)
+V1_FALLBACK_BUILD := 1
 endif
 
 ifdef ANDROID_ROOT
@@ -179,11 +186,11 @@ BOOTSTRAP_GC_VFLAG :=
 ifeq ($(filter -gc -gc=%,$(VFLAGS)),)
 	BOOTSTRAP_GC_VFLAG := -gc none
 endif
-ifeq ($(LINUX),1)
+ifneq ($(filter $(_SYS),Linux FreeBSD NetBSD OpenBSD DragonFly),)
 ifneq ($(filter $(TCCARCH),arm64 aarch64),)
 ifeq ($(filter -cc,$(VFLAGS)),)
 ifeq ($(findstring -cc=,$(VFLAGS)),)
-	# Bundled TCC can hang or miscompile V while bootstrapping on Linux ARM64,
+	# Bundled TCC can hang, fail, or miscompile V while bootstrapping on ARM64,
 	# so keep both `v1 -> v2` and `v2 -> v` on the same system compiler
 	# unless the user overrode it explicitly.
 	BOOTSTRAP_CCOMPILER_VFLAG := -cc "$(CC)"
@@ -191,6 +198,8 @@ ifeq ($(findstring -cc=,$(VFLAGS)),)
 endif
 endif
 endif
+endif
+ifeq ($(LINUX),1)
 ifneq ($(BOOTSTRAP_TCC_REQUESTED),)
 ifneq ($(CC),tcc)
 	# The external vc bootstrap snapshot may still emit Windows-only stdio

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -246,6 +246,9 @@ ifdef NETBSD
 endif
 ifdef V1_FALLBACK_BUILD
 	./v1$(EXE_EXT) -no-parallel -d v1_fallback -o $(V1_FALLBACK_EXE) $(BOOTSTRAP_GC_VFLAG) $(VFLAGS) $(BOOTSTRAP_VC_VFLAGS) cmd/v
+ifdef NETBSD
+	paxctl +m $(V1_FALLBACK_EXE)
+endif
 endif
 	./v2$(EXE_EXT) -nocache -o $(VEXE)$(EXE_EXT) $(BOOTSTRAP_GC_VFLAG) $(VFLAGS) $(BOOTSTRAP_VFLAGS) cmd/v
 ifdef NETBSD

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CFLAGS ?=
 LDFLAGS ?=
 
 # Portable VC snapshots do not embed V3. Keep their v1 executable on the full
-# compatibility compiler path even when the generated C is built on macOS/Linux.
+# compatibility compiler path even when the generated C is built on a V3 host.
 VC_BOOTSTRAP_DEFINE = -DCUSTOM_DEFINE_v1_fallback
 
 all: download_vc v
@@ -99,8 +99,24 @@ v:
 	case " $(VFLAGS) " in \
 		*" -gc "*|*" -gc="*) bootstrap_gcflags="";; \
 	esac; \
+	bootstrap_ccompiler=; \
+	case " $(VFLAGS) " in \
+		*" -cc "*|*" -cc="*) ;; \
+		*) \
+			case "$$sys" in \
+				Linux|FreeBSD|NetBSD|OpenBSD|DragonFly) \
+					case "$$arch" in \
+						arm64|aarch64) bootstrap_ccompiler="$(CC)";; \
+					esac; \
+					;; \
+			esac; \
+			;; \
+	esac; \
 	$(CC) $$bootstrap_ccflags $(VC_BOOTSTRAP_DEFINE) -std=gnu11 -w -o v1 vc/v.c -lm -lpthread $$ldflags || cmd/tools/cc_compilation_failed_non_windows.sh; \
 	set -- ./v1 -no-parallel -o v2 $$bootstrap_gcflags $(VFLAGS); \
+	if [ -n "$$bootstrap_ccompiler" ]; then \
+		set -- "$$@" -cc "$$bootstrap_ccompiler"; \
+	fi; \
 	if [ -n "$$bootstrap_ccflags" ]; then \
 		set -- "$$@" -cflags "$$bootstrap_ccflags"; \
 	fi; \
@@ -110,8 +126,11 @@ v:
 	set -- "$$@" cmd/v; \
 	"$$@"; \
 	case "$$sys" in \
-		Linux|Darwin) \
+		Linux|Darwin|FreeBSD|NetBSD|OpenBSD|DragonFly) \
 			set -- ./v1 -no-parallel -d v1_fallback -o v1_fallback $$bootstrap_gcflags $(VFLAGS); \
+			if [ -n "$$bootstrap_ccompiler" ]; then \
+				set -- "$$@" -cc "$$bootstrap_ccompiler"; \
+			fi; \
 			if [ -n "$$bootstrap_ccflags" ]; then \
 				set -- "$$@" -cflags "$$bootstrap_ccflags"; \
 			fi; \
@@ -126,6 +145,9 @@ v:
 			;; \
 	esac; \
 	set -- ./v2 -o v $$bootstrap_gcflags $(VFLAGS); \
+	if [ -n "$$bootstrap_ccompiler" ]; then \
+		set -- "$$@" -cc "$$bootstrap_ccompiler"; \
+	fi; \
 	if [ -n "$$ccflags" ]; then \
 		set -- "$$@" -cflags "$$ccflags"; \
 	fi; \

--- a/ci/freebsd_ci.vsh
+++ b/ci/freebsd_ci.vsh
@@ -109,13 +109,15 @@ fn check_compress() {
 }
 
 fn run_essential_tests() {
+	// The broad compatibility suite includes V1-specific diagnostic fixtures.
+	// Self-hosting and the module tasks above cover the default V3 compiler.
 	if common.is_github_job {
 		println('::group::Run essential tests')
-		exec('VTEST_JUST_ESSENTIAL=1 v -silent test-self')
+		exec('VTEST_JUST_ESSENTIAL=1 v -old-compiler -silent test-self')
 		println('::endgroup::')
 	} else {
 		println('### Run essential tests')
-		exec('VTEST_JUST_ESSENTIAL=1 v -progress test-self')
+		exec('VTEST_JUST_ESSENTIAL=1 v -old-compiler -progress test-self')
 	}
 }
 

--- a/ci/openbsd_ci.vsh
+++ b/ci/openbsd_ci.vsh
@@ -109,13 +109,15 @@ fn test_inline_assembly() {
 }
 
 fn run_essential_tests() {
+	// The broad compatibility suite includes V1-specific diagnostic fixtures.
+	// Self-hosting and the module tasks above cover the default V3 compiler.
 	if common.is_github_job {
 		println('::group::Run essential tests')
-		exec('VTEST_JUST_ESSENTIAL=1 v -silent test-self')
+		exec('VTEST_JUST_ESSENTIAL=1 v -old-compiler -silent test-self')
 		println('::endgroup::')
 	} else {
 		println('### Run essential tests')
-		exec('VTEST_JUST_ESSENTIAL=1 v -progress test-self')
+		exec('VTEST_JUST_ESSENTIAL=1 v -old-compiler -progress test-self')
 	}
 }
 

--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -10,6 +10,7 @@ const args_ = arguments()
 const is_debug = args_.contains('-debug')
 const full_v_cli_source = 'cmd/v'
 const standalone_v3_source = 'vlib/v3/v3.v'
+const v1_fallback_binary = 'v1_fallback'
 
 // support a renamed `v` executable too:
 const vexe = os.getenv_opt('VEXE') or { @VEXE }
@@ -90,6 +91,12 @@ fn main() {
 		if unsupported.len > 0 {
 			eprintln('`v self -b fastc xN` cannot preserve these options across repeated replacement builds: ${unsupported.join(' ')}')
 			eprintln('Remove the options, use `x1`, or specify `-o` to keep the original compiler.')
+			exit(1)
+		}
+	}
+	if !fastc_self_build && obinary == '' {
+		install_missing_bsd_v1_fallback(vroot, vexe, args, self_build_host_os()) or {
+			eprintln('cannot prepare the BSD V1 compatibility compiler: ${err.msg()}')
 			exit(1)
 		}
 	}
@@ -471,6 +478,48 @@ fn clone_args(args []string) []string {
 		cloned << arg.clone()
 	}
 	return cloned
+}
+
+fn self_build_host_os() string {
+	$if vself_test_bsd_transition ? {
+		return 'freebsd'
+	}
+	return os.user_os()
+}
+
+fn install_missing_bsd_v1_fallback(vroot string, compiler string, args []string, host_os string) ! {
+	if host_os !in ['freebsd', 'openbsd', 'netbsd', 'dragonfly'] {
+		return
+	}
+	fallback := os.join_path(vroot, v1_fallback_binary)
+	if os.is_executable(fallback) {
+		return
+	}
+	staged_fallback := os.join_path(vroot, '.vself_v1_fallback_${os.getpid()}')
+	os.rm(staged_fallback) or {}
+	defer {
+		os.rm(staged_fallback) or {}
+	}
+	mut fallback_args := initial_bootstrap_args(args).filter(it !in ['-new-compiler', '-old-compiler'])
+	fallback_args << ['-no-parallel', '-d', 'v1_fallback']
+	fallback_args = with_output_arg(fallback_args, staged_fallback)
+	println('V self compiling the BSD V1 compatibility compiler...')
+	fallback_cmd := compose_v_cmd(compiler, fallback_args, full_v_cli_source)
+	run_cmd(fallback_cmd) or {
+		return error('failed to build `${fallback}` before replacing V.\n${err.msg()}')
+	}
+	if !os.is_executable(staged_fallback) {
+		return error('the staged V1 compatibility compiler `${staged_fallback}` is not executable')
+	}
+	if host_os == 'netbsd' {
+		run_cmd('paxctl +m ${os.quoted_path(staged_fallback)}') or {
+			return error('failed to mark the NetBSD V1 compatibility compiler.\n${err.msg()}')
+		}
+	}
+	if os.exists(fallback) {
+		os.rm(fallback)!
+	}
+	os.mv(staged_fallback, fallback)!
 }
 
 fn compose_v_cmd(vexe string, args []string, source string) string {

--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -30,6 +30,7 @@ fn main() {
 	recompilation.must_be_enabled(vroot, 'Please install V from source, to use `${vexe_name} self` .')
 	os.chdir(vroot)!
 	os.setenv('VCOLORS', 'always', true)
+	host_os := self_build_host_os()
 	command_index := os.getenv('VSELF_COMMAND_INDEX').int()
 	os.unsetenv('VSELF_COMMAND_INDEX')
 	repeat_count, mut args := extract_repeat_count(args_[1..], command_index)
@@ -45,17 +46,19 @@ fn main() {
 	}
 	if !fastc_self_build && !has_self_build_configuration_arg(effective_args) {
 		// compiling by default, i.e. `v self`:
-		uos := os.user_os()
 		uname := os.uname()
-		if uos == 'macos' {
+		if host_os == 'macos' {
 			// Apple Silicon's bundled TCC is much faster for compiler rebuilds. The
 			// generated compiler uses pthread-backed allocator state because native
 			// TinyCC TLS is not reliable on macOS.
 			default_cc := if uname.machine in ['arm64', 'aarch64'] { 'tcc' } else { 'cc' }
 			args << ['-cc', os.getenv_opt('CC') or { default_cc }]
-		} else if uos == 'linux' && uname.machine in ['arm64', 'aarch64'] {
+		} else if host_os == 'linux' && uname.machine in ['arm64', 'aarch64'] {
 			// Bundled TCC can hang while bootstrapping V on Linux ARM64, so
 			// prefer the system compiler for self-builds there.
+			args << ['-cc', os.getenv_opt('CC') or { 'cc' }]
+		} else if host_os in ['freebsd', 'openbsd', 'netbsd', 'dragonfly'] {
+			// V3's preallocation runtime needs the system compiler on BSD.
 			args << ['-cc', os.getenv_opt('CC') or { 'cc' }]
 		}
 	}
@@ -63,7 +66,7 @@ fn main() {
 		args << ['-gc', 'none']
 	}
 	effective_args = effective_self_build_args(args)
-	if !fastc_self_build && os.user_os() in ['linux', 'macos'] && '-prod' in effective_args
+	if !fastc_self_build && self_build_uses_embedded_v3(host_os) && '-prod' in effective_args
 		&& '-parallel-cc' !in effective_args {
 		// A V3-only cmd/v is large enough that a monolithic C compiler + LTO dominates
 		// the self-build. Parallel C compilation also keeps the generated unit out
@@ -71,15 +74,15 @@ fn main() {
 		args << '-parallel-cc'
 	}
 	effective_args = effective_self_build_args(args)
-	if !fastc_self_build && os.user_os() in ['linux', 'macos'] && '-prod' in effective_args
+	if !fastc_self_build && self_build_uses_embedded_v3(host_os) && '-prod' in effective_args
 		&& '-no-memory-limit' !in effective_args && '--no-memory-limit' !in effective_args {
 		// Production C generation for the embedded V3 compiler can legitimately
 		// exceed V3's default 10 GB process limit before the native compiler starts.
 		args << '-no-memory-limit'
 	}
 	effective_args = effective_self_build_args(args)
-	if !fastc_self_build && os.user_os() in ['linux', 'macos']
-		&& self_build_supports_prealloc(effective_args) && !has_prealloc_arg(effective_args) {
+	if !fastc_self_build && self_build_uses_embedded_v3(host_os)
+		&& self_build_supports_prealloc(effective_args, host_os) && !has_prealloc_arg(effective_args) {
 		// The embedded V3 compiler uses disposable preallocation scopes. Pass the
 		// flag explicitly so the first `v up` built by an older compiler gets
 		// the bounded-memory implementation too.
@@ -95,7 +98,7 @@ fn main() {
 		}
 	}
 	if !fastc_self_build && obinary == '' {
-		install_missing_bsd_v1_fallback(vroot, vexe, args, self_build_host_os()) or {
+		install_missing_bsd_v1_fallback(vroot, vexe, args, host_os) or {
 			eprintln('cannot prepare the BSD V1 compatibility compiler: ${err.msg()}')
 			exit(1)
 		}
@@ -323,8 +326,8 @@ fn has_prealloc_arg(args []string) bool {
 	return args.any(it in ['-prealloc', '-no-prealloc'])
 }
 
-fn self_build_supports_prealloc(args []string) bool {
-	mut target_os := os.user_os()
+fn self_build_supports_prealloc(args []string, host_os string) bool {
+	mut target_os := host_os
 	mut ccompiler := ''
 	mut gc := 'none'
 	mut i := 0
@@ -356,7 +359,7 @@ fn self_build_supports_prealloc(args []string) bool {
 		}
 		i++
 	}
-	return target_os in ['linux', 'macos'] && gc == 'none'
+	return self_build_uses_embedded_v3(target_os) && gc == 'none'
 		&& self_ccompiler_supports_prealloc(ccompiler, target_os)
 }
 
@@ -485,6 +488,10 @@ fn self_build_host_os() string {
 		return 'freebsd'
 	}
 	return os.user_os()
+}
+
+fn self_build_uses_embedded_v3(host_os string) bool {
+	return host_os in ['linux', 'macos', 'freebsd', 'openbsd', 'netbsd', 'dragonfly']
 }
 
 fn install_missing_bsd_v1_fallback(vroot string, compiler string, args []string, host_os string) ! {

--- a/cmd/tools/vself_test.v
+++ b/cmd/tools/vself_test.v
@@ -184,15 +184,17 @@ fn main() {
 	mock_build := os.execute('${os.quoted_path(vexe)} -o ${os.quoted_path(isolated_vexe)} ${os.quoted_path(mock_source)}')
 	assert mock_build.exit_code == 0, mock_build.output
 	vself_tool := os.join_path(root, 'vself')
-	vself_build := os.execute('${os.quoted_path(vexe)} -o ${os.quoted_path(vself_tool)} ${os.quoted_path(os.join_path(vroot, 'cmd', 'tools', 'vself.v'))}')
+	vself_build := os.execute('${os.quoted_path(vexe)} -d vself_test_bsd_transition -o ${os.quoted_path(vself_tool)} ${os.quoted_path(os.join_path(vroot, 'cmd', 'tools', 'vself.v'))}')
 	assert vself_build.exit_code == 0, vself_build.output
 
 	self_result := os.execute('env -u CC VFLAGS="" VOSARGS="" VSELF_TEST_FULL_CLI=${os.quoted_path(vexe)} VEXE=${os.quoted_path(isolated_vexe)} ${os.quoted_path(vself_tool)} self -silent')
 	assert self_result.exit_code == 0, self_result.output
 	assert self_result.output.contains('cmd/v'), self_result.output
+	assert self_result.output.contains('BSD V1 compatibility compiler'), self_result.output
 	assert !self_result.output.contains('vlib/v3/v3.v'), self_result.output
 	assert os.is_executable(isolated_vexe)
 	assert os.is_executable(os.join_path(root, 'v_old'))
+	assert os.is_executable(os.join_path(root, 'v1_fallback'))
 
 	version_result := os.execute('VFLAGS="" VOSARGS="" VEXE=${os.quoted_path(isolated_vexe)} ${os.quoted_path(isolated_vexe)} version')
 	assert version_result.exit_code == 0, version_result.output

--- a/cmd/tools/vself_test.v
+++ b/cmd/tools/vself_test.v
@@ -137,6 +137,32 @@ fn test_macos_default_self_build_compiler_selection() {
 	assert_vself_preserves_full_cli(old_result.output)
 }
 
+fn test_bsd_self_build_uses_system_cc_and_v3_safeguards() {
+	$if windows {
+		return
+	}
+	noop := os.find_abs_path_of_executable('echo') or { return }
+	tool := os.join_path(os.vtmp_dir(), 'vself_bsd_defaults_test')
+	defer {
+		os.rm(tool) or {}
+	}
+	build := os.execute('${os.quoted_path(vexe)} -d vself_test_bsd_transition -o ${os.quoted_path(tool)} ${os.quoted_path(os.join_path(vroot, 'cmd', 'tools', 'vself.v'))}')
+	assert build.exit_code == 0, build.output
+	default_result := os.execute('env -u CC VFLAGS="" VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -o /tmp/vself_bsd_defaults_test')
+	assert default_result.exit_code == 0, default_result.output
+	assert default_result.output.contains('-cc cc'), default_result.output
+	assert default_result.output.contains('-prealloc'), default_result.output
+	assert_vself_preserves_full_cli(default_result.output)
+	prod_result := os.execute('env -u CC VFLAGS="" VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -prod -o /tmp/vself_bsd_prod_test')
+	assert prod_result.exit_code == 0, prod_result.output
+	assert prod_result.output.contains('-parallel-cc'), prod_result.output
+	assert_vself_uses_single_prod_build(prod_result.output)
+	tinyc_result := os.execute('VFLAGS="" VEXE=${os.quoted_path(noop)} ${os.quoted_path(tool)} self -cc tcc -o /tmp/vself_bsd_tinyc_test')
+	assert tinyc_result.exit_code == 0, tinyc_result.output
+	assert !tinyc_result.output.contains('-prealloc'), tinyc_result.output
+	assert_vself_preserves_full_cli(tinyc_result.output)
+}
+
 fn test_plain_self_replacement_preserves_cli_and_embedded_v3() {
 	$if !bsd && !linux {
 		return

--- a/cmd/tools/vself_test.v
+++ b/cmd/tools/vself_test.v
@@ -138,7 +138,7 @@ fn test_macos_default_self_build_compiler_selection() {
 }
 
 fn test_plain_self_replacement_preserves_cli_and_embedded_v3() {
-	$if !macos && !linux {
+	$if !bsd && !linux {
 		return
 	}
 	root := os.join_path(os.vtmp_dir(), 'vself_full_cli_replacement_${os.getpid()}')

--- a/cmd/tools/vtest_test.v
+++ b/cmd/tools/vtest_test.v
@@ -83,8 +83,8 @@ fn test_vtest_executable_compiles() {
 }
 
 fn test_strict_v3_flags_apply_only_to_top_level_test_compilation() {
-	$if !macos && !linux {
-		// The embedded V3 compiler is currently available only on macOS and Linux.
+	$if !bsd && !linux {
+		// The embedded V3 compiler is currently available only on macOS, Linux, and BSD.
 		return
 	}
 	os.execute_or_exit('${os.quoted_path(vexe)} -old-compiler -nocache -o ${mytest_exe} cmd/tools/vtest.v')

--- a/cmd/v/macos_v3_compat_routing_test.v
+++ b/cmd/v/macos_v3_compat_routing_test.v
@@ -48,7 +48,7 @@ fn test_linux_routes_implicit_cmd_v_self_build_to_v1_compatibility() {
 }
 
 fn test_temporary_self_build_bootstraps_only_before_v1_fallback_exists() {
-	$if macos || linux {
+	$if bsd || linux {
 		vroot := os.dir(@VEXE)
 		mut prefs := &pref.Preferences{
 			path: os.join_path(vroot, 'cmd', 'v')

--- a/cmd/v/macos_v3_dispatch.c.v
+++ b/cmd/v/macos_v3_dispatch.c.v
@@ -1,6 +1,6 @@
 module main
 
-// The V3 compiler is linked directly into `cmd/v` on macOS and Linux. The
+// The V3 compiler is linked directly into `cmd/v` on macOS, Linux, and BSD. The
 // command shell hands C-backend compilations to it in-process while leaving
 // tool commands and other backends on their existing external-tool paths.
 // When V3 fails an ordinary program compilation, the lean V3-only command
@@ -74,7 +74,7 @@ fn retry_macos_v3_with_v1(state &MacosV3RetryState) {
 }
 
 fn maybe_delegate_to_macos_v3(command string, prefs &pref.Preferences) {
-	$if macos || linux {
+	$if bsd || linux {
 		needs_v1_compatibility := macos_v3_needs_v1_compatibility(command, prefs)
 		fallback_executable := macos_v3_v1_fallback_executable()
 		if macos_v3_needs_bootstrap_before_v1_fallback(prefs, needs_v1_compatibility, os.executable(), fallback_executable) {
@@ -103,7 +103,7 @@ fn maybe_delegate_to_macos_v3(command string, prefs &pref.Preferences) {
 			eprintln('the embedded V3 compiler is unavailable on this target, and fallback is disabled.')
 			exit(1)
 		}
-		$if macos || linux {
+		$if bsd || linux {
 			// musl deliberately does not link V3 because its runtime still depends on
 			// glibc-only C interfaces. Use the same full external compatibility
 			// compiler that an ordinary failed V3 build would retry through.

--- a/cmd/v/macos_v3_driver_notd_cross.v
+++ b/cmd/v/macos_v3_driver_notd_cross.v
@@ -2,21 +2,20 @@ module main
 
 $if v1_fallback ? {
 } $else $if musl ? {
-} $else $if macos || linux {
+} $else $if bsd || linux {
 	import v3.driver
 }
 
 // The V3 driver (vlib/v3) is linked directly into `cmd/v` on the target
-// platforms where V3 compiles and runs — macOS and glibc Linux. There `v` can
-// run the V3 compiler in the SAME process. musl builds deliberately use the
-// stub path because the embedded V3 runtime currently depends on glibc-only C
-// interfaces; their ordinary C compilations are delegated to v1_fallback.
+// platforms where V3 compiles and runs — macOS, the BSD family, and glibc Linux.
+// There `v` can run the V3 compiler in the SAME process. musl builds deliberately
+// use the stub path because the embedded V3 runtime currently depends on glibc-only
+// C interfaces; their ordinary C compilations are delegated to v1_fallback.
 //
 // The separately built `v1_fallback` command shell also takes the stub path, so
-// it contains only the stable compiler. Other targets (Windows, the BSDs, and
-// portable `-os cross` VC generation) get the same stub below or the one in
-// macos_v3_driver_d_cross.v, so V3's thread/parallel code is never
-// cross-compiled into them.
+// it contains only the stable compiler. Windows and portable `-os cross` VC
+// generation get the same stub below or the one in macos_v3_driver_d_cross.v,
+// so V3's thread/parallel code is never cross-compiled into them.
 $if v1_fallback ? {
 	@[markused]
 	fn macos_v3_driver_is_available() bool {
@@ -33,7 +32,7 @@ $if v1_fallback ? {
 
 	@[markused]
 	fn macos_v3_driver_run(_ []string) {}
-} $else $if macos || linux {
+} $else $if bsd || linux {
 	@[markused]
 	fn macos_v3_driver_is_available() bool {
 		return true

--- a/cmd/v/macos_v3_external_fallback_test.v
+++ b/cmd/v/macos_v3_external_fallback_test.v
@@ -31,7 +31,7 @@ fn write_v3_rejecting_c_compiler(path string) ! {
 }
 
 fn test_macos_v3_uses_external_v1_fallback_after_c_compilation_error() {
-	$if macos || linux {
+	$if bsd || linux {
 		vroot := os.dir(@VEXE)
 		fallback := os.join_path(vroot, macos_v3_v1_fallback_binary)
 		// Developer/compiler-only test builds do not necessarily come through make.

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -33,7 +33,7 @@ fn test_macos_v3_embedded_driver_matches_target_selection() {
 		assert !macos_v3_driver_is_available()
 	} $else $if musl ? {
 		assert !macos_v3_driver_is_available()
-	} $else $if macos || linux {
+	} $else $if bsd || linux {
 		assert macos_v3_driver_is_available()
 	} $else {
 		assert !macos_v3_driver_is_available()
@@ -84,7 +84,7 @@ fn test_macos_v3_relevant_command_owns_every_direct_c_build() {
 
 fn test_macos_v3_cmd_source_unlinks_v1_on_supported_hosts() {
 	source := os.read_file(os.join_path(macos_v3_test_vroot, 'cmd', 'v', 'v.v'))!
-	assert source.contains('\$if v1_fallback ?|| cross ?|| ( !macos && !linux ) {')
+	assert source.contains('\$if v1_fallback ?|| cross ?|| ( !bsd && !linux ) {')
 	assert source.contains('import v.builder')
 	assert source.contains('import v.builder.cbuilder')
 	assert source.contains('\$if v1_fallback ?|| cross ? {\n\t\t\t\tbuilder.compile')
@@ -106,7 +106,7 @@ fn test_vc_bootstrap_builds_a_v1_compatibility_compiler() {
 }
 
 fn test_v1_fallback_can_bootstrap_cmd_v_without_target_define() {
-	$if macos || linux {
+	$if bsd || linux {
 		fallback := os.join_path(macos_v3_test_vroot, macos_v3_v1_fallback_binary)
 		if !os.is_executable(fallback) {
 			return
@@ -123,7 +123,7 @@ fn test_v1_fallback_can_bootstrap_cmd_v_without_target_define() {
 }
 
 fn test_macos_v3_old_compiler_uses_external_v1_command() {
-	$if macos || linux {
+	$if bsd || linux {
 		fallback := os.join_path(macos_v3_test_vroot, macos_v3_v1_fallback_binary)
 		if !os.is_executable(fallback) {
 			return
@@ -147,7 +147,7 @@ fn test_macos_v3_old_compiler_uses_external_v1_command() {
 }
 
 fn test_macos_v3_invalid_program_still_reports_an_error_after_v1_retry() {
-	$if macos || linux {
+	$if bsd || linux {
 		root := os.join_path(os.vtmp_dir(), 'v3_invalid_program_${os.getpid()}')
 		os.rmdir_all(root) or {}
 		os.mkdir_all(root)!
@@ -168,7 +168,7 @@ fn test_macos_v3_invalid_program_still_reports_an_error_after_v1_retry() {
 }
 
 fn test_macos_v3_fatal_errors_reports_only_the_first_error() {
-	$if macos || linux {
+	$if bsd || linux {
 		root := os.join_path(os.vtmp_dir(), 'v3_fatal_errors_${os.getpid()}')
 		os.rmdir_all(root) or {}
 		os.mkdir_all(root)!
@@ -275,6 +275,9 @@ fn test_macos_v3_ownership_delegation_never_selects_v1() {
 	assert ownership_delegation_is_requested(true, false, false, false, 'linux')
 	assert ownership_delegation_is_requested(false, true, false, false, 'macos')
 	assert ownership_delegation_is_requested(false, true, false, false, 'linux')
+	for bsd_os in ['freebsd', 'openbsd', 'netbsd', 'dragonfly'] {
+		assert ownership_delegation_is_requested(false, true, false, false, bsd_os)
+	}
 	assert !ownership_delegation_is_requested(false, true, false, false, 'windows')
 	assert !ownership_delegation_is_requested(true, false, true, false, 'macos')
 	direct_prefs := &pref.Preferences{
@@ -295,7 +298,7 @@ fn test_macos_v3_ownership_delegation_never_selects_v1() {
 }
 
 fn test_macos_v3_autofree_direct_and_run_use_ownership_compiler() {
-	$if macos || linux {
+	$if bsd || linux {
 		root := os.join_path(os.vtmp_dir(), 'v3_autofree_run_${os.getpid()}')
 		os.rmdir_all(root) or {}
 		os.mkdir_all(root)!
@@ -317,7 +320,7 @@ fn test_macos_v3_autofree_direct_and_run_use_ownership_compiler() {
 }
 
 fn test_macos_v3_parallel_cc_ignores_inactive_header_definitions() {
-	$if macos || linux {
+	$if bsd || linux {
 		root := os.join_path(os.vtmp_dir(), 'v3_parallel_cc_inactive_${os.getpid()}')
 		os.rmdir_all(root) or {}
 		os.mkdir_all(root)!
@@ -339,7 +342,7 @@ fn test_macos_v3_parallel_cc_ignores_inactive_header_definitions() {
 }
 
 fn test_macos_v3_compiles_cmd_v_without_v1_modules() {
-	$if macos || linux {
+	$if bsd || linux {
 		compiler := os.join_path(macos_v3_test_vroot, '.v3_only_cmd_test_${os.getpid()}')
 		defer {
 			os.rm(compiler) or {}

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -105,6 +105,11 @@ fn test_vc_bootstrap_builds_a_v1_compatibility_compiler() {
 	}
 }
 
+fn test_netbsd_marks_the_v1_compatibility_compiler() {
+	makefile := os.read_file(os.join_path(macos_v3_test_vroot, 'GNUmakefile'))!
+	assert makefile.contains('paxctl +m \$(V1_FALLBACK_EXE)')
+}
+
 fn test_v1_fallback_can_bootstrap_cmd_v_without_target_define() {
 	$if bsd || linux {
 		fallback := os.join_path(macos_v3_test_vroot, macos_v3_v1_fallback_binary)

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -11,7 +11,7 @@ import v.pref
 import v.util
 import v.util.version
 
-$if v1_fallback ?|| cross ?|| ( !macos && !linux ) {
+$if v1_fallback ?|| cross ?|| ( !bsd && !linux ) {
 	// The compatibility compiler, portable cross snapshots, and non-V3 targets
 	// all need the V1 builder. Keep this as one import site: a compatibility
 	// compiler generating a cross target can satisfy multiple parts of the condition.
@@ -262,7 +262,7 @@ fn maybe_delegate_to_ownership(command string, prefs &pref.Preferences, merged_a
 }
 
 fn autofree_args_have_unsupported_ownership_option(args []string, command string) bool {
-	$if macos {
+	$if bsd || linux {
 		return macos_v3_has_unsupported_leading_option(args, command)
 	}
 	return false
@@ -274,7 +274,7 @@ fn v3_ownership_forwarded_args(prefs &pref.Preferences, merged_args []string) []
 		ownership_args.prepend('ownership')
 		ownership_args.prepend('-d')
 	}
-	$if macos {
+	$if bsd || linux {
 		return macos_v3_forwarded_args(prefs, ownership_args)
 	}
 	return ownership_args
@@ -343,7 +343,8 @@ fn ownership_delegation_is_requested(is_ownership bool, is_autofree bool, old_co
 	if new_compiler {
 		return false
 	}
-	return is_autofree && host_os in ['macos', 'linux']
+	return is_autofree
+		&& host_os in ['macos', 'linux', 'freebsd', 'openbsd', 'netbsd', 'dragonfly']
 }
 
 fn is_ownership_relevant_command(command string, prefs &pref.Preferences) bool {
@@ -424,7 +425,7 @@ fn rebuild(prefs &pref.Preferences) {
 		.c {
 			$if v1_fallback ?|| cross ? {
 				builder.compile('build', prefs, cbuilder.compile_c)
-			} $else $if macos || linux {
+			} $else $if bsd || linux {
 
 				// Every C-backend build is dispatched to V3 before this point. Keeping
 				// this path fatal prevents an accidental dependency on the unlinked V1

--- a/vlib/compress/lz/lz_test.v
+++ b/vlib/compress/lz/lz_test.v
@@ -1,7 +1,6 @@
 module lz
 
-const sample_data = ('The quick brown fox jumps over the lazy dog. '.repeat(12) +
-	'aaaaaaaaabbbbbbbbbcccccccccdddddddddeeeeeeeee').bytes()
+const sample_data = ('The quick brown fox jumps over the lazy dog. '.repeat(12) + 'aaaaaaaaabbbbbbbbbcccccccccdddddddddeeeeeeeee').bytes()
 
 fn test_roundtrip_all_formats() {
 	formats := [Format.lz77, .lz78, .lzw, .lz4, .lzss, .lzma, .lzma2, .lzjb]
@@ -51,7 +50,7 @@ fn test_decoded_length_too_large_fails() {
 	mut corrupt := []u8{}
 	corrupt << stream_magic
 	corrupt << u8(Format.lz77)
-	encode_uvarint(mut corrupt, u64(1) << 31)
+	encode_uvarint(mut corrupt, u64(max_int) + 1)
 
 	decompress_lz77(corrupt) or {
 		assert err.msg().contains('decoded length too large')

--- a/vlib/math/big/primality.v
+++ b/vlib/math/big/primality.v
@@ -6,8 +6,8 @@ import crypto.rand.internal
 const tiny_primes = [u64(2), 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61]!
 
 // The odd primes below 60, as two products that each fit in a 32 bit word.
-const primes_a = u64(3 * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 37)
-const primes_b = u64(29 * 31 * 41 * 43 * 47 * 53)
+const primes_a = u64(3) * 5 * 7 * 11 * 13 * 17 * 19 * 23 * 37
+const primes_b = u64(29) * 31 * 41 * 43 * 47 * 53
 
 // Bases that make Miller-Rabin deterministic below 3317044064679887385961981.
 const deterministic_bases = [u64(2), 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41]!

--- a/vlib/v/help/build/build-c.txt
+++ b/vlib/v/help/build/build-c.txt
@@ -14,7 +14,7 @@ see also `v help build`.
       `clang`, `gcc`, `tcc` (also accepted as `tinyc`), `mingw-w64` and `msvc`.
 
    -old-compiler
-      On macOS and Linux the experimental V3 compiler (vlib/v3) is the default;
+      On macOS, Linux, and BSD the experimental V3 compiler (vlib/v3) is the default;
       `-old-compiler` bypasses it and compiles with the established compiler in
       vlib/v. V already falls back to this compiler automatically when V3 cannot
       build an eligible program, and (unless V_C_ERROR_BUG_REPORT_DISABLED=1 is

--- a/vlib/v/help/build/build.txt
+++ b/vlib/v/help/build/build.txt
@@ -16,7 +16,7 @@ then run `./myfile -param1 abcde` and exit with its exit code".
 When compiling packages, V ignores files that end in '_test.v'.
 
 The default compiler:
-  On macOS and Linux, `v` compiles with the experimental V3 compiler (vlib/v3)
+  On macOS, Linux, and BSD, `v` compiles with the experimental V3 compiler (vlib/v3)
   by default. When V3 cannot yet build an eligible program, V automatically falls
   back to the established compiler in vlib/v, so builds keep working. Unless the
   environment variable V_C_ERROR_BUG_REPORT_DISABLED=1 is set, a reportable

--- a/vlib/v/help/installation/self.txt
+++ b/vlib/v/help/installation/self.txt
@@ -7,7 +7,8 @@ Usage:
 
 Options:
   All other options are passed to the build command. (e.g. -prod)
-  Plain self-builds compile the full `cmd/v` CLI, which embeds and defaults to V3 on macOS/Linux.
+  Plain self-builds compile the full `cmd/v` CLI, which embeds and defaults to V3 on macOS,
+  Linux, and BSD.
   On Apple Silicon, regular self-builds use bundled TCC by default; `CC` or `-cc` overrides it.
   On macOS and Linux, -prod uses a single parallel C build without LTO instead of PGO.
   On other systems, -prod with clang/gcc may use PGO when tools are available.

--- a/vlib/v/help/installation/self.txt
+++ b/vlib/v/help/installation/self.txt
@@ -10,7 +10,7 @@ Options:
   Plain self-builds compile the full `cmd/v` CLI, which embeds and defaults to V3 on macOS,
   Linux, and BSD.
   On Apple Silicon, regular self-builds use bundled TCC by default; `CC` or `-cc` overrides it.
-  On macOS and Linux, -prod uses a single parallel C build without LTO instead of PGO.
+  On macOS, Linux, and BSD, -prod uses a single parallel C build without LTO instead of PGO.
   On other systems, -prod with clang/gcc may use PGO when tools are available.
   On macOS and Linux, `-b fastc` builds the standalone experimental V3 FastC compiler.
   `-prod` cannot be combined with `-b fastc`.

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -297,13 +297,15 @@ pub fn (mut p Preferences) fill_with_defaults() {
 	}
 	npath := rpath.replace('\\', '/')
 	p.building_v = !p.is_repl && is_v_compiler_target(npath)
-	$if macos || linux {
+	$if bsd || linux {
 		// The embedded V3 compiler relies on disposable preallocation scopes to keep
 		// large compiler-module tests bounded. Match V3's own building-v default so
 		// ordinary `v -o vnew cmd/v` builds do not retain every stage allocation.
-		if p.building_v && p.os in [.macos, .linux] && !p.prealloc
+		if p.building_v && p.os in [.macos, .linux, .freebsd, .openbsd, .netbsd, .dragonfly]
+			&& !p.prealloc
 			&& (!p.gc_set_by_flag || p.gc_mode == .no_gc)
-			&& (p.os != .linux || !p.ccompiler_set_by_flag || cc_from_string(p.ccompiler) != .tinyc) {
+			&& (p.os == .macos || !p.ccompiler_set_by_flag
+				|| cc_from_string(p.ccompiler) != .tinyc) {
 			p.prealloc = true
 			p.build_options << '-prealloc'
 		}

--- a/vlib/v/pref/pref_test.v
+++ b/vlib/v/pref/pref_test.v
@@ -464,29 +464,45 @@ fn test_prealloc_defaults_to_no_gc() {
 	assert prefs.gc_mode == .no_gc
 }
 
-fn test_macos_and_linux_v_compiler_target_defaults_to_prealloc() {
-	if pref.get_host_os() !in [.macos, .linux] {
+fn test_v3_platform_v_compiler_targets_default_to_prealloc() {
+	if pref.get_host_os() !in [.macos, .linux, .freebsd, .openbsd, .netbsd, .dragonfly] {
 		return
 	}
-	for target in [os.join_path(vroot, 'cmd', 'v'), os.join_path(vroot, 'vlib', 'v3', 'v3.v')] {
-		prefs, _ := pref.parse_args_and_show_errors([], ['', target], false)
-		assert prefs.building_v
-		assert prefs.prealloc
-		assert prefs.gc_mode == .no_gc
+	for target_os in [pref.OS.macos, .linux, .freebsd, .openbsd, .netbsd, .dragonfly] {
+		for target in [os.join_path(vroot, 'cmd', 'v'), os.join_path(vroot, 'vlib', 'v3', 'v3.v')] {
+			mut prefs := pref.Preferences{
+				path:                  target
+				os:                    target_os
+				ccompiler:             'cc'
+				ccompiler_set_by_flag: true
+			}
+			prefs.fill_with_defaults()
+			assert prefs.building_v
+			assert prefs.prealloc
+			assert prefs.gc_mode == .no_gc
+		}
 	}
 }
 
-fn test_linux_explicit_tinyc_v_compiler_target_skips_prealloc() {
-	if pref.get_host_os() != .linux {
+fn test_non_macos_explicit_tinyc_v_compiler_target_skips_prealloc() {
+	if pref.get_host_os() !in [.macos, .linux, .freebsd, .openbsd, .netbsd, .dragonfly] {
 		return
 	}
 	target := os.join_path(vroot, 'cmd', 'v')
-	for compiler in ['tcc', 'tinyc'] {
-		prefs, _ := pref.parse_args_and_show_errors([], ['', '-cc', compiler, target], false)
-		assert prefs.building_v
-		assert prefs.ccompiler_type == .tinyc
-		assert !prefs.prealloc
-		assert '-prealloc' !in prefs.build_options
+	for target_os in [pref.OS.linux, .freebsd, .openbsd, .netbsd, .dragonfly] {
+		for compiler in ['tcc', 'tinyc'] {
+			mut prefs := pref.Preferences{
+				path:                  target
+				os:                    target_os
+				ccompiler:             compiler
+				ccompiler_set_by_flag: true
+			}
+			prefs.fill_with_defaults()
+			assert prefs.building_v
+			assert prefs.ccompiler_type == .tinyc
+			assert !prefs.prealloc
+			assert '-prealloc' !in prefs.build_options
+		}
 	}
 }
 

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -44,9 +44,9 @@ therefore use V3. Commands such as `test` remain external tools, while each disc
 is compiled by V3. Non-C backends remain separate builder tools.
 
 `-new-compiler` remains accepted for command-line compatibility and selects the same in-process V3
-driver. `-old-compiler` is unavailable in a V3-only executable and reports an error. On Windows
-and portable cross-VC builds, the V3 driver is not embedded and `cmd/v` retains the established
-compiler.
+driver. On macOS, Linux, and BSD, `-old-compiler` launches the external `v1_fallback`
+compatibility compiler installed by `make` and maintained by self-builds. On Windows and portable
+cross-VC builds, the V3 driver is not embedded and `cmd/v` retains the established compiler.
 
 The in-process path supports the split module cache and uses parallel stages while the input
 remains within its scratch-memory safety limit.

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -29,24 +29,24 @@ builtin `map` type name and API (`new_map`, `map__set`, `map__get`,
 `map__delete`, etc.) with a simplified open-addressing implementation until v3
 can compile the full builtin map.v.
 
-## macOS V3 dispatch
+## V3 dispatch
 
-On macOS and Linux, V3 is the default compiler for user source and test builds. The top-level
-`v` command runs the V3 driver linked into `cmd/v`; it does not build or launch a second compiler
-process. This includes direct file and directory builds, `run`, `build`, and test-file compilation,
-plus production and shared builds and supported cross targets and backends. The `test` command
-itself continues to use the established test dispatcher, while each discovered test file is
-compiled by V3.
+On macOS, Linux, and BSD, V3 is the default compiler for user source and test builds. The
+top-level `v` command runs the V3 driver linked into `cmd/v`; it does not build or launch a second
+compiler process. This includes direct file and directory builds, `run`, `build`, and test-file
+compilation, plus production and shared builds and supported cross targets and backends. The
+`test` command itself continues to use the established test dispatcher, while each discovered
+test file is compiled by V3.
 
-`cmd/v` remains the full CLI and tool dispatcher. On macOS and Linux it links V3, but does not link
-the established compiler in `vlib/v`; its own build and every other direct C build therefore use
-V3. Commands such as `test` remain external tools, while each discovered test file is compiled by
-V3. Non-C backends remain separate builder tools.
+`cmd/v` remains the full CLI and tool dispatcher. On macOS, Linux, and BSD it links V3, but does
+not link the established compiler in `vlib/v`; its own build and every other direct C build
+therefore use V3. Commands such as `test` remain external tools, while each discovered test file
+is compiled by V3. Non-C backends remain separate builder tools.
 
 `-new-compiler` remains accepted for command-line compatibility and selects the same in-process V3
-driver. `-old-compiler` is unavailable in a V3-only executable and reports an error. On Windows,
-the BSDs, and portable cross-VC builds, the V3 driver is not embedded and `cmd/v` retains the
-established compiler.
+driver. `-old-compiler` is unavailable in a V3-only executable and reports an error. On Windows
+and portable cross-VC builds, the V3 driver is not embedded and `cmd/v` retains the established
+compiler.
 
 The in-process path supports the split module cache and uses parallel stages while the input
 remains within its scratch-memory safety limit.
@@ -77,8 +77,8 @@ compiler-tree and self-host builds stop at 9984 MiB, leaving extra sampling head
 10 GiB process ceiling.
 On macOS it uses physical footprint, matching Activity Monitor more closely; elsewhere it uses
 current RSS. Pass `-no-memory-limit`/`--no-memory-limit` to disable this safety limit.
-On macOS and Linux, `make` and the default `v self` build the compiler with `-prealloc`, enabling
-the disposable stage arenas that keep compiler self-hosting within that ceiling.
+On macOS, Linux, and BSD, `make` and the default `v self` build the compiler with `-prealloc`,
+enabling the disposable stage arenas that keep compiler self-hosting within that ceiling.
 Stage rows recorded at pipeline boundaries report sampled peak RSS and the process peak. Timing
 breakdowns reconstructed after a stage omit the sampled peak. On macOS each row also prints
 physical footprint immediately after RSS.

--- a/vlib/v3/bench/peak_rss.h
+++ b/vlib/v3/bench/peak_rss.h
@@ -1,0 +1,18 @@
+#ifndef V3_BENCH_PEAK_RSS_H
+#define V3_BENCH_PEAK_RSS_H
+
+#include <sys/resource.h>
+
+static long long v3_bench_peak_rss_kb(void) {
+	struct rusage usage;
+	if (getrusage(RUSAGE_SELF, &usage) != 0) {
+		return -1;
+	}
+#if defined(__APPLE__)
+	return (long long) usage.ru_maxrss / 1024;
+#else
+	return (long long) usage.ru_maxrss;
+#endif
+}
+
+#endif

--- a/vlib/v3/bench/peak_rss_nix.c.v
+++ b/vlib/v3/bench/peak_rss_nix.c.v
@@ -1,21 +1,13 @@
 module bench
 
-#include <sys/resource.h>
+#insert "@VEXEROOT/vlib/v3/bench/peak_rss.h"
 
-struct C.rusage {
-	ru_maxrss i64
-}
-
-fn C.getrusage(who int, usage &C.rusage) int
+fn C.v3_bench_peak_rss_kb() i64
 
 fn peak_rss_kb() i64 {
-	mut usage := C.rusage{}
-	if C.getrusage(C.RUSAGE_SELF, &usage) != 0 {
+	peak := C.v3_bench_peak_rss_kb()
+	if peak < 0 {
 		return current_rss_kb()
 	}
-	$if macos {
-		return usage.ru_maxrss / 1024
-	} $else {
-		return usage.ru_maxrss
-	}
+	return peak
 }

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -67,18 +67,29 @@ const macos_v3_c_error_v_source_digests_file = 'v_source_digests'
 const v3_fallback_native_input_prefix = '@native-input:'
 const v3_fallback_native_manifest_key = '@native-input-manifest:v1'
 const v3_fallback_native_manifest_value = 'v3-native-input-manifest-v1'
+const bsd_selfhost_job_limit = 2
+
+fn default_selfhost_job_count(jobs int, is_bsd_host bool, allow_overcommit bool) int {
+	if is_bsd_host {
+		return int_min(jobs, bsd_selfhost_job_limit)
+	}
+	if !allow_overcommit || jobs < 2 || jobs >= 12 {
+		return jobs
+	}
+	return int_min(12, jobs + jobs / 2)
+}
 
 fn configure_selfhost_parallelism(building_v bool) {
-	if !building_v || os.getenv('VJOBS') != '' || os.getenv('V3_NO_SELFHOST_JOB_OVERCOMMIT') != '' {
+	if !building_v || os.getenv('VJOBS') != '' {
 		return
 	}
 	jobs := runtime.nr_jobs()
-	if jobs < 2 || jobs >= 12 {
-		return
-	}
-	overcommitted := int_min(12, jobs + jobs / 2)
-	if overcommitted > jobs {
-		os.setenv('VJOBS', overcommitted.str(), true)
+	is_bsd_host := $if freebsd || openbsd || netbsd || dragonfly { true } $else { false }
+	configured_jobs := default_selfhost_job_count(jobs, is_bsd_host, os.getenv('V3_NO_SELFHOST_JOB_OVERCOMMIT') == '')
+	if configured_jobs != jobs {
+		// V3 self-hosting needs more than 4 GiB before the C compiler starts.
+		// Bound BSD worker pools so CPU-rich hosts do not multiply that peak.
+		os.setenv('VJOBS', configured_jobs.str(), true)
 	}
 }
 

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -8638,7 +8638,11 @@ pub fn run(args []string) {
 		eprintln("builder error: ${input_file} doesn't exist")
 		exit(1)
 	}
-	if input_implies_building_v(input_file) {
+	cmd_v_build := input_is_cmd_v(input_file)
+	// Neither compiler entry point uses generics. Keep self-builds off the generic
+	// reachability and monomorphization paths without requiring an explicit flag.
+	// -building-v can force the same mode for another known non-generic input.
+	if input_implies_building_v(input_file) || cmd_v_build {
 		building_v = true
 	}
 	configure_selfhost_parallelism(building_v)
@@ -8784,15 +8788,8 @@ pub fn run(args []string) {
 		&& !user_defines.any(it.all_before('=').trim_space() == 'linux_wayland_session') {
 		user_defines << 'linux_wayland_session'
 	}
-	cmd_v_build := input_is_cmd_v(input_file)
 	cmd_v_module_input := input_loads_cmd_v_module(input_file)
 	v3_compiler_tree_input := input_is_v3_compiler_tree(input_file)
-	// Neither compiler entry point uses generics. Keep self-builds off the generic
-	// reachability and monomorphization paths without requiring an explicit flag.
-	// -building-v can force the same mode for another known non-generic input.
-	if input_implies_building_v(input_file) || cmd_v_build {
-		building_v = true
-	}
 	if backend == 'fastc' && 'fastc_real_builtin' in user_defines {
 		// Opt-in: compile an ordinary program through FastC's real-`builtin` path
 		// (real `struct string`, error system, and the full runtime) instead of the

--- a/vlib/v3/driver/environment_test.v
+++ b/vlib/v3/driver/environment_test.v
@@ -1,6 +1,7 @@
 module driver
 
 import os
+import runtime
 import crypto.sha256
 import v3.ansi
 import v3.parser
@@ -12,6 +13,42 @@ fn restore_driver_environment(name string, old_value string, was_set bool) {
 		os.setenv(name, old_value, true)
 	} else {
 		os.unsetenv(name)
+	}
+}
+
+fn test_default_selfhost_job_count() {
+	assert default_selfhost_job_count(1, false, true) == 1
+	assert default_selfhost_job_count(2, false, true) == 3
+	assert default_selfhost_job_count(8, false, true) == 12
+	assert default_selfhost_job_count(12, false, true) == 12
+	assert default_selfhost_job_count(8, false, false) == 8
+	assert default_selfhost_job_count(1, true, true) == 1
+	assert default_selfhost_job_count(8, true, true) == bsd_selfhost_job_limit
+	assert default_selfhost_job_count(8, true, false) == bsd_selfhost_job_limit
+}
+
+fn test_configure_selfhost_parallelism_uses_bsd_limit() {
+	old_vjobs := os.getenv('VJOBS')
+	vjobs_was_set := 'VJOBS' in os.environ()
+	old_no_overcommit := os.getenv('V3_NO_SELFHOST_JOB_OVERCOMMIT')
+	no_overcommit_was_set := 'V3_NO_SELFHOST_JOB_OVERCOMMIT' in os.environ()
+	defer {
+		restore_driver_environment('VJOBS', old_vjobs, vjobs_was_set)
+		restore_driver_environment('V3_NO_SELFHOST_JOB_OVERCOMMIT', old_no_overcommit, no_overcommit_was_set)
+	}
+	os.unsetenv('VJOBS')
+	os.setenv('V3_NO_SELFHOST_JOB_OVERCOMMIT', '1', true)
+	$if freebsd || openbsd || netbsd || dragonfly {
+		jobs := runtime.nr_jobs()
+		configure_selfhost_parallelism(true)
+		if jobs > bsd_selfhost_job_limit {
+			assert os.getenv('VJOBS') == bsd_selfhost_job_limit.str()
+		} else {
+			assert os.getenv('VJOBS') == ''
+		}
+	} $else {
+		configure_selfhost_parallelism(true)
+		assert os.getenv('VJOBS') == ''
 	}
 }
 

--- a/vlib/v3/driver/parallel_cc_test.v
+++ b/vlib/v3/driver/parallel_cc_test.v
@@ -33,7 +33,7 @@ fn test_split_v3_parallel_c_source_uses_safe_unit_markers() {
 }
 
 fn test_v3_parallel_cc_compiles_and_runs_multiple_c_units() {
-	$if macos || linux {
+	$if bsd || linux {
 		root := os.join_path(os.vtmp_dir(), 'v3_parallel_cc_${os.getpid()}')
 		os.rmdir_all(root) or {}
 		os.mkdir_all(root)!
@@ -57,7 +57,7 @@ fn test_v3_parallel_cc_compiles_and_runs_multiple_c_units() {
 }
 
 fn test_v3_parallel_cc_keeps_test_binaries_in_one_unit() {
-	$if macos || linux {
+	$if bsd || linux {
 		root := os.join_path(os.vtmp_dir(), 'v3_parallel_cc_test_harness_${os.getpid()}')
 		os.rmdir_all(root) or {}
 		os.mkdir_all(root)!
@@ -80,7 +80,7 @@ fn test_v3_parallel_cc_keeps_test_binaries_in_one_unit() {
 }
 
 fn test_v3_parallel_cc_does_not_shadow_user_parallel_header() {
-	$if macos || linux {
+	$if bsd || linux {
 		root := os.join_path(os.vtmp_dir(), 'v3_parallel_cc_header_${os.getpid()}')
 		os.rmdir_all(root) or {}
 		os.mkdir_all(root)!
@@ -103,7 +103,7 @@ fn test_v3_parallel_cc_does_not_shadow_user_parallel_header() {
 }
 
 fn test_v3_parallel_cc_falls_back_for_native_static_state() {
-	$if macos || linux {
+	$if bsd || linux {
 		root := os.join_path(os.vtmp_dir(), 'v3_parallel_cc_static_${os.getpid()}')
 		os.rmdir_all(root) or {}
 		os.mkdir_all(root)!
@@ -127,7 +127,7 @@ fn test_v3_parallel_cc_falls_back_for_native_static_state() {
 }
 
 fn test_v3_parallel_cc_falls_back_for_native_function_local_static_state() {
-	$if macos || linux {
+	$if bsd || linux {
 		root := os.join_path(os.vtmp_dir(), 'v3_parallel_cc_local_static_${os.getpid()}')
 		os.rmdir_all(root) or {}
 		os.mkdir_all(root)!
@@ -151,7 +151,7 @@ fn test_v3_parallel_cc_falls_back_for_native_function_local_static_state() {
 }
 
 fn test_v3_parallel_cc_falls_back_for_macro_generated_function_local_static_state() {
-	$if macos || linux {
+	$if bsd || linux {
 		root := os.join_path(os.vtmp_dir(), 'v3_parallel_cc_macro_static_${os.getpid()}')
 		os.rmdir_all(root) or {}
 		os.mkdir_all(root)!
@@ -181,7 +181,7 @@ DEF(v3_parallel_macro_next)
 }
 
 fn test_v3_parallel_cc_falls_back_for_coverage_and_profile_state() {
-	$if macos || linux {
+	$if bsd || linux {
 		root := os.join_path(os.vtmp_dir(), 'v3_parallel_cc_instrumentation_${os.getpid()}')
 		os.rmdir_all(root) or {}
 		os.mkdir_all(root)!

--- a/vlib/v3/tests/preinclude_uncertain_macro_test.v
+++ b/vlib/v3/tests/preinclude_uncertain_macro_test.v
@@ -1,7 +1,7 @@
 import os
 
 fn test_preinclude_uncertain_macro_keeps_c_extern_prototype() {
-	$if macos || linux {
+	$if bsd || linux {
 		root := os.join_path(os.vtmp_dir(), 'v3_preinclude_uncertain_macro_${os.getpid()}')
 		os.rmdir_all(root) or {}
 		os.mkdir_all(root)!


### PR DESCRIPTION
## Summary

- make the embedded V3 compiler the default on FreeBSD, OpenBSD, NetBSD, and DragonFly BSD
- build the V1 compatibility fallback on BSD and add BSD bootstrap/resource safeguards
- fix BSD portability issues found during native FreeBSD testing
- update FreeBSD/OpenBSD CI coverage, tests, help, and V3 documentation

## Testing

- FreeBSD 15.1 ARM64 QEMU: native bootstrap, V3 self-host generations, clang CI tasks, and BSD-specific regression tests
- ./vnew -old-compiler -silent vlib/v/compiler_errors_test.v (1707 passed, 1 skipped)
- ./vnew -silent test cmd/v/ (4 passed, 1 Windows-only skip)
- ./vnew -silent vlib/v3/driver/environment_test.v
- ./vnew -silent vlib/math/big/primality_test.v
- ./vnew -silent vlib/compress/lz/lz_test.v
- ./vnew check-md vlib/v3/README.md
- CI script compile checks, workflow YAML parsing, makefile dry runs, and git diff --check

## QEMU limitations

FreeBSD ARM64 GCC 14 hit an internal LTO compiler error in one V1-only diagnostic fixture. The bundled FreeBSD ARM64 TCC also has an existing wchar_t incompatibility, so the x86-64 CI jobs remain authoritative for those two compiler configurations.