### PR TITLE
v3: qualify cached shared global storage

### DIFF
--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -1012,6 +1012,17 @@ fn (g &FlatGen) local_storage_is_shared(name string) bool {
 	return false
 }
 
+// shared_storage_ident_c_name qualifies shared globals while preserving local storage names.
+fn (g &FlatGen) shared_storage_ident_c_name(name string) string {
+	owner := g.local_storage_owner(name) or { return g.cname(name) }
+	if g.tc.file_scope != unsafe { nil } && owner.belongs_to_scope(g.tc.file_scope) {
+		if global_name := g.global_name_for_ident(name) {
+			return g.global_c_name(global_name)
+		}
+	}
+	return g.cname(name)
+}
+
 fn (mut g FlatGen) declare_local_fn_value_c_name(owner types.ScopeBindingOwner, c_name string) {
 	key := owner.storage_key()
 	if key.len == 0 {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -1020,7 +1020,7 @@ fn (g &FlatGen) shared_storage_ident_c_name(name string) string {
 			return g.global_c_name(global_name)
 		}
 	}
-	return g.cname(name)
+	return g.local_cname(name)
 }
 
 fn (mut g FlatGen) declare_local_fn_value_c_name(owner types.ScopeBindingOwner, c_name string) {

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -4072,7 +4072,7 @@ fn (g &FlatGen) shared_local_arg_c_expr(arg_id flat.NodeId) ?string {
 		}
 	}
 	if arg.kind == .ident && g.local_storage_is_shared(arg.value) {
-		return g.cname(arg.value)
+		return g.shared_storage_ident_c_name(arg.value)
 	}
 	return none
 }
@@ -4091,7 +4091,7 @@ fn (g &FlatGen) shared_payload_deref_storage_c_expr(id flat.NodeId) ?string {
 	base_id := g.a.child(&node, 0)
 	base := g.a.nodes[int(base_id)]
 	if base.kind == .ident && g.local_storage_is_shared(base.value) {
-		return g.cname(base.value)
+		return g.shared_storage_ident_c_name(base.value)
 	}
 	return none
 }
@@ -4353,7 +4353,7 @@ fn (g &FlatGen) spawn_shared_value_selector_storage(child flat.Node) ?string {
 	if base.kind != .ident || !g.local_ident_is_shared_wrapper(base.value) {
 		return none
 	}
-	return g.cname(base.value)
+	return g.shared_storage_ident_c_name(base.value)
 }
 
 fn (g &FlatGen) local_ident_is_shared_wrapper(name string) bool {

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -157,7 +157,7 @@ fn (g &FlatGen) shared_array_payload_lvalue(id flat.NodeId) ?string {
 		return g.shared_array_payload_lvalue(g.a.child(&node, 0))
 	}
 	if node.kind == .ident && g.local_storage_is_shared(node.value) {
-		return '${g.cname(node.value)}->val'
+		return '${g.shared_storage_ident_c_name(node.value)}->val'
 	}
 	return none
 }
@@ -316,7 +316,7 @@ fn (mut g FlatGen) gen_lock_mutex_addr(lock_id flat.NodeId) {
 	lock_node := g.a.nodes[int(lock_id)]
 	if lock_node.kind == .ident && g.local_storage_is_shared(lock_node.value) {
 		g.write('(uintptr_t)&')
-		g.write(g.cname(lock_node.value))
+		g.write(g.shared_storage_ident_c_name(lock_node.value))
 		g.write('->mtx')
 		return
 	}
@@ -7303,7 +7303,7 @@ fn (mut g FlatGen) gen_decl_init_expr(rhs_id flat.NodeId, rhs flat.Node, v_type 
 		return
 	}
 	if v_type is types.Pointer && rhs.kind == .ident && g.local_storage_is_shared(rhs.value) {
-		g.write('&(${g.local_cname(rhs.value)}->val)')
+		g.write('&(${g.shared_storage_ident_c_name(rhs.value)}->val)')
 		return
 	}
 	if v_type is types.Pointer && rhs.kind == .ident && !g.local_storage_is_pointer(rhs.value) {

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -3257,7 +3257,7 @@ fn (mut g FlatGen) gen_shared_storage_expr(id flat.NodeId) bool {
 		return g.gen_shared_storage_expr(g.a.child(&node, 0))
 	}
 	if node.kind == .ident && g.local_storage_is_shared(node.value) {
-		g.write(g.cname(node.value))
+		g.write(g.shared_storage_ident_c_name(node.value))
 		return true
 	}
 	if node.kind == .index && node.children_count > 1 {
@@ -3279,7 +3279,7 @@ fn (mut g FlatGen) gen_local_shared_value_selector(base_id flat.NodeId, field st
 	if base.kind != .ident || !g.local_storage_is_shared(base.value) {
 		return false
 	}
-	g.write(g.cname(base.value))
+	g.write(g.shared_storage_ident_c_name(base.value))
 	g.write('->val.')
 	g.write(c_field_name(field))
 	mut base_type := types.unwrap_pointer(g.usable_expr_type(base_id))
@@ -3313,7 +3313,7 @@ fn (mut g FlatGen) gen_shared_field_storage_selector(base_id flat.NodeId, base_t
 	}
 	base := g.a.nodes[int(base_id)]
 	if base.kind == .ident && g.local_storage_is_shared(base.value) {
-		g.write(g.cname(base.value))
+		g.write(g.shared_storage_ident_c_name(base.value))
 		g.write('->val.')
 		g.write(c_field_name(field))
 		return true

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -5296,23 +5296,38 @@ pub fn count() int {
 }
 ')
 	main_file := os.join_path(root, 'main.v')
-	write_module_cache_file(root, 'main.v', 'module main
+	write_module_cache_file(root, 'main.v', '@[has_globals]
+module main
 
 import guarded
+
+__global guarded_items shared []int
+
+fn local_summary() string {
+	shared guarded_items := &[41]
+	mut summary := ""
+	lock guarded_items {
+		guarded_items << 42
+		alias := guarded_items
+		summary = int_str(alias.len) + ":" + int_str(alias[0]) + ":" + int_str(alias[1])
+	}
+	return summary
+}
 
 fn main() {
 	guarded.append(42)
 	println(guarded.count())
+	println(local_summary())
 }
 ')
 	cache_dir := os.join_path(root, 'cache')
 	first_output := os.join_path(root, 'first')
 	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
-	assert run_module_cache_binary(first_output) == '1'
+	assert run_module_cache_binary(first_output) == '1\n2:41:42'
 
 	second_output := os.join_path(root, 'second')
 	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
-	assert run_module_cache_binary(second_output) == '1'
+	assert run_module_cache_binary(second_output) == '1\n2:41:42'
 }
 
 fn test_cached_header_preserves_noreturn_attribute() {

--- a/vlib/v3/tests/module_cache_test.v
+++ b/vlib/v3/tests/module_cache_test.v
@@ -5270,6 +5270,51 @@ fn main() {
 	assert changed_module_cache_objects(first_hashes, module_cache_object_hashes(cache_dir)).len == 0
 }
 
+fn test_cached_module_shared_global_lock_uses_qualified_storage() {
+	v3_bin := build_module_cache_v3()
+	root := os.join_path(os.temp_dir(), 'v3_module_cache_shared_global_lock_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	write_module_cache_file(root, 'guarded/guarded.v', '@[has_globals]
+module guarded
+
+__global guarded_items shared []int
+
+pub fn append(value int) {
+	lock guarded_items {
+		guarded_items << value
+	}
+}
+
+pub fn count() int {
+	return rlock guarded_items {
+		guarded_items.len
+	}
+}
+')
+	main_file := os.join_path(root, 'main.v')
+	write_module_cache_file(root, 'main.v', 'module main
+
+import guarded
+
+fn main() {
+	guarded.append(42)
+	println(guarded.count())
+}
+')
+	cache_dir := os.join_path(root, 'cache')
+	first_output := os.join_path(root, 'first')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, first_output)
+	assert run_module_cache_binary(first_output) == '1'
+
+	second_output := os.join_path(root, 'second')
+	compile_module_cache_project(v3_bin, cache_dir, main_file, second_output)
+	assert run_module_cache_binary(second_output) == '1'
+}
+
 fn test_cached_header_preserves_noreturn_attribute() {
 	v3_bin := build_module_cache_v3()
 	root := os.join_path(os.temp_dir(), 'v3_module_cache_noreturn_${os.getpid()}')


### PR DESCRIPTION
## What does this PR do?

- qualify V3 shared-global storage references with their module C name
- preserve binding-aware C names for local shared variables, including renamed shadowing locals
- add cold/warm module-cache coverage for `lock`, `rlock`, and pointer-valued local aliases

This fixes cached modules emitting references such as
`&zoneinfo_loaders->mtx` when the declared symbol is
`time__zoneinfo_loaders`. That C compilation failure made V3 fall back to V1.

It also preserves a local shared declaration's `__local` suffix when its source
name shadows a main/builtin global or another C-level symbol.

## Tests

- `./vnew -run-only test_cached_module_shared_global_lock_uses_qualified_storage vlib/v3/tests/module_cache_test.v`
- `V3CACHE=<fresh> V_MACOS_V3_NO_FALLBACK=1 ./vnew -prod -no-parallel -o /tmp/v3-x-pr-check /Users/alex/code/x`
- `./vnew -silent test vlib/v3/gen/c/` (19/19 passed)
- targeted shared-global initializer/evaluation tests in `vlib/v3/tests/global_decl_codegen_test.v`

Broad compiler suites skipped at the requester's direction.