### PR TITLE
v3: harden asm goto lowering (case-insensitive mnemonics, lock-scope diagnostic)

### DIFF
--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -3356,20 +3356,23 @@ fn (mut g FlatGen) lower_c_inline_asm_goto_raw_labels(template string, labels []
 	return lowered
 }
 
+// c_inline_asm_goto_branch_label_operand_index matches mnemonics case-insensitively,
+// since GNU as accepts `JNE`/`B.EQ` just like their lowercase forms.
 fn c_inline_asm_goto_branch_label_operand_index(instruction string, arch string, operand_count int) int {
 	if operand_count == 0 {
 		return -1
 	}
+	name := instruction.to_lower_ascii()
 	if is_c_inline_asm_x86_arch(arch) {
-		return if instruction.starts_with('call') || instruction.starts_with('j')
-			|| instruction in ['loop', 'loope', 'loopne', 'loopz', 'loopnz'] {
+		return if name.starts_with('call') || name.starts_with('j')
+			|| name in ['loop', 'loope', 'loopne', 'loopz', 'loopnz'] {
 			0
 		} else {
 			-1
 		}
 	}
-	if arch in ['arm64', 'aarch64'] && (instruction == 'b' || instruction == 'bl'
-		|| instruction.starts_with('b.') || instruction.starts_with('cb') || instruction.starts_with('tb')) {
+	if arch in ['arm64', 'aarch64'] && (name == 'b' || name == 'bl'
+		|| name.starts_with('b.') || name.starts_with('cb') || name.starts_with('tb')) {
 		return operand_count - 1
 	}
 	return -1

--- a/vlib/v3/tests/inline_asm_c_lowering_test.v
+++ b/vlib/v3/tests/inline_asm_c_lowering_test.v
@@ -425,6 +425,86 @@ fn main() {
 	assert !c_source.contains('#error asm goto'), c_source
 }
 
+fn test_asm_goto_across_rlock_scope_is_rejected() {
+	generate, _ := generate_inline_asm_c('goto_rlock_scope_program', 'struct Counter {
+mut:
+	value int
+}
+
+fn main() {
+	shared counter := Counter{}
+	rlock counter {
+		asm goto amd64 {
+			jmp done
+			; ; ; ; done
+		}
+	}
+	done:
+}
+')
+	assert generate.exit_code != 0, generate.output
+	assert generate.output.contains('different `lock`/`rlock` scope'), generate.output
+}
+
+fn test_asm_goto_across_lock_scope_inside_closure_is_rejected() {
+	generate, _ := generate_inline_asm_c('goto_lock_scope_closure_program', 'struct Counter {
+mut:
+	value int
+}
+
+fn main() {
+	shared counter := Counter{}
+	f := fn [shared counter] () {
+		lock counter {
+			asm goto amd64 {
+				jmp done
+				; ; ; ; done
+			}
+		}
+		done:
+	}
+	f()
+}
+')
+	assert generate.exit_code != 0, generate.output
+	assert generate.output.contains('different `lock`/`rlock` scope'), generate.output
+}
+
+fn test_asm_goto_to_undeclared_label_in_lock_scope_is_rejected() {
+	generate, _ := generate_inline_asm_c('goto_undeclared_label_program', 'struct Counter {
+mut:
+	value int
+}
+
+fn main() {
+	shared counter := Counter{}
+	lock counter {
+		asm goto amd64 {
+			jmp done
+			; ; ; ; done
+		}
+	}
+}
+')
+	assert generate.exit_code != 0, generate.output
+}
+
+fn test_asm_goto_across_objectless_lock_is_allowed() {
+	generate, c_source := generate_inline_asm_c('goto_objectless_lock_program', 'fn main() {
+	lock {
+		asm goto amd64 {
+			jmp done
+			; ; ; ; done
+		}
+	}
+	done:
+}
+')
+	assert generate.exit_code == 0, generate.output
+	assert c_source.contains('jmp %l[__v_user_goto_0]'), c_source
+	assert !c_source.contains('#error asm goto'), c_source
+}
+
 fn generate_inline_asm_c(name string, source string) (os.Result, string) {
 	return generate_inline_asm_c_for_arch(name, source, 'amd64')
 }

--- a/vlib/v3/tests/inline_asm_c_lowering_test.v
+++ b/vlib/v3/tests/inline_asm_c_lowering_test.v
@@ -383,7 +383,7 @@ fn test_raw_asm_goto_keeps_symbolic_label_references_valid() {
 }
 
 fn test_asm_goto_across_lock_scope_is_rejected() {
-	generate, c_source := generate_inline_asm_c('goto_lock_scope_program', 'struct Counter {
+	generate, _ := generate_inline_asm_c('goto_lock_scope_program', 'struct Counter {
 mut:
 	value int
 }
@@ -399,8 +399,30 @@ fn main() {
 	done:
 }
 ')
+	assert generate.exit_code != 0, generate.output
+	assert generate.output.contains('different `lock`/`rlock` scope'), generate.output
+}
+
+fn test_asm_goto_within_lock_scope_is_allowed() {
+	generate, c_source := generate_inline_asm_c('goto_within_lock_scope_program', 'struct Counter {
+mut:
+	value int
+}
+
+fn main() {
+	shared counter := Counter{}
+	lock counter {
+		asm goto amd64 {
+			jmp done
+			; ; ; ; done
+		}
+		done:
+	}
+}
+')
 	assert generate.exit_code == 0, generate.output
-	assert c_source.contains('#error asm goto into or out of a lock scope is not supported'), c_source
+	assert c_source.contains('jmp %l[__v_user_goto_0]'), c_source
+	assert !c_source.contains('#error asm goto'), c_source
 }
 
 fn generate_inline_asm_c(name string, source string) (os.Result, string) {

--- a/vlib/v3/tests/inline_asm_c_lowering_test.v
+++ b/vlib/v3/tests/inline_asm_c_lowering_test.v
@@ -355,6 +355,19 @@ fn test_asm_goto_lowers_branch_after_leading_local_label() {
 	assert c_source.contains('"retry: jne %l[__v_user_goto_0]\\n\\t"'), c_source
 }
 
+fn test_asm_goto_lowers_uppercase_branch_mnemonics() {
+	generate, c_source := generate_inline_asm_c('goto_uppercase_mnemonic_program', 'fn main() {
+	asm goto amd64 {
+		retry: JNE done
+		; ; ; ; done
+	}
+	done:
+}
+')
+	assert generate.exit_code == 0, generate.output
+	assert c_source.contains('"retry: JNE %l[__v_user_goto_0]\\n\\t"'), c_source
+}
+
 fn test_raw_asm_goto_keeps_symbolic_label_references_valid() {
 	generate, c_source := generate_inline_asm_c('raw_goto_program', 'fn main() {
 	asm goto amd64 raw {

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -2484,12 +2484,20 @@ fn (mut tc TypeChecker) check_asm_goto_lock_scopes(node flat.Node) {
 			tc.collect_asm_goto_lock_scopes(child_id, []int{}, mut scan)
 		}
 	}
+	tc.report_asm_goto_lock_crossings(scan)
+}
+
+// report_asm_goto_lock_crossings emits a diagnostic for every collected `asm goto`
+// whose target label resolves to a different `lock`/`rlock` scope path than the
+// block. A target not declared in this function scope resolves to the empty path,
+// matching the C backend (`goto_label_lock_scopes[label] or { [] }`).
+fn (mut tc TypeChecker) report_asm_goto_lock_crossings(scan AsmGotoLockScan) {
 	for asm_id in scan.asm_gotos {
 		asm_node := tc.a.node(asm_id)
 		active := scan.asm_goto_scopes[int(asm_id)]
 		for target in inline_asm_goto_labels(asm_node.value) {
-			if target in scan.label_scopes
-				&& !asm_goto_lock_scopes_equal(scan.label_scopes[target], active) {
+			target_scope := scan.label_scopes[target] or { []int{} }
+			if !asm_goto_lock_scopes_equal(target_scope, active) {
 				tc.record_error_at(.compile_error, asm_goto_lock_scope_error(target), asm_id,
 					asm_node.pos)
 				break
@@ -2504,15 +2512,29 @@ fn asm_goto_lock_scope_error(target string) string {
 
 // collect_asm_goto_lock_scopes walks a function body, recording the `lock`/`rlock`
 // scope path (a stack of enclosing `lock_expr` node ids) at every label declaration
-// and at every `asm goto` block, so check_asm_goto_lock_scopes can compare them.
+// and at every `asm goto` block, so report_asm_goto_lock_crossings can compare them.
 fn (mut tc TypeChecker) collect_asm_goto_lock_scopes(id flat.NodeId, scopes []int, mut scan AsmGotoLockScan) {
 	node := tc.a.node(id)
 	if node.kind in [.fn_decl, .c_fn_decl, .fn_literal] {
-		// A nested function or closure has its own lock nesting.
+		// A nested function or closure is lowered to its own C function with a
+		// fresh lock stack (`collect_fn_prelude_scan` runs per function), so scan
+		// and report its body independently against an empty scope path -- the
+		// enclosing function's locks are not active inside it.
+		mut nested := AsmGotoLockScan{}
+		for i in 0 .. node.children_count {
+			child_id := tc.a.child(node, i)
+			if tc.a.node(child_id).kind != .param {
+				tc.collect_asm_goto_lock_scopes(child_id, []int{}, mut nested)
+			}
+		}
+		tc.report_asm_goto_lock_crossings(nested)
 		return
 	}
 	mut cur := scopes.clone()
-	if node.kind == .lock_expr {
+	// `gen_lock_enter` skips a `lock {}` / `rlock {}` with no lock objects
+	// (`lock_count = children_count - 1 <= 0`), so it never becomes an active
+	// scope at runtime -- do not treat it as one here either.
+	if node.kind == .lock_expr && node.children_count > 1 {
 		cur << int(id)
 	}
 	if node.kind == .label_stmt && node.value.len > 0 {

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -1714,6 +1714,7 @@ fn (mut tc TypeChecker) check_fn_decl_semantics(fn_idx int, node flat.Node, file
 				tc.record_unused_fn_vars(node)
 				tc.record_unused_fn_params(node)
 				tc.record_unused_fn_labels(node)
+				tc.check_asm_goto_lock_scopes(node)
 			}
 			tc.check_fn_bare_generic_fntype_params(node)
 		}
@@ -2461,6 +2462,80 @@ fn (mut tc TypeChecker) record_unused_fn_labels(node flat.Node) {
 				label_id, tc.a.node(label_id).pos)
 		}
 	}
+}
+
+struct AsmGotoLockScan {
+mut:
+	label_scopes    map[string][]int
+	asm_gotos       []flat.NodeId
+	asm_goto_scopes map[int][]int
+}
+
+// check_asm_goto_lock_scopes reports an `asm goto` whose target label sits in a
+// different `lock`/`rlock` scope than the block itself. The C backend cannot lower a
+// jump that enters or leaves a lock scope (the scope's unlock/cleanup would be
+// skipped), so it otherwise emits an `#error` into the generated C with no V source
+// position; this turns that into a positioned compiler diagnostic.
+fn (mut tc TypeChecker) check_asm_goto_lock_scopes(node flat.Node) {
+	mut scan := AsmGotoLockScan{}
+	for i in 0 .. node.children_count {
+		child_id := tc.a.child(&node, i)
+		if tc.a.node(child_id).kind != .param {
+			tc.collect_asm_goto_lock_scopes(child_id, []int{}, mut scan)
+		}
+	}
+	for asm_id in scan.asm_gotos {
+		asm_node := tc.a.node(asm_id)
+		active := scan.asm_goto_scopes[int(asm_id)]
+		for target in inline_asm_goto_labels(asm_node.value) {
+			if target in scan.label_scopes
+				&& !asm_goto_lock_scopes_equal(scan.label_scopes[target], active) {
+				tc.record_error_at(.compile_error, asm_goto_lock_scope_error(target), asm_id,
+					asm_node.pos)
+				break
+			}
+		}
+	}
+}
+
+fn asm_goto_lock_scope_error(target string) string {
+	return '`asm goto` cannot jump to label `${target}`: it is in a different `lock`/`rlock` scope, and the C backend cannot lower a jump that enters or leaves a lock scope'
+}
+
+// collect_asm_goto_lock_scopes walks a function body, recording the `lock`/`rlock`
+// scope path (a stack of enclosing `lock_expr` node ids) at every label declaration
+// and at every `asm goto` block, so check_asm_goto_lock_scopes can compare them.
+fn (mut tc TypeChecker) collect_asm_goto_lock_scopes(id flat.NodeId, scopes []int, mut scan AsmGotoLockScan) {
+	node := tc.a.node(id)
+	if node.kind in [.fn_decl, .c_fn_decl, .fn_literal] {
+		// A nested function or closure has its own lock nesting.
+		return
+	}
+	mut cur := scopes.clone()
+	if node.kind == .lock_expr {
+		cur << int(id)
+	}
+	if node.kind == .label_stmt && node.value.len > 0 {
+		scan.label_scopes[node.value] = cur.clone()
+	} else if node.kind == .asm_stmt && inline_asm_goto_labels(node.value).len > 0 {
+		scan.asm_gotos << id
+		scan.asm_goto_scopes[int(id)] = cur.clone()
+	}
+	for i in 0 .. node.children_count {
+		tc.collect_asm_goto_lock_scopes(tc.a.child(node, i), cur, mut scan)
+	}
+}
+
+fn asm_goto_lock_scopes_equal(a []int, b []int) bool {
+	if a.len != b.len {
+		return false
+	}
+	for i, scope in a {
+		if b[i] != scope {
+			return false
+		}
+	}
+	return true
 }
 
 fn (tc &TypeChecker) fn_body_uses_ident(node flat.Node, name string) bool {


### PR DESCRIPTION
Small, related hardening fixes for the v3 backend's `asm goto` support
(follows #28460), turning silent-corruption / opaque-C-error paths into
correct behavior or positioned V diagnostics — in the spirit of #28467.

### 1. Case-insensitive branch mnemonics

`c_inline_asm_goto_branch_label_operand_index` matched mnemonics against
lowercase literals only (`call`, `j*`, `loop*` on x86; `b`/`bl`/`b.*`/
`cb*`/`tb*` on arm64). An uppercase branch such as

```v
asm goto amd64 {
    retry: JNE done
    ; ; ; ; done
}
```

was not recognised as a branch, so its label was never lowered to the
`%l[...]` placeholder and the generated C was invalid. The mnemonic is now
lower-cased before matching (GNU `as` accepts either case). Classification
only — emitted assembly keeps the author's casing.

### 2. `asm goto` across a `lock` scope → checker diagnostic

The C backend cannot lower an `asm goto` whose target label is in a
different `lock`/`rlock` scope than the block, so `gen_c_inline_asm_stmt`
wrote `#error asm goto into or out of a lock scope is not supported` into
the generated C — invisible to `v -check` and to editor tooling, surfacing
only as an opaque C-toolchain failure with no source position.

A new checker pass (`check_asm_goto_lock_scopes`) walks each function body,
records the enclosing `lock_expr` path at every label declaration and
every `asm goto` block, and emits a positioned `.compile_error` when a
target crosses a lock-scope boundary. Same-scope `asm goto` inside a
`lock` block stays allowed (the backend already lowers it). The codegen
`#error` is kept as an unreachable backstop.

Part of #28467.


### 3. Parity-gap fixes for change 2 (adversarial review)

A multi-agent adversarial review of change 2 found three cases where the new
checker pass and the codegen `#error` disagreed, all now fixed:

- **Closures / `spawn fn(){}`** — the walk bailed at the `fn_literal`
  boundary, so a crossing jump *inside a closure* was never diagnosed while
  codegen still emitted `#error`. Each nested function body is now scanned
  and reported independently against a fresh scope path, mirroring codegen's
  per-function `collect_fn_prelude_scan`.
- **Undeclared target label** — the pass skipped a label it hadn't recorded;
  codegen treats a missing label as the empty path and still flags it when
  the block sits in a lock. Matched via `label_scopes[target] or { [] }`.
- **Objectless `lock {}` / `rlock {}`** — was counted as a lock scope,
  spuriously rejecting a valid jump past it; `gen_lock_enter` skips a lock
  with no objects, and the pass now does too.

New tests: closure, `rlock`, undeclared-label, objectless-lock.

### Test plan

- [x] `./vnew -stats test vlib/v3/tests/inline_asm_c_lowering_test.v` — 34/34, incl. new mnemonic-case, within-lock, across-lock (rewritten to assert the V diagnostic), rlock, closure, undeclared-label and objectless-lock tests
- [x] Negative checks: revert each hunk in turn → the matching test fails on the pre-change code; restore → passes
- [x] `v fmt -verify` clean on all touched files
- [x] `vlib/v3/tests/{mixed_lock_codegen,checker_diagnostic_files,match_and_wasm_diagnostics}_test.v` pass (two unrelated pre-existing macOS/v3 cross-compile failures in `lock_codegen_test.v` / `type_checker_errors_test.v` confirmed against a clean baseline)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgHwaPqQYDjtcWLCZJNex5
