### PR TITLE
v3: restore BSD production self-build performance

### DIFF
--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -95,6 +95,10 @@ The cap does not apply to compiler/self-host inputs or to V3 executables built w
 preallocation. It depends on how the V3 compiler executable was built, so passing `-no-prealloc`
 for the user program being compiled does not disable the compiler's own job cap.
 
+BSD compiler and self-host builds normally keep their V stages at two jobs. Production builds
+using `-parallel-cc` allow one job per 2 GiB of physical memory, up to eight jobs, and use the same
+limit for the split C compilation. Other parallel C builds remain limited to two jobs.
+
 ## Fast C backend
 
 `-b fastc` selects the embedded V3 driver and its AST-free parser for the shortest edit-run cycle.

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -2137,7 +2137,7 @@ fn split_v3_parallel_c_source(source string, max_units int) !(string, []string) 
 	return split.prefix, merge_v3_parallel_c_units(units, max_units)
 }
 
-fn compile_v3_parallel_c(source_path string, c_compiler string, c_flag_plan &V3CCompilerFlagPlan, native_support_inputs []string, cached_objects []string, cached_dev_dylib string, objective_c bool, build_dir string, show_command bool, job_count int, unit_count int) os.Result {
+fn compile_v3_parallel_c(source_path string, c_compiler string, c_flag_plan &V3CCompilerFlagPlan, large_c_flag_plan &V3CCompilerFlagPlan, native_support_inputs []string, cached_objects []string, cached_dev_dylib string, objective_c bool, build_dir string, show_command bool, job_count int, unit_count int) os.Result {
 	source := os.read_file(source_path) or {
 		return os.Result{
 			exit_code: 1
@@ -2169,19 +2169,27 @@ fn compile_v3_parallel_c(source_path string, c_compiler string, c_flag_plan &V3C
 	}
 	mut tasks := []&V3ParallelCCompileTask{cap: bodies.len + 1}
 	mut objects := []string{cap: bodies.len + 1}
-	mut compile_flags := c_object_compile_flags(c_flag_plan.before_inputs)
-	compile_flags << c_object_compile_flags(c_flag_plan.after_inputs)
+	mut small_compile_flags := c_object_compile_flags(c_flag_plan.before_inputs)
+	small_compile_flags << c_object_compile_flags(c_flag_plan.after_inputs)
+	mut large_compile_flags := c_object_compile_flags(large_c_flag_plan.before_inputs)
+	large_compile_flags << c_object_compile_flags(large_c_flag_plan.after_inputs)
 	for unit_index := 0; unit_index <= bodies.len; unit_index++ {
 		source_name := 'unit_${unit_index}.c'
 		object_name := 'unit_${unit_index}.o'
 		unit_source := if unit_index == 0 { prefix } else { bodies[unit_index - 1] }
-		write_v3_parallel_c_source(os.join_path_single(build_dir, source_name), header_name, unit_source, unit_index == 0) or {
+		unit_path := os.join_path_single(build_dir, source_name)
+		write_v3_parallel_c_source(unit_path, header_name, unit_source, unit_index == 0) or {
 			return os.Result{
 				exit_code: 1
 				output: 'failed to write parallel C unit ${source_name}: ${err.msg()}'
 			}
 		}
-		mut compile_args := compile_flags.clone()
+		unit_is_large := v3_parallel_c_unit_is_large(os.file_size(unit_path), u64(header.len), unit_index == 0)
+		mut compile_args := if unit_is_large {
+			large_compile_flags.clone()
+		} else {
+			small_compile_flags.clone()
+		}
 		compile_args << ['-x', if objective_c { 'objective-c' } else { 'c' }, '-c', '-o',
 			object_name, source_name]
 		if show_command {
@@ -7654,8 +7662,16 @@ fn v3_effective_warns_are_errors(explicit bool, is_prod bool) bool {
 
 const v3_large_prod_c_unit_threshold = u64(8 * 1024 * 1024)
 
-fn v3_is_large_prod_c_unit(source_size u64, split_parallel bool) bool {
-	return !split_parallel && source_size >= v3_large_prod_c_unit_threshold
+fn v3_is_large_prod_c_unit(source_size u64) bool {
+	return source_size >= v3_large_prod_c_unit_threshold
+}
+
+fn v3_parallel_c_unit_is_large(source_size u64, declaration_header_size u64, owns_declarations bool) bool {
+	return v3_is_large_prod_c_unit(source_size + if owns_declarations {
+		u64(0)
+	} else {
+		declaration_header_size
+	})
 }
 
 fn v3_prod_c_optimization_flags(is_prod bool, no_prod_options bool, is_shared bool, parallel_cc bool, large_c_unit bool, limit_inlining bool, explicit_tcc bool) []string {
@@ -11300,8 +11316,8 @@ pub fn run(args []string) {
 		all_compile_c_flags << generated_c_flags
 		needs_objective_c := c_flags_need_objective_c(all_compile_c_flags)
 			|| cgen.cache_native_inputs_need_objective_c(a, prefs.vroot, user_c_flags, prefs.c99, prefs.ccompiler, prefs.target)
-		large_prod_c_unit := os.is_file(published_c_source)
-			&& v3_is_large_prod_c_unit(os.file_size(published_c_source), use_parallel_c_compilation)
+		large_prod_c_unit := !use_parallel_c_compilation && os.is_file(published_c_source)
+			&& v3_is_large_prod_c_unit(os.file_size(published_c_source))
 		limit_large_unit_inlining := large_prod_c_unit && effective_c_compiler == 'clang'
 		link_uses_non_c_language := c_link_flags_use_non_c_language(all_compile_c_flags)
 		link_c_standard := if link_uses_non_c_language {
@@ -11337,7 +11353,7 @@ pub fn run(args []string) {
 		} else {
 			''
 		}
-		c_flag_plan := v3_c_compiler_flag_plan(V3CCompilerFlagOptions{
+		c_flag_options := V3CCompilerFlagOptions{
 			environment_c_flags: environment_c_flags
 			link_ld_flags: link_ld_flags
 			target_args: target_args
@@ -11359,7 +11375,14 @@ pub fn run(args []string) {
 			is_c_debug: is_c_debug
 			is_o: is_o
 			is_liveshared: is_liveshared
-		})
+		}
+		c_flag_plan := v3_c_compiler_flag_plan(c_flag_options)
+		large_c_flag_options := V3CCompilerFlagOptions{
+			...c_flag_options
+			large_c_unit: true
+			limit_inlining: effective_c_compiler == 'clang'
+		}
+		large_c_flag_plan := v3_c_compiler_flag_plan(large_c_flag_options)
 		mut native_support_inputs := []string{}
 		if explicit_tcc {
 			atomic_input := if generate_c_project.len > 0 {
@@ -11961,7 +11984,7 @@ pub fn run(args []string) {
 			}
 			if use_parallel_c_compilation && cached_program_main_object.len == 0
 				&& fallback_source == 'src.c' {
-				result = compile_v3_parallel_c(cc_src, c_compiler, &c_flag_plan, native_support_inputs, cached_objects, cached_dev_dylib, needs_objective_c, cc_dir, !silent || show_cc, parallel_c_job_count, parallel_c_unit_count)
+				result = compile_v3_parallel_c(cc_src, c_compiler, &c_flag_plan, &large_c_flag_plan, native_support_inputs, cached_objects, cached_dev_dylib, needs_objective_c, cc_dir, !silent || show_cc, parallel_c_job_count, parallel_c_unit_count)
 			} else {
 				cc_args := c_flag_plan.compiler_args('out', compiler_inputs, [])
 				if !silent || show_cc {

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -1860,8 +1860,8 @@ mut:
 	result os.Result
 }
 
-fn v3_parallel_c_job_count(available_jobs int, building_v bool, is_bsd_host bool) int {
-	max_jobs := if building_v && is_bsd_host {
+fn v3_parallel_c_job_count(available_jobs int, building_v bool, is_bsd_host bool, prod_parallel_cc bool) int {
+	max_jobs := if building_v && is_bsd_host && prod_parallel_cc {
 		bsd_selfhost_parallel_cc_job_limit
 	} else {
 		v3_parallel_cc_max_jobs
@@ -8690,7 +8690,7 @@ pub fn run(args []string) {
 	configure_selfhost_parallelism(building_v, is_prod && parallel_cc)
 	available_parallel_c_jobs := runtime.nr_jobs()
 	is_bsd_host := $if freebsd || openbsd || netbsd || dragonfly { true } $else { false }
-	parallel_c_job_count := v3_parallel_c_job_count(available_parallel_c_jobs, building_v, is_bsd_host)
+	parallel_c_job_count := v3_parallel_c_job_count(available_parallel_c_jobs, building_v, is_bsd_host, is_prod && parallel_cc)
 	parallel_c_unit_count := v3_parallel_c_unit_count(parallel_c_job_count, building_v, is_bsd_host)
 	if generate_c_project.len > 0 {
 		if backend != 'c' {

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -68,9 +68,16 @@ const v3_fallback_native_input_prefix = '@native-input:'
 const v3_fallback_native_manifest_key = '@native-input-manifest:v1'
 const v3_fallback_native_manifest_value = 'v3-native-input-manifest-v1'
 const bsd_selfhost_job_limit = 2
+const bsd_selfhost_parallel_cc_job_limit = 8
+const bsd_selfhost_parallel_cc_unit_count = 8
+const bsd_prod_selfhost_memory_per_job = u64(2) * 1024 * 1024 * 1024
 
-fn default_selfhost_job_count(jobs int, is_bsd_host bool, allow_overcommit bool) int {
+fn default_selfhost_job_count(jobs int, is_bsd_host bool, allow_overcommit bool, prod_parallel_cc bool, total_memory u64) int {
 	if is_bsd_host {
+		if prod_parallel_cc && total_memory > 0 {
+			memory_jobs := int((total_memory + bsd_prod_selfhost_memory_per_job - 1) / bsd_prod_selfhost_memory_per_job)
+			return int_min(jobs, int_max(bsd_selfhost_job_limit, int_min(memory_jobs, bsd_selfhost_parallel_cc_job_limit)))
+		}
 		return int_min(jobs, bsd_selfhost_job_limit)
 	}
 	if !allow_overcommit || jobs < 2 || jobs >= 12 {
@@ -79,13 +86,17 @@ fn default_selfhost_job_count(jobs int, is_bsd_host bool, allow_overcommit bool)
 	return int_min(12, jobs + jobs / 2)
 }
 
-fn configure_selfhost_parallelism(building_v bool) {
+fn configure_selfhost_parallelism(building_v bool, prod_parallel_cc bool) {
 	if !building_v || os.getenv('VJOBS') != '' {
 		return
 	}
 	jobs := runtime.nr_jobs()
 	is_bsd_host := $if freebsd || openbsd || netbsd || dragonfly { true } $else { false }
-	configured_jobs := default_selfhost_job_count(jobs, is_bsd_host, os.getenv('V3_NO_SELFHOST_JOB_OVERCOMMIT') == '')
+	mut total_memory := u64(0)
+	if is_bsd_host && prod_parallel_cc {
+		total_memory = u64(runtime.total_memory() or { 0 })
+	}
+	configured_jobs := default_selfhost_job_count(jobs, is_bsd_host, os.getenv('V3_NO_SELFHOST_JOB_OVERCOMMIT') == '', prod_parallel_cc, total_memory)
 	if configured_jobs != jobs {
 		// V3 self-hosting needs more than 4 GiB before the C compiler starts.
 		// Bound BSD worker pools so CPU-rich hosts do not multiply that peak.
@@ -1849,6 +1860,22 @@ mut:
 	result os.Result
 }
 
+fn v3_parallel_c_job_count(available_jobs int, building_v bool, is_bsd_host bool) int {
+	max_jobs := if building_v && is_bsd_host {
+		bsd_selfhost_parallel_cc_job_limit
+	} else {
+		v3_parallel_cc_max_jobs
+	}
+	return int_max(1, int_min(max_jobs, available_jobs))
+}
+
+fn v3_parallel_c_unit_count(job_count int, building_v bool, is_bsd_host bool) int {
+	if building_v && is_bsd_host {
+		return bsd_selfhost_parallel_cc_unit_count
+	}
+	return job_count * v3_parallel_cc_units_per_job
+}
+
 fn (plan &V3CCompilerFlagPlan) compiler_args(output string, inputs []string, support_inputs []string) []string {
 	mut args := plan.before_inputs.clone()
 	args << ['-o', output]
@@ -2110,15 +2137,14 @@ fn split_v3_parallel_c_source(source string, max_units int) !(string, []string) 
 	return split.prefix, merge_v3_parallel_c_units(units, max_units)
 }
 
-fn compile_v3_parallel_c(source_path string, c_compiler string, c_flag_plan &V3CCompilerFlagPlan, native_support_inputs []string, cached_objects []string, cached_dev_dylib string, objective_c bool, build_dir string, show_command bool) os.Result {
+fn compile_v3_parallel_c(source_path string, c_compiler string, c_flag_plan &V3CCompilerFlagPlan, native_support_inputs []string, cached_objects []string, cached_dev_dylib string, objective_c bool, build_dir string, show_command bool, job_count int, unit_count int) os.Result {
 	source := os.read_file(source_path) or {
 		return os.Result{
 			exit_code: 1
 			output: 'failed to read generated C source ${source_path}: ${err.msg()}'
 		}
 	}
-	job_count := int_max(1, int_min(v3_parallel_cc_max_jobs, runtime.nr_jobs()))
-	prefix, bodies := split_v3_parallel_c_source(source, job_count * v3_parallel_cc_units_per_job) or {
+	prefix, bodies := split_v3_parallel_c_source(source, unit_count) or {
 		return os.Result{
 			exit_code: 1
 			output: 'failed to split generated C source: ${err.msg()}'
@@ -7628,8 +7654,8 @@ fn v3_effective_warns_are_errors(explicit bool, is_prod bool) bool {
 
 const v3_large_prod_c_unit_threshold = u64(8 * 1024 * 1024)
 
-fn v3_is_large_prod_c_unit(source_size u64) bool {
-	return source_size >= v3_large_prod_c_unit_threshold
+fn v3_is_large_prod_c_unit(source_size u64, split_parallel bool) bool {
+	return !split_parallel && source_size >= v3_large_prod_c_unit_threshold
 }
 
 fn v3_prod_c_optimization_flags(is_prod bool, no_prod_options bool, is_shared bool, parallel_cc bool, large_c_unit bool, limit_inlining bool, explicit_tcc bool) []string {
@@ -8645,7 +8671,11 @@ pub fn run(args []string) {
 	if input_implies_building_v(input_file) || cmd_v_build {
 		building_v = true
 	}
-	configure_selfhost_parallelism(building_v)
+	configure_selfhost_parallelism(building_v, is_prod && parallel_cc)
+	available_parallel_c_jobs := runtime.nr_jobs()
+	is_bsd_host := $if freebsd || openbsd || netbsd || dragonfly { true } $else { false }
+	parallel_c_job_count := v3_parallel_c_job_count(available_parallel_c_jobs, building_v, is_bsd_host)
+	parallel_c_unit_count := v3_parallel_c_unit_count(parallel_c_job_count, building_v, is_bsd_host)
 	if generate_c_project.len > 0 {
 		if backend != 'c' {
 			eprintln('`-generate-c-project` is currently supported only for the C backend')
@@ -11271,7 +11301,7 @@ pub fn run(args []string) {
 		needs_objective_c := c_flags_need_objective_c(all_compile_c_flags)
 			|| cgen.cache_native_inputs_need_objective_c(a, prefs.vroot, user_c_flags, prefs.c99, prefs.ccompiler, prefs.target)
 		large_prod_c_unit := os.is_file(published_c_source)
-			&& v3_is_large_prod_c_unit(os.file_size(published_c_source))
+			&& v3_is_large_prod_c_unit(os.file_size(published_c_source), use_parallel_c_compilation)
 		limit_large_unit_inlining := large_prod_c_unit && effective_c_compiler == 'clang'
 		link_uses_non_c_language := c_link_flags_use_non_c_language(all_compile_c_flags)
 		link_c_standard := if link_uses_non_c_language {
@@ -11931,7 +11961,7 @@ pub fn run(args []string) {
 			}
 			if use_parallel_c_compilation && cached_program_main_object.len == 0
 				&& fallback_source == 'src.c' {
-				result = compile_v3_parallel_c(cc_src, c_compiler, &c_flag_plan, native_support_inputs, cached_objects, cached_dev_dylib, needs_objective_c, cc_dir, !silent || show_cc)
+				result = compile_v3_parallel_c(cc_src, c_compiler, &c_flag_plan, native_support_inputs, cached_objects, cached_dev_dylib, needs_objective_c, cc_dir, !silent || show_cc, parallel_c_job_count, parallel_c_unit_count)
 			} else {
 				cc_args := c_flag_plan.compiler_args('out', compiler_inputs, [])
 				if !silent || show_cc {

--- a/vlib/v3/driver/environment_test.v
+++ b/vlib/v3/driver/environment_test.v
@@ -17,14 +17,41 @@ fn restore_driver_environment(name string, old_value string, was_set bool) {
 }
 
 fn test_default_selfhost_job_count() {
-	assert default_selfhost_job_count(1, false, true) == 1
-	assert default_selfhost_job_count(2, false, true) == 3
-	assert default_selfhost_job_count(8, false, true) == 12
-	assert default_selfhost_job_count(12, false, true) == 12
-	assert default_selfhost_job_count(8, false, false) == 8
-	assert default_selfhost_job_count(1, true, true) == 1
-	assert default_selfhost_job_count(8, true, true) == bsd_selfhost_job_limit
-	assert default_selfhost_job_count(8, true, false) == bsd_selfhost_job_limit
+	assert bsd_prod_selfhost_memory_per_job == u64(2_147_483_648)
+	assert default_selfhost_job_count(1, false, true, false, 0) == 1
+	assert default_selfhost_job_count(2, false, true, false, 0) == 3
+	assert default_selfhost_job_count(8, false, true, false, 0) == 12
+	assert default_selfhost_job_count(12, false, true, false, 0) == 12
+	assert default_selfhost_job_count(8, false, false, false, 0) == 8
+	assert default_selfhost_job_count(1, true, true, false, 0) == 1
+	assert default_selfhost_job_count(8, true, true, false, 0) == bsd_selfhost_job_limit
+	assert default_selfhost_job_count(8, true, false, false, 0) == bsd_selfhost_job_limit
+	assert default_selfhost_job_count(8, true, true, true, 0) == bsd_selfhost_job_limit
+	assert default_selfhost_job_count(8, true, true, true, u64(4) * 1024 * 1024 * 1024) == 2
+	assert default_selfhost_job_count(8, true, true, true, u64(8) * 1024 * 1024 * 1024) == 4
+	assert default_selfhost_job_count(16, true, true, true, u64(16) * 1024 * 1024 * 1024) == 8
+}
+
+fn test_v3_parallel_c_job_count() {
+	assert v3_parallel_c_job_count(0, false, false) == 1
+	assert v3_parallel_c_job_count(8, false, false) == v3_parallel_cc_max_jobs
+	assert v3_parallel_c_job_count(8, true, false) == v3_parallel_cc_max_jobs
+	assert v3_parallel_c_job_count(1, true, true) == 1
+	assert v3_parallel_c_job_count(4, true, true) == 4
+	assert v3_parallel_c_job_count(16, true, true) == bsd_selfhost_parallel_cc_job_limit
+}
+
+fn test_v3_parallel_c_unit_count() {
+	assert v3_parallel_c_unit_count(2, false, false) == 2 * v3_parallel_cc_units_per_job
+	assert v3_parallel_c_unit_count(2, true, false) == 2 * v3_parallel_cc_units_per_job
+	assert v3_parallel_c_unit_count(2, true, true) == bsd_selfhost_parallel_cc_unit_count
+	assert v3_parallel_c_unit_count(8, true, true) == bsd_selfhost_parallel_cc_unit_count
+}
+
+fn test_v3_large_prod_c_unit_uses_the_compiled_unit_size() {
+	assert !v3_is_large_prod_c_unit(v3_large_prod_c_unit_threshold - 1, false)
+	assert v3_is_large_prod_c_unit(v3_large_prod_c_unit_threshold, false)
+	assert !v3_is_large_prod_c_unit(v3_large_prod_c_unit_threshold, true)
 }
 
 fn test_configure_selfhost_parallelism_uses_bsd_limit() {
@@ -40,14 +67,14 @@ fn test_configure_selfhost_parallelism_uses_bsd_limit() {
 	os.setenv('V3_NO_SELFHOST_JOB_OVERCOMMIT', '1', true)
 	$if freebsd || openbsd || netbsd || dragonfly {
 		jobs := runtime.nr_jobs()
-		configure_selfhost_parallelism(true)
+		configure_selfhost_parallelism(true, false)
 		if jobs > bsd_selfhost_job_limit {
 			assert os.getenv('VJOBS') == bsd_selfhost_job_limit.str()
 		} else {
 			assert os.getenv('VJOBS') == ''
 		}
 	} $else {
-		configure_selfhost_parallelism(true)
+		configure_selfhost_parallelism(true, false)
 		assert os.getenv('VJOBS') == ''
 	}
 }
@@ -512,8 +539,8 @@ fn test_v3_prod_c_optimization_flags_skip_lto_for_tcc() {
 	]
 	assert v3_prod_c_optimization_flags(false, false, false, false, false, false, false) == []
 	assert v3_prod_c_optimization_flags(true, true, false, false, false, false, false) == []
-	assert !v3_is_large_prod_c_unit(v3_large_prod_c_unit_threshold - 1)
-	assert v3_is_large_prod_c_unit(v3_large_prod_c_unit_threshold)
+	assert !v3_is_large_prod_c_unit(v3_large_prod_c_unit_threshold - 1, false)
+	assert v3_is_large_prod_c_unit(v3_large_prod_c_unit_threshold, false)
 }
 
 fn test_v3_prod_c_object_optimization_flags_keep_cached_objects_out_of_lto() {

--- a/vlib/v3/driver/environment_test.v
+++ b/vlib/v3/driver/environment_test.v
@@ -49,9 +49,12 @@ fn test_v3_parallel_c_unit_count() {
 }
 
 fn test_v3_large_prod_c_unit_uses_the_compiled_unit_size() {
-	assert !v3_is_large_prod_c_unit(v3_large_prod_c_unit_threshold - 1, false)
-	assert v3_is_large_prod_c_unit(v3_large_prod_c_unit_threshold, false)
-	assert !v3_is_large_prod_c_unit(v3_large_prod_c_unit_threshold, true)
+	assert !v3_is_large_prod_c_unit(v3_large_prod_c_unit_threshold - 1)
+	assert v3_is_large_prod_c_unit(v3_large_prod_c_unit_threshold)
+	assert !v3_parallel_c_unit_is_large(v3_large_prod_c_unit_threshold - 1, 0, true)
+	assert v3_parallel_c_unit_is_large(v3_large_prod_c_unit_threshold, 0, true)
+	assert !v3_parallel_c_unit_is_large(v3_large_prod_c_unit_threshold - 100, 99, false)
+	assert v3_parallel_c_unit_is_large(v3_large_prod_c_unit_threshold - 100, 100, false)
 }
 
 fn test_configure_selfhost_parallelism_uses_bsd_limit() {
@@ -539,8 +542,8 @@ fn test_v3_prod_c_optimization_flags_skip_lto_for_tcc() {
 	]
 	assert v3_prod_c_optimization_flags(false, false, false, false, false, false, false) == []
 	assert v3_prod_c_optimization_flags(true, true, false, false, false, false, false) == []
-	assert !v3_is_large_prod_c_unit(v3_large_prod_c_unit_threshold - 1, false)
-	assert v3_is_large_prod_c_unit(v3_large_prod_c_unit_threshold, false)
+	assert !v3_is_large_prod_c_unit(v3_large_prod_c_unit_threshold - 1)
+	assert v3_is_large_prod_c_unit(v3_large_prod_c_unit_threshold)
 }
 
 fn test_v3_prod_c_object_optimization_flags_keep_cached_objects_out_of_lto() {

--- a/vlib/v3/driver/environment_test.v
+++ b/vlib/v3/driver/environment_test.v
@@ -33,12 +33,13 @@ fn test_default_selfhost_job_count() {
 }
 
 fn test_v3_parallel_c_job_count() {
-	assert v3_parallel_c_job_count(0, false, false) == 1
-	assert v3_parallel_c_job_count(8, false, false) == v3_parallel_cc_max_jobs
-	assert v3_parallel_c_job_count(8, true, false) == v3_parallel_cc_max_jobs
-	assert v3_parallel_c_job_count(1, true, true) == 1
-	assert v3_parallel_c_job_count(4, true, true) == 4
-	assert v3_parallel_c_job_count(16, true, true) == bsd_selfhost_parallel_cc_job_limit
+	assert v3_parallel_c_job_count(0, false, false, false) == 1
+	assert v3_parallel_c_job_count(8, false, false, false) == v3_parallel_cc_max_jobs
+	assert v3_parallel_c_job_count(8, true, false, false) == v3_parallel_cc_max_jobs
+	assert v3_parallel_c_job_count(16, true, true, false) == v3_parallel_cc_max_jobs
+	assert v3_parallel_c_job_count(1, true, true, true) == 1
+	assert v3_parallel_c_job_count(4, true, true, true) == 4
+	assert v3_parallel_c_job_count(16, true, true, true) == bsd_selfhost_parallel_cc_job_limit
 }
 
 fn test_v3_parallel_c_unit_count() {


### PR DESCRIPTION
## Summary

- keep the two-job safeguard for normal BSD compiler builds, but scale `-prod -parallel-cc` self-builds by physical memory up to eight jobs
- compile BSD self-build C output as eight balanced bodies and classify the split bodies correctly for production optimization
- cover the job, memory, unit, and optimization selection and document the BSD policy

## FreeBSD benchmark

FreeBSD 15.1 arm64 under QEMU, 8 vCPUs / 16 GiB:

- merged direct production `cmd/v` build: 42.95 s, 1.99 GiB peak RSS
- fixed direct production `cmd/v` build: 17.01 s, 2.28 GiB peak RSS
- fixed exact `v -prod -parallel-cc self` flow: 15.77 s, 2.26 GiB peak RSS
- fixed constrained `VJOBS=2` build: 37.29 s, 1.87 GiB peak RSS

## Tests

- `./vnew -silent test vlib/v3/driver/` (9/9)
- `./vnew -silent vlib/v3/driver/environment_test.v` on FreeBSD
- `./vnew -silent vlib/v3/driver/parallel_cc_test.v` on FreeBSD
- `./vnew check-md vlib/v3/README.md`
- macOS `-prod -parallel-cc` compiler build