### PR TITLE
v3: enable by default on Windows

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,7 +6,7 @@ TMPDIR ?= /tmp
 VROOT  ?= .
 VC     ?= ./vc
 VEXE   ?= ./v
-V1_FALLBACK_EXE := $(dir $(VEXE))v1_fallback
+V1_FALLBACK_EXE = $(dir $(VEXE))v1_fallback$(EXE_EXT)
 # Portable VC snapshots do not embed V3. Keep their v1 executable on the full
 # compatibility compiler path even when the generated C is built on a V3 host.
 VC_BOOTSTRAP_DEFINE := -DCUSTOM_DEFINE_v1_fallback
@@ -226,6 +226,7 @@ all: latest_vc latest_tcc latest_legacy
 ifdef WIN32
 	$(CC) $(CPPFLAGS) $(BOOTSTRAP_VC_CC_CFLAGS) $(VC_BOOTSTRAP_DEFINE) -std=c99 -municode -w -o v1$(EXE_EXT) $(VC)/$(VCFILE) $(LDFLAGS) -lws2_32 || cmd/tools/cc_compilation_failed_windows.sh
 	./v1$(EXE_EXT) -no-parallel -o v2$(EXE_EXT) $(BOOTSTRAP_GC_VFLAG) $(VFLAGS) $(BOOTSTRAP_VC_VFLAGS) cmd/v
+	./v1$(EXE_EXT) -no-parallel -d v1_fallback -o $(V1_FALLBACK_EXE) $(BOOTSTRAP_GC_VFLAG) $(VFLAGS) $(BOOTSTRAP_VC_VFLAGS) cmd/v
 	./v2$(EXE_EXT) -o $(VEXE)$(EXE_EXT) $(BOOTSTRAP_GC_VFLAG) $(VFLAGS) $(BOOTSTRAP_VFLAGS) cmd/v
 	$(RM) v1$(EXE_EXT)
 	$(RM) v2$(EXE_EXT)

--- a/cmd/tools/vself.v
+++ b/cmd/tools/vself.v
@@ -98,8 +98,8 @@ fn main() {
 		}
 	}
 	if !fastc_self_build && obinary == '' {
-		install_missing_bsd_v1_fallback(vroot, vexe, args, host_os) or {
-			eprintln('cannot prepare the BSD V1 compatibility compiler: ${err.msg()}')
+		install_missing_v1_fallback(vroot, vexe, args, host_os) or {
+			eprintln('cannot prepare the V1 compatibility compiler: ${err.msg()}')
 			exit(1)
 		}
 	}
@@ -365,6 +365,10 @@ fn self_build_supports_prealloc(args []string, host_os string) bool {
 
 fn self_ccompiler_supports_prealloc(ccompiler string, target_os string) bool {
 	cc := os.file_name(ccompiler.trim_space()).to_lower_ascii()
+	// Windows defaults to bundled TCC when no compiler is explicit.
+	if target_os == 'windows' && cc == '' {
+		return false
+	}
 	is_tinyc := cc.contains('tcc') || cc.contains('tinyc') || cc.contains('tinygcc')
 		|| cc.contains('tiny_gcc') || cc.contains('tiny-gcc')
 	return !is_tinyc || target_os == 'macos'
@@ -484,6 +488,9 @@ fn clone_args(args []string) []string {
 }
 
 fn self_build_host_os() string {
+	$if vself_test_windows_transition ? {
+		return 'windows'
+	}
 	$if vself_test_bsd_transition ? {
 		return 'freebsd'
 	}
@@ -491,18 +498,19 @@ fn self_build_host_os() string {
 }
 
 fn self_build_uses_embedded_v3(host_os string) bool {
-	return host_os in ['linux', 'macos', 'freebsd', 'openbsd', 'netbsd', 'dragonfly']
+	return host_os in ['linux', 'macos', 'windows', 'freebsd', 'openbsd', 'netbsd', 'dragonfly']
 }
 
-fn install_missing_bsd_v1_fallback(vroot string, compiler string, args []string, host_os string) ! {
-	if host_os !in ['freebsd', 'openbsd', 'netbsd', 'dragonfly'] {
+fn install_missing_v1_fallback(vroot string, compiler string, args []string, host_os string) ! {
+	if host_os !in ['windows', 'freebsd', 'openbsd', 'netbsd', 'dragonfly'] {
 		return
 	}
-	fallback := os.join_path(vroot, v1_fallback_binary)
+	exe_ext := if host_os == 'windows' { '.exe' } else { '' }
+	fallback := os.join_path(vroot, '${v1_fallback_binary}${exe_ext}')
 	if os.is_executable(fallback) {
 		return
 	}
-	staged_fallback := os.join_path(vroot, '.vself_v1_fallback_${os.getpid()}')
+	staged_fallback := os.join_path(vroot, '.vself_v1_fallback_${os.getpid()}${exe_ext}')
 	os.rm(staged_fallback) or {}
 	defer {
 		os.rm(staged_fallback) or {}
@@ -510,7 +518,7 @@ fn install_missing_bsd_v1_fallback(vroot string, compiler string, args []string,
 	mut fallback_args := initial_bootstrap_args(args).filter(it !in ['-new-compiler', '-old-compiler'])
 	fallback_args << ['-no-parallel', '-d', 'v1_fallback']
 	fallback_args = with_output_arg(fallback_args, staged_fallback)
-	println('V self compiling the BSD V1 compatibility compiler...')
+	println('V self compiling the V1 compatibility compiler...')
 	fallback_cmd := compose_v_cmd(compiler, fallback_args, full_v_cli_source)
 	run_cmd(fallback_cmd) or {
 		return error('failed to build `${fallback}` before replacing V.\n${err.msg()}')

--- a/cmd/tools/vself_test.v
+++ b/cmd/tools/vself_test.v
@@ -17,6 +17,35 @@ fn assert_vself_uses_single_prod_build(output string) {
 	assert_vself_preserves_full_cli(output)
 }
 
+fn vself_mock_compiler_source() string {
+	return "module main
+
+import os
+
+fn main() {
+	if os.args.last() != 'cmd/v' {
+		eprintln('expected cmd/v, got ' + os.args.last())
+		exit(1)
+	}
+	mut output := ''
+	for i, arg in os.args {
+		if arg == '-o' && i + 1 < os.args.len {
+			output = os.args[i + 1]
+		}
+	}
+	if output == '' {
+		eprintln('missing -o')
+		exit(1)
+	}
+	os.cp(os.getenv('VSELF_TEST_FULL_CLI'), output) or {
+		eprintln(err)
+		exit(1)
+	}
+	println(os.args.last())
+}
+"
+}
+
 fn test_linux_tinyc_self_build_does_not_enable_prealloc() {
 	$if !linux {
 		return
@@ -164,7 +193,7 @@ fn test_bsd_self_build_uses_system_cc_and_v3_safeguards() {
 }
 
 fn test_plain_self_replacement_preserves_cli_and_embedded_v3() {
-	$if !bsd && !linux && !windows {
+	$if !bsd && !linux {
 		return
 	}
 	root := os.join_path(os.vtmp_dir(), 'vself_full_cli_replacement_${os.getpid()}')
@@ -180,32 +209,7 @@ fn test_plain_self_replacement_preserves_cli_and_embedded_v3() {
 	// The stub keeps this test fast, but only emits a replacement when vself asks
 	// for cmd/v. Targeting standalone v3.v makes the replacement fail.
 	mock_source := os.join_path(root, 'mock_compiler.v')
-	os.write_file(mock_source, "module main
-
-import os
-
-fn main() {
-	if os.args.last() != 'cmd/v' {
-		eprintln('expected cmd/v, got ' + os.args.last())
-		exit(1)
-	}
-	mut output := ''
-	for i, arg in os.args {
-		if arg == '-o' && i + 1 < os.args.len {
-			output = os.args[i + 1]
-		}
-	}
-	if output == '' {
-		eprintln('missing -o')
-		exit(1)
-	}
-	os.cp(os.getenv('VSELF_TEST_FULL_CLI'), output) or {
-		eprintln(err)
-		exit(1)
-	}
-	println(os.args.last())
-}
-") or { panic(err) }
+	os.write_file(mock_source, vself_mock_compiler_source()) or { panic(err) }
 	isolated_vexe := os.join_path(root, 'v')
 	mock_build := os.execute('${os.quoted_path(vexe)} -o ${os.quoted_path(isolated_vexe)} ${os.quoted_path(mock_source)}')
 	assert mock_build.exit_code == 0, mock_build.output
@@ -216,7 +220,7 @@ fn main() {
 	self_result := os.execute('env -u CC VFLAGS="" VOSARGS="" VSELF_TEST_FULL_CLI=${os.quoted_path(vexe)} VEXE=${os.quoted_path(isolated_vexe)} ${os.quoted_path(vself_tool)} self -silent')
 	assert self_result.exit_code == 0, self_result.output
 	assert self_result.output.contains('cmd/v'), self_result.output
-	assert self_result.output.contains('BSD V1 compatibility compiler'), self_result.output
+	assert self_result.output.contains('V1 compatibility compiler'), self_result.output
 	assert !self_result.output.contains('vlib/v3/v3.v'), self_result.output
 	assert os.is_executable(isolated_vexe)
 	assert os.is_executable(os.join_path(root, 'v_old'))
@@ -237,4 +241,34 @@ fn main() {
 	program_result := os.execute(os.quoted_path(program))
 	assert program_result.exit_code == 0, program_result.output
 	assert program_result.output.trim_space() == '42', program_result.output
+}
+
+fn test_windows_plain_self_transition_installs_exe_fallback() {
+	$if windows {
+		return
+	}
+	root := os.join_path(os.vtmp_dir(), 'vself_windows_transition_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root) or { panic(err) }
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	for directory in ['vlib', 'thirdparty'] {
+		os.symlink(os.join_path(vroot, directory), os.join_path(root, directory)) or { panic(err) }
+	}
+
+	mock_source := os.join_path(root, 'mock_compiler.v')
+	os.write_file(mock_source, vself_mock_compiler_source()) or { panic(err) }
+	isolated_vexe := os.join_path(root, 'v')
+	mock_build := os.execute('${os.quoted_path(vexe)} -o ${os.quoted_path(isolated_vexe)} ${os.quoted_path(mock_source)}')
+	assert mock_build.exit_code == 0, mock_build.output
+	vself_tool := os.join_path(root, 'vself')
+	vself_build := os.execute('${os.quoted_path(vexe)} -d vself_test_windows_transition -o ${os.quoted_path(vself_tool)} ${os.quoted_path(os.join_path(vroot, 'cmd', 'tools', 'vself.v'))}')
+	assert vself_build.exit_code == 0, vself_build.output
+
+	self_result := os.execute('env -u CC VFLAGS="" VOSARGS="" VSELF_TEST_FULL_CLI=${os.quoted_path(vexe)} VEXE=${os.quoted_path(isolated_vexe)} ${os.quoted_path(vself_tool)} self -silent')
+	assert self_result.exit_code == 0, self_result.output
+	assert self_result.output.contains('V1 compatibility compiler'), self_result.output
+	assert !self_result.output.contains('-prealloc'), self_result.output
+	assert os.is_executable(os.join_path(root, 'v1_fallback.exe'))
 }

--- a/cmd/tools/vself_test.v
+++ b/cmd/tools/vself_test.v
@@ -164,7 +164,7 @@ fn test_bsd_self_build_uses_system_cc_and_v3_safeguards() {
 }
 
 fn test_plain_self_replacement_preserves_cli_and_embedded_v3() {
-	$if !bsd && !linux {
+	$if !bsd && !linux && !windows {
 		return
 	}
 	root := os.join_path(os.vtmp_dir(), 'vself_full_cli_replacement_${os.getpid()}')

--- a/cmd/v/macos_v3_compat_routing_test.v
+++ b/cmd/v/macos_v3_compat_routing_test.v
@@ -22,6 +22,22 @@ fn test_macos_v3_routes_cross_modes_to_v1_compatibility() {
 	assert macos_v3_needs_v1_compatibility('cmd/v', portable)
 }
 
+fn test_windows_msvc_routes_to_v1_compatibility() {
+	mut prefs := &pref.Preferences{
+		path: 'main.v'
+		backend: .c
+		ccompiler: 'msvc'
+		ccompiler_type: .msvc
+	}
+	assert macos_v3_windows_msvc_needs_v1_compatibility(prefs, .windows)
+	assert !macos_v3_windows_msvc_needs_v1_compatibility(prefs, .linux)
+	prefs.new_compiler = true
+	assert macos_v3_windows_msvc_needs_v1_compatibility(prefs, .windows)
+	$if windows {
+		assert macos_v3_needs_v1_compatibility('main.v', prefs)
+	}
+}
+
 fn test_macos_v3_routes_internal_tool_bootstrap_to_v1_compatibility() {
 	vroot := os.dir(@VEXE)
 	tool_path := os.join_path(vroot, 'cmd', 'tools', 'vpm')

--- a/cmd/v/macos_v3_compat_routing_test.v
+++ b/cmd/v/macos_v3_compat_routing_test.v
@@ -48,7 +48,7 @@ fn test_linux_routes_implicit_cmd_v_self_build_to_v1_compatibility() {
 }
 
 fn test_temporary_self_build_bootstraps_only_before_v1_fallback_exists() {
-	$if bsd || linux {
+	$if bsd || linux || windows {
 		vroot := os.dir(@VEXE)
 		mut prefs := &pref.Preferences{
 			path: os.join_path(vroot, 'cmd', 'v')

--- a/cmd/v/macos_v3_dispatch.c.v
+++ b/cmd/v/macos_v3_dispatch.c.v
@@ -172,7 +172,13 @@ fn macos_v3_needs_bootstrap_before_v1_fallback(prefs &pref.Preferences, needs_v1
 }
 
 fn macos_v3_needs_v1_compatibility(command string, prefs &pref.Preferences) bool {
-	// FastC and explicit `-new-compiler` are deliberately strict V3 requests.
+	if macos_v3_windows_msvc_needs_v1_compatibility(prefs, pref.get_host_os()) {
+		// V3 does not have an MSVC command-line driver. Preserve the supported
+		// Windows mode by selecting the compatibility compiler before V3 runs.
+		return true
+	}
+	// Apart from the unsupported MSVC driver above, FastC and explicit
+	// `-new-compiler` are deliberately strict V3 requests.
 	if prefs.new_compiler || prefs.is_fastc || prefs.backend != .c || prefs.path == ''
 		|| command == 'test' || command in external_tools
 		|| macos_v3_non_compilation_command(command) {
@@ -200,6 +206,10 @@ fn macos_v3_needs_v1_compatibility(command string, prefs &pref.Preferences) bool
 	target := os.real_path(prefs.path).replace('\\', '/').trim_right('/')
 	tools := '${vroot}/cmd/tools'
 	return target == tools || target.starts_with(tools + '/')
+}
+
+fn macos_v3_windows_msvc_needs_v1_compatibility(prefs &pref.Preferences, host_os pref.OS) bool {
+	return host_os == .windows && prefs.ccompiler_type == .msvc
 }
 
 fn is_macos_v3_relevant_command(command string, prefs &pref.Preferences) bool {

--- a/cmd/v/macos_v3_dispatch.c.v
+++ b/cmd/v/macos_v3_dispatch.c.v
@@ -1,6 +1,6 @@
 module main
 
-// The V3 compiler is linked directly into `cmd/v` on macOS, Linux, and BSD. The
+// The V3 compiler is linked directly into `cmd/v` on macOS, BSD, Linux, and Windows. The
 // command shell hands C-backend compilations to it in-process while leaving
 // tool commands and other backends on their existing external-tool paths.
 // When V3 fails an ordinary program compilation, the lean V3-only command
@@ -74,7 +74,7 @@ fn retry_macos_v3_with_v1(state &MacosV3RetryState) {
 }
 
 fn maybe_delegate_to_macos_v3(command string, prefs &pref.Preferences) {
-	$if bsd || linux {
+	$if bsd || linux || windows {
 		needs_v1_compatibility := macos_v3_needs_v1_compatibility(command, prefs)
 		fallback_executable := macos_v3_v1_fallback_executable()
 		if macos_v3_needs_bootstrap_before_v1_fallback(prefs, needs_v1_compatibility, os.executable(), fallback_executable) {
@@ -103,7 +103,7 @@ fn maybe_delegate_to_macos_v3(command string, prefs &pref.Preferences) {
 			eprintln('the embedded V3 compiler is unavailable on this target, and fallback is disabled.')
 			exit(1)
 		}
-		$if bsd || linux {
+		$if bsd || linux || windows {
 			// musl deliberately does not link V3 because its runtime still depends on
 			// glibc-only C interfaces. Use the same full external compatibility
 			// compiler that an ordinary failed V3 build would retry through.
@@ -145,7 +145,7 @@ fn launch_macos_v1_fallback(executable string, args []string, is_verbose bool, r
 }
 
 fn macos_v3_v1_fallback_executable() string {
-	return os.join_path(os.dir(pref.vexe_path()), macos_v3_v1_fallback_binary)
+	return util.path_of_executable(os.join_path(os.dir(pref.vexe_path()), macos_v3_v1_fallback_binary))
 }
 
 fn macos_v3_is_self_build_target(prefs &pref.Preferences) bool {

--- a/cmd/v/macos_v3_driver_notd_cross.v
+++ b/cmd/v/macos_v3_driver_notd_cross.v
@@ -2,19 +2,20 @@ module main
 
 $if v1_fallback ? {
 } $else $if musl ? {
-} $else $if bsd || linux {
+} $else $if bsd || linux || windows {
 	import v3.driver
 }
 
 // The V3 driver (vlib/v3) is linked directly into `cmd/v` on the target
-// platforms where V3 compiles and runs — macOS, the BSD family, and glibc Linux.
-// There `v` can run the V3 compiler in the SAME process. musl builds deliberately
-// use the stub path because the embedded V3 runtime currently depends on glibc-only
-// C interfaces; their ordinary C compilations are delegated to v1_fallback.
+// platforms where V3 compiles and runs — macOS, the BSD family, glibc Linux, and
+// Windows. There `v` can run the V3 compiler in the SAME process. musl builds
+// deliberately use the stub path because the embedded V3 runtime currently depends
+// on glibc-only C interfaces; their ordinary C compilations are delegated to
+// v1_fallback.
 //
 // The separately built `v1_fallback` command shell also takes the stub path, so
-// it contains only the stable compiler. Windows and portable `-os cross` VC
-// generation get the same stub below or the one in macos_v3_driver_d_cross.v,
+// it contains only the stable compiler. Portable `-os cross` VC generation gets
+// the same stub below or the one in macos_v3_driver_d_cross.v,
 // so V3's thread/parallel code is never cross-compiled into them.
 $if v1_fallback ? {
 	@[markused]
@@ -32,7 +33,7 @@ $if v1_fallback ? {
 
 	@[markused]
 	fn macos_v3_driver_run(_ []string) {}
-} $else $if bsd || linux {
+} $else $if bsd || linux || windows {
 	@[markused]
 	fn macos_v3_driver_is_available() bool {
 		return true

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -122,6 +122,7 @@ fn test_windows_makev_builds_the_v1_fallback_executable() {
 	assert source.contains('set V1_FALLBACK=./v1_fallback.exe')
 	assert source.contains('"%V_BOOTSTRAP%" %V_BOOTSTRAP_VFLAGS% -keepc -g -showcc -d v1_fallback -o "%V1_FALLBACK%" cmd/v')
 	assert source.contains('"%V_STAGE%" %V_BOOTSTRAP_VFLAGS% -keepc -g -showcc -cc "!tcc_exe!" -o "%V_UPDATED%" cmd/v')
+	assert source.contains('"%V_BOOTSTRAP%" %V_BOOTSTRAP_VFLAGS% -keepc -g -showcc !stage_vflags! -d v1_fallback -o "%V_STAGE%" cmd/v')
 	assert !source.contains('"%V_STAGE%" %V_BOOTSTRAP_VFLAGS% -keepc -g -showcc -cc "!tcc_exe!" -cflags -Bthirdparty/tcc')
 	normalized := source.replace('\r\n', '\n')
 	assert normalized.count('call :move_updated_to_v\nif !ERRORLEVEL! NEQ 0 goto :compile_error') == 5

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -33,7 +33,7 @@ fn test_macos_v3_embedded_driver_matches_target_selection() {
 		assert !macos_v3_driver_is_available()
 	} $else $if musl ? {
 		assert !macos_v3_driver_is_available()
-	} $else $if bsd || linux {
+	} $else $if bsd || linux || windows {
 		assert macos_v3_driver_is_available()
 	} $else {
 		assert !macos_v3_driver_is_available()
@@ -84,7 +84,7 @@ fn test_macos_v3_relevant_command_owns_every_direct_c_build() {
 
 fn test_macos_v3_cmd_source_unlinks_v1_on_supported_hosts() {
 	source := os.read_file(os.join_path(macos_v3_test_vroot, 'cmd', 'v', 'v.v'))!
-	assert source.contains('\$if v1_fallback ?|| cross ?|| ( !bsd && !linux ) {')
+	assert source.contains('\$if v1_fallback ?|| cross ?|| ( !bsd && !linux && !windows ) {')
 	assert source.contains('import v.builder')
 	assert source.contains('import v.builder.cbuilder')
 	assert source.contains('\$if v1_fallback ?|| cross ? {\n\t\t\t\tbuilder.compile')
@@ -110,9 +110,26 @@ fn test_netbsd_marks_the_v1_compatibility_compiler() {
 	assert makefile.contains('paxctl +m \$(V1_FALLBACK_EXE)')
 }
 
+fn test_windows_make_builds_the_v1_fallback_executable() {
+	source := os.read_file(os.join_path(macos_v3_test_vroot, 'GNUmakefile'))!
+	assert source.contains('V1_FALLBACK_EXE = \$(dir \$(VEXE))v1_fallback\$(EXE_EXT)')
+	fallback_build := './v1\$(EXE_EXT) -no-parallel -d v1_fallback -o \$(V1_FALLBACK_EXE)'
+	assert source.count(fallback_build) == 2
+}
+
+fn test_windows_makev_builds_the_v1_fallback_executable() {
+	source := os.read_file(os.join_path(macos_v3_test_vroot, 'makev.bat'))!
+	assert source.contains('set V1_FALLBACK=./v1_fallback.exe')
+	assert source.contains('"%V_BOOTSTRAP%" %V_BOOTSTRAP_VFLAGS% -keepc -g -showcc -d v1_fallback -o "%V1_FALLBACK%" cmd/v')
+	assert source.contains('"%V_STAGE%" %V_BOOTSTRAP_VFLAGS% -keepc -g -showcc -cc "!tcc_exe!" -o "%V_UPDATED%" cmd/v')
+	assert !source.contains('"%V_STAGE%" %V_BOOTSTRAP_VFLAGS% -keepc -g -showcc -cc "!tcc_exe!" -cflags -Bthirdparty/tcc')
+	normalized := source.replace('\r\n', '\n')
+	assert normalized.count('call :move_updated_to_v\nif !ERRORLEVEL! NEQ 0 goto :compile_error') == 5
+}
+
 fn test_v1_fallback_can_bootstrap_cmd_v_without_target_define() {
-	$if bsd || linux {
-		fallback := os.join_path(macos_v3_test_vroot, macos_v3_v1_fallback_binary)
+	$if bsd || linux || windows {
+		fallback := macos_v3_v1_fallback_executable()
 		if !os.is_executable(fallback) {
 			return
 		}
@@ -128,8 +145,8 @@ fn test_v1_fallback_can_bootstrap_cmd_v_without_target_define() {
 }
 
 fn test_macos_v3_old_compiler_uses_external_v1_command() {
-	$if bsd || linux {
-		fallback := os.join_path(macos_v3_test_vroot, macos_v3_v1_fallback_binary)
+	$if bsd || linux || windows {
+		fallback := macos_v3_v1_fallback_executable()
 		if !os.is_executable(fallback) {
 			return
 		}
@@ -152,7 +169,7 @@ fn test_macos_v3_old_compiler_uses_external_v1_command() {
 }
 
 fn test_macos_v3_invalid_program_still_reports_an_error_after_v1_retry() {
-	$if bsd || linux {
+	$if bsd || linux || windows {
 		root := os.join_path(os.vtmp_dir(), 'v3_invalid_program_${os.getpid()}')
 		os.rmdir_all(root) or {}
 		os.mkdir_all(root)!
@@ -173,7 +190,7 @@ fn test_macos_v3_invalid_program_still_reports_an_error_after_v1_retry() {
 }
 
 fn test_macos_v3_fatal_errors_reports_only_the_first_error() {
-	$if bsd || linux {
+	$if bsd || linux || windows {
 		root := os.join_path(os.vtmp_dir(), 'v3_fatal_errors_${os.getpid()}')
 		os.rmdir_all(root) or {}
 		os.mkdir_all(root)!
@@ -347,7 +364,7 @@ fn test_macos_v3_parallel_cc_ignores_inactive_header_definitions() {
 }
 
 fn test_macos_v3_compiles_cmd_v_without_v1_modules() {
-	$if bsd || linux {
+	$if bsd || linux || windows {
 		compiler := os.join_path(macos_v3_test_vroot, '.v3_only_cmd_test_${os.getpid()}')
 		defer {
 			os.rm(compiler) or {}

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -120,7 +120,11 @@ fn test_windows_make_builds_the_v1_fallback_executable() {
 fn test_windows_makev_builds_the_v1_fallback_executable() {
 	source := os.read_file(os.join_path(macos_v3_test_vroot, 'makev.bat'))!
 	assert source.contains('set V1_FALLBACK=./v1_fallback.exe')
-	assert source.contains('"%V_BOOTSTRAP%" %V_BOOTSTRAP_VFLAGS% -keepc -g -showcc -d v1_fallback -o "%V1_FALLBACK%" cmd/v')
+	assert source.contains('"%V_BOOTSTRAP%" %V_BOOTSTRAP_VFLAGS% -keepc -g -showcc !V_FALLBACK_CC_ARGS! -d v1_fallback -o "%V1_FALLBACK%" cmd/v')
+	assert source.contains('set V_FALLBACK_CC_ARGS=-cc "!tcc_exe!" -cflags -Bthirdparty/tcc')
+	assert source.contains('set V_FALLBACK_CC_ARGS=-cc clang -cflags "--target=!clang_target!"')
+	assert source.contains('set V_FALLBACK_CC_ARGS=-cc "!gcc_exe!"')
+	assert source.contains('set V_FALLBACK_CC_ARGS=-cc msvc')
 	assert source.contains('"%V_STAGE%" %V_BOOTSTRAP_VFLAGS% -keepc -g -showcc -cc "!tcc_exe!" -o "%V_UPDATED%" cmd/v')
 	assert source.contains('"%V_BOOTSTRAP%" %V_BOOTSTRAP_VFLAGS% -keepc -g -showcc !stage_vflags! -d v1_fallback -o "%V_STAGE%" cmd/v')
 	assert !source.contains('"%V_STAGE%" %V_BOOTSTRAP_VFLAGS% -keepc -g -showcc -cc "!tcc_exe!" -cflags -Bthirdparty/tcc')

--- a/cmd/v/v.v
+++ b/cmd/v/v.v
@@ -11,7 +11,7 @@ import v.pref
 import v.util
 import v.util.version
 
-$if v1_fallback ?|| cross ?|| ( !bsd && !linux ) {
+$if v1_fallback ?|| cross ?|| ( !bsd && !linux && !windows ) {
 	// The compatibility compiler, portable cross snapshots, and non-V3 targets
 	// all need the V1 builder. Keep this as one import site: a compatibility
 	// compiler generating a cross target can satisfy multiple parts of the condition.
@@ -425,7 +425,7 @@ fn rebuild(prefs &pref.Preferences) {
 		.c {
 			$if v1_fallback ?|| cross ? {
 				builder.compile('build', prefs, cbuilder.compile_c)
-			} $else $if bsd || linux {
+			} $else $if bsd || linux || windows {
 
 				// Every C-backend build is dispatched to V3 before this point. Keeping
 				// this path fatal prevents an accidental dependency on the unlinked V1

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -75,16 +75,19 @@ project boundaries such as `.git`, `.hg`, `.svn`, and `.v.mod.stop`.
 
 ## The default compiler
 
-On macOS and Linux, the top-level `v` executable contains only the experimental
-**V3** C compiler (whose source lives in `vlib/v3`). Every direct C build,
-including compiler self-builds, is compiled by V3 in-process. The CLI and tool
-commands remain in `cmd/v`; commands such as `test` and `fmt` are external tools,
-and non-C backends remain separate builder tools.
+On macOS, Linux, and Windows, the top-level `v` executable contains only the
+experimental **V3** C compiler (whose source lives in `vlib/v3`). Every direct C
+build, including compiler self-builds, is compiled by V3 in-process. The CLI and
+tool commands remain in `cmd/v`; commands such as `test` and `fmt` are external
+tools, and non-C backends remain separate builder tools.
 
-V3 compilation errors are returned directly. These builds do not silently retry
-with the established compiler, and `-old-compiler` reports that the executable
-contains only V3. `-new-compiler` remains accepted for command-line compatibility
-and selects the same embedded driver.
+The standard bootstrap builds a sibling `v1_fallback` executable
+(`v1_fallback.exe` on Windows). `-old-compiler` launches it explicitly, and
+ordinary user builds retry through it after a V3 compiler or C compilation
+failure. Explicit `-new-compiler` builds and native compiler self-builds remain
+strict V3 operations. A separately built V3-only executable without the sibling
+cannot use the fallback. `-new-compiler` remains accepted for command-line
+compatibility and selects the same embedded driver.
 
 On platforms that do not embed V3, `cmd/v` still contains the established
 compiler from `vlib/v`. There, `-new-compiler` reports that the current build does

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -85,9 +85,11 @@ The standard bootstrap builds a sibling `v1_fallback` executable
 (`v1_fallback.exe` on Windows). `-old-compiler` launches it explicitly, and
 ordinary user builds retry through it after a V3 compiler or C compilation
 failure. Explicit `-new-compiler` builds and native compiler self-builds remain
-strict V3 operations. A separately built V3-only executable without the sibling
+strict V3 operations, except for `-new-compiler -cc msvc` on Windows. V3 does
+not yet generate MSVC command lines, so that combination intentionally launches
+`v1_fallback.exe`. A separately built V3-only executable without the sibling
 cannot use the fallback. `-new-compiler` remains accepted for command-line
-compatibility and selects the same embedded driver.
+compatibility and otherwise selects the same embedded driver.
 
 On platforms that do not embed V3, `cmd/v` still contains the established
 compiler from `vlib/v`. There, `-new-compiler` reports that the current build does

--- a/makev.bat
+++ b/makev.bat
@@ -16,6 +16,7 @@ set V_BOOTSTRAP=./v_win_bootstrap.exe
 set V_OLD=./v_old.exe
 set V_UPDATED=./v_up.exe
 set V_STAGE=./v_stage.exe
+set V1_FALLBACK=./v1_fallback.exe
 set V_C_FILE=./vc/v_win.c
 REM Existing vc bootstraps may predate the TCC Win64 CRT prelude fix, so keep
 REM their cgen single-threaded while they build a fresh compiler from sources.
@@ -165,6 +166,7 @@ if !ERRORLEVEL! NEQ 0 goto :compile_error
 call :build_fresh_v_with_tcc
 if !ERRORLEVEL! NEQ 0 goto :tcc_retry_with_host_bootstrap
 call :move_updated_to_v
+if !ERRORLEVEL! NEQ 0 goto :compile_error
 goto :success
 
 :tcc_retry_with_host_bootstrap
@@ -181,12 +183,13 @@ if !ERRORLEVEL! NEQ 0 (
 	goto :compile_error
 )
 call :move_updated_to_v
+if !ERRORLEVEL! NEQ 0 goto :compile_error
 goto :success
 
 :build_fresh_v_with_tcc
 echo  ^> Compiling "%V_STAGE%" with "%V_BOOTSTRAP%"
-REM Keep the TCC root relative here; V forwards -cflags through a response file.
-REM An absolute -B path breaks there when the checkout path contains spaces.
+REM Keep the V1 bootstrap's TCC root relative; it forwards -cflags through a
+REM response file, where an absolute -B path breaks when the checkout has spaces.
 "%V_BOOTSTRAP%" %V_BOOTSTRAP_VFLAGS% -keepc -g -showcc -cc "!tcc_exe!" -cflags -Bthirdparty/tcc -o "%V_STAGE%" cmd/v
 set stage_error=!ERRORLEVEL!
 if !stage_error! NEQ 0 (
@@ -194,7 +197,9 @@ if !stage_error! NEQ 0 (
 	exit /b !stage_error!
 )
 echo  ^> Compiling "%V_EXE%" with "%V_STAGE%"
-"%V_STAGE%" %V_BOOTSTRAP_VFLAGS% -keepc -g -showcc -cc "!tcc_exe!" -cflags -Bthirdparty/tcc -o "%V_UPDATED%" cmd/v
+REM V3 supplies the absolute bundled-TCC root itself. A relative -B here would
+REM override it after V3 changes into its isolated link directory.
+"%V_STAGE%" %V_BOOTSTRAP_VFLAGS% -keepc -g -showcc -cc "!tcc_exe!" -o "%V_UPDATED%" cmd/v
 set stage_error=!ERRORLEVEL!
 if exist "%V_STAGE%" del "%V_STAGE%"
 exit /b !stage_error!
@@ -210,6 +215,7 @@ echo  ^> Compiling "%V_EXE%" with "%V_BOOTSTRAP%"
 "%V_BOOTSTRAP%" %V_BOOTSTRAP_VFLAGS% -keepc -g -showcc -cc clang -cflags "--target=!clang_target!" -o "%V_UPDATED%" cmd/v
 if !ERRORLEVEL! NEQ 0 goto :compile_error
 call :move_updated_to_v
+if !ERRORLEVEL! NEQ 0 goto :compile_error
 goto :success
 
 :gcc_strap
@@ -223,6 +229,7 @@ echo  ^> Compiling "%V_EXE%" with "%V_BOOTSTRAP%"
 "%V_BOOTSTRAP%" %V_BOOTSTRAP_VFLAGS% -keepc -g -showcc -cc "!gcc_exe!" -o "%V_UPDATED%" cmd/v
 if !ERRORLEVEL! NEQ 0 goto :compile_error
 call :move_updated_to_v
+if !ERRORLEVEL! NEQ 0 goto :compile_error
 goto :success
 
 :msvc_strap
@@ -287,6 +294,7 @@ if exist %ObjFile% del %ObjFile%
 if exist "%V_STAGE%" del "%V_STAGE%"
 if %msvc_error% NEQ 0 goto :compile_error
 call :move_updated_to_v
+if !ERRORLEVEL! NEQ 0 goto :compile_error
 goto :success
 
 :download_tcc
@@ -521,6 +529,9 @@ endlocal
 exit /b 0
 
 :move_updated_to_v
+echo  ^> Compiling "%V1_FALLBACK%" with "%V_BOOTSTRAP%"
+"%V_BOOTSTRAP%" %V_BOOTSTRAP_VFLAGS% -keepc -g -showcc -d v1_fallback -o "%V1_FALLBACK%" cmd/v
+if !ERRORLEVEL! NEQ 0 exit /b !ERRORLEVEL!
 @REM del "%V_EXE%" &:: breaks if `makev.bat` is run from `v up` b/c of held file handle on `%V_EXE%`
 if exist "%V_EXE%" move "%V_EXE%" "%V_OLD%" >nul
 REM sleep for at most 100ms

--- a/makev.bat
+++ b/makev.bat
@@ -280,7 +280,8 @@ if not defined stage_vflags (
 )
 
 echo  ^> Compiling "%V_STAGE%" with "%V_BOOTSTRAP%"
-"%V_BOOTSTRAP%" %V_BOOTSTRAP_VFLAGS% -keepc -g -showcc !stage_vflags! -o "%V_STAGE%" cmd/v
+REM Keep this stage on V1: only the established compiler emits MSVC command lines.
+"%V_BOOTSTRAP%" %V_BOOTSTRAP_VFLAGS% -keepc -g -showcc !stage_vflags! -d v1_fallback -o "%V_STAGE%" cmd/v
 if !ERRORLEVEL! NEQ 0 (
 	if exist %ObjFile% del %ObjFile%
 	if exist "%V_STAGE%" del "%V_STAGE%"

--- a/makev.bat
+++ b/makev.bat
@@ -18,6 +18,7 @@ set V_UPDATED=./v_up.exe
 set V_STAGE=./v_stage.exe
 set V1_FALLBACK=./v1_fallback.exe
 set V_C_FILE=./vc/v_win.c
+set V_FALLBACK_CC_ARGS=
 REM Existing vc bootstraps may predate the TCC Win64 CRT prelude fix, so keep
 REM their cgen single-threaded while they build a fresh compiler from sources.
 REM TODO: remove this after vc/v_win.c is regenerated with the fixed CRT prelude.
@@ -187,6 +188,7 @@ if !ERRORLEVEL! NEQ 0 goto :compile_error
 goto :success
 
 :build_fresh_v_with_tcc
+set V_FALLBACK_CC_ARGS=-cc "!tcc_exe!" -cflags -Bthirdparty/tcc
 echo  ^> Compiling "%V_STAGE%" with "%V_BOOTSTRAP%"
 REM Keep the V1 bootstrap's TCC root relative; it forwards -cflags through a
 REM response file, where an absolute -B path breaks when the checkout has spaces.
@@ -211,6 +213,7 @@ if !ERRORLEVEL! NEQ 0 (
 	goto :gcc_strap
 )
 
+set V_FALLBACK_CC_ARGS=-cc clang -cflags "--target=!clang_target!"
 echo  ^> Compiling "%V_EXE%" with "%V_BOOTSTRAP%"
 "%V_BOOTSTRAP%" %V_BOOTSTRAP_VFLAGS% -keepc -g -showcc -cc clang -cflags "--target=!clang_target!" -o "%V_UPDATED%" cmd/v
 if !ERRORLEVEL! NEQ 0 goto :compile_error
@@ -225,6 +228,7 @@ if !ERRORLEVEL! NEQ 0 (
 	goto :msvc_strap
 )
 
+set V_FALLBACK_CC_ARGS=-cc "!gcc_exe!"
 echo  ^> Compiling "%V_EXE%" with "%V_BOOTSTRAP%"
 "%V_BOOTSTRAP%" %V_BOOTSTRAP_VFLAGS% -keepc -g -showcc -cc "!gcc_exe!" -o "%V_UPDATED%" cmd/v
 if !ERRORLEVEL! NEQ 0 goto :compile_error
@@ -289,6 +293,7 @@ if !ERRORLEVEL! NEQ 0 (
 )
 
 echo  ^> Compiling "%V_EXE%" with "%V_STAGE%"
+set V_FALLBACK_CC_ARGS=-cc msvc
 "%V_STAGE%" %V_BOOTSTRAP_VFLAGS% -keepc -g -showcc -cc msvc -o "%V_UPDATED%" cmd/v
 set msvc_error=!ERRORLEVEL!
 if exist %ObjFile% del %ObjFile%
@@ -531,7 +536,7 @@ exit /b 0
 
 :move_updated_to_v
 echo  ^> Compiling "%V1_FALLBACK%" with "%V_BOOTSTRAP%"
-"%V_BOOTSTRAP%" %V_BOOTSTRAP_VFLAGS% -keepc -g -showcc -d v1_fallback -o "%V1_FALLBACK%" cmd/v
+"%V_BOOTSTRAP%" %V_BOOTSTRAP_VFLAGS% -keepc -g -showcc !V_FALLBACK_CC_ARGS! -d v1_fallback -o "%V1_FALLBACK%" cmd/v
 if !ERRORLEVEL! NEQ 0 exit /b !ERRORLEVEL!
 @REM del "%V_EXE%" &:: breaks if `makev.bat` is run from `v up` b/c of held file handle on `%V_EXE%`
 if exist "%V_EXE%" move "%V_EXE%" "%V_OLD%" >nul

--- a/vlib/net/net_windows.c.v
+++ b/vlib/net/net_windows.c.v
@@ -215,6 +215,17 @@ pub fn error_code() int {
 	return C.WSAGetLastError()
 }
 
+pub struct C.WSAData {
+mut:
+	wVersion       u16
+	wHighVersion   u16
+	szDescription  [257]u8
+	szSystemStatus [129]u8
+	iMaxSockets    u16
+	iMaxUdpDg      u16
+	lpVendorInfo   &u8
+}
+
 @[typedef]
 pub struct C.WSADATA {
 mut:

--- a/vlib/net/net_windows.c.v
+++ b/vlib/net/net_windows.c.v
@@ -215,7 +215,8 @@ pub fn error_code() int {
 	return C.WSAGetLastError()
 }
 
-pub struct C.WSAData {
+@[typedef]
+pub struct C.WSADATA {
 mut:
 	wVersion       u16
 	wHighVersion   u16
@@ -227,7 +228,7 @@ mut:
 }
 
 fn init() {
-	mut wsadata := C.WSAData{
+	mut wsadata := C.WSADATA{
 		lpVendorInfo: 0
 	}
 	res := C.WSAStartup(wsa_v22, &wsadata)

--- a/vlib/net/wsa_data_windows_test.c.v
+++ b/vlib/net/wsa_data_windows_test.c.v
@@ -1,0 +1,14 @@
+// vtest build: windows
+
+import net as _
+
+fn accept_wsa_data(_ &C.WSAData) {}
+
+fn accept_wsadata(_ &C.WSADATA) {}
+
+fn test_wsa_data_names_remain_available() {
+	legacy := C.WSAData{}
+	typedef := C.WSADATA{}
+	accept_wsa_data(&legacy)
+	accept_wsadata(&typedef)
+}

--- a/vlib/v/help/build/build-c.txt
+++ b/vlib/v/help/build/build-c.txt
@@ -78,6 +78,7 @@ see also `v help build`.
       When set to `console` V will generate a `wmain` main function.
       When set to `windows` V will generate a `wWinMain` main function,
       even when you are not compiling `gg` apps.
+      The FastC backend does not support `-subsystem windows` yet.
 
    -icon <path>
    --icon=<path>

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -31,28 +31,30 @@ can compile the full builtin map.v.
 
 ## V3 dispatch
 
-On macOS, Linux, and BSD, V3 is the default compiler for user source and test builds. The
+On macOS, BSD, Linux, and Windows, V3 is the default compiler for user source and test builds. The
 top-level `v` command runs the V3 driver linked into `cmd/v`; it does not build or launch a second
 compiler process. This includes direct file and directory builds, `run`, `build`, and test-file
 compilation, plus production and shared builds and supported cross targets and backends. The
 `test` command itself continues to use the established test dispatcher, while each discovered
 test file is compiled by V3.
 
-`cmd/v` remains the full CLI and tool dispatcher. On macOS, Linux, and BSD it links V3, but does
-not link the established compiler in `vlib/v`; its own build and every other direct C build
-therefore use V3. Commands such as `test` remain external tools, while each discovered test file
-is compiled by V3. Non-C backends remain separate builder tools.
+`cmd/v` remains the full CLI and tool dispatcher. On these platforms it links V3, but does not
+link the established compiler in `vlib/v`; its own build and every other direct C build therefore
+use V3. Commands such as `test` remain external tools, while each discovered test file is compiled
+by V3. Non-C backends remain separate builder tools.
 
 `-new-compiler` remains accepted for command-line compatibility and selects the same in-process V3
-driver. On macOS, Linux, and BSD, `-old-compiler` launches the external `v1_fallback`
-compatibility compiler installed by `make` and maintained by self-builds. On Windows and portable
-cross-VC builds, the V3 driver is not embedded and `cmd/v` retains the established compiler.
+driver. The standard bootstrap also builds `v1_fallback` (`v1_fallback.exe` on Windows) beside
+`v`; `-old-compiler` launches it explicitly, and ordinary user builds retry through it after a V3
+compiler or C compilation failure. A separately built V3-only executable without that sibling
+cannot use the fallback. On portable cross-VC builds, the V3 driver is not embedded and `cmd/v`
+retains the established compiler.
 
 The in-process path supports the split module cache and uses parallel stages while the input
 remains within its scratch-memory safety limit.
 
-V3 parser, checker, code-generation, and C-compiler failures are returned directly; `cmd/v` does
-not retry them with V1.
+Explicit `-new-compiler` builds and native `cmd/v` self-builds remain strict V3 operations and do
+not retry with V1.
 
 ## Target selection
 

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -43,18 +43,20 @@ link the established compiler in `vlib/v`; its own build and every other direct 
 use V3. Commands such as `test` remain external tools, while each discovered test file is compiled
 by V3. Non-C backends remain separate builder tools.
 
-`-new-compiler` remains accepted for command-line compatibility and selects the same in-process V3
-driver. The standard bootstrap also builds `v1_fallback` (`v1_fallback.exe` on Windows) beside
-`v`; `-old-compiler` launches it explicitly, and ordinary user builds retry through it after a V3
-compiler or C compilation failure. A separately built V3-only executable without that sibling
-cannot use the fallback. On portable cross-VC builds, the V3 driver is not embedded and `cmd/v`
-retains the established compiler.
+`-new-compiler` remains accepted for command-line compatibility and normally selects the same
+in-process V3 driver. The standard bootstrap also builds `v1_fallback` (`v1_fallback.exe` on
+Windows) beside `v`; `-old-compiler` launches it explicitly, and ordinary user builds retry through
+it after a V3 compiler or C compilation failure. A separately built V3-only executable without
+that sibling cannot use the fallback. On portable cross-VC builds, the V3 driver is not embedded
+and `cmd/v` retains the established compiler.
 
 The in-process path supports the split module cache and uses parallel stages while the input
 remains within its scratch-memory safety limit.
 
 Explicit `-new-compiler` builds and native `cmd/v` self-builds remain strict V3 operations and do
-not retry with V1.
+not retry with V1, except for `-new-compiler -cc msvc` on Windows. V3 does not yet generate MSVC
+command lines, so that combination intentionally launches `v1_fallback.exe` instead of exercising
+V3.
 
 ## Target selection
 

--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -28,6 +28,15 @@ fn test_v3_prefers_bundled_tcc_for_debug_selfhost() {
 	assert !v3_should_prefer_bundled_tcc_for_selfhost(true, 'c', false, false, false, false, host, false)
 }
 
+fn test_v3_windows_default_compiler_requires_bundled_tcc() {
+	bundled_tcc := os.join_path(os.temp_dir(), 'thirdparty', 'tcc', 'tcc.exe')
+	assert v3_select_windows_default_c_compiler('cc', false, 'windows', 'windows', bundled_tcc, true) == bundled_tcc
+	assert v3_select_windows_default_c_compiler('cc', false, 'windows', 'windows', bundled_tcc, false) == 'cc'
+	assert v3_select_windows_default_c_compiler('clang', true, 'windows', 'windows', bundled_tcc, true) == 'clang'
+	assert v3_select_windows_default_c_compiler('cc', false, 'linux', 'windows', bundled_tcc, true) == 'cc'
+	assert v3_select_windows_default_c_compiler('cc', false, 'windows', 'linux', bundled_tcc, true) == 'cc'
+}
+
 fn test_v3_regenerates_cc_fallback_after_preferred_tcc() {
 	assert !v3_should_regenerate_for_cc_fallback(false, false, 0)
 	assert !v3_should_regenerate_for_cc_fallback(false, true, 1)

--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -153,6 +153,24 @@ fn test_v3_windows_default_tcc_prod_build() {
 	assert run_result.exit_code == 42, run_result.output
 }
 
+fn test_v3_windows_auto_gui_build_uses_windows_subsystem() {
+	$if !windows {
+		return
+	}
+	root := os.join_path(os.vtmp_dir(), 'v3_windows_auto_gui_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root)!
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	source := os.join_path(root, 'main.v')
+	output := os.join_path(root, 'main.exe')
+	os.write_file(source, '#flag windows -lgdi32\n\nfn main() {}\n')!
+	build := cmdexec.run(@VEXE, ['-new-compiler', '-nocache', '-showcc', '-o', output, source])
+	assert build.exit_code == 0, build.output
+	assert build.output.contains('-mwindows'), build.output
+}
+
 fn test_add_v3_tcc_compat_defines() {
 	mut macos_arm64 := []string{}
 	add_v3_tcc_compat_defines(mut macos_arm64, 'macos', 'arm64', false, true)
@@ -193,28 +211,42 @@ fn test_v3_fastc_default_linker_flags() {
 
 fn test_v3_windows_executable_linker_flags() {
 	expected := ['-municode', '-Wl,-stack=33554432']
-	assert v3_windows_executable_linker_flags('windows', 'tinyc', false, false, .auto) == expected
-	assert v3_windows_executable_linker_flags('windows', 'gcc', false, false, .auto) == expected
-	assert v3_windows_executable_linker_flags('windows', 'tinyc', false, false, .console) == [
-		'-municode',
-		'-mconsole',
-		'-Wl,-stack=33554432',
-	]
-	assert v3_windows_executable_linker_flags('windows', 'tinyc', false, false, .windows) == [
+	assert v3_windows_executable_linker_flags('windows', 'tinyc', false, false, .auto, false) == expected
+	assert v3_windows_executable_linker_flags('windows', 'gcc', false, false, .auto, false) == expected
+	assert v3_windows_executable_linker_flags('windows', 'tinyc', false, false, .auto, true) == [
 		'-municode',
 		'-mwindows',
 		'-Wl,-stack=33554432',
 	]
-	assert v3_windows_executable_linker_flags('windows', 'msvc', false, false, .auto) == []
-	assert v3_windows_executable_linker_flags('windows', 'tinyc', true, false, .auto) == []
-	assert v3_windows_executable_linker_flags('windows', 'tinyc', false, true, .auto) == []
-	assert v3_windows_executable_linker_flags('linux', 'tinyc', false, false, .auto) == []
+	assert v3_windows_executable_linker_flags('windows', 'tinyc', false, false, .console, true) == [
+		'-municode',
+		'-mconsole',
+		'-Wl,-stack=33554432',
+	]
+	assert v3_windows_executable_linker_flags('windows', 'tinyc', false, false, .windows, false) == [
+		'-municode',
+		'-mwindows',
+		'-Wl,-stack=33554432',
+	]
+	assert v3_windows_executable_linker_flags('windows', 'msvc', false, false, .auto, true) == []
+	assert v3_windows_executable_linker_flags('windows', 'tinyc', true, false, .auto, true) == []
+	assert v3_windows_executable_linker_flags('windows', 'tinyc', false, true, .auto, true) == []
+	assert v3_windows_executable_linker_flags('linux', 'tinyc', false, false, .auto, true) == []
 	plan := v3_c_compiler_flag_plan(V3CCompilerFlagOptions{
 		target_os: 'windows'
 		c_compiler: 'tinyc'
+		windows_gui_app: true
 	})
 	assert '-municode' in plan.before_inputs
+	assert '-mwindows' in plan.before_inputs
 	assert '-Wl,-stack=33554432' in plan.before_inputs
+}
+
+fn test_v3_cgen_metadata_preserves_windows_gui_entry_point() {
+	encoded := encode_v3_cgen_metadata(['-lgdi32'], 'interfaces', 'prefix', true, []V3CachedTypeDiagnostic{})
+	decoded := decode_v3_cgen_metadata(encoded) or { panic('could not decode Cgen metadata') }
+	assert decoded.windows_gui_entry_point
+	assert decoded.flags == ['-lgdi32']
 }
 
 fn test_v3_fastc_rejects_windows_gui_subsystem() {

--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -217,6 +217,21 @@ fn test_v3_windows_executable_linker_flags() {
 	assert '-Wl,-stack=33554432' in plan.before_inputs
 }
 
+fn test_v3_fastc_rejects_windows_gui_subsystem() {
+	root := os.join_path(os.vtmp_dir(), 'v3_fastc_windows_subsystem_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root)!
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	source := os.join_path(root, 'main.v')
+	os.write_file(source, 'fn main() {}\n')!
+	build := cmdexec.run(@VEXE, ['-new-compiler', '-nocache', '-b', 'fastc', '-os', 'windows',
+		'-subsystem', 'windows', source])
+	assert build.exit_code != 0, build.output
+	assert build.output.contains('the V3 fastc backend does not support `-subsystem windows`'), build.output
+}
+
 fn test_add_c_language_runtime_link_flags() {
 	target := pref.Target{
 		os: 'linux'

--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -1,6 +1,7 @@
 module driver
 
 import os
+import v3.cmdexec
 import v3.pref
 
 fn test_input_is_cmd_v_accepts_relative_entry_file() {
@@ -35,10 +36,10 @@ fn test_v3_regenerates_cc_fallback_after_preferred_tcc() {
 	assert v3_should_regenerate_for_cc_fallback(true, false, 0)
 }
 
-fn test_v3_explicit_tcc_flag_plan_skips_backtrace_on_macos_arm64() {
+fn test_v3_tcc_flag_plan_skips_backtrace_on_macos_arm64() {
 	vroot := os.join_path(os.temp_dir(), 'v3_tcc_flag_plan')
 	plan := v3_c_compiler_flag_plan(V3CCompilerFlagOptions{
-		explicit_tcc: true
+		is_tcc: true
 		target_os: 'macos'
 		target_arch: 'arm64'
 		vroot: vroot
@@ -67,10 +68,36 @@ fn test_v3_tcc_resource_flags_use_windows_bundle_root() {
 	assert resources.library_arg == '-L${tcc_lib}'
 }
 
-fn test_v3_explicit_tcc_flag_plan_restores_native_local_prefix() {
+fn test_v3_windows_tcc_prod_flag_plan_uses_tcc_resources() {
+	vroot := os.join_path(os.vtmp_dir(), 'v3_windows_tcc_prod_flag_plan_${os.getpid()}')
+	os.rmdir_all(vroot) or {}
+	tcc_root := os.join_path(vroot, 'thirdparty', 'tcc')
+	tcc_lib := os.join_path_single(tcc_root, 'lib')
+	tcc_include := os.join_path_single(tcc_root, 'include')
+	os.mkdir_all(tcc_lib)!
+	os.mkdir_all(os.join_path_single(tcc_include, 'winapi'))!
+	defer {
+		os.rmdir_all(vroot) or {}
+	}
+	plan := v3_c_compiler_flag_plan(V3CCompilerFlagOptions{
+		is_tcc: true
+		is_prod: true
+		target_os: 'windows'
+		target_arch: 'amd64'
+		c_compiler: 'tinyc'
+		vroot: vroot
+	})
+	assert '-O3' in plan.before_inputs
+	assert '-flto' !in plan.before_inputs
+	assert '-B${tcc_root}' in plan.before_inputs
+	assert '-I${tcc_include}' in plan.before_inputs
+	assert '-L${tcc_lib}' in plan.before_inputs
+}
+
+fn test_v3_tcc_flag_plan_restores_native_local_prefix() {
 	host_os := os.user_os()
 	plan := v3_c_compiler_flag_plan(V3CCompilerFlagOptions{
-		explicit_tcc: true
+		is_tcc: true
 		target_os: host_os
 		target_arch: 'amd64'
 		vroot: os.join_path(os.temp_dir(), 'v3_tcc_native_flag_plan')
@@ -82,6 +109,39 @@ fn test_v3_explicit_tcc_flag_plan_restores_native_local_prefix() {
 		assert '-I/usr/local/include' in plan.before_inputs
 		assert '-L/usr/local/lib' in plan.before_inputs
 	}
+}
+
+fn test_v3_windows_default_tcc_prod_build() {
+	$if !windows {
+		return
+	}
+	bundled_tcc := os.join_path(@VEXEROOT, 'thirdparty', 'tcc', 'tcc.exe')
+	assert os.is_executable(bundled_tcc)
+	root := os.join_path(os.vtmp_dir(), 'v3_windows_default_tcc_prod_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root)!
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	source := os.join_path(root, 'main.v')
+	output := os.join_path(root, 'main.exe')
+	os.write_file(source, 'fn main() {\n\texit(42)\n}\n')!
+	old_vflags := os.getenv_opt('VFLAGS')
+	os.unsetenv('VFLAGS')
+	defer {
+		if value := old_vflags {
+			os.setenv('VFLAGS', value, true)
+		}
+	}
+	build := cmdexec.run(@VEXE, ['-new-compiler', '-nocache', '-prod', '-showcc', '-o', output,
+		source])
+	assert build.exit_code == 0, build.output
+	normalized_output := build.output.replace('\\', '/')
+	assert normalized_output.contains('thirdparty/tcc/tcc.exe'), build.output
+	assert normalized_output.contains('-B') && normalized_output.contains('thirdparty/tcc'), build.output
+	assert !normalized_output.contains('-flto'), build.output
+	run_result := cmdexec.run(output, [])
+	assert run_result.exit_code == 42, run_result.output
 }
 
 fn test_add_v3_tcc_compat_defines() {

--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -184,12 +184,22 @@ fn test_v3_fastc_default_linker_flags() {
 
 fn test_v3_windows_executable_linker_flags() {
 	expected := ['-municode', '-Wl,-stack=33554432']
-	assert v3_windows_executable_linker_flags('windows', 'tinyc', false, false) == expected
-	assert v3_windows_executable_linker_flags('windows', 'gcc', false, false) == expected
-	assert v3_windows_executable_linker_flags('windows', 'msvc', false, false) == []
-	assert v3_windows_executable_linker_flags('windows', 'tinyc', true, false) == []
-	assert v3_windows_executable_linker_flags('windows', 'tinyc', false, true) == []
-	assert v3_windows_executable_linker_flags('linux', 'tinyc', false, false) == []
+	assert v3_windows_executable_linker_flags('windows', 'tinyc', false, false, .auto) == expected
+	assert v3_windows_executable_linker_flags('windows', 'gcc', false, false, .auto) == expected
+	assert v3_windows_executable_linker_flags('windows', 'tinyc', false, false, .console) == [
+		'-municode',
+		'-mconsole',
+		'-Wl,-stack=33554432',
+	]
+	assert v3_windows_executable_linker_flags('windows', 'tinyc', false, false, .windows) == [
+		'-municode',
+		'-mwindows',
+		'-Wl,-stack=33554432',
+	]
+	assert v3_windows_executable_linker_flags('windows', 'msvc', false, false, .auto) == []
+	assert v3_windows_executable_linker_flags('windows', 'tinyc', true, false, .auto) == []
+	assert v3_windows_executable_linker_flags('windows', 'tinyc', false, true, .auto) == []
+	assert v3_windows_executable_linker_flags('linux', 'tinyc', false, false, .auto) == []
 	plan := v3_c_compiler_flag_plan(V3CCompilerFlagOptions{
 		target_os: 'windows'
 		c_compiler: 'tinyc'

--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -50,6 +50,23 @@ fn test_v3_explicit_tcc_flag_plan_skips_backtrace_on_macos_arm64() {
 	assert '-L${tcc_install_dir}' in plan.before_inputs
 }
 
+fn test_v3_tcc_resource_flags_use_windows_bundle_root() {
+	vroot := os.join_path(os.temp_dir(), 'v3_windows_tcc_flag_plan_${os.getpid()}')
+	os.rmdir_all(vroot) or {}
+	tcc_root := os.join_path(vroot, 'thirdparty', 'tcc')
+	tcc_lib := os.join_path_single(tcc_root, 'lib')
+	tcc_include := os.join_path_single(tcc_root, 'include')
+	os.mkdir_all(tcc_lib)!
+	os.mkdir_all(os.join_path_single(tcc_include, 'winapi'))!
+	defer {
+		os.rmdir_all(vroot) or {}
+	}
+	resources := v3_tcc_resource_flags(vroot)
+	assert resources.base_arg == '-B${tcc_root}'
+	assert resources.include_arg == '-I${tcc_include}'
+	assert resources.library_arg == '-L${tcc_lib}'
+}
+
 fn test_v3_explicit_tcc_flag_plan_restores_native_local_prefix() {
 	host_os := os.user_os()
 	plan := v3_c_compiler_flag_plan(V3CCompilerFlagOptions{
@@ -86,7 +103,7 @@ fn test_add_v3_tcc_compat_defines() {
 }
 
 fn test_v3_default_linker_flags() {
-	assert v3_default_linker_flags('windows', false) == ['-lm']
+	assert v3_default_linker_flags('windows', false) == []
 	assert v3_default_linker_flags('linux', false) == ['-lm', '-lpthread']
 	assert v3_default_linker_flags('freebsd', false) == ['-lm', '-lpthread', '-lexecinfo', '-lelf']
 	assert v3_default_linker_flags('netbsd', false) == ['-lm', '-lpthread', '-lexecinfo', '-lelf']
@@ -97,6 +114,28 @@ fn test_v3_default_linker_flags_do_not_duplicate_existing_flags() {
 	mut flags := ['-lpthread', '-lm']
 	add_v3_default_linker_flags(mut flags, 'linux', false)
 	assert flags == ['-lpthread', '-lm']
+}
+
+fn test_v3_fastc_default_linker_flags() {
+	assert v3_fastc_default_linker_flags('windows', true) == []
+	assert v3_fastc_default_linker_flags('linux', false) == ['-lm']
+	assert v3_fastc_default_linker_flags('linux', true) == ['-lpthread', '-lm']
+}
+
+fn test_v3_windows_executable_linker_flags() {
+	expected := ['-municode', '-Wl,-stack=33554432']
+	assert v3_windows_executable_linker_flags('windows', 'tinyc', false, false) == expected
+	assert v3_windows_executable_linker_flags('windows', 'gcc', false, false) == expected
+	assert v3_windows_executable_linker_flags('windows', 'msvc', false, false) == []
+	assert v3_windows_executable_linker_flags('windows', 'tinyc', true, false) == []
+	assert v3_windows_executable_linker_flags('windows', 'tinyc', false, true) == []
+	assert v3_windows_executable_linker_flags('linux', 'tinyc', false, false) == []
+	plan := v3_c_compiler_flag_plan(V3CCompilerFlagOptions{
+		target_os: 'windows'
+		c_compiler: 'tinyc'
+	})
+	assert '-municode' in plan.before_inputs
+	assert '-Wl,-stack=33554432' in plan.before_inputs
 }
 
 fn test_add_c_language_runtime_link_flags() {

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -8866,6 +8866,10 @@ pub fn run(args []string) {
 		eprintln(err.msg())
 		exit(1)
 	}
+	if backend == 'fastc' && target.os == 'windows' && subsystem == .windows {
+		eprintln('the V3 fastc backend does not support `-subsystem windows`')
+		exit(1)
+	}
 	// V's platform `int` is 64-bit on 64-bit targets and 32-bit on 32-bit ones;
 	// pin the C spelling from the target width before any checking or codegen.
 	types.set_platform_int_bits(target.pointer_bits)

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -1825,6 +1825,7 @@ struct V3CCompilerFlagOptions {
 	vroot               string
 	target_os           string
 	target_arch         string
+	c_compiler          string
 	macos_sdk_root      string
 	pic_flag            string
 	is_prod             bool
@@ -2276,7 +2277,10 @@ fn v3_default_linker_flags(target_os string, is_o bool) []string {
 	if is_o {
 		return []
 	}
-	mut flags := ['-lm']
+	mut flags := []string{}
+	if target_os != 'windows' {
+		flags << '-lm'
+	}
 	if target_os in ['linux', 'freebsd', 'openbsd', 'netbsd', 'dragonfly', 'solaris', 'haiku'] {
 		flags << '-lpthread'
 	}
@@ -2292,6 +2296,25 @@ fn add_v3_default_linker_flags(mut flags []string, target_os string, is_o bool) 
 			flags << flag
 		}
 	}
+}
+
+fn v3_fastc_default_linker_flags(target_os string, uses_threads bool) []string {
+	if target_os == 'windows' {
+		return []
+	}
+	mut flags := []string{}
+	if uses_threads {
+		flags << '-lpthread'
+	}
+	flags << '-lm'
+	return flags
+}
+
+fn v3_windows_executable_linker_flags(target_os string, c_compiler string, is_shared bool, is_o bool) []string {
+	if target_os == 'windows' && c_compiler != 'msvc' && !is_shared && !is_o {
+		return ['-municode', '-Wl,-stack=33554432']
+	}
+	return []
 }
 
 struct V3TccResourceFlags {
@@ -2311,9 +2334,16 @@ fn v3_tcc_resource_flags(vroot string) V3TccResourceFlags {
 	if !os.is_dir(include_dir) && os.is_dir(tcc_root_include_dir) {
 		include_dir = tcc_root_include_dir
 	}
+	// Windows TCC keeps its WinAPI headers beside the root include directory.
+	// Point -B at that root so TCC adds include/winapi to its system search path.
+	base_dir := if os.is_dir(os.join_path_single(tcc_root_include_dir, 'winapi')) {
+		tcc_root_dir
+	} else {
+		install_dir
+	}
 	return V3TccResourceFlags{
 		install_dir: install_dir
-		base_arg: '-B${install_dir}'
+		base_arg: '-B${base_dir}'
 		include_arg: '-I${include_dir}'
 		library_arg: '-L${install_dir}'
 	}
@@ -2365,6 +2395,7 @@ fn v3_c_compiler_flag_plan(options V3CCompilerFlagOptions) V3CCompilerFlagPlan {
 	if options.pic_flag.len > 0 {
 		before_inputs << options.pic_flag
 	}
+	before_inputs << v3_windows_executable_linker_flags(options.target_os, options.c_compiler, options.is_shared, options.is_o)
 	mut tcc_includes := ''
 	if options.explicit_tcc {
 		tcc_resources := v3_tcc_resource_flags(options.vroot)
@@ -2979,14 +3010,14 @@ fn persistent_program_cache_enabled(cache_enabled bool, test_input bool, vtmp_di
 		&& (!os.base(vtmp_dir).starts_with('tsession_') || os.getenv('V3CACHE') != '')
 }
 
-fn prepare_v3_cache_external_inputs(mut state V3ModuleCacheState, a &flat.FlatAst, prefs &pref.Preferences, user_files []string, user_c_flags []string) bool {
+fn prepare_v3_cache_external_inputs(mut state V3ModuleCacheState, a &flat.FlatAst, prefs &pref.Preferences, user_files []string, user_c_flags []string, c_compiler string) bool {
 	mut cache_input_modules := map[string]bool{}
 	for module_name in state.module_sources.keys() {
 		cache_input_modules[module_name] = true
 	}
 	cache_input_modules['main'] = true
 	native_inputs_language := cgen.cache_native_inputs_language(a, prefs.vroot, user_c_flags, prefs.c99, prefs.ccompiler, prefs.target)
-	compiler_macros, compiler_macro_environment_complete := cache_c_compiler_predefined_macros(user_c_flags, prefs.ccompiler, prefs.target, native_inputs_language)
+	compiler_macros, compiler_macro_environment_complete := cache_c_compiler_predefined_macros(user_c_flags, c_compiler, prefs.target, native_inputs_language)
 	mut external_inputs, mut native_source_roots, mut native_root_contexts, unscoped_inputs, static_storage_inputs, resolution_dirs, missing_resolution_paths, mut external_input_digests, has_untracked_c_include := cgen.cache_external_input_snapshot_with_resolved_flags(a, prefs.vroot, cache_input_modules, user_c_flags, prefs.target, module_cache_source_path_set(user_files), compiler_macros, compiler_macro_environment_complete)
 	state.module_external_inputs = external_inputs.move()
 	state.module_native_roots = native_source_roots.move()
@@ -2998,7 +3029,7 @@ fn prepare_v3_cache_external_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 	state.external_resolution_dirs = resolution_dirs.filter(!v3_path_is_within(it, cache_dir)
 		&& !v3_path_is_within(it, real_cache_dir))
 	state.external_missing_paths = missing_resolution_paths.filter(!v3_path_is_within(it, cache_dir) && !v3_path_is_within(it, real_cache_dir))
-	mut native_source_modules, can_scope_static_inputs := cache_external_input_owner_modules(state, a, unscoped_inputs, static_storage_inputs, user_files, user_c_flags, prefs.ccompiler, prefs.target)
+	mut native_source_modules, can_scope_static_inputs := cache_external_input_owner_modules(state, a, unscoped_inputs, static_storage_inputs, user_files, user_c_flags, c_compiler, prefs.target)
 	state.native_source_modules = native_source_modules.move()
 	state.native_root_owners = map[string]string{}
 	for raw_module_name, roots in state.module_native_roots {
@@ -3014,7 +3045,7 @@ fn prepare_v3_cache_external_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 			state.native_root_owners[os.real_path(root)] = module_name
 		}
 	}
-	can_extract_native_types := prepare_v3_cache_native_type_declarations(mut state, user_c_flags, prefs.ccompiler, prefs.target)
+	can_extract_native_types := prepare_v3_cache_native_type_declarations(mut state, user_c_flags, c_compiler, prefs.target)
 	state.external_inputs_ready = true
 	state.external_inputs_complete = !has_untracked_c_include
 		&& v3_external_input_digests_complete(state)
@@ -3031,12 +3062,12 @@ fn prepare_v3_cache_external_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 
 // prepare_v3_cache_external_inputs_scoped releases the large preprocessor and
 // declaration-scanner scratch buffers while retaining the compact cache manifest.
-fn prepare_v3_cache_external_inputs_scoped(mut state V3ModuleCacheState, a &flat.FlatAst, prefs &pref.Preferences, user_files []string, user_c_flags []string, scope_enabled bool) bool {
+fn prepare_v3_cache_external_inputs_scoped(mut state V3ModuleCacheState, a &flat.FlatAst, prefs &pref.Preferences, user_files []string, user_c_flags []string, c_compiler string, scope_enabled bool) bool {
 	if !scope_enabled {
-		return prepare_v3_cache_external_inputs(mut state, a, prefs, user_files, user_c_flags)
+		return prepare_v3_cache_external_inputs(mut state, a, prefs, user_files, user_c_flags, c_compiler)
 	}
 	scope := prealloc_scope_begin_for_v3()
-	complete := prepare_v3_cache_external_inputs(mut state, a, prefs, user_files, user_c_flags)
+	complete := prepare_v3_cache_external_inputs(mut state, a, prefs, user_files, user_c_flags, c_compiler)
 	prealloc_scope_leave_for_v3(scope)
 	state.module_external_inputs = clone_string_list_map(state.module_external_inputs)
 	state.module_native_roots = clone_string_list_map(state.module_native_roots)
@@ -3057,14 +3088,14 @@ fn prepare_v3_cache_external_inputs_scoped(mut state V3ModuleCacheState, a &flat
 // the checker can register their typedefs, skipping the cache-unit ownership
 // scan and native type-declaration extraction whose outputs only cache-enabled
 // builds consume (cache dependency manifests and per-unit C source rewriting).
-fn prepare_v3_checker_native_inputs(mut state V3ModuleCacheState, a &flat.FlatAst, prefs &pref.Preferences, user_files []string, user_c_flags []string) {
+fn prepare_v3_checker_native_inputs(mut state V3ModuleCacheState, a &flat.FlatAst, prefs &pref.Preferences, user_files []string, user_c_flags []string, c_compiler string) {
 	mut cache_input_modules := map[string]bool{}
 	for module_name in state.module_sources.keys() {
 		cache_input_modules[module_name] = true
 	}
 	cache_input_modules['main'] = true
 	native_inputs_language := cgen.cache_native_inputs_language(a, prefs.vroot, user_c_flags, prefs.c99, prefs.ccompiler, prefs.target)
-	compiler_macros, compiler_macro_environment_complete := cache_c_compiler_predefined_macros(user_c_flags, prefs.ccompiler, prefs.target, native_inputs_language)
+	compiler_macros, compiler_macro_environment_complete := cache_c_compiler_predefined_macros(user_c_flags, c_compiler, prefs.target, native_inputs_language)
 	mut external_inputs, mut native_source_roots, mut native_root_contexts, _, _, resolution_dirs, missing_resolution_paths, mut external_input_digests, has_untracked_c_include := cgen.cache_external_input_snapshot_with_resolved_flags(a, prefs.vroot, cache_input_modules, user_c_flags, prefs.target, module_cache_source_path_set(user_files), compiler_macros, compiler_macro_environment_complete)
 	state.module_external_inputs = external_inputs.move()
 	state.module_native_roots = native_source_roots.move()
@@ -3086,13 +3117,13 @@ fn prepare_v3_checker_native_inputs(mut state V3ModuleCacheState, a &flat.FlatAs
 
 // prepare_v3_checker_native_inputs_scoped releases the native preprocessor's
 // scratch buffers while retaining the small manifest needed by checking and Cgen.
-fn prepare_v3_checker_native_inputs_scoped(mut state V3ModuleCacheState, a &flat.FlatAst, prefs &pref.Preferences, user_files []string, user_c_flags []string, scope_enabled bool) {
+fn prepare_v3_checker_native_inputs_scoped(mut state V3ModuleCacheState, a &flat.FlatAst, prefs &pref.Preferences, user_files []string, user_c_flags []string, c_compiler string, scope_enabled bool) {
 	if !scope_enabled {
-		prepare_v3_checker_native_inputs(mut state, a, prefs, user_files, user_c_flags)
+		prepare_v3_checker_native_inputs(mut state, a, prefs, user_files, user_c_flags, c_compiler)
 		return
 	}
 	scope := prealloc_scope_begin_for_v3()
-	prepare_v3_checker_native_inputs(mut state, a, prefs, user_files, user_c_flags)
+	prepare_v3_checker_native_inputs(mut state, a, prefs, user_files, user_c_flags, c_compiler)
 	prealloc_scope_leave_for_v3(scope)
 	state.module_external_inputs = clone_string_list_map(state.module_external_inputs)
 	state.module_native_roots = clone_string_list_map(state.module_native_roots)
@@ -3110,6 +3141,7 @@ struct PrepareV3CheckerNativeInputsArgs {
 	prefs         &pref.Preferences
 	user_files    []string
 	user_c_flags  []string
+	c_compiler    string
 	scope_enabled bool
 	done          chan bool
 	release       chan bool
@@ -3117,7 +3149,7 @@ struct PrepareV3CheckerNativeInputsArgs {
 
 fn prepare_v3_checker_native_inputs_thread(args &PrepareV3CheckerNativeInputsArgs) {
 	mut state := unsafe { &V3ModuleCacheState(args.state) }
-	prepare_v3_checker_native_inputs_scoped(mut state, args.a, args.prefs, args.user_files, args.user_c_flags, args.scope_enabled)
+	prepare_v3_checker_native_inputs_scoped(mut state, args.a, args.prefs, args.user_files, args.user_c_flags, args.c_compiler, args.scope_enabled)
 	args.done <- true
 	_ := <-args.release
 }
@@ -7910,10 +7942,7 @@ $if !skip_fastc ? {
 			}
 			final_args << fastc_system_tbd
 		} else {
-			if uses_threads {
-				final_args << '-lpthread'
-			}
-			final_args << '-lm'
+			final_args << v3_fastc_default_linker_flags(prefs.normalized_target_os(), uses_threads)
 		}
 		atomic_arg := tcc_atomic_arg(prefs, tcc_path, tcc_resources.include_arg)
 		if atomic_arg.len > 0 {
@@ -8813,7 +8842,8 @@ pub fn run(args []string) {
 	// V's platform `int` is 64-bit on 64-bit targets and 32-bit on 32-bit ones;
 	// pin the C spelling from the target width before any checking or codegen.
 	types.set_platform_int_bits(target.pointer_bits)
-	constraint_ccompiler := if backend == 'arm64' {
+	constraint_ccompiler := if backend == 'arm64'
+		|| (!c_compiler_explicit && os.user_os() == 'windows' && target.os == 'windows') {
 		'tinyc'
 	} else {
 		effective_c_compiler_name(c_compiler, target)
@@ -9755,7 +9785,7 @@ pub fn run(args []string) {
 		} else {
 			mut crun_c_flags := user_c_flags.clone()
 			crun_c_flags << cgen.cache_directive_flags(a, prefs.vroot, prefs.target, prefs.compile_values)
-			_ = prepare_v3_cache_external_inputs_scoped(mut cache_state, a, prefs, user_files, crun_c_flags, scope_prealloc_stages)
+			_ = prepare_v3_cache_external_inputs_scoped(mut cache_state, a, prefs, user_files, crun_c_flags, c_compiler, scope_prealloc_stages)
 			crun_build_identity = v3_crun_build_identity(&cache_state, prefs, user_files, crun_c_flags, link_ld_flags, is_strict, enable_globals_compat, input_file)
 			if crun_build_identity.len > 0 {
 				os.setenv(v3_crun_build_identity_env, crun_build_identity, true)
@@ -9812,17 +9842,17 @@ pub fn run(args []string) {
 	mut incremental_tcc_declarations_path := ''
 	if backend == 'c' && program_cache_enabled && !cache_state.force_source
 		&& cache_state.parsed_from_source.len == 0 {
-		mut external_inputs_ready := restore_v3_cache_external_inputs(mut cache_state, user_files, cache_c_flags, prefs.ccompiler, prefs.target, '')
+		mut external_inputs_ready := restore_v3_cache_external_inputs(mut cache_state, user_files, cache_c_flags, c_compiler, prefs.target, '')
 		if !external_inputs_ready && incremental_cache_enabled {
 			incremental_snapshot = incremental_program_snapshot(a, user_files)
 			incremental_snapshot_ready = true
 			if os.getenv('V3_CACHE_TRACE') != '' {
 				eprintln('  V3 incremental snapshot: declarations=${incremental_snapshot.declaration_signature} functions=${incremental_snapshot.functions.len}')
 			}
-			external_inputs_ready = restore_v3_cache_external_inputs(mut cache_state, user_files, cache_c_flags, prefs.ccompiler, prefs.target, incremental_snapshot.declaration_signature)
+			external_inputs_ready = restore_v3_cache_external_inputs(mut cache_state, user_files, cache_c_flags, c_compiler, prefs.target, incremental_snapshot.declaration_signature)
 		}
 		if !external_inputs_ready
-			&& !prepare_v3_cache_external_inputs_scoped(mut cache_state, a, prefs, user_files, cache_c_flags, scope_prealloc_stages) {
+			&& !prepare_v3_cache_external_inputs_scoped(mut cache_state, a, prefs, user_files, cache_c_flags, c_compiler, scope_prealloc_stages) {
 			trace_v3_cache_fallback('external C inputs cannot be assigned to cache units')
 			restart_v3_without_cache()
 		}
@@ -10000,6 +10030,7 @@ pub fn run(args []string) {
 		prefs: prefs
 		user_files: user_files
 		user_c_flags: cache_c_flags
+		c_compiler: c_compiler
 		scope_enabled: scope_prealloc_stages
 		done: native_inputs_done
 		release: native_inputs_release
@@ -10008,9 +10039,9 @@ pub fn run(args []string) {
 		spawn prepare_v3_checker_native_inputs_thread(&native_inputs_args)
 	} else if native_inputs_needed {
 		if cache_state.manager.enabled {
-			_ = prepare_v3_cache_external_inputs_scoped(mut cache_state, a, prefs, user_files, cache_c_flags, scope_prealloc_stages)
+			_ = prepare_v3_cache_external_inputs_scoped(mut cache_state, a, prefs, user_files, cache_c_flags, c_compiler, scope_prealloc_stages)
 		} else {
-			prepare_v3_checker_native_inputs_scoped(mut cache_state, a, prefs, user_files, cache_c_flags, scope_prealloc_stages)
+			prepare_v3_checker_native_inputs_scoped(mut cache_state, a, prefs, user_files, cache_c_flags, c_compiler, scope_prealloc_stages)
 		}
 	}
 	if verbose {
@@ -10254,7 +10285,7 @@ pub fn run(args []string) {
 		}
 		if cache_state.manager.enabled {
 			const_init_order := cgen.module_const_init_order(a, pre_tc)
-			if !prepare_v3_cache_external_inputs_scoped(mut cache_state, a, prefs, user_files, cache_c_flags, scope_prealloc_stages) {
+			if !prepare_v3_cache_external_inputs_scoped(mut cache_state, a, prefs, user_files, cache_c_flags, c_compiler, scope_prealloc_stages) {
 				trace_v3_cache_fallback('external C inputs cannot be assigned to cache units')
 				restart_v3_without_cache()
 			}
@@ -10446,11 +10477,11 @@ pub fn run(args []string) {
 		// retry prints the fallback notice but does not submit an unverified report.
 		if backend == 'c' && !cache_state.external_inputs_ready {
 			if cache_state.manager.enabled {
-				_ = prepare_v3_cache_external_inputs_scoped(mut cache_state, a, prefs, user_files, cache_c_flags, scope_prealloc_stages)
+				_ = prepare_v3_cache_external_inputs_scoped(mut cache_state, a, prefs, user_files, cache_c_flags, c_compiler, scope_prealloc_stages)
 			} else {
 				// Cache ownership and native declaration extraction have no consumer on
 				// an uncached build. Keep only the manifest needed by Cgen and fallback.
-				prepare_v3_checker_native_inputs_scoped(mut cache_state, a, prefs, user_files, cache_c_flags, scope_prealloc_stages)
+				prepare_v3_checker_native_inputs_scoped(mut cache_state, a, prefs, user_files, cache_c_flags, c_compiler, scope_prealloc_stages)
 			}
 		}
 		if backend == 'c' && cache_state.external_inputs_ready {
@@ -11363,6 +11394,7 @@ pub fn run(args []string) {
 			vroot: prefs.vroot
 			target_os: prefs.normalized_target_os()
 			target_arch: prefs.normalized_target_arch()
+			c_compiler: effective_c_compiler
 			macos_sdk_root: flag_plan_sdk_root
 			pic_flag: pic_flag
 			is_prod: is_prod
@@ -11830,6 +11862,7 @@ pub fn run(args []string) {
 			if wrapv_flag.len > 0 {
 				tcc_args << wrapv_flag
 			}
+			tcc_args << v3_windows_executable_linker_flags(prefs.normalized_target_os(), 'tinyc', is_shared, is_o)
 			tcc_args << tcc_cached_main_flags(resolved_c_flags)
 			tcc_args << ['-o', 'out', os.base(tcc_main_file)]
 			atomic_s := tcc_atomic_arg(prefs, tcc_path, tcc_resources.include_arg)
@@ -11918,6 +11951,7 @@ pub fn run(args []string) {
 			} else if is_o {
 				tcc_args << '-c'
 			}
+			tcc_args << v3_windows_executable_linker_flags(prefs.normalized_target_os(), 'tinyc', is_shared, is_o)
 			tcc_source := if cache_full_tcc_source.len > 0 {
 				os.base(cache_full_tcc_source)
 			} else {

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -182,6 +182,7 @@ struct V3CgenCacheInput {
 struct V3CgenCacheMetadata {
 	interface_impl_signature string
 	prefix_source_identity   string
+	windows_gui_entry_point  bool
 	flags                    []string
 	diagnostics              []V3CachedTypeDiagnostic
 }
@@ -1827,6 +1828,7 @@ struct V3CCompilerFlagOptions {
 	target_arch         string
 	c_compiler          string
 	subsystem           pref.Subsystem
+	windows_gui_app     bool
 	macos_sdk_root      string
 	pic_flag            string
 	is_prod             bool
@@ -2311,13 +2313,17 @@ fn v3_fastc_default_linker_flags(target_os string, uses_threads bool) []string {
 	return flags
 }
 
-fn v3_windows_executable_linker_flags(target_os string, c_compiler string, is_shared bool, is_o bool, subsystem pref.Subsystem) []string {
+fn v3_windows_executable_linker_flags(target_os string, c_compiler string, is_shared bool, is_o bool, subsystem pref.Subsystem, windows_gui_app bool) []string {
 	if target_os == 'windows' && c_compiler != 'msvc' && !is_shared && !is_o {
 		mut flags := ['-municode']
 		match subsystem {
 			.console { flags << '-mconsole' }
 			.windows { flags << '-mwindows' }
-			.auto {}
+			.auto {
+				if windows_gui_app {
+					flags << '-mwindows'
+				}
+			}
 		}
 		flags << '-Wl,-stack=33554432'
 		return flags
@@ -2403,7 +2409,7 @@ fn v3_c_compiler_flag_plan(options V3CCompilerFlagOptions) V3CCompilerFlagPlan {
 	if options.pic_flag.len > 0 {
 		before_inputs << options.pic_flag
 	}
-	before_inputs << v3_windows_executable_linker_flags(options.target_os, options.c_compiler, options.is_shared, options.is_o, options.subsystem)
+	before_inputs << v3_windows_executable_linker_flags(options.target_os, options.c_compiler, options.is_shared, options.is_o, options.subsystem, options.windows_gui_app)
 	mut tcc_includes := ''
 	if options.is_tcc {
 		tcc_resources := v3_tcc_resource_flags(options.vroot)
@@ -5146,9 +5152,9 @@ fn restore_v3_cache_external_inputs(mut state V3ModuleCacheState, user_files []s
 	return true
 }
 
-fn encode_v3_cgen_metadata(flags []string, interface_impl_signature string, prefix_source_identity string, diagnostics []V3CachedTypeDiagnostic) string {
-	mut parts := ['v3-cgen-metadata-v4', interface_impl_signature, prefix_source_identity,
-		flags.len.str()]
+fn encode_v3_cgen_metadata(flags []string, interface_impl_signature string, prefix_source_identity string, windows_gui_entry_point bool, diagnostics []V3CachedTypeDiagnostic) string {
+	mut parts := ['v3-cgen-metadata-v5', interface_impl_signature, prefix_source_identity,
+		windows_gui_entry_point.str(), flags.len.str()]
 	parts << flags
 	parts << diagnostics.len.str()
 	for diagnostic in diagnostics {
@@ -5167,14 +5173,21 @@ fn encode_v3_cgen_metadata(flags []string, interface_impl_signature string, pref
 
 fn decode_v3_cgen_metadata(metadata string) ?V3CgenCacheMetadata {
 	parts := metadata.split('\x00')
-	if parts.len < 5 || parts[0] != 'v3-cgen-metadata-v4' {
+	if parts.len < 6 || parts[0] != 'v3-cgen-metadata-v5' {
 		return none
 	}
-	flag_count := strconv.atoi(parts[3]) or { return none }
-	if flag_count < 0 || 4 + flag_count >= parts.len {
+	windows_gui_entry_point := match parts[3] {
+		'true' { true }
+		'false' { false }
+		else {
+			return none
+		}
+	}
+	flag_count := strconv.atoi(parts[4]) or { return none }
+	if flag_count < 0 || 5 + flag_count >= parts.len {
 		return none
 	}
-	mut index := 4 + flag_count
+	mut index := 5 + flag_count
 	diagnostic_count := strconv.atoi(parts[index]) or { return none }
 	if diagnostic_count < 0 {
 		return none
@@ -5212,7 +5225,8 @@ fn decode_v3_cgen_metadata(metadata string) ?V3CgenCacheMetadata {
 	return V3CgenCacheMetadata{
 		interface_impl_signature: parts[1]
 		prefix_source_identity: parts[2]
-		flags: parts[4..4 + flag_count].clone()
+		windows_gui_entry_point: windows_gui_entry_point
+		flags: parts[5..5 + flag_count].clone()
 		diagnostics: diagnostics
 	}
 }
@@ -11168,6 +11182,7 @@ pub fn run(args []string) {
 			''
 		}
 		mut generated_c_flags := cgen_cache_metadata.flags.clone()
+		mut windows_gui_entry_point := cgen_cache_metadata.windows_gui_entry_point
 		mut interface_impl_signature := cgen_cache_metadata.interface_impl_signature
 		mut cgen_was_parallel := false
 		incremental_c_declarations := if incremental_cache_hit {
@@ -11253,6 +11268,9 @@ pub fn run(args []string) {
 				exit(1)
 			}
 			cgen_was_parallel = g.was_parallel()
+			if generated_gui_entry_point := g.generated_windows_gui_entry_point() {
+				windows_gui_entry_point = generated_gui_entry_point
+			}
 			if !incremental_cache_hit {
 				scoped_generated_c_flags = g.c_flags()
 			}
@@ -11309,6 +11327,9 @@ pub fn run(args []string) {
 				exit(1)
 			}
 			cgen_was_parallel = g.was_parallel()
+			if generated_gui_entry_point := g.generated_windows_gui_entry_point() {
+				windows_gui_entry_point = generated_gui_entry_point
+			}
 			if !incremental_cache_hit {
 				generated_c_flags = g.c_flags()
 			}
@@ -11424,6 +11445,7 @@ pub fn run(args []string) {
 			target_arch: prefs.normalized_target_arch()
 			c_compiler: effective_c_compiler
 			subsystem: prefs.subsystem
+			windows_gui_app: windows_gui_entry_point
 			macos_sdk_root: flag_plan_sdk_root
 			pic_flag: pic_flag
 			is_prod: is_prod
@@ -11668,7 +11690,7 @@ pub fn run(args []string) {
 				}
 				if !cgen_cache_hit && program_cache_enabled {
 					published_cgen_cache_input := v3_cgen_cache_input(cache_state, user_files, cache_c_flags)
-					prepared_plan_entry = cache_state.manager.write_cgen(published_cgen_cache_input.source_files, published_cgen_cache_input.generation_signature, published_cgen_cache_input.dependency_inputs, generated_source, encode_v3_cgen_metadata(generated_c_flags, interface_impl_signature, prefix_source_identity, cached_checker_diagnostics)) or { modulecache.CgenEntry{} }
+					prepared_plan_entry = cache_state.manager.write_cgen(published_cgen_cache_input.source_files, published_cgen_cache_input.generation_signature, published_cgen_cache_input.dependency_inputs, generated_source, encode_v3_cgen_metadata(generated_c_flags, interface_impl_signature, prefix_source_identity, windows_gui_entry_point, cached_checker_diagnostics)) or { modulecache.CgenEntry{} }
 				}
 				if incremental_cache_restored && prepared_plan_entry.source.len > 0 {
 					stable_body_source := os.read_file(prepared_plan_entry.source) or {
@@ -11695,7 +11717,7 @@ pub fn run(args []string) {
 				if !generic_cache_hit && generic_cache_signature.len > 0
 					&& generated_monomorph_specs.len > 0 {
 					published_generic_input := v3_cgen_cache_input(cache_state, user_files, cache_c_flags)
-					cache_state.manager.write_generic_program(published_generic_input.source_files, generic_cache_signature, published_generic_input.generation_signature, published_generic_input.dependency_inputs, encode_monomorph_cache_specs(generated_monomorph_specs), encode_cached_used_fns(program_used_fns), prepared_cache.program_prefix_source, modulecache.prune_unreferenced_static_string_definitions(prepared_cache.program_declarations), prepared_cache.program_body_cache, encode_cached_runtime_strings(generic_cache_runtime_strings), encode_v3_cgen_metadata(generated_c_flags, interface_impl_signature, prefix_source_identity, cached_checker_diagnostics)) or {}
+					cache_state.manager.write_generic_program(published_generic_input.source_files, generic_cache_signature, published_generic_input.generation_signature, published_generic_input.dependency_inputs, encode_monomorph_cache_specs(generated_monomorph_specs), encode_cached_used_fns(program_used_fns), prepared_cache.program_prefix_source, modulecache.prune_unreferenced_static_string_definitions(prepared_cache.program_declarations), prepared_cache.program_body_cache, encode_cached_runtime_strings(generic_cache_runtime_strings), encode_v3_cgen_metadata(generated_c_flags, interface_impl_signature, prefix_source_identity, windows_gui_entry_point, cached_checker_diagnostics)) or {}
 				}
 				if (!generic_cache_hit || incremental_cache_hit)
 					&& incremental_snapshot.declaration_signature.len > 0 {
@@ -11721,7 +11743,7 @@ pub fn run(args []string) {
 					} else {
 						prepared_cache.tcc_program_declarations
 					}
-					cache_state.manager.write_incremental_program(published_incremental_input.source_files, incremental_snapshot.declaration_signature, published_incremental_input.generation_signature, published_incremental_input.dependency_inputs, encode_incremental_manifest(incremental_snapshot), incremental_body, encode_cached_used_fns(incremental_used), encode_monomorph_cache_specs(incremental_specs), prepared_cache.program_prefix_source, incremental_declarations, incremental_tcc_declarations, prepared_cache.objects, encode_v3_cgen_metadata(generated_c_flags, interface_impl_signature, prefix_source_identity, cached_checker_diagnostics)) or {}
+					cache_state.manager.write_incremental_program(published_incremental_input.source_files, incremental_snapshot.declaration_signature, published_incremental_input.generation_signature, published_incremental_input.dependency_inputs, encode_incremental_manifest(incremental_snapshot), incremental_body, encode_cached_used_fns(incremental_used), encode_monomorph_cache_specs(incremental_specs), prepared_cache.program_prefix_source, incremental_declarations, incremental_tcc_declarations, prepared_cache.objects, encode_v3_cgen_metadata(generated_c_flags, interface_impl_signature, prefix_source_identity, windows_gui_entry_point, cached_checker_diagnostics)) or {}
 				}
 			}
 			prealloc_scope_leave_for_v3(cache_prepare_scope)
@@ -11891,7 +11913,7 @@ pub fn run(args []string) {
 			if wrapv_flag.len > 0 {
 				tcc_args << wrapv_flag
 			}
-			tcc_args << v3_windows_executable_linker_flags(prefs.normalized_target_os(), 'tinyc', is_shared, is_o, prefs.subsystem)
+			tcc_args << v3_windows_executable_linker_flags(prefs.normalized_target_os(), 'tinyc', is_shared, is_o, prefs.subsystem, windows_gui_entry_point)
 			tcc_args << tcc_cached_main_flags(resolved_c_flags)
 			tcc_args << ['-o', 'out', os.base(tcc_main_file)]
 			atomic_s := tcc_atomic_arg(prefs, tcc_path, tcc_resources.include_arg)
@@ -11980,7 +12002,7 @@ pub fn run(args []string) {
 			} else if is_o {
 				tcc_args << '-c'
 			}
-			tcc_args << v3_windows_executable_linker_flags(prefs.normalized_target_os(), 'tinyc', is_shared, is_o, prefs.subsystem)
+			tcc_args << v3_windows_executable_linker_flags(prefs.normalized_target_os(), 'tinyc', is_shared, is_o, prefs.subsystem, windows_gui_entry_point)
 			tcc_source := if cache_full_tcc_source.len > 0 {
 				os.base(cache_full_tcc_source)
 			} else {

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -6611,6 +6611,14 @@ fn effective_c_compiler_name(compiler string, target pref.Target) string {
 	return if target.os in ['macos', 'ios'] { 'clang' } else { 'gcc' }
 }
 
+fn v3_select_windows_default_c_compiler(c_compiler string, c_compiler_explicit bool, host_os string, target_os string, bundled_tcc string, bundled_tcc_available bool) string {
+	if !c_compiler_explicit && host_os == 'windows' && target_os == 'windows'
+		&& bundled_tcc_available {
+		return bundled_tcc
+	}
+	return c_compiler
+}
+
 fn v3_should_prefer_bundled_tcc_for_selfhost(building_v bool, backend string, c_only bool, is_prod bool, is_c_debug bool, c_compiler_explicit bool, target pref.Target, bundled_tcc_available bool) bool {
 	if !building_v || backend != 'c' || c_only || is_prod || is_c_debug || c_compiler_explicit
 		|| !bundled_tcc_available {
@@ -8861,24 +8869,6 @@ pub fn run(args []string) {
 	// V's platform `int` is 64-bit on 64-bit targets and 32-bit on 32-bit ones;
 	// pin the C spelling from the target width before any checking or codegen.
 	types.set_platform_int_bits(target.pointer_bits)
-	constraint_ccompiler := if backend == 'arm64'
-		|| (!c_compiler_explicit && os.user_os() == 'windows' && target.os == 'windows') {
-		'tinyc'
-	} else {
-		effective_c_compiler_name(c_compiler, target)
-	}
-	incompatible_direct_test := v3_direct_test_input_is_incompatible(is_test_command, input_file, backend, target, constraint_ccompiler, is_prod, user_defines)
-	if incompatible_direct_test {
-		// Directory test discovery already excludes incompatible backend/platform files.
-		// Apply the same backend, platform, and `// vtest build:` rules to a direct single-file
-		// test before parsing it; otherwise unavailable symbols and dependencies emit
-		// misleading diagnostics instead of reporting a skip.
-		if !silent {
-			println('SKIP ${input_file}')
-		}
-		clear_macos_v3_compiler_error_fallback(macos_v3_fallback_file)
-		return
-	}
 	if is_linux_wayland_only_session(target.os, os.getenv('DISPLAY'), os.getenv('WAYLAND_DISPLAY'), os.getenv('XDG_SESSION_TYPE'))
 		&& !user_defines.any(it.all_before('=').trim_space() == 'linux_wayland_session') {
 		user_defines << 'linux_wayland_session'
@@ -9103,11 +9093,7 @@ pub fn run(args []string) {
 	}
 	bundled_tcc := os.join_path(prefs.vroot, 'thirdparty', 'tcc', 'tcc.exe')
 	bundled_tcc_available := os.is_executable(bundled_tcc)
-	if !c_compiler_explicit && os.user_os() == 'windows' && target.os == 'windows' {
-		if os.is_executable(bundled_tcc) {
-			c_compiler = bundled_tcc
-		}
-	}
+	c_compiler = v3_select_windows_default_c_compiler(c_compiler, c_compiler_explicit, os.user_os(), target.os, bundled_tcc, bundled_tcc_available)
 	// The non-production C path tries bundled TCC before its `cc` fallback. Select
 	// TinyCC compile-time branches for a self-host too, so system headers and inline
 	// assembly intended for Clang do not prevent that first attempt.
@@ -9119,6 +9105,18 @@ pub fn run(args []string) {
 		'tinyc'
 	} else {
 		effective_c_compiler_name(c_compiler, target)
+	}
+	incompatible_direct_test := v3_direct_test_input_is_incompatible(is_test_command, input_file, backend, target, effective_c_compiler, is_prod, user_defines)
+	if incompatible_direct_test {
+		// Directory test discovery already excludes incompatible backend/platform files.
+		// Apply the same backend, platform, compiler, and `// vtest build:` rules to a direct
+		// single-file test before parsing it; otherwise unavailable symbols and dependencies
+		// emit misleading diagnostics instead of reporting a skip.
+		if !silent {
+			println('SKIP ${input_file}')
+		}
+		clear_macos_v3_compiler_error_fallback(macos_v3_fallback_file)
+		return
 	}
 	// Windows selects its bundled TCC without an explicit `-cc`. Compiler flags
 	// follow that effective compiler, while retry policy still follows user intent.

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -1834,7 +1834,7 @@ struct V3CCompilerFlagOptions {
 	parallel_cc         bool
 	large_c_unit        bool
 	limit_inlining      bool
-	explicit_tcc        bool
+	is_tcc              bool
 	is_c_debug          bool
 	is_o                bool
 	is_liveshared       bool
@@ -2263,8 +2263,8 @@ fn v3_tcc_backtrace_enabled(target_os string, target_arch string, is_shared bool
 	return !is_shared && !(target_os == 'macos' && target_arch == 'arm64')
 }
 
-fn add_v3_tcc_compat_defines(mut user_defines []string, target_os string, target_arch string, is_shared bool, explicit_tcc bool) {
-	if explicit_tcc && !v3_tcc_backtrace_enabled(target_os, target_arch, is_shared)
+fn add_v3_tcc_compat_defines(mut user_defines []string, target_os string, target_arch string, is_shared bool, is_tcc bool) {
+	if is_tcc && !v3_tcc_backtrace_enabled(target_os, target_arch, is_shared)
 		&& 'no_backtrace' !in user_defines {
 		// The builtin backtrace implementation must match the native TCC flag plan.
 		// Shared libraries cannot link TCC's runtime symbols, while its initializer
@@ -2391,13 +2391,13 @@ fn v3_c_compiler_flag_plan(options V3CCompilerFlagOptions) V3CCompilerFlagPlan {
 	if options.link_c_standard.len > 0 {
 		before_inputs << options.link_c_standard
 	}
-	before_inputs << v3_prod_c_optimization_flags(options.is_prod, options.no_prod_options, options.is_shared, options.parallel_cc, options.large_c_unit, options.limit_inlining, options.explicit_tcc)
+	before_inputs << v3_prod_c_optimization_flags(options.is_prod, options.no_prod_options, options.is_shared, options.parallel_cc, options.large_c_unit, options.limit_inlining, options.is_tcc)
 	if options.pic_flag.len > 0 {
 		before_inputs << options.pic_flag
 	}
 	before_inputs << v3_windows_executable_linker_flags(options.target_os, options.c_compiler, options.is_shared, options.is_o)
 	mut tcc_includes := ''
-	if options.explicit_tcc {
+	if options.is_tcc {
 		tcc_resources := v3_tcc_resource_flags(options.vroot)
 		tcc_includes = tcc_resources.include_arg
 		before_inputs << [tcc_resources.base_arg, tcc_resources.include_arg,
@@ -2409,11 +2409,11 @@ fn v3_c_compiler_flag_plan(options V3CCompilerFlagOptions) V3CCompilerFlagPlan {
 	}
 	before_inputs << options.warn_args
 	before_inputs << '-Wno-int-conversion'
-	if options.target_os == 'macos' && !options.is_shared && !options.explicit_tcc {
+	if options.target_os == 'macos' && !options.is_shared && !options.is_tcc {
 		before_inputs << '-Wl,-stack_size,0x4000000'
 	}
 	if options.is_c_debug && options.target_os == 'macos' && !options.is_shared
-		&& !options.explicit_tcc {
+		&& !options.is_tcc {
 		before_inputs << '-Wl,-export_dynamic'
 	}
 	if options.is_shared {
@@ -2424,7 +2424,7 @@ fn v3_c_compiler_flag_plan(options V3CCompilerFlagOptions) V3CCompilerFlagPlan {
 	} else if options.is_o {
 		before_inputs << '-c'
 	}
-	if options.is_liveshared && options.target_os == 'macos' && !options.explicit_tcc {
+	if options.is_liveshared && options.target_os == 'macos' && !options.is_tcc {
 		before_inputs << ['-flat_namespace', '-undefined', 'dynamic_lookup']
 	}
 	mut after_inputs := options.dependencies.clone()
@@ -7706,14 +7706,14 @@ fn v3_parallel_c_unit_is_large(source_size u64, declaration_header_size u64, own
 	})
 }
 
-fn v3_prod_c_optimization_flags(is_prod bool, no_prod_options bool, is_shared bool, parallel_cc bool, large_c_unit bool, limit_inlining bool, explicit_tcc bool) []string {
+fn v3_prod_c_optimization_flags(is_prod bool, no_prod_options bool, is_shared bool, parallel_cc bool, large_c_unit bool, limit_inlining bool, is_tcc bool) []string {
 	if !is_prod || no_prod_options {
 		return []
 	}
 	// Clang's -O3 compile cost grows sharply on very large generated translation
 	// units. -O2 retains whole-program LTO while avoiding those costly passes.
 	mut flags := [if large_c_unit { '-O2' } else { '-O3' }]
-	if !is_shared && !parallel_cc && !explicit_tcc {
+	if !is_shared && !parallel_cc && !is_tcc {
 		flags << '-flto'
 	}
 	if large_c_unit && limit_inlining {
@@ -7724,11 +7724,11 @@ fn v3_prod_c_optimization_flags(is_prod bool, no_prod_options bool, is_shared bo
 	return flags
 }
 
-fn v3_prod_c_object_optimization_flags(is_prod bool, no_prod_options bool, is_shared bool, parallel_cc bool, explicit_tcc bool) []string {
+fn v3_prod_c_object_optimization_flags(is_prod bool, no_prod_options bool, is_shared bool, parallel_cc bool, is_tcc bool) []string {
 	// Native support sources are cached as independently compiled objects. Emitting
 	// LLVM bitcode here makes every program link optimize those unchanged sources
 	// again; keep the per-object -O3 work in the cache instead.
-	return v3_prod_c_optimization_flags(is_prod, no_prod_options, is_shared, parallel_cc, false, false, explicit_tcc).filter(it != '-flto')
+	return v3_prod_c_optimization_flags(is_prod, no_prod_options, is_shared, parallel_cc, false, false, is_tcc).filter(it != '-flto')
 }
 
 fn append_v3_c_compile_mode_flags(mut args []string, c_standard string, opt_flags string, pic_flag string) {
@@ -8169,7 +8169,6 @@ pub fn run(args []string) {
 	mut c_compiler := 'cc'
 	mut c_compiler_explicit := false
 	mut c_compiler_arg_index := -1
-	mut explicit_tcc := false
 	mut retry_compilation := true
 	mut gc_mode := 'none'
 	mut enable_globals_compat := false
@@ -9101,8 +9100,11 @@ pub fn run(args []string) {
 	} else {
 		effective_c_compiler_name(c_compiler, target)
 	}
-	explicit_tcc = c_compiler_explicit && effective_c_compiler == 'tinyc'
-	add_v3_tcc_compat_defines(mut user_defines, target.os, target.arch, is_shared, explicit_tcc || prefer_bundled_tcc)
+	// Windows selects its bundled TCC without an explicit `-cc`. Compiler flags
+	// follow that effective compiler, while retry policy still follows user intent.
+	effective_tcc := backend in ['c', 'fastc'] && effective_c_compiler == 'tinyc'
+	explicit_tcc := c_compiler_explicit && effective_tcc
+	add_v3_tcc_compat_defines(mut user_defines, target.os, target.arch, is_shared, effective_tcc)
 	if os.getenv('FASTC_BENCH_PHASES') != '' {
 		eprintln('fastc-phase driver.defines ${driver_sw.elapsed().microseconds()}us')
 	}
@@ -9402,7 +9404,7 @@ pub fn run(args []string) {
 	minimal_literal_output := !is_prof
 		&& input_uses_minimal_literal_output_builtin(input_file, prefs, is_test_command, is_checker_fixture)
 	host_target := pref.host_target()
-	mut use_parallel_c_compilation := parallel_cc && backend == 'c' && !c_only && !explicit_tcc
+	mut use_parallel_c_compilation := parallel_cc && backend == 'c' && !c_only && !effective_tcc
 		&& !is_o && target.os != 'windows' && coverage_dir.len == 0 && profile_file.len == 0
 		&& v3_parallel_cc_monolithic_define !in user_defines
 	// `-keepc` and explicit `-b c` promise a complete generated C translation unit.
@@ -11362,7 +11364,7 @@ pub fn run(args []string) {
 			generated_c_flags.clone()
 		}
 		if !c_only || (dump_c_flags.len > 0 && generate_c_project.len == 0) {
-			object_optimization_flags := v3_prod_c_object_optimization_flags(is_prod, no_prod_options, is_shared, parallel_cc, explicit_tcc)
+			object_optimization_flags := v3_prod_c_object_optimization_flags(is_prod, no_prod_options, is_shared, parallel_cc, effective_tcc)
 			resolved_c_flags = prepare_c_flags_for_link(generated_c_flags, environment_c_flags, object_optimization_flags, prefs.c99, pic_flag, target_args, prefs.target, c_compiler, cc_dir, mut c_object_cache_stats) or {
 				message := err.msg()
 				if request_macos_v3_c_error_fallback_from_message(macos_v3_fallback_file, macos_v3_c_error_dir, c_compiler, message, [
@@ -11379,7 +11381,7 @@ pub fn run(args []string) {
 			}
 			b.step('C object cache')
 		}
-		flag_plan_sdk_root := if explicit_tcc && prefs.normalized_target_os() == 'macos' {
+		flag_plan_sdk_root := if effective_tcc && prefs.normalized_target_os() == 'macos' {
 			macos_sdk_root_cache.get()
 		} else {
 			''
@@ -11403,7 +11405,7 @@ pub fn run(args []string) {
 			parallel_cc: parallel_cc
 			large_c_unit: large_prod_c_unit
 			limit_inlining: limit_large_unit_inlining
-			explicit_tcc: explicit_tcc
+			is_tcc: effective_tcc
 			is_c_debug: is_c_debug
 			is_o: is_o
 			is_liveshared: is_liveshared
@@ -11416,7 +11418,7 @@ pub fn run(args []string) {
 		}
 		large_c_flag_plan := v3_c_compiler_flag_plan(large_c_flag_options)
 		mut native_support_inputs := []string{}
-		if explicit_tcc {
+		if effective_tcc {
 			atomic_input := if generate_c_project.len > 0 {
 				tcc_atomic_s_arg(prefs)
 			} else {
@@ -11498,7 +11500,7 @@ pub fn run(args []string) {
 			if interface_impl_signature.len == 0 {
 				interface_impl_signature = pre_tc.interface_impl_set_signature()
 			}
-			opt_flag := v3_prod_c_optimization_flags(is_prod, no_prod_options, is_shared, parallel_cc, large_prod_c_unit, limit_large_unit_inlining, explicit_tcc).join(' ')
+			opt_flag := v3_prod_c_optimization_flags(is_prod, no_prod_options, is_shared, parallel_cc, large_prod_c_unit, limit_large_unit_inlining, effective_tcc).join(' ')
 			warning_flags := warn_args.join(' ')
 			mut compile_signature := v3_cached_object_compile_signature(c_standard, opt_flag, pic_flag, warning_flags, resolved_c_flags, needs_objective_c, interface_impl_signature)
 			mut prepared_plan_entry := cgen_cache_entry

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -1826,6 +1826,7 @@ struct V3CCompilerFlagOptions {
 	target_os           string
 	target_arch         string
 	c_compiler          string
+	subsystem           pref.Subsystem
 	macos_sdk_root      string
 	pic_flag            string
 	is_prod             bool
@@ -2310,9 +2311,16 @@ fn v3_fastc_default_linker_flags(target_os string, uses_threads bool) []string {
 	return flags
 }
 
-fn v3_windows_executable_linker_flags(target_os string, c_compiler string, is_shared bool, is_o bool) []string {
+fn v3_windows_executable_linker_flags(target_os string, c_compiler string, is_shared bool, is_o bool, subsystem pref.Subsystem) []string {
 	if target_os == 'windows' && c_compiler != 'msvc' && !is_shared && !is_o {
-		return ['-municode', '-Wl,-stack=33554432']
+		mut flags := ['-municode']
+		match subsystem {
+			.console { flags << '-mconsole' }
+			.windows { flags << '-mwindows' }
+			.auto {}
+		}
+		flags << '-Wl,-stack=33554432'
+		return flags
 	}
 	return []
 }
@@ -2395,7 +2403,7 @@ fn v3_c_compiler_flag_plan(options V3CCompilerFlagOptions) V3CCompilerFlagPlan {
 	if options.pic_flag.len > 0 {
 		before_inputs << options.pic_flag
 	}
-	before_inputs << v3_windows_executable_linker_flags(options.target_os, options.c_compiler, options.is_shared, options.is_o)
+	before_inputs << v3_windows_executable_linker_flags(options.target_os, options.c_compiler, options.is_shared, options.is_o, options.subsystem)
 	mut tcc_includes := ''
 	if options.is_tcc {
 		tcc_resources := v3_tcc_resource_flags(options.vroot)
@@ -7760,7 +7768,7 @@ fn v3_driver_option_requires_value(option string) bool {
 	return option in ['-o', '-output', '-b', '-backend', '-os', '-arch', '-compile-backend',
 		'--compile-backend', '-d', '-define', '-gc', '-cc', '-thread-stack-size', '-path', '-cov',
 		'-coverage', '-file-list', '-message-limit', '-printfn', '-generate-c-project', '-test-runner',
-		'-run-only', '-profile-fns']
+		'-run-only', '-profile-fns', '-subsystem']
 }
 
 fn v3_driver_option_consumes_value(option string) bool {
@@ -8177,6 +8185,7 @@ pub fn run(args []string) {
 	mut is_shared := false
 	mut is_livemain := false
 	mut is_liveshared := false
+	mut subsystem := pref.Subsystem.auto
 	mut is_strict := false
 	mut is_selfhost := false
 	mut no_builtin := false
@@ -8310,6 +8319,17 @@ pub fn run(args []string) {
 		} else if args[i] == '-shared' || args[i] == '--shared' {
 			is_shared = true
 			i++
+		} else if args[i] == '-subsystem' && i + 1 < args.len {
+			subsystem = match args[i + 1] {
+				'auto' { pref.Subsystem.auto }
+				'console' { pref.Subsystem.console }
+				'windows' { pref.Subsystem.windows }
+				else {
+					eprintln('invalid subsystem: ${args[i + 1]}')
+					exit(1)
+				}
+			}
+			i += 2
 		} else if args[i] == '-live' {
 			is_livemain = true
 			// Live builds need every module in the reloadable source artifact. A
@@ -9136,6 +9156,7 @@ pub fn run(args []string) {
 	prefs.is_livemain = is_livemain
 	prefs.is_liveshared = is_liveshared
 	prefs.is_shared = is_shared
+	prefs.subsystem = subsystem
 	prefs.no_builtin = no_builtin
 	prefs.no_preludes = no_preludes
 	prefs.verbose = verbose
@@ -9436,6 +9457,7 @@ pub fn run(args []string) {
 		'debug=${is_debug}',
 		'c_debug=${is_c_debug}',
 		'shared=${is_shared}',
+		'subsystem=${prefs.subsystem}',
 		'selfhost=${is_selfhost}',
 		'c99=${c99}',
 		'thread_stack_size=${prefs.thread_stack_size}',
@@ -11201,6 +11223,7 @@ pub fn run(args []string) {
 			g.set_compiler_vexe(prefs.vexe)
 			g.set_compiler_vexe_env_setup(!pref.has_macos_v3_caller_environment())
 			g.set_target(prefs.target)
+			g.set_subsystem(prefs.subsystem)
 			g.set_thread_stack_size(prefs.thread_stack_size)
 			g.set_show_test_stats(show_test_stats)
 			g.set_show_test_summary(is_test_command)
@@ -11257,6 +11280,7 @@ pub fn run(args []string) {
 			g.set_compiler_vexe(prefs.vexe)
 			g.set_compiler_vexe_env_setup(!pref.has_macos_v3_caller_environment())
 			g.set_target(prefs.target)
+			g.set_subsystem(prefs.subsystem)
 			g.set_thread_stack_size(prefs.thread_stack_size)
 			g.set_show_test_stats(show_test_stats)
 			g.set_show_test_summary(is_test_command)
@@ -11397,6 +11421,7 @@ pub fn run(args []string) {
 			target_os: prefs.normalized_target_os()
 			target_arch: prefs.normalized_target_arch()
 			c_compiler: effective_c_compiler
+			subsystem: prefs.subsystem
 			macos_sdk_root: flag_plan_sdk_root
 			pic_flag: pic_flag
 			is_prod: is_prod
@@ -11864,7 +11889,7 @@ pub fn run(args []string) {
 			if wrapv_flag.len > 0 {
 				tcc_args << wrapv_flag
 			}
-			tcc_args << v3_windows_executable_linker_flags(prefs.normalized_target_os(), 'tinyc', is_shared, is_o)
+			tcc_args << v3_windows_executable_linker_flags(prefs.normalized_target_os(), 'tinyc', is_shared, is_o, prefs.subsystem)
 			tcc_args << tcc_cached_main_flags(resolved_c_flags)
 			tcc_args << ['-o', 'out', os.base(tcc_main_file)]
 			atomic_s := tcc_atomic_arg(prefs, tcc_path, tcc_resources.include_arg)
@@ -11953,7 +11978,7 @@ pub fn run(args []string) {
 			} else if is_o {
 				tcc_args << '-c'
 			}
-			tcc_args << v3_windows_executable_linker_flags(prefs.normalized_target_os(), 'tinyc', is_shared, is_o)
+			tcc_args << v3_windows_executable_linker_flags(prefs.normalized_target_os(), 'tinyc', is_shared, is_o, prefs.subsystem)
 			tcc_source := if cache_full_tcc_source.len > 0 {
 				os.base(cache_full_tcc_source)
 			} else {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -4853,7 +4853,17 @@ fn normalized_c_include_arg_path(include_arg string) string {
 }
 
 fn (mut g FlatGen) emit_preinclude_directives() {
+	// WinAPI leaf headers such as synchapi.h assume that windows.h has already
+	// declared their shared base types. Emit it before every user/module include,
+	// regardless of source traversal order or include directive kind.
+	early_windows_header := g.target.os == 'windows'
+	if early_windows_header {
+		g.writeln('#include <windows.h>')
+	}
 	for directive in g.preinclude_directives {
+		if early_windows_header && directive == '#include <windows.h>' {
+			continue
+		}
 		g.writeln(directive)
 	}
 	if g.preinclude_directives.len > 0 {
@@ -16780,12 +16790,20 @@ fn (mut g FlatGen) system_libc_headers() {
 	// GCC's Objective-C frontend does not implement the C11 `_Atomic` qualifier,
 	// but its stdatomic macros still work with volatile storage and __atomic builtins.
 	// Clang implements `_Atomic` in Objective-C and must retain the native qualifier.
+	// Windows TCC uses V's WinAPI atomic compatibility header instead. It must be
+	// available before struct declarations that contain atomic_uintptr_t fields, and
+	// including both implementations redefines atomic_flag and the operation macros.
+	windows_atomic_header := os.join_path(g.compiler_vroot, 'thirdparty', 'stdatomic', 'win', 'atomic.h').replace('\\', '/')
+	g.writeln('#if defined(_WIN32) && defined(__TINYC__)')
+	g.writeln('#include "${windows_atomic_header}"')
+	g.writeln('#else')
 	g.writeln('#if defined(__OBJC__) && defined(__GNUC__) && !defined(__clang__)')
 	g.writeln('#define _Atomic volatile')
 	g.writeln('#endif')
 	g.writeln('#include <stdatomic.h>')
 	g.writeln('#if defined(__OBJC__) && defined(__GNUC__) && !defined(__clang__)')
 	g.writeln('#undef _Atomic')
+	g.writeln('#endif')
 	g.writeln('#endif')
 	g.writeln('#if defined(__linux__) || defined(__ANDROID__)')
 	g.writeln('#include <sys/syscall.h>')
@@ -19204,7 +19222,9 @@ fn (mut g FlatGen) atomic_thread_fence_compat_decls() {
 	// `atomic_thread_fence` and maps `__atomic_thread_fence` to it. Redeclaring the
 	// mapped name with `int` conflicts with TCC's `memory_order` enum parameter.
 	// clang/gcc keep the builtin.
-	g.writeln('#if defined(__TINYC__) && (defined(__i386__) || defined(__arm__) || defined(__aarch64__) || defined(__riscv) || (defined(__x86_64__) && defined(_WIN32)))')
+	g.writeln('#if defined(_WIN32) && defined(__TINYC__)')
+	g.writeln('/* V atomic.h supplies atomic_thread_fence on Windows TCC. */')
+	g.writeln('#elif defined(__TINYC__) && (defined(__i386__) || defined(__arm__) || defined(__aarch64__) || defined(__riscv))')
 	g.writeln('extern void _V_atomic_thread_fence(int order);')
 	g.writeln('#define atomic_thread_fence(order) _V_atomic_thread_fence(order)')
 	g.writeln('#define __atomic_thread_fence(order) _V_atomic_thread_fence(order)')

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -3505,18 +3505,19 @@ fn (mut g FlatGen) gen_translation_unit_prefix() {
 }
 
 fn (mut g FlatGen) emit_translation_unit_include_directives() {
-	windows_header_emitted := g.emit_preinclude_directives()
-	g.emit_preserved_c_directives_scoped()
+	mut windows_header_emitted := g.emit_preinclude_directives()
+	windows_header_emitted = g.emit_preserved_c_directives_scoped(windows_header_emitted)
 	if g.target.os == 'windows' && !windows_header_emitted {
 		// Winsock2 must precede windows.h, which otherwise includes legacy winsock.h.
 		g.writeln('#include <windows.h>')
 	}
 }
 
-fn (mut g FlatGen) emit_preserved_c_directives_scoped() {
+fn (mut g FlatGen) emit_preserved_c_directives_scoped(windows_header_emitted bool) bool {
 	state := g.begin_scoped_append()
-	g.emit_preserved_c_directives()
+	emitted_windows_header := g.emit_preserved_c_directives(windows_header_emitted)
 	g.finish_scoped_append(state)
+	return emitted_windows_header
 }
 
 fn (mut g FlatGen) emit_c_directives_scoped(late bool) {
@@ -9328,10 +9329,12 @@ fn c_is_late_source_include_directive(directive string) bool {
 	return arg.ends_with('.m') || arg.ends_with('.mm')
 }
 
-fn (mut g FlatGen) emit_preserved_c_directives() {
+fn (mut g FlatGen) emit_preserved_c_directives(windows_header_emitted bool) bool {
 	mut emitted := false
 	mut emitted_includes := map[string]bool{}
 	mut has_mach_headers := false
+	mut emitted_windows_header := windows_header_emitted
+	mut deferred_synchapi_indices := []int{}
 	directives := g.ordered_c_directives(false)
 	use_system_libc := g.c_directives_use_system_libc()
 	for i, directive in directives {
@@ -9350,31 +9353,34 @@ fn (mut g FlatGen) emit_preserved_c_directives() {
 			emitted = true
 			continue
 		}
-		prefix := if c_lifted_include_skips_context(directive) {
-			[]string{}
-		} else {
-			c_lifted_include_context_prefix(directives, i)
-		}
-		if c_is_preserved_system_include_directive(clean) {
-			// Dedupe on the include *together with* its lifted guard context: the
-			// same header may legitimately appear under different guards (e.g. one
-			// `#ifdef __linux__` block and one `#ifdef __APPLE__` block), and each
-			// occurrence needs its own context emitted. Keying on the raw include
-			// line alone would drop the second, differently-guarded include.
-			key := prefix.join('\n') + '\x00' + clean
-			if emitted_includes[key] {
+		if g.target.os == 'windows' {
+			if clean == '#include <windows.h>' {
+				if emitted_windows_header {
+					continue
+				}
+				emitted_windows_header = true
+			}
+			if !emitted_windows_header && clean == '#include <synchapi.h>' {
+				deferred_synchapi_indices << i
 				continue
 			}
-			emitted_includes[key] = true
 		}
-		for line in prefix {
-			g.writeln(line)
+		if g.emit_preserved_c_directive_at(directives, i, mut emitted_includes) {
 			emitted = true
 		}
-		g.emit_preserved_c_directive(directive)
-		emitted = true
-		for _ in 0 .. c_lifted_include_context_depth(prefix) {
-			g.writeln('#endif')
+	}
+	if deferred_synchapi_indices.len > 0 {
+		if !emitted_windows_header {
+			// Preserve Winsock2 ahead of windows.h while keeping synchapi.h after
+			// the WinAPI base declarations that it requires.
+			g.writeln('#include <windows.h>')
+			emitted_windows_header = true
+			emitted = true
+		}
+		for i in deferred_synchapi_indices {
+			if g.emit_preserved_c_directive_at(directives, i, mut emitted_includes) {
+				emitted = true
+			}
 		}
 	}
 	refs := g.c_extern_referenced_symbols()
@@ -9388,6 +9394,37 @@ fn (mut g FlatGen) emit_preserved_c_directives() {
 	if emitted {
 		g.writeln('')
 	}
+	return emitted_windows_header
+}
+
+fn (mut g FlatGen) emit_preserved_c_directive_at(directives []string, index int, mut emitted_includes map[string]bool) bool {
+	directive := directives[index]
+	clean := trimmed_space(directive)
+	prefix := if c_lifted_include_skips_context(directive) {
+		[]string{}
+	} else {
+		c_lifted_include_context_prefix(directives, index)
+	}
+	if c_is_preserved_system_include_directive(clean) {
+		// Dedupe on the include *together with* its lifted guard context: the
+		// same header may legitimately appear under different guards (e.g. one
+		// `#ifdef __linux__` block and one `#ifdef __APPLE__` block), and each
+		// occurrence needs its own context emitted. Keying on the raw include
+		// line alone would drop the second, differently-guarded include.
+		key := prefix.join('\n') + '\x00' + clean
+		if emitted_includes[key] {
+			return false
+		}
+		emitted_includes[key] = true
+	}
+	for line in prefix {
+		g.writeln(line)
+	}
+	g.emit_preserved_c_directive(directive)
+	for _ in 0 .. c_lifted_include_context_depth(prefix) {
+		g.writeln('#endif')
+	}
+	return true
 }
 
 fn c_lifted_include_skips_context(directive string) bool {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -4853,18 +4853,27 @@ fn normalized_c_include_arg_path(include_arg string) string {
 }
 
 fn (mut g FlatGen) emit_preinclude_directives() {
-	// WinAPI leaf headers such as synchapi.h assume that windows.h has already
-	// declared their shared base types. Emit it before every user/module include,
-	// regardless of source traversal order or include directive kind.
-	early_windows_header := g.target.os == 'windows'
-	if early_windows_header {
-		g.writeln('#include <windows.h>')
-	}
+	// Configuration preincludes must run before windows.h so they can select the
+	// requested WinAPI surface. Only interpose windows.h before a leaf header that
+	// specifically requires its base declarations.
+	windows_target := g.target.os == 'windows'
+	mut emitted_windows_header := false
 	for directive in g.preinclude_directives {
-		if early_windows_header && directive == '#include <windows.h>' {
+		if windows_target && directive == '#include <windows.h>' {
+			if !emitted_windows_header {
+				g.writeln(directive)
+				emitted_windows_header = true
+			}
 			continue
 		}
+		if windows_target && !emitted_windows_header && directive == '#include <synchapi.h>' {
+			g.writeln('#include <windows.h>')
+			emitted_windows_header = true
+		}
 		g.writeln(directive)
+	}
+	if windows_target && !emitted_windows_header {
+		g.writeln('#include <windows.h>')
 	}
 	if g.preinclude_directives.len > 0 {
 		g.writeln('')

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -3487,8 +3487,7 @@ fn (mut g FlatGen) gen_translation_unit_prefix() {
 		g.writeln('#define _VPROFILE (1)')
 	}
 	g.thread_stack_size_definition()
-	g.emit_preinclude_directives()
-	g.emit_preserved_c_directives_scoped()
+	g.emit_translation_unit_include_directives()
 	g.preamble()
 	if g.cache_split {
 		g.writeln('/* V3CACHE_NATIVE_DIRECTIVES_BEGIN */')
@@ -3496,6 +3495,15 @@ fn (mut g FlatGen) gen_translation_unit_prefix() {
 	g.emit_c_directives_scoped(false)
 	if g.cache_split {
 		g.writeln('/* V3CACHE_NATIVE_DIRECTIVES_END */')
+	}
+}
+
+fn (mut g FlatGen) emit_translation_unit_include_directives() {
+	windows_header_emitted := g.emit_preinclude_directives()
+	g.emit_preserved_c_directives_scoped()
+	if g.target.os == 'windows' && !windows_header_emitted {
+		// Winsock2 must precede windows.h, which otherwise includes legacy winsock.h.
+		g.writeln('#include <windows.h>')
 	}
 }
 
@@ -4852,7 +4860,7 @@ fn normalized_c_include_arg_path(include_arg string) string {
 	return path.replace('\\', '/')
 }
 
-fn (mut g FlatGen) emit_preinclude_directives() {
+fn (mut g FlatGen) emit_preinclude_directives() bool {
 	// Configuration preincludes must run before windows.h so they can select the
 	// requested WinAPI surface. Only interpose windows.h before a leaf header that
 	// specifically requires its base declarations.
@@ -4872,12 +4880,10 @@ fn (mut g FlatGen) emit_preinclude_directives() {
 		}
 		g.writeln(directive)
 	}
-	if windows_target && !emitted_windows_header {
-		g.writeln('#include <windows.h>')
-	}
 	if g.preinclude_directives.len > 0 {
 		g.writeln('')
 	}
+	return emitted_windows_header
 }
 
 fn (mut g FlatGen) emit_postinclude_directives() {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -484,6 +484,8 @@ mut:
 	ccompiler                     string
 	target                        pref.Target
 	subsystem                     pref.Subsystem
+	windows_entry_point_generated bool
+	windows_gui_entry_point       bool
 	// C spelling for V's platform-width `int`: `i64` on 64-bit targets, `i32` on
 	// 32-bit. Used by hand-written runtime helpers that operate on `[]int`
 	// elements or `int` values directly (kept in sync with set_target).
@@ -1285,6 +1287,15 @@ pub fn (mut g FlatGen) set_target(target pref.Target) {
 // set_subsystem configures the Windows executable subsystem.
 pub fn (mut g FlatGen) set_subsystem(subsystem pref.Subsystem) {
 	g.subsystem = subsystem
+}
+
+// generated_windows_gui_entry_point reports the GUI decision when this generator emitted a
+// Windows executable entry point, or none when the current generation did not emit one.
+pub fn (g &FlatGen) generated_windows_gui_entry_point() ?bool {
+	if !g.windows_entry_point_generated {
+		return none
+	}
+	return g.windows_gui_entry_point
 }
 
 // set_thread_stack_size configures the stack size used by generated worker threads.

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -483,6 +483,7 @@ mut:
 	compiler_vexe_env_setup       bool = true
 	ccompiler                     string
 	target                        pref.Target
+	subsystem                     pref.Subsystem
 	// C spelling for V's platform-width `int`: `i64` on 64-bit targets, `i32` on
 	// 32-bit. Used by hand-written runtime helpers that operate on `[]int`
 	// elements or `int` values directly (kept in sync with set_target).
@@ -1279,6 +1280,11 @@ pub fn (mut g FlatGen) set_compiler_vexe_env_setup(enabled bool) {
 pub fn (mut g FlatGen) set_target(target pref.Target) {
 	g.target = target
 	g.int_ct = if target.pointer_bits == 32 { 'i32' } else { 'i64' }
+}
+
+// set_subsystem configures the Windows executable subsystem.
+pub fn (mut g FlatGen) set_subsystem(subsystem pref.Subsystem) {
+	g.subsystem = subsystem
 }
 
 // set_thread_stack_size configures the stack size used by generated worker threads.

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -521,11 +521,13 @@ fn windows_gui_stdio_setup(force_console bool) string {
 	return '\tBOOL con_valid = FALSE;\n' + console_setup + '\tFILE* res_fp = 0;\n' + '\terrno_t err;\n' + '\tif (con_valid) {\n' + '\t\terr = freopen_s(&res_fp, "CON", "w", stdout);\n' + '\t\terr = freopen_s(&res_fp, "CON", "w", stderr);\n' + '\t} else {\n' + '\t\terr = freopen_s(&res_fp, "NUL", "w", stdout);\n' + '\t\terr = freopen_s(&res_fp, "NUL", "w", stderr);\n' + '\t}\n' + '\t(void)err;'
 }
 
-fn (g &FlatGen) c_main_declaration(force_main_console bool) string {
+fn (mut g FlatGen) c_main_declaration(force_main_console bool) string {
 	if g.target.os != 'windows' {
 		return 'int main(int argc, char** argv) {'
 	}
-	if !g.is_gui_app(force_main_console) {
+	g.windows_entry_point_generated = true
+	g.windows_gui_entry_point = g.is_gui_app(force_main_console)
+	if !g.windows_gui_entry_point {
 		return 'int wmain(int argc, wchar_t** argv) {'
 	}
 	return 'int WINAPI wWinMain(HINSTANCE instance, HINSTANCE prev_instance, LPWSTR cmd_line, int show_cmd) {\n' + '\tLPWSTR full_cmd_line = GetCommandLineW(); /* do not use cmd_line */\n' + '\ttypedef LPWSTR*(WINAPI *cmd_line_to_argv)(LPCWSTR, int*);\n' + '\tHMODULE shell32_module = LoadLibrary(L"shell32.dll");\n' + '\tcmd_line_to_argv CommandLineToArgvW = (cmd_line_to_argv)GetProcAddress(shell32_module, "CommandLineToArgvW");\n' + '\tint argc;\n' + '\twchar_t** argv = CommandLineToArgvW(full_cmd_line, &argc);\n' + windows_gui_stdio_setup(force_main_console)

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -490,6 +490,13 @@ fn c_backend_fn_file_rank(file string) int {
 	return 0
 }
 
+fn (g &FlatGen) c_main_declaration() string {
+	if g.target.os == 'windows' {
+		return 'int wmain(int argc, wchar_t** argv) {'
+	}
+	return 'int main(int argc, char** argv) {'
+}
+
 fn (mut g FlatGen) gen_synthetic_main_after_fns() {
 	if g.suppress_main {
 		if g.needs_no_main_runtime_init_caller() {
@@ -4671,7 +4678,7 @@ fn (mut g FlatGen) gen_fn_in_module(node_id flat.NodeId, node flat.Node, module_
 	fn_start_pos := g.sb.len
 	mut is_direct_no_main_export := false
 	if is_entry_main {
-		g.writeln('int main(int argc, char** argv) {')
+		g.writeln(g.c_main_declaration())
 		if g.has_builtins {
 			g.writeln('\tg_main_argc = argc;')
 			g.writeln('\tg_main_argv = argv;')
@@ -5078,7 +5085,7 @@ fn (mut g FlatGen) gen_top_level_main(stmts []TopLevelStmt) {
 	g.goto_label_c_names.clear()
 	g.goto_label_count = 0
 	fn_start_pos := g.sb.len
-	g.writeln('int main(int argc, char** argv) {')
+	g.writeln(g.c_main_declaration())
 	if g.has_builtins {
 		g.writeln('\tg_main_argc = argc;')
 		g.writeln('\tg_main_argv = argv;')
@@ -5177,7 +5184,7 @@ fn (mut g FlatGen) gen_test_main() {
 		g.writeln('}')
 		g.writeln('')
 	}
-	g.writeln('int main(int argc, char** argv) {')
+	g.writeln(g.c_main_declaration())
 	if g.has_builtins {
 		g.writeln('\tg_main_argc = argc;')
 		g.writeln('\tg_main_argv = argv;')
@@ -6221,6 +6228,13 @@ fn (mut g FlatGen) gen_call(id flat.NodeId, node flat.Node) {
 	}
 	resolved_target_name := g.tc.resolved_call_name(id) or { '' }
 	callee_is_fn_value := g.fn_value_call_param_types(g.a.child(&node, 0)) != none
+	if fn_node.kind == .selector && node.children_count == 2 && target_name.starts_with('C.')
+		&& target_name in g.tc.type_aliases {
+		g.write('(${g.direct_call_name(target_name)})(')
+		g.gen_expr(g.a.child(&node, 1))
+		g.write(')')
+		return
+	}
 	if g.gen_c_va_macro_call(node, target_name, resolved_target_name) {
 		return
 	}

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -490,11 +490,45 @@ fn c_backend_fn_file_rank(file string) int {
 	return 0
 }
 
-fn (g &FlatGen) c_main_declaration() string {
-	if g.target.os == 'windows' {
+fn (g &FlatGen) is_gui_app(force_main_console bool) bool {
+	match g.subsystem {
+		.windows {
+			return true
+		}
+		.console {
+			return false
+		}
+		.auto {}
+	}
+	if g.target.os != 'windows' || force_main_console {
+		return false
+	}
+	for flag in g.c_flags {
+		clean := flag.trim_space().to_lower_ascii()
+		if clean in ['gdi32', '-lgdi32', 'gdi32.lib'] {
+			return true
+		}
+	}
+	return false
+}
+
+fn windows_gui_stdio_setup(force_console bool) string {
+	console_setup := if force_console {
+		'\tcon_valid = AllocConsole();\n'
+	} else {
+		'\tcon_valid = AttachConsole(ATTACH_PARENT_PROCESS);\n'
+	}
+	return '\tBOOL con_valid = FALSE;\n' + console_setup + '\tFILE* res_fp = 0;\n' + '\terrno_t err;\n' + '\tif (con_valid) {\n' + '\t\terr = freopen_s(&res_fp, "CON", "w", stdout);\n' + '\t\terr = freopen_s(&res_fp, "CON", "w", stderr);\n' + '\t} else {\n' + '\t\terr = freopen_s(&res_fp, "NUL", "w", stdout);\n' + '\t\terr = freopen_s(&res_fp, "NUL", "w", stderr);\n' + '\t}\n' + '\t(void)err;'
+}
+
+fn (g &FlatGen) c_main_declaration(force_main_console bool) string {
+	if g.target.os != 'windows' {
+		return 'int main(int argc, char** argv) {'
+	}
+	if !g.is_gui_app(force_main_console) {
 		return 'int wmain(int argc, wchar_t** argv) {'
 	}
-	return 'int main(int argc, char** argv) {'
+	return 'int WINAPI wWinMain(HINSTANCE instance, HINSTANCE prev_instance, LPWSTR cmd_line, int show_cmd) {\n' + '\tLPWSTR full_cmd_line = GetCommandLineW(); /* do not use cmd_line */\n' + '\ttypedef LPWSTR*(WINAPI *cmd_line_to_argv)(LPCWSTR, int*);\n' + '\tHMODULE shell32_module = LoadLibrary(L"shell32.dll");\n' + '\tcmd_line_to_argv CommandLineToArgvW = (cmd_line_to_argv)GetProcAddress(shell32_module, "CommandLineToArgvW");\n' + '\tint argc;\n' + '\twchar_t** argv = CommandLineToArgvW(full_cmd_line, &argc);\n' + windows_gui_stdio_setup(force_main_console)
 }
 
 fn (mut g FlatGen) gen_synthetic_main_after_fns() {
@@ -4678,7 +4712,8 @@ fn (mut g FlatGen) gen_fn_in_module(node_id flat.NodeId, node flat.Node, module_
 	fn_start_pos := g.sb.len
 	mut is_direct_no_main_export := false
 	if is_entry_main {
-		g.writeln(g.c_main_declaration())
+		force_main_console := g.tc.declaration_has_attribute(node_id, 'console')
+		g.writeln(g.c_main_declaration(force_main_console))
 		if g.has_builtins {
 			g.writeln('\tg_main_argc = argc;')
 			g.writeln('\tg_main_argv = argv;')
@@ -5085,7 +5120,7 @@ fn (mut g FlatGen) gen_top_level_main(stmts []TopLevelStmt) {
 	g.goto_label_c_names.clear()
 	g.goto_label_count = 0
 	fn_start_pos := g.sb.len
-	g.writeln(g.c_main_declaration())
+	g.writeln(g.c_main_declaration(false))
 	if g.has_builtins {
 		g.writeln('\tg_main_argc = argc;')
 		g.writeln('\tg_main_argv = argv;')
@@ -5184,7 +5219,7 @@ fn (mut g FlatGen) gen_test_main() {
 		g.writeln('}')
 		g.writeln('')
 	}
-	g.writeln(g.c_main_declaration())
+	g.writeln(g.c_main_declaration(false))
 	if g.has_builtins {
 		g.writeln('\tg_main_argc = argc;')
 		g.writeln('\tg_main_argv = argv;')

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -1110,6 +1110,10 @@ fn (mut g FlatGen) write_scoped_cgen_batch_output(batch &FlatGen) bool {
 // and, when needed, output into the helper's result arena.
 fn (mut g FlatGen) absorb_scoped_cgen_batch(batch &FlatGen, output_streamed bool) {
 	mut b := unsafe { batch }
+	if batch.windows_entry_point_generated {
+		g.windows_entry_point_generated = true
+		g.windows_gui_entry_point = batch.windows_gui_entry_point
+	}
 	if !output_streamed {
 		output := b.sb.str()
 		if output.len > 0 {
@@ -2858,6 +2862,10 @@ fn (mut g FlatGen) merge_parallel_worker_into(w &FlatGen, mut ordered []string, 
 	mut ww := unsafe { w }
 	if g.output_error.len == 0 && w.output_error.len > 0 {
 		g.output_error = w.output_error.clone()
+	}
+	if w.windows_entry_point_generated {
+		g.windows_entry_point_generated = true
+		g.windows_gui_entry_point = w.windows_gui_entry_point
 	}
 	string_id_remap := g.publish_worker_string_literals(w)
 	borrow_worker_segments := os.getenv('V3_RETAIN_CGEN_RESULT_SCOPES') != ''

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -2511,6 +2511,8 @@ fn (g &FlatGen) new_parallel_worker_config(worker_id int, result_only bool) &Fla
 		compiler_vexe_env_setup: g.compiler_vexe_env_setup
 		ccompiler: g.ccompiler
 		target: g.target
+		subsystem: g.subsystem
+		c_flags: g.c_flags
 		suppress_main: g.suppress_main
 		cur_param_names: if result_only {
 			g.cur_param_names

--- a/vlib/v3/gen/c/preamble_test.v
+++ b/vlib/v3/gen/c/preamble_test.v
@@ -1,13 +1,20 @@
 module c
 
+import v3.flat
 import v3.pref
 
-fn test_windows_translation_unit_preserves_configuration_preincludes() {
+fn windows_preamble_test_gen() FlatGen {
 	mut g := FlatGen.new()
+	g.a = &flat.FlatAst{}
 	g.target = pref.target_from('windows', 'amd64') or { panic(err) }
+	return g
+}
+
+fn test_windows_translation_unit_preserves_configuration_preincludes() {
+	mut g := windows_preamble_test_gen()
 	g.preinclude_directives = ['#include "winapi_config.h"', '#include <synchapi.h>',
 		'#include <windows.h>']
-	g.emit_preinclude_directives()
+	g.emit_translation_unit_include_directives()
 	c_code := g.sb.str()
 	assert c_code.index('#include "winapi_config.h"')? < c_code.index('#include <windows.h>')?
 	assert c_code.index('#include <windows.h>')? < c_code.index('#include <synchapi.h>')?
@@ -15,12 +22,28 @@ fn test_windows_translation_unit_preserves_configuration_preincludes() {
 }
 
 fn test_windows_translation_unit_adds_windows_header_after_configuration_preincludes() {
-	mut g := FlatGen.new()
-	g.target = pref.target_from('windows', 'amd64') or { panic(err) }
+	mut g := windows_preamble_test_gen()
 	g.preinclude_directives = ['#include "winapi_config.h"']
-	g.emit_preinclude_directives()
+	g.emit_translation_unit_include_directives()
 	c_code := g.sb.str()
 	assert c_code.index('#include "winapi_config.h"')? < c_code.index('#include <windows.h>')?
+}
+
+fn test_windows_translation_unit_keeps_preserved_winsock_headers_before_windows_header() {
+	mut g := windows_preamble_test_gen()
+	g.preinclude_directives = ['#include "winapi_config.h"']
+	g.add_c_directive('net', '#include <winsock2.h>', false)
+	g.add_c_directive('net', '#include <ws2tcpip.h>', false)
+	g.emit_translation_unit_include_directives()
+	c_code := g.sb.str()
+	config_index := c_code.index('#include "winapi_config.h"')?
+	winsock_index := c_code.index('#include <winsock2.h>')?
+	ws2tcpip_index := c_code.index('#include <ws2tcpip.h>')?
+	windows_index := c_code.index('#include <windows.h>')?
+	assert config_index < winsock_index
+	assert winsock_index < ws2tcpip_index
+	assert ws2tcpip_index < windows_index
+	assert c_code.count('#include <windows.h>') == 1
 }
 
 fn test_thread_local_decl_uses_portable_c_dialects() {

--- a/vlib/v3/gen/c/preamble_test.v
+++ b/vlib/v3/gen/c/preamble_test.v
@@ -1,5 +1,17 @@
 module c
 
+import v3.pref
+
+fn test_windows_translation_unit_starts_includes_with_windows_header() {
+	mut g := FlatGen.new()
+	g.target = pref.target_from('windows', 'amd64') or { panic(err) }
+	g.preinclude_directives = ['#include <synchapi.h>', '#include <windows.h>']
+	g.emit_preinclude_directives()
+	c_code := g.sb.str()
+	assert c_code.index('#include <windows.h>')? < c_code.index('#include <synchapi.h>')?
+	assert c_code.count('#include <windows.h>') == 1
+}
+
 fn test_thread_local_decl_uses_portable_c_dialects() {
 	mut g := FlatGen.new()
 	g.emit_thread_local_decl_after_tinyc('int state;')
@@ -174,6 +186,7 @@ fn test_builtin_abi_decls_reuse_tcc_x64_stdatomic_fence_declaration() {
 	mut g := FlatGen.new()
 	g.atomic_thread_fence_compat_decls()
 	c_code := g.sb.str()
+	assert c_code.contains('#if defined(_WIN32) && defined(__TINYC__)\n/* V atomic.h supplies atomic_thread_fence on Windows TCC. */')
 	assert c_code.contains('#define atomic_thread_fence(order) __atomic_thread_fence(order)')
 	assert !c_code.contains('extern void __atomic_thread_fence(int order);')
 }
@@ -193,6 +206,8 @@ fn test_system_libc_headers_make_stdatomic_compatible_with_gnu_objective_c() {
 	mut g := FlatGen.new()
 	g.system_libc_headers()
 	c_code := g.sb.str()
+	assert c_code.contains('#if defined(_WIN32) && defined(__TINYC__)')
+	assert c_code.contains('thirdparty/stdatomic/win/atomic.h"\n#else')
 	compat_guard := '#if defined(__OBJC__) && defined(__GNUC__) && !defined(__clang__)'
 	assert c_code.contains('${compat_guard}\n#define _Atomic volatile\n#endif\n#include <stdatomic.h>')
 	assert c_code.contains('#include <stdatomic.h>\n${compat_guard}\n#undef _Atomic\n#endif')

--- a/vlib/v3/gen/c/preamble_test.v
+++ b/vlib/v3/gen/c/preamble_test.v
@@ -2,14 +2,25 @@ module c
 
 import v3.pref
 
-fn test_windows_translation_unit_starts_includes_with_windows_header() {
+fn test_windows_translation_unit_preserves_configuration_preincludes() {
 	mut g := FlatGen.new()
 	g.target = pref.target_from('windows', 'amd64') or { panic(err) }
-	g.preinclude_directives = ['#include <synchapi.h>', '#include <windows.h>']
+	g.preinclude_directives = ['#include "winapi_config.h"', '#include <synchapi.h>',
+		'#include <windows.h>']
 	g.emit_preinclude_directives()
 	c_code := g.sb.str()
+	assert c_code.index('#include "winapi_config.h"')? < c_code.index('#include <windows.h>')?
 	assert c_code.index('#include <windows.h>')? < c_code.index('#include <synchapi.h>')?
 	assert c_code.count('#include <windows.h>') == 1
+}
+
+fn test_windows_translation_unit_adds_windows_header_after_configuration_preincludes() {
+	mut g := FlatGen.new()
+	g.target = pref.target_from('windows', 'amd64') or { panic(err) }
+	g.preinclude_directives = ['#include "winapi_config.h"']
+	g.emit_preinclude_directives()
+	c_code := g.sb.str()
+	assert c_code.index('#include "winapi_config.h"')? < c_code.index('#include <windows.h>')?
 }
 
 fn test_thread_local_decl_uses_portable_c_dialects() {

--- a/vlib/v3/gen/c/preamble_test.v
+++ b/vlib/v3/gen/c/preamble_test.v
@@ -46,6 +46,26 @@ fn test_windows_translation_unit_keeps_preserved_winsock_headers_before_windows_
 	assert c_code.count('#include <windows.h>') == 1
 }
 
+fn test_windows_translation_unit_interposes_windows_header_before_preserved_synchapi() {
+	mut g := windows_preamble_test_gen()
+	g.preinclude_directives = ['#include "winapi_config.h"']
+	g.add_c_directive('sync', '#include <synchapi.h>', false)
+	g.add_c_directive('net', '#include <winsock2.h>', false)
+	g.add_c_directive('net', '#include <ws2tcpip.h>', false)
+	g.emit_translation_unit_include_directives()
+	c_code := g.sb.str()
+	config_index := c_code.index('#include "winapi_config.h"')?
+	winsock_index := c_code.index('#include <winsock2.h>')?
+	ws2tcpip_index := c_code.index('#include <ws2tcpip.h>')?
+	windows_index := c_code.index('#include <windows.h>')?
+	synchapi_index := c_code.index('#include <synchapi.h>')?
+	assert config_index < winsock_index
+	assert winsock_index < ws2tcpip_index
+	assert ws2tcpip_index < windows_index
+	assert windows_index < synchapi_index
+	assert c_code.count('#include <windows.h>') == 1
+}
+
 fn test_thread_local_decl_uses_portable_c_dialects() {
 	mut g := FlatGen.new()
 	g.emit_thread_local_decl_after_tinyc('int state;')

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -5238,7 +5238,8 @@ fn c_struct_needs_typedef(name string) bool {
 		return true
 	}
 	raw := name[2..]
-	if raw.len > 0 && raw[0] >= `a` && raw[0] <= `z` && !raw.ends_with('_t') {
+	if raw.starts_with('_')
+		|| (raw.len > 0 && raw[0] >= `a` && raw[0] <= `z` && !raw.ends_with('_t')) {
 		return false
 	}
 	return true
@@ -5417,7 +5418,8 @@ fn (mut g FlatGen) struct_decls() {
 			// An inlined header that defines `struct zip_t` without a typedef
 			// leaves V references to the bare name dangling; supply the alias
 			// (skipped when the header already typedefs it).
-			if name.starts_with('C.') && name !in c_preamble_defined_structs && c_struct_needs_typedef(name) && g.inlined_c_structs[name[2..]]
+			if name.starts_with('C.') && name !in c_preamble_defined_structs && name[2..] !in c_system_header_struct_names && c_struct_needs_typedef(name)
+				&& g.inlined_c_structs[name[2..]]
 				&& !g.inlined_c_typedef_names[name[2..]] && !(g.cache_split
 				&& name[2..] in c_cache_system_header_struct_names) {
 				ityp := if name in g.tc.unions { 'union' } else { 'struct' }

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -703,6 +703,10 @@ fn optional_payload_is_bare_struct(t types.Type) bool {
 // optional_typedefs supports optional typedefs handling for FlatGen.
 fn (mut g FlatGen) optional_typedefs() {
 	g.collect_optional_typedefs()
+	// Declaration collection can have completed before the final selected-function
+	// list is available. Revisit that concrete list immediately before emission so
+	// every wrapper used by forward_decls() is already defined.
+	g.collect_selected_declaration_signature_types()
 	mut wrote := false
 	mut names := g.needed_optional_types.keys()
 	names.sort()
@@ -817,8 +821,8 @@ fn (mut g FlatGen) collect_declaration_signature_types() {
 		g.tc.cur_file = old_file
 	}
 	// Parallel monomorph workers can append concrete declarations before their
-	// checker signature maps are merged. Read declaration nodes directly too, so
-	// an option/result used only by a worker specialization still gets a typedef.
+	// checker signature maps are merged. Read those declaration nodes directly too,
+	// so an option/result used only by a worker specialization still gets a typedef.
 	mut cur_module := ''
 	mut cur_file := ''
 	for idx in g.top_level_nodes() {
@@ -835,26 +839,38 @@ fn (mut g FlatGen) collect_declaration_signature_types() {
 		if node.kind != .fn_decl {
 			continue
 		}
-		concrete_optional := g.a.specialized_fn_nodes[idx]
-			|| g.name_uses_specialized_generic_abi(node.value)
-		if !concrete_optional {
-			continue
-		}
 		g.tc.cur_module = g.a.specialized_fn_modules[idx] or { cur_module }
 		g.tc.cur_file = g.a.specialized_fn_files[idx] or {
 			g.tc.fn_type_files[node.value] or { cur_file }
 		}
-		if node.typ.len > 0 {
-			g.collect_declaration_signature_type_for_context(g.tc.parse_type(node.typ), concrete_optional)
+		concrete_optional := g.is_program_specialization_fn_node(node, idx, g.tc.cur_module)
+		if !concrete_optional {
+			continue
 		}
+		return_type := g.fn_node_return_type(node, g.tc.cur_module)
+		g.collect_declaration_signature_type_for_context(return_type, concrete_optional)
+		typed_params := g.fn_node_param_types(node, g.tc.cur_module)
+		mut param_idx := 0
 		for i in 0 .. node.children_count {
 			param := g.a.child_node(&node, i)
 			if param.kind != .param {
 				break
 			}
-			g.collect_declaration_signature_type_for_context(g.tc.parse_type(param.typ), concrete_optional)
+			raw_type := if param_idx < typed_params.len {
+				typed_params[param_idx]
+			} else {
+				g.tc.parse_resolution_type(param.typ)
+			}
+			param_idx++
+			g.collect_declaration_signature_type_for_context(g.fn_node_effective_param_type(param, raw_type), concrete_optional)
 		}
 	}
+	// The selected function list excludes open generic templates and carries the
+	// exact module/file context later used by forward_decls(). Collect those known
+	// concrete signatures without the conservative placeholder-name filter: in a
+	// large program it can mistake short nominal payloads such as `Token` or `Type`
+	// for generic parameters and omit their optional wrapper typedefs.
+	g.collect_selected_declaration_signature_types()
 	mut seen := &PreseedTypeSeen{}
 	for name, ret in g.tc.fn_ret_types {
 		// Generic template signatures keep unspecialized placeholder types
@@ -922,6 +938,38 @@ fn (mut g FlatGen) collect_declaration_signature_types() {
 	g.multi_return_types_ready = true
 }
 
+fn (mut g FlatGen) collect_selected_declaration_signature_types() {
+	old_module := g.tc.cur_module
+	old_file := g.tc.cur_file
+	defer {
+		g.tc.cur_module = old_module
+		g.tc.cur_file = old_file
+	}
+	for item in g.ensure_fn_gen_items() {
+		node := g.a.nodes[int(item.node_id)]
+		g.tc.cur_module = item.module
+		g.tc.cur_file = item.file
+		concrete_optional := g.is_program_specialization_fn_node(node, int(item.node_id), item.module)
+		return_type := g.fn_node_return_type(node, item.module)
+		g.collect_known_declaration_signature_type_for_context(return_type, concrete_optional)
+		typed_params := g.fn_node_param_types(node, item.module)
+		mut param_idx := 0
+		for i in 0 .. node.children_count {
+			param := g.a.child_node(&node, i)
+			if param.kind != .param {
+				break
+			}
+			raw_type := if param_idx < typed_params.len {
+				typed_params[param_idx]
+			} else {
+				g.tc.parse_resolution_type(param.typ)
+			}
+			param_idx++
+			g.collect_known_declaration_signature_type_for_context(g.fn_node_effective_param_type(param, raw_type), concrete_optional)
+		}
+	}
+}
+
 @[inline]
 fn cgen_type_first_seen(typ &types.Type, mut seen PreseedTypeSeen) bool {
 	words := unsafe { &u64(voidptr(typ)) }
@@ -953,6 +1001,10 @@ fn (mut g FlatGen) collect_declaration_signature_type_for_context(t types.Type, 
 	if skip {
 		return
 	}
+	g.collect_known_declaration_signature_type_for_context(t, concrete_optional)
+}
+
+fn (mut g FlatGen) collect_known_declaration_signature_type_for_context(t types.Type, concrete_optional bool) {
 	g.collect_concrete_optional_typedef_type_for_context(t, concrete_optional)
 	g.collect_known_concrete_multi_return_type(t)
 }
@@ -1205,9 +1257,11 @@ fn (mut g FlatGen) emit_optional_typedef(opt_name string, val_type string) bool 
 	bare_val_type := val_type.trim_right('*')
 	interface_matches := g.qualified_interface_c_types(bare_val_type.all_after_last('__'))
 	is_known_interface := bare_val_type in interface_matches
+	is_known_sum_type := g.is_known_sum_c_type(bare_val_type)
 	// Multi-return names can contain a module-qualified field component, but the
 	// payload is the generated tuple struct rather than a stale source struct.
-	if !is_known_interface && !bare_val_type.starts_with('multi_return_')
+	if bare_val_type != 'Array' && !is_known_interface && !is_known_sum_type
+		&& !bare_val_type.starts_with('multi_return_')
 		&& (g.stale_ambiguous_qualified_struct_c_type(bare_val_type)
 			|| g.stale_missing_qualified_struct_c_type(bare_val_type)) {
 		// Stale generic annotations can lose the declaration module or inherit the
@@ -1216,7 +1270,8 @@ fn (mut g FlatGen) emit_optional_typedef(opt_name string, val_type string) bool 
 		g.emitted_optional_types[opt_name] = true
 		return false
 	}
-	if !bare_val_type.contains('__') && g.stale_ambiguous_qualified_interface_c_type(bare_val_type) {
+	if bare_val_type != 'Array' && !bare_val_type.contains('__')
+		&& g.stale_ambiguous_qualified_interface_c_type(bare_val_type) {
 		// A stale unqualified signature cannot identify which imported interface it
 		// belongs to. Its concrete, module-qualified signature registers the usable
 		// typedef; do not emit an invalid C type for the ambiguous collector entry.
@@ -1236,6 +1291,15 @@ fn (mut g FlatGen) emit_optional_typedef(opt_name string, val_type string) bool 
 	g.writeln('typedef struct ${opt_name} { bool ok; ${err_field}${val_type} value; } ${opt_name};')
 	g.emitted_optional_types[opt_name] = true
 	return true
+}
+
+fn (g &FlatGen) is_known_sum_c_type(c_type string) bool {
+	for name, _ in g.tc.sum_types {
+		if g.cname(name) == c_type {
+			return true
+		}
+	}
+	return false
 }
 
 // ensure_fn_ptr_typedef_by_name emits the `_fn_ptr_<hash>` typedef registered under

--- a/vlib/v3/gen/c/types_test.v
+++ b/vlib/v3/gen/c/types_test.v
@@ -450,6 +450,39 @@ fn test_optional_payload_does_not_qualify_ambiguous_interface() {
 	assert g.stale_ambiguous_qualified_interface_c_type('Value')
 }
 
+fn test_optional_array_typedef_ignores_nominal_name_collisions() {
+	mut ast := &flat.FlatAst{}
+	mut tc := types.TypeChecker.new(ast)
+	tc.interface_names['first.Array'] = true
+	tc.interface_names['second.Array'] = true
+	tc.structs['first.Array'] = []types.StructField{}
+	tc.structs['second.Array'] = []types.StructField{}
+	mut g := FlatGen.new()
+	g.a = ast
+	g.tc = &tc
+
+	assert g.stale_ambiguous_qualified_interface_c_type('Array')
+	assert g.stale_ambiguous_qualified_struct_c_type('Array')
+	assert g.emit_optional_typedef('Optional_Array', 'Array')
+	assert g.sb.str().contains('Array value; } Optional_Array;')
+}
+
+fn test_optional_sum_typedef_ignores_struct_name_collisions() {
+	mut ast := &flat.FlatAst{}
+	mut tc := types.TypeChecker.new(ast)
+	tc.sum_types['types.Type'] = ['types.Primitive', 'types.Struct']
+	tc.structs['first.Type'] = []types.StructField{}
+	tc.structs['second.Type'] = []types.StructField{}
+	mut g := FlatGen.new()
+	g.a = ast
+	g.tc = &tc
+
+	assert g.stale_missing_qualified_struct_c_type('types__Type')
+	assert g.is_known_sum_c_type('types__Type')
+	assert g.emit_optional_typedef('Optional_types__Type', 'types__Type')
+	assert g.sb.str().contains('types__Type value; } Optional_types__Type;')
+}
+
 fn test_declaration_signature_scan_ignores_unscoped_regular_fn_nodes() {
 	mut ast := flat.FlatAst.new()
 	ast.add_node(flat.Node{

--- a/vlib/v3/gen/c/windows_entry_point_test.v
+++ b/vlib/v3/gen/c/windows_entry_point_test.v
@@ -11,9 +11,10 @@ fn windows_entry_point_gen(subsystem pref.Subsystem, c_flags []string) FlatGen {
 }
 
 fn test_windows_entry_point_uses_gui_subsystem_for_gdi32() {
-	g := windows_entry_point_gen(.auto, ['-lgdi32'])
+	mut g := windows_entry_point_gen(.auto, ['-lgdi32'])
 	declaration := g.c_main_declaration(false)
 	assert declaration.starts_with('int WINAPI wWinMain(')
+	assert g.generated_windows_gui_entry_point()? == true
 	assert declaration.contains('GetCommandLineW()')
 	assert declaration.contains('CommandLineToArgvW(full_cmd_line, &argc)')
 	assert declaration.contains('AttachConsole(ATTACH_PARENT_PROCESS)')
@@ -21,19 +22,23 @@ fn test_windows_entry_point_uses_gui_subsystem_for_gdi32() {
 }
 
 fn test_windows_entry_point_honors_console_attribute_and_subsystem() {
-	auto := windows_entry_point_gen(.auto, ['-lgdi32'])
+	mut auto := windows_entry_point_gen(.auto, ['-lgdi32'])
 	assert auto.c_main_declaration(true).starts_with('int wmain(')
+	assert auto.generated_windows_gui_entry_point()? == false
 
-	console := windows_entry_point_gen(.console, ['-lgdi32'])
+	mut console := windows_entry_point_gen(.console, ['-lgdi32'])
 	assert console.c_main_declaration(false).starts_with('int wmain(')
+	assert console.generated_windows_gui_entry_point()? == false
 
-	windows := windows_entry_point_gen(.windows, []string{})
+	mut windows := windows_entry_point_gen(.windows, []string{})
 	windows_declaration := windows.c_main_declaration(true)
 	assert windows_declaration.starts_with('int WINAPI wWinMain(')
+	assert windows.generated_windows_gui_entry_point()? == true
 	assert windows_declaration.contains('AllocConsole()')
 }
 
 fn test_windows_entry_point_defaults_to_console() {
-	g := windows_entry_point_gen(.auto, []string{})
+	mut g := windows_entry_point_gen(.auto, []string{})
 	assert g.c_main_declaration(false).starts_with('int wmain(')
+	assert g.generated_windows_gui_entry_point()? == false
 }

--- a/vlib/v3/gen/c/windows_entry_point_test.v
+++ b/vlib/v3/gen/c/windows_entry_point_test.v
@@ -1,0 +1,39 @@
+module c
+
+import v3.pref
+
+fn windows_entry_point_gen(subsystem pref.Subsystem, c_flags []string) FlatGen {
+	mut g := FlatGen.new()
+	g.set_target(pref.target_from('windows', 'amd64') or { panic(err) })
+	g.set_subsystem(subsystem)
+	g.c_flags = c_flags
+	return g
+}
+
+fn test_windows_entry_point_uses_gui_subsystem_for_gdi32() {
+	g := windows_entry_point_gen(.auto, ['-lgdi32'])
+	declaration := g.c_main_declaration(false)
+	assert declaration.starts_with('int WINAPI wWinMain(')
+	assert declaration.contains('GetCommandLineW()')
+	assert declaration.contains('CommandLineToArgvW(full_cmd_line, &argc)')
+	assert declaration.contains('AttachConsole(ATTACH_PARENT_PROCESS)')
+	assert declaration.contains('freopen_s(&res_fp, "NUL", "w", stderr)')
+}
+
+fn test_windows_entry_point_honors_console_attribute_and_subsystem() {
+	auto := windows_entry_point_gen(.auto, ['-lgdi32'])
+	assert auto.c_main_declaration(true).starts_with('int wmain(')
+
+	console := windows_entry_point_gen(.console, ['-lgdi32'])
+	assert console.c_main_declaration(false).starts_with('int wmain(')
+
+	windows := windows_entry_point_gen(.windows, []string{})
+	windows_declaration := windows.c_main_declaration(true)
+	assert windows_declaration.starts_with('int WINAPI wWinMain(')
+	assert windows_declaration.contains('AllocConsole()')
+}
+
+fn test_windows_entry_point_defaults_to_console() {
+	g := windows_entry_point_gen(.auto, []string{})
+	assert g.c_main_declaration(false).starts_with('int wmain(')
+}

--- a/vlib/v3/gen/fastc/macho_sign.v
+++ b/vlib/v3/gen/fastc/macho_sign.v
@@ -3,8 +3,6 @@ module fastc
 import crypto.sha256
 import os
 
-fn C.ftruncate(i32, u64) i32
-
 // TinyCC signs the executables it links on macOS by running Apple's
 // `codesign -f -s - <file>`, and that tool costs about 50 ms per build,
 // half of TinyCC's own time for the self-host. The drivers therefore put a
@@ -132,7 +130,7 @@ fn fastc_sign_macho_adhoc_buffered(path string) ! {
 	if patch.original_len > patch.final_len {
 		// A larger old signature is cut off.
 		out.flush()
-		if C.ftruncate(i32(out.fd), u64(patch.final_len)) != 0 {
+		if fastc_truncate_file_descriptor(i32(out.fd), u64(patch.final_len)) != 0 {
 			out.close()
 			return error('`${path}`: could not truncate the old signature')
 		}

--- a/vlib/v3/gen/fastc/macho_sign_truncate.c.v
+++ b/vlib/v3/gen/fastc/macho_sign_truncate.c.v
@@ -1,0 +1,13 @@
+module fastc
+
+fn C.ftruncate(i32, u64) i32
+
+fn C._chsize_s(i32, u64) i32
+
+fn fastc_truncate_file_descriptor(fd i32, len u64) i32 {
+	$if windows {
+		return C._chsize_s(fd, len)
+	} $else {
+		return C.ftruncate(fd, len)
+	}
+}

--- a/vlib/v3/gen/fastc/unit_compile_windows.c.v
+++ b/vlib/v3/gen/fastc/unit_compile_windows.c.v
@@ -38,6 +38,21 @@ pub fn fastc_compile_prestarted_rendering_c_units(mut _ FastcPrestartedCUnits, m
 	return error('prestarted FastC units are unavailable on Windows')
 }
 
+// fastc_compile_rendering_c_units waits for the rendering workers, writes their
+// output to the temporary unit files, and compiles those files concurrently.
+// Windows' process wrapper cannot stream the rendered source over stdin yet.
+pub fn fastc_compile_rendering_c_units(tcc string, base_args []string, mut rendering FastcRenderingCUnits, prepared FastcPreparedUnits, mut _ FastcPreparedLink, _ bool) ![]string {
+	if rendering.paths.len != rendering.workers.len
+		|| prepared.entries.len != rendering.paths.len {
+		return error('invalid rendering FastC unit layout')
+	}
+	mut sources := []string{len: rendering.paths.len}
+	for i in rendering.order {
+		sources[i] = rendering.workers[i].wait()
+	}
+	return fastc_compile_c_unit_texts(tcc, base_args, rendering.paths, sources, prepared)
+}
+
 // fastc_compile_c_units compiles the translation units to objects with
 // concurrent TinyCC processes and returns the object paths, or the output of
 // the first compile that failed.

--- a/vlib/v3/pref/pref.v
+++ b/vlib/v3/pref/pref.v
@@ -27,6 +27,13 @@ const macos_v3_private_environment_names = [
 	macos_v3_caller_no_fallback_present_env,
 ]
 
+// Subsystem selects the Windows executable subsystem.
+pub enum Subsystem {
+	auto
+	console
+	windows
+}
+
 // Preferences represents preferences data used by pref.
 pub struct Preferences {
 pub mut:
@@ -55,6 +62,7 @@ pub mut:
 	is_livemain           bool
 	is_liveshared         bool
 	is_shared             bool
+	subsystem             Subsystem
 	no_builtin            bool
 	no_preludes           bool
 	module_search_paths   []string

--- a/vlib/v3/tests/header_owned_c_struct_codegen_test.v
+++ b/vlib/v3/tests/header_owned_c_struct_codegen_test.v
@@ -43,6 +43,9 @@ fn test_plain_v_header_owned_c_structs_are_not_redeclared() {
 typedef struct V3HeaderOwnedImpl_ {
 	long long value;
 } V3HeaderOwnedAlias;
+typedef struct {
+	long long value;
+} _V3HeaderOwnedAlias;
 typedef struct V3HeaderOwnedTag {
 	long long value;
 } V3HeaderOwnedTag;
@@ -59,18 +62,26 @@ struct C.V3HeaderOwnedAlias {
 	value int
 }
 
+@[typedef]
+struct C._V3HeaderOwnedAlias {
+	value int
+}
+
 struct C.V3HeaderOwnedTag {
 	value int
 }
 
 fn main() {
 	alias := C.V3HeaderOwnedAlias{
-		value: 40
+		value: 20
+	}
+	private_alias := C._V3HeaderOwnedAlias{
+		value: 20
 	}
 	tag := C.V3HeaderOwnedTag{
 		value: 2
 	}
-	println(alias.value + tag.value)
+	println(alias.value + private_alias.value + tag.value)
 }
 ')!
 	out := os.join_path(root, 'out')
@@ -82,6 +93,7 @@ fn main() {
 	generated := os.read_file(out + '.c')!
 	assert !generated.contains('typedef struct V3HeaderOwnedAlias V3HeaderOwnedAlias;'), generated
 	assert !generated.contains('struct V3HeaderOwnedAlias {'), generated
+	assert !generated.contains('struct _V3HeaderOwnedAlias'), generated
 	assert !generated.contains('struct V3HeaderOwnedTag {'), generated
 }
 

--- a/vlib/v3/tests/windows_c_alias_cast_codegen_test.v
+++ b/vlib/v3/tests/windows_c_alias_cast_codegen_test.v
@@ -1,0 +1,30 @@
+import os
+
+const windows_c_alias_vexe = @VEXE
+const windows_c_alias_tests_dir = os.dir(@FILE)
+const windows_c_alias_v3_dir = os.dir(windows_c_alias_tests_dir)
+const windows_c_alias_vlib_dir = os.dir(windows_c_alias_v3_dir)
+const windows_c_alias_v3_src = os.join_path(windows_c_alias_v3_dir, 'v3.v')
+
+fn test_windows_c_alias_cast_generates_a_c_cast() {
+	root := os.join_path(os.temp_dir(), 'v3_windows_c_alias_${os.getpid()}')
+	os.rmdir_all(root) or {}
+	os.mkdir_all(root)!
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	v3_bin := os.join_path(root, 'v3')
+	build := os.execute('${os.quoted_path(windows_c_alias_vexe)} -old-compiler -gc none -path "${windows_c_alias_vlib_dir}|@vlib|@vmodules" -o ${os.quoted_path(v3_bin)} ${os.quoted_path(windows_c_alias_v3_src)}')
+	assert build.exit_code == 0, build.output
+	source := os.join_path(root, 'main.v')
+	os.write_file(source, "import os\nimport v.build_constraint\n\nfn main() {\n\t_ := os.stat('.') or { return }\n\tenvironment := build_constraint.new_environment(['windows'], [])\n\t_ := environment.eval('windows') or { false }\n}\n")!
+	c_path := os.join_path(root, 'main.c')
+	generate := os.execute('${os.quoted_path(v3_bin)} -silent -no-parallel -os windows -cc tcc -gc none -o ${os.quoted_path(c_path)} ${os.quoted_path(source)}')
+	assert generate.exit_code == 0, generate.output
+	c_source := os.read_file(c_path)!
+	assert c_source.contains('int wmain(int argc, wchar_t** argv) {'), c_source
+	assert c_source.contains('u32 mode = (DWORD)(0);'), c_source
+	assert !c_source.contains('typedef struct __stat64 __stat64;'), c_source
+	assert c_source.contains('typedef struct Optional_Array {'), c_source
+	assert !c_source.contains('CreatePipe(&__ref_arg_'), c_source
+}

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -1827,9 +1827,16 @@ fn (mut t Transformer) transform_call_arg_for_named_param(arg_id flat.NodeId, pa
 	// C declarations often use `voidptr` as an intentionally opaque placeholder
 	// for a native by-value type whose full declaration lives in an inserted C or
 	// Objective-C source. Match the legacy backend by leaving such C arguments in
-	// value form; callers that need an actual pointer spell `&value` explicitly.
-	if call_name.starts_with('C.') && transform_param_type_is_void_pointer(param_type) {
-		return t.transform_expr(arg_id)
+	// value form. An explicit opaque-pointer cast also owns its pointer depth even
+	// when an included header refines the parameter to `void**` (for example,
+	// `CreatePipe(voidptr(&handle))`).
+	if call_name.starts_with('C.') {
+		arg_node := t.a.nodes[int(arg_id)]
+		if transform_param_type_is_void_pointer(param_type)
+			|| (arg_node.kind == .cast_expr
+				&& transform_param_type_is_void_pointer(t.node_type(arg_id))) {
+			return t.transform_expr(arg_id)
+		}
 	}
 	return t.transform_call_arg_for_param(arg_id, param_type)
 }

--- a/vlib/v3/types/c_type_cache_identity_test.v
+++ b/vlib/v3/types/c_type_cache_identity_test.v
@@ -54,3 +54,12 @@ fn test_c_type_cache_reuses_entry_for_equal_types() {
 	})
 	assert tc.c_type(first) == tc.c_type(again)
 }
+
+fn test_private_c_struct_names_keep_the_struct_tag() {
+	mut a := flat.FlatAst.new()
+	mut tc := TypeChecker.new(&a)
+	stat_type := Type(Struct{
+		name: 'C.__stat64'
+	})
+	assert tc.c_type(stat_type) == 'struct __stat64'
+}

--- a/vlib/v3/types/c_type_cache_identity_test.v
+++ b/vlib/v3/types/c_type_cache_identity_test.v
@@ -12,13 +12,13 @@ fn test_c_type_cache_distinguishes_same_named_fixed_arrays() {
 
 	t3 := Type(ArrayFixed{
 		elem_type: Type(int_)
-		len:       3
-		len_expr:  'size'
+		len: 3
+		len_expr: 'size'
 	})
 	t5 := Type(ArrayFixed{
 		elem_type: Type(int_)
-		len:       5
-		len_expr:  'size'
+		len: 5
+		len_expr: 'size'
 	})
 
 	// Same source spelling: this is what a textual cache key would collapse.
@@ -44,13 +44,13 @@ fn test_c_type_cache_reuses_entry_for_equal_types() {
 	mut tc := TypeChecker.new(&a)
 	first := Type(ArrayFixed{
 		elem_type: Type(int_)
-		len:       7
-		len_expr:  'n'
+		len: 7
+		len_expr: 'n'
 	})
 	again := Type(ArrayFixed{
 		elem_type: Type(int_)
-		len:       7
-		len_expr:  'n'
+		len: 7
+		len_expr: 'n'
 	})
 	assert tc.c_type(first) == tc.c_type(again)
 }
@@ -62,4 +62,14 @@ fn test_private_c_struct_names_keep_the_struct_tag() {
 		name: 'C.__stat64'
 	})
 	assert tc.c_type(stat_type) == 'struct __stat64'
+}
+
+fn test_private_typedef_c_struct_names_keep_the_typedef_name() {
+	mut a := flat.FlatAst.new()
+	mut tc := TypeChecker.new(&a)
+	tc.c_typedef_structs['C._Foo'] = true
+	typedef_type := Type(Struct{
+		name: 'C._Foo'
+	})
+	assert tc.c_type(typedef_type) == '_Foo'
 }

--- a/vlib/v3/types/c_type_cache_identity_test.v
+++ b/vlib/v3/types/c_type_cache_identity_test.v
@@ -64,6 +64,15 @@ fn test_private_c_struct_names_keep_the_struct_tag() {
 	assert tc.c_type(stat_type) == 'struct __stat64'
 }
 
+fn test_wsa_data_keeps_the_windows_struct_tag() {
+	mut a := flat.FlatAst.new()
+	mut tc := TypeChecker.new(&a)
+	wsa_data_type := Type(Struct{
+		name: 'C.WSAData'
+	})
+	assert tc.c_type(wsa_data_type) == 'struct WSAData'
+}
+
 fn test_private_typedef_c_struct_names_keep_the_typedef_name() {
 	mut a := flat.FlatAst.new()
 	mut tc := TypeChecker.new(&a)

--- a/vlib/v3/types/checker_tail.v
+++ b/vlib/v3/types/checker_tail.v
@@ -3322,6 +3322,9 @@ fn (mut tc TypeChecker) check_call(id flat.NodeId, node flat.Node) {
 		}
 		callee_id := tc.a.child(&node, 0)
 		callee := tc.a.child_node(&node, 0)
+		if tc.check_c_alias_cast_call(id, node, callee) {
+			return
+		}
 		if callee.kind == .selector && callee.children_count > 0 {
 			receiver_id := tc.a.child(callee, 0)
 			receiver := tc.a.node(receiver_id)
@@ -4041,7 +4044,7 @@ fn (tc &TypeChecker) v_source_fn_has_body(name string) bool {
 	return false
 }
 
-fn (mut tc TypeChecker) rewrite_c_alias_call_as_cast(id flat.NodeId, node flat.Node, callee flat.Node) bool {
+fn (mut tc TypeChecker) check_c_alias_cast_call(id flat.NodeId, node flat.Node, callee flat.Node) bool {
 	if callee.kind != .selector || callee.children_count == 0 || node.children_count != 2 {
 		return false
 	}
@@ -4050,7 +4053,7 @@ fn (mut tc TypeChecker) rewrite_c_alias_call_as_cast(id flat.NodeId, node flat.N
 	if base.kind != .ident || base.value != 'C' || type_name !in tc.type_aliases {
 		return false
 	}
-	tc.a.nodes[int(id)] = flat.Node{
+	cast_node := flat.Node{
 		kind:                 .cast_expr
 		value:                type_name
 		typ:                  node.typ
@@ -4062,7 +4065,7 @@ fn (mut tc TypeChecker) rewrite_c_alias_call_as_cast(id flat.NodeId, node flat.N
 		op:                   node.op
 		skip_ownership_drops: node.skip_ownership_drops
 	}
-	tc.check_cast_expr(id, tc.a.nodes[int(id)])
+	tc.check_cast_expr(id, cast_node)
 	return true
 }
 

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -16223,6 +16223,13 @@ fn (tc &TypeChecker) c_type_uncached(t Type) string {
 		}
 		if t.name.starts_with('C.') {
 			raw := t.name[2..]
+			// A struct declared `@[typedef] struct C.foo {}` is referenced by its
+			// typedef name (`foo`), never as `struct foo` — the C header (and v3's own
+			// emitted `typedef struct {...} foo;`) has no matching `struct foo` tag, so
+			// a `struct foo` reference would stay an incomplete type.
+			if t.name in tc.c_typedef_structs {
+				return raw
+			}
 			if raw.starts_with('_') {
 				return 'struct ${raw}'
 			}
@@ -16231,13 +16238,6 @@ fn (tc &TypeChecker) c_type_uncached(t Type) string {
 				if closure_name in tc.structs {
 					return tc.c_struct_type_name(closure_name)
 				}
-			}
-			// A struct declared `@[typedef] struct C.foo {}` is referenced by its
-			// typedef name (`foo`), never as `struct foo` — the C header (and v3's own
-			// emitted `typedef struct {...} foo;`) has no matching `struct foo` tag, so
-			// a `struct foo` reference would stay an incomplete type.
-			if t.name in tc.c_typedef_structs {
-				return raw
 			}
 			if raw.ends_with('_s')
 				|| (raw.len > 0 && raw[0] >= `a` && raw[0] <= `z` && !raw.ends_with('_t')) {

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -16223,6 +16223,9 @@ fn (tc &TypeChecker) c_type_uncached(t Type) string {
 		}
 		if t.name.starts_with('C.') {
 			raw := t.name[2..]
+			if raw.starts_with('_') {
+				return 'struct ${raw}'
+			}
 			if raw.starts_with('builtin__closure__') {
 				closure_name := 'closure.${raw['builtin__closure__'.len..]}'
 				if closure_name in tc.structs {

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -16230,7 +16230,8 @@ fn (tc &TypeChecker) c_type_uncached(t Type) string {
 			if t.name in tc.c_typedef_structs {
 				return raw
 			}
-			if raw.starts_with('_') {
+			// Winsock exposes WSAData only as a struct tag; its typedef is WSADATA.
+			if raw == 'WSAData' || raw.starts_with('_') {
 				return 'struct ${raw}'
 			}
 			if raw.starts_with('builtin__closure__') {


### PR DESCRIPTION
## Summary

- embed the V3 driver in the default Windows `cmd/v`, matching macOS, BSD, and Linux
- build `v1_fallback.exe` in both GNU make and `makev.bat` bootstrap flows so `-old-compiler` and automatic compatibility retries remain available
- make V3 Windows/TCC compilation use the correct compiler resources, WinAPI preamble, Unicode entry point, PE stack reserve, C alias lowering, and concrete optional signatures
- add the missing Windows FastC unit renderer and a portable Mach-O truncation helper
- document the expanded default-platform and fallback behavior

## Testing

- `./v -nocache -g -keepc -o ./vnew cmd/v`
- `./vnew -silent cmd/v/macos_v3_test.v`
- `./vnew -silent cmd/v/macos_v3_compat_routing_test.v`
- `./vnew -silent cmd/tools/vself_test.v`
- `./vnew -silent test vlib/v3/driver/` — 9/9 passed
- `./vnew -silent test vlib/v3/gen/c/` — 19/19 passed
- `./vnew -silent vlib/v3/gen/fastc/macho_sign_test.v`
- `./vnew -silent vlib/v3/tests/windows_c_alias_cast_codegen_test.v`
- `./vnew -old-compiler -silent vlib/v/compiler_errors_test.v` — 1707 passed, 1 skipped
- `./vnew fmt -verify` for every changed V file
- `./vnew check-md vlib/v3/README.md`
- full `WINEDEBUG=-all VFLAGS=-nocache wine cmd /d /c makev.bat -tcc --local` bootstrap in the available x86_64 QEMU guest
- verified the resulting `v.exe` and `v1_fallback.exe` both reserve 32 MiB stacks and compile/run hello-world through default V3 and `-old-compiler`

The available QEMU guest runs Debian 13 with Wine 10 rather than a Windows kernel, so native Windows CI remains the final platform check. Repository-wide `test-all` was not run locally.