### PR TITLE
v3: support single-quoted VML strings

### DIFF
--- a/doc/docs.md
+++ b/doc/docs.md
@@ -7286,6 +7286,9 @@ by an `id`. An ID on an earlier node is available to following nodes in the same
 Both quoted and unquoted `#RRGGBB` color values are accepted. A `Repeater` requires `model`
 and stable `key` properties and exposes `item` and `index` inside its delegate.
 
+String literals may use either double (`"`) or single (`'`) quote delimiters. Escape a matching
+quote or a backslash with `\`; `\n` and `\t` are also supported.
+
 The `bind.text`, `bind.checked`, `bind.active`, and `bind.value` properties create two-way
 bindings to mutable top-level fields on `app`. Event properties `on_tap`, `on_change`,
 `on_active`, `on_text`, and `on_submit` call an `app` method with zero or one argument. These

--- a/vlib/v3/parser/vml.v
+++ b/vlib/v3/parser/vml.v
@@ -491,23 +491,23 @@ fn (mut p VmlSourceParser) parse_primary() !&VmlExpr {
 }
 
 fn vml_interpolation_end(value string, start int) ?int {
-	mut quoted := false
+	mut quote := u8(0)
 	mut escaped := false
 	mut nested_braces := 0
 	for i := start; i < value.len; i++ {
 		ch := value[i]
-		if quoted {
+		if quote != 0 {
 			if escaped {
 				escaped = false
 			} else if ch == `\\` {
 				escaped = true
-			} else if ch == `"` {
-				quoted = false
+			} else if ch == quote {
+				quote = 0
 			}
 			continue
 		}
-		if ch == `"` {
-			quoted = true
+		if ch == `"` || ch == `'` {
+			quote = ch
 		} else if ch == `{` {
 			nested_braces++
 		} else if ch == `}` {

--- a/vlib/v3/parser/vml.v
+++ b/vlib/v3/parser/vml.v
@@ -102,7 +102,7 @@ fn (mut l VmlLexer) read_number() VmlToken {
 
 fn (mut l VmlLexer) read_string() !VmlToken {
 	line := l.line
-	l.advance()
+	quote := l.advance()
 	mut value := []u8{}
 	for l.pos < l.source.len {
 		c := l.advance()
@@ -113,9 +113,10 @@ fn (mut l VmlLexer) read_string() !VmlToken {
 				`t` { value << `\t` }
 				`\\` { value << `\\` }
 				`"` { value << `"` }
+				`'` { value << `'` }
 				else { value << next }
 			}
-		} else if c == `"` {
+		} else if c == quote {
 			return VmlToken{.string_, value.bytestr(), line}
 		} else {
 			value << c
@@ -196,7 +197,7 @@ fn tokenize_vml(source string) ![]VmlToken {
 				}
 				tokens << VmlToken{.or, '||', line}
 			}
-			`"` {
+			`"`, `'` {
 				tokens << lexer.read_string()!
 				continue
 			}

--- a/vlib/v3/tests/vml_codegen_test.v
+++ b/vlib/v3/tests/vml_codegen_test.v
@@ -260,6 +260,18 @@ fn main() {
 	invalid_private := os.execute('${v3_bin} -nocache -path "${root}|${vml_codegen_vlib_dir}" -b c -o ${bin} ${main_path}')
 	assert invalid_private.exit_code != 0, invalid_private.output
 	assert invalid_private.output.contains('must be public'), invalid_private.output
+	os.write_file(os.join_path(root, 'single_quotes.vml'), 'Screen { Label { text: \'It\\\'s "ready"\' tooltip: \'line one\\nline two\' } }') or {
+		panic(err)
+	}
+	single_quotes_path := os.join_path(root, 'single_quotes.v')
+	os.write_file(single_quotes_path, "module main\n\nimport ui2\n\nstruct App {}\n\nfn build(app &App) ui2.Element {\n\treturn \$vml('single_quotes.vml')\n}\n\nfn main() {\n\tapp := App{}\n\troot := build(&app)\n\tprintln(root.children[0].text + ':' + root.children[0].tooltip)\n}\n") or {
+		panic(err)
+	}
+	single_quotes_compile := os.execute('${v3_bin} -nocache -path "${root}|${vml_codegen_vlib_dir}" -b c -o ${bin} ${single_quotes_path}')
+	assert single_quotes_compile.exit_code == 0, single_quotes_compile.output
+	single_quotes_run := os.execute(bin)
+	assert single_quotes_run.exit_code == 0, single_quotes_run.output
+	assert single_quotes_run.output == 'It\'s "ready":line one\nline two\n', single_quotes_run.output
 }
 
 /* MOCK_UI2

--- a/vlib/v3/tests/vml_codegen_test.v
+++ b/vlib/v3/tests/vml_codegen_test.v
@@ -260,18 +260,18 @@ fn main() {
 	invalid_private := os.execute('${v3_bin} -nocache -path "${root}|${vml_codegen_vlib_dir}" -b c -o ${bin} ${main_path}')
 	assert invalid_private.exit_code != 0, invalid_private.output
 	assert invalid_private.output.contains('must be public'), invalid_private.output
-	os.write_file(os.join_path(root, 'single_quotes.vml'), 'Screen { Label { text: \'It\\\'s "ready"\' tooltip: \'line one\\nline two\' } }') or {
+	os.write_file(os.join_path(root, 'single_quotes.vml'), 'Screen { Label { text: \'It\\\'s "ready"\' tooltip: \'line one\\nline two\' } Label { text: "\${app.label(\'}\')}" } }') or {
 		panic(err)
 	}
 	single_quotes_path := os.join_path(root, 'single_quotes.v')
-	os.write_file(single_quotes_path, "module main\n\nimport ui2\n\nstruct App {}\n\nfn build(app &App) ui2.Element {\n\treturn \$vml('single_quotes.vml')\n}\n\nfn main() {\n\tapp := App{}\n\troot := build(&app)\n\tprintln(root.children[0].text + ':' + root.children[0].tooltip)\n}\n") or {
+	os.write_file(single_quotes_path, "module main\n\nimport ui2\n\nstruct App {}\n\npub fn (app &App) label(value string) string {\n\t_ = app\n\treturn value\n}\n\nfn build(app &App) ui2.Element {\n\treturn \$vml('single_quotes.vml')\n}\n\nfn main() {\n\tapp := App{}\n\troot := build(&app)\n\tprintln(root.children[0].text + ':' + root.children[0].tooltip + ':' + root.children[1].text)\n}\n") or {
 		panic(err)
 	}
 	single_quotes_compile := os.execute('${v3_bin} -nocache -path "${root}|${vml_codegen_vlib_dir}" -b c -o ${bin} ${single_quotes_path}')
 	assert single_quotes_compile.exit_code == 0, single_quotes_compile.output
 	single_quotes_run := os.execute(bin)
 	assert single_quotes_run.exit_code == 0, single_quotes_run.output
-	assert single_quotes_run.output == 'It\'s "ready":line one\nline two\n', single_quotes_run.output
+	assert single_quotes_run.output == 'It\'s "ready":line one\nline two:}\n', single_quotes_run.output
 }
 
 /* MOCK_UI2


### PR DESCRIPTION
Adds single-quoted string literals to compile-time `$vml`, including escaped apostrophes.

This matches UI2 runtime VML support from vlang/ui2#21.

Tests: `./vnew -path "/Users/alex/code/v-vml-single-quotes/vlib|@vlib|@vmodules" vlib/v3/tests/vml_codegen_test.v`