### PR TITLE
json2: avoid panic on malformed JSON ending with newline

### DIFF
--- a/vlib/json2/decode.v
+++ b/vlib/json2/decode.v
@@ -212,7 +212,7 @@ fn (mut checker Decoder) checker_error(message string) ! {
 	mut context_end := int_min(checker.json.len, position + max_extra_characters)
 	context_end_newline := checker.json[position..context_end].index_u8(`\n`)
 
-	if context_end_newline != -1 {
+	if context_end_newline > 0 {
 		context_end = position + context_end_newline
 	}
 

--- a/vlib/json2/tests/checker_test.v
+++ b/vlib/json2/tests/checker_test.v
@@ -168,6 +168,10 @@ fn test_check_json_format() {
 			'json':  '{"key": "value"    '
 			'error': 'Syntax: EOF: expected object end'
 		},
+		{
+			'json':  '{\n"a": 1\n'
+			'error': 'Syntax: EOF: expected object end'
+		},
 	]
 
 	for json_and_error in json_and_error_message {


### PR DESCRIPTION
## Summary

- prevent error-context construction from creating a reversed string slice when the error byte is a newline
- return `JsonDecodeError` for an unterminated object ending with a newline
- add a regression case for the reported malformed input

## Tests

- `./vnew -silent vlib/json2/tests/checker_test.v`
- exact `x.json2` reproducer
- `./vnew -old-compiler -silent test vlib/json2/` (73 passed, 1 skipped)

The default V3 full suite has one unrelated `decode_embed_reference_test.v` failure that is reproducible with `decode.v` restored to `HEAD`; the targeted default-compiler regression test passes.