### PR TITLE
cmd: dispatch explicit build commands to V3

### DIFF
--- a/cmd/v/macos_v3_dispatch.c.v
+++ b/cmd/v/macos_v3_dispatch.c.v
@@ -230,8 +230,10 @@ fn launch_macos_v3_compiler(prefs &pref.Preferences, raw_args []string) {
 	mut environment := macos_v3_child_environment(vexe, caller_environment, dispatch_environment)
 	no_fallback := environment[macos_v3_no_fallback_env] or { '' }
 	// cmd/v self-builds deliberately remain V3-only. The compatibility compiler
-	// exists for user programs and tools, not as an alternate self-host path.
-	fallback_enabled := !prefs.new_compiler && no_fallback != '1'
+	// exists for user programs and tools, not as an alternate self-host path. An
+	// empty path belongs to explicit `build` argument validation, which V1 cannot
+	// recover and would only report again with a less useful empty-path error.
+	fallback_enabled := prefs.path != '' && !prefs.new_compiler && no_fallback != '1'
 		&& !macos_v3_is_self_build_target(prefs)
 	fallback_file := macos_v3_fallback_file_for_pid()
 	c_error_dir := macos_v3_c_error_report_dir(fallback_file)

--- a/cmd/v/macos_v3_dispatch.c.v
+++ b/cmd/v/macos_v3_dispatch.c.v
@@ -197,11 +197,21 @@ fn macos_v3_windows_msvc_needs_v1_compatibility(prefs &pref.Preferences, host_os
 
 fn is_macos_v3_relevant_command(command string, prefs &pref.Preferences) bool {
 	if prefs.backend != .c || command == 'test' || command in external_tools
-		|| macos_v3_non_compilation_command(command) || prefs.path == '' {
+		|| macos_v3_non_compilation_command(command) {
+		return false
+	}
+	// The legacy preference parser deliberately rejects `v build <source>`, so it
+	// does not populate prefs.path for the explicit build command. Let V3 parse the
+	// original arguments and report missing or invalid inputs instead of reaching
+	// the V3-only command shell's unreachable V1 builder guard.
+	if command == 'build' {
+		return true
+	}
+	if prefs.path == '' {
 		return false
 	}
 	normalized_path := prefs.path.replace('\\', '/').trim_right('/')
-	return command in ['run', 'build'] || prefs.is_script || os.is_dir(prefs.path)
+	return command == 'run' || prefs.is_script || os.is_dir(prefs.path)
 		|| normalized_path.ends_with('.v') || normalized_path.ends_with('.vsh')
 		|| normalized_path.ends_with('.vv')
 }

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -82,8 +82,12 @@ fn test_macos_v3_explicit_build_reports_a_regular_input_error() {
 	for args in [['build', 'help'], ['-new-compiler', 'build', 'help']] {
 		result := run_macos_v3_test_process(@VEXE, args, macos_v3_test_vroot, {})
 		assert result.exit_code == 1, result.output
-		assert result.output.contains("builder error: help doesn't exist"), result.output
-		assert !result.output.contains('C-backend compilation was not dispatched to V3'), result.output
+		assert result.output.trim_space() == "builder error: help doesn't exist", result.output
+	}
+	for args in [['build'], ['-new-compiler', 'build']] {
+		result := run_macos_v3_test_process(@VEXE, args, macos_v3_test_vroot, {})
+		assert result.exit_code == 1, result.output
+		assert result.output.trim_space() == 'no input file', result.output
 	}
 }
 

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -68,13 +68,22 @@ fn test_macos_v3_relevant_command_owns_every_direct_c_build() {
 	assert is_macos_v3_relevant_command('cmd/v', prefs)
 	prefs.old_compiler = false
 	prefs.path = ''
-	assert !is_macos_v3_relevant_command('build', prefs)
+	assert is_macos_v3_relevant_command('build', prefs)
 	prefs.path = 'main.v'
 	prefs.backend = .js_node
 	assert !is_macos_v3_relevant_command('main.v', prefs)
 	prefs.backend = .c
 	for command in ['test', 'fmt', 'version', 'crun', 'build-module'] {
 		assert !is_macos_v3_relevant_command(command, prefs)
+	}
+}
+
+fn test_macos_v3_explicit_build_reports_a_regular_input_error() {
+	for args in [['build', 'help'], ['-new-compiler', 'build', 'help']] {
+		result := run_macos_v3_test_process(@VEXE, args, macos_v3_test_vroot, {})
+		assert result.exit_code == 1, result.output
+		assert result.output.contains("builder error: help doesn't exist"), result.output
+		assert !result.output.contains('C-backend compilation was not dispatched to V3'), result.output
 	}
 }
 


### PR DESCRIPTION
## Summary

- route explicit `build` commands to the embedded V3 driver even when the legacy preference parser leaves `prefs.path` empty
- report normal missing or invalid input diagnostics instead of reaching the V3-only command shell internal-error guard
- cover both default and strict `-new-compiler` invocation paths

## Tests

- `./v -g -keepc -o ./vnew cmd/v`
- `./vnew -silent test cmd/v/macos_v3_test.v`
- `./vnew -silent test cmd/v/macos_v3_compat_routing_test.v`
- manual `./vnew build help` regression check
- `./vnew fmt -w cmd/v/macos_v3_dispatch.c.v cmd/v/macos_v3_test.v`
- `git diff --check`

The broader `./vnew -silent vlib/v/compiler_errors_test.v` was attempted but current master produced unrelated V3 output mismatches and stalled in existing malformed-parser fixtures.