### PR TITLE
vfmt: preserve original string literal spelling

### DIFF
--- a/vlib/v3/gen/v/README.md
+++ b/vlib/v3/gen/v/README.md
@@ -1,0 +1,25 @@
+# V3 source formatter
+
+The V3 formatter formats source syntax without type checking.
+
+## String literal spelling
+
+Non-interpolated string literals retain their original source spelling, including
+quote delimiters, escape sequences, and the `r`, `c`, or `js` prefix. For example,
+`'x=\0'` stays `'x=\0'`, `'x=\x00'` stays `'x=\x00'`, and `"text"` keeps its double
+quotes. Surrounding code is still formatted normally.
+
+The formatter uses the original literal's source span rather than decoding and
+re-encoding it. This also avoids collapsing hex or Unicode escapes into characters
+and keeps a NUL followed by digits distinct from an octal escape.
+
+Literals without a usable source spelling, such as synthesized AST nodes, still
+use the existing escaping fallback. That fallback emits NUL as `\x00` so that
+following octal digits cannot change the value.
+
+The C-backend rewrite from a string literal's `.str` selector to a `c` literal
+retains the literal spelling and is stable on subsequent formatting passes.
+
+This policy does not change interpolation formatting, attribute formatting, or
+compiler/scanner escape semantics. Interpolated strings continue to use their
+existing formatting path so embedded expressions can be formatted.

--- a/vlib/v3/gen/v/gen.v
+++ b/vlib/v3/gen/v/gen.v
@@ -115,7 +115,7 @@ pub fn (mut g Gen) reset() {
 	g.suppress_trailing_comments = 0
 }
 
-// format_file parses-independent convenience: format the file whose trailing
+// format_file parses-independent convenience: format the file's trailing
 // `.file` node id is `file_id` within `a`.
 pub fn format_file(a &flat.FlatAst, file_id flat.NodeId) string {
 	mut g := Gen.new()
@@ -867,7 +867,7 @@ fn (mut g Gen) expr(id flat.NodeId) {
 		}
 		.char_literal {
 			if n.value.starts_with('c:') {
-				g.write(c_string_literal_text(n.value))
+				g.write(g.string_literal_text(n))
 			} else {
 				g.write(g.rune_literal(n))
 			}
@@ -1768,7 +1768,7 @@ fn (g &Gen) map_key_width(id flat.NodeId) int {
 		}
 		.char_literal {
 			if n.value.starts_with('c:') {
-				c_string_literal_text(n.value)
+				g.string_literal_text(n)
 			} else {
 				g.rune_literal(n)
 			}
@@ -4239,11 +4239,27 @@ fn op_str(op flat.Op) string {
 }
 
 fn (g &Gen) string_literal_text(n &flat.Node) string {
+	is_c_string := n.kind == .char_literal && n.value.starts_with('c:')
+	prefix := if is_c_string {
+		'c'
+	} else if n.typ.starts_with('raw:') {
+		'r'
+	} else if n.typ.starts_with('js:') {
+		'js'
+	} else {
+		''
+	}
 	if source := g.source_span(n.pos.offset, n.pos.end) {
-		// Physical newlines are part of a multiline literal's value and layout.
-		if source.contains('\n') || source.contains('\r') {
+		// Keep the original quotes and escapes, as gofmt does for string literals.
+		// Empty or non-literal spans can belong to synthesized nodes; use the fallback below.
+		if source.len >= prefix.len + 2 && source.starts_with(prefix)
+			&& source[prefix.len] in [`'`, `"`]
+			&& source[source.len - 1] == source[prefix.len] {
 			return source
 		}
+	}
+	if is_c_string {
+		return c_string_literal_text(n.value)
 	}
 	if n.typ.starts_with('raw:') {
 		quote := if n.typ.ends_with('"') { '"' } else { "'" }

--- a/vlib/v3/gen/v/gen.v
+++ b/vlib/v3/gen/v/gen.v
@@ -115,7 +115,7 @@ pub fn (mut g Gen) reset() {
 	g.suppress_trailing_comments = 0
 }
 
-// format_file parses-independent convenience: format the file's trailing
+// format_file parses-independent convenience: format the file whose trailing
 // `.file` node id is `file_id` within `a`.
 pub fn format_file(a &flat.FlatAst, file_id flat.NodeId) string {
 	mut g := Gen.new()
@@ -4249,7 +4249,14 @@ fn (g &Gen) string_literal_text(n &flat.Node) string {
 	} else {
 		''
 	}
-	if source := g.source_span(n.pos.offset, n.pos.end) {
+	mut start := n.pos.offset
+	// The scanner starts C-string spans at the quote, unlike raw and JS strings.
+	// Recover the adjacent prefix without changing scanner positions or synthesized nodes.
+	if is_c_string && start > 0 && start < g.source.len
+		&& g.source[start] in [`'`, `"`] && g.source[start - 1] == `c` {
+		start--
+	}
+	if source := g.source_span(start, n.pos.end) {
 		// Keep the original quotes and escapes, as gofmt does for string literals.
 		// Empty or non-literal spans can belong to synthesized nodes; use the fallback below.
 		if source.len >= prefix.len + 2 && source.starts_with(prefix)

--- a/vlib/v3/gen/v/string_literal_spelling_test.v
+++ b/vlib/v3/gen/v/string_literal_spelling_test.v
@@ -1,0 +1,148 @@
+module v
+
+import os
+import v3.flat
+import v3.parser
+import v3.pref
+
+fn parse_literal_spelling_source(name string, source string) &flat.FlatAst {
+	path := os.join_path(os.temp_dir(), 'v3_vfmt_spelling_${name}_${os.getpid()}.v')
+	os.write_file(path, source) or { panic(err) }
+	defer {
+		os.rm(path) or {}
+	}
+	mut prefs := pref.new_preferences()
+	prefs.is_fmt = true
+	prefs.preserve_comptime_conditionals = true
+	prefs.supports_inline_asm = true
+	mut p := parser.Parser.new(prefs)
+	a := p.parse_file(path)
+	assert p.diagnostics.len == 0, name
+	return a
+}
+
+fn format_literal_spelling_source(name string, source string) string {
+	return format(parse_literal_spelling_source(name, source))
+}
+
+fn assert_literal_spelling(name string, literal string) {
+	source := 'fn main() {\n\ts := ${literal}\n\t_ = s\n}\n'
+	out := format_literal_spelling_source(name, source)
+	assert out == source, '${name}: ${out}'
+	assert format_literal_spelling_source('${name}_twice', out) == out
+}
+
+fn test_formatter_preserves_each_nul_escape_spelling() {
+	literals := [
+		r"'x=\0'",
+		r"'r=nonce,x=before\0after'",
+		r"'x=\x00'",
+		r"'r=nonce,x=before\x00after'",
+		r"'x\x0041y'",
+		r"'x\041y'",
+		r"'x\00041y'",
+	]
+	for i, literal in literals {
+		assert_literal_spelling('nul_${i}', literal)
+	}
+}
+
+fn test_formatter_preserves_hex_unicode_and_backslash_spelling() {
+	literals := [
+		r"'A\x5cnB'",
+		r"'A\u005cnB'",
+		r"'A\U0000005CnB'",
+		r"'\x41\u0042\U00000043'",
+		r"'\x1B\x7f\xFF'",
+		r"'\a\b\t\n\v\f\r'",
+		r"'\$name and \\n'",
+	]
+	for i, literal in literals {
+		assert_literal_spelling('escapes_${i}', literal)
+	}
+}
+
+fn test_formatter_preserves_string_quote_delimiters() {
+	literals := [
+		r"''",
+		r'""',
+		r"'single quoted'",
+		r'"double quoted"',
+		r"'it\'s still single quoted'",
+		r'"\"double\""',
+	]
+	for i, literal in literals {
+		assert_literal_spelling('quotes_${i}', literal)
+	}
+}
+
+fn test_formatter_preserves_prefixed_string_spelling() {
+	literals := [
+		r"r'\0\x00 $name'",
+		r'r"\0\x00 $name"',
+		r"js'\x41'",
+		r'js"\x41"',
+		r"c'\0'",
+		r'c"\0"',
+		r"c'A\x5cnB'",
+	]
+	for i, literal in literals {
+		assert_literal_spelling('prefixes_${i}', literal)
+	}
+}
+
+fn test_formatter_preserves_literals_while_formatting_surrounding_code() {
+	source := "fn main(){\n  s:='x=\\0'\n  println( s )\n}\n"
+	expected := "fn main() {\n\ts := 'x=\\0'\n\tprintln(s)\n}\n"
+	out := format_literal_spelling_source('surrounding_code', source)
+	assert out == expected, out
+	assert format_literal_spelling_source('surrounding_code_twice', out) == out
+}
+
+fn test_formatter_aligns_map_keys_using_preserved_literal_spelling() {
+	source := "fn main() {\n\t_ := {\n\t\t'\\x41': 1\n\t\t'B':    2\n\t}\n}\n"
+	out := format_literal_spelling_source('map_keys', source)
+	assert out == source, out
+	assert format_literal_spelling_source('map_keys_twice', out) == out
+}
+
+fn test_formatter_keeps_c_string_selector_rewrite_idempotent() {
+	source := 'fn main() {\n\ts := "\\x41".str\n}\n'
+	expected := 'fn main() {\n\ts := c"\\x41"\n}\n'
+	out := format_literal_spelling_source('c_string_selector_spelling', source)
+	assert out == expected, out
+	assert format_literal_spelling_source('c_string_selector_spelling_twice', out) == out
+	js_out := format_with_options(parse_literal_spelling_source('js_string_selector', source),
+		FormatOptions{
+			backend: 'js'
+		})
+	assert js_out == source, js_out
+}
+
+fn test_formatter_preserves_multiline_string_contents() {
+	source := "fn main() {\n\ts := 'first\n\t  second\nlast'\n\t_ = s\n}\n"
+	out := format_literal_spelling_source('multiline', source)
+	assert out == source, out
+	assert format_literal_spelling_source('multiline_twice', out) == out
+}
+
+fn test_formatter_keeps_safe_escaping_without_literal_source() {
+	g := Gen.new()
+	// Without a source span, the fallback must not turn NUL + `41` into `\041`.
+	nul := flat.Node{
+		kind: .string_literal
+		value: 'x\x0041y'
+	}
+	assert g.string_literal_text(&nul) == r"'x\x0041y'"
+	// An ordinary string starting with `c:` is not a C-string node.
+	ordinary := flat.Node{
+		kind: .string_literal
+		value: 'c:plain'
+	}
+	assert g.string_literal_text(&ordinary) == "'c:plain'"
+	c_string := flat.Node{
+		kind: .char_literal
+		value: r'c:\0'
+	}
+	assert g.string_literal_text(&c_string) == r"c'\0'"
+}

--- a/vlib/v3/gen/v/string_literal_spelling_test.v
+++ b/vlib/v3/gen/v/string_literal_spelling_test.v
@@ -4,6 +4,7 @@ import os
 import v3.flat
 import v3.parser
 import v3.pref
+import v3.token
 
 fn parse_literal_spelling_source(name string, source string) &flat.FlatAst {
 	path := os.join_path(os.temp_dir(), 'v3_vfmt_spelling_${name}_${os.getpid()}.v')
@@ -82,12 +83,55 @@ fn test_formatter_preserves_prefixed_string_spelling() {
 		r'r"\0\x00 $name"',
 		r"js'\x41'",
 		r'js"\x41"',
+		r"c''",
+		r'c""',
 		r"c'\0'",
 		r'c"\0"',
+		r"c'\x41'",
+		r'c"\x41"',
+		r'c"\"quoted\""',
 		r"c'A\x5cnB'",
 	]
 	for i, literal in literals {
 		assert_literal_spelling('prefixes_${i}', literal)
+	}
+}
+
+fn test_formatter_recovers_c_string_prefix_from_quote_only_spans() {
+	mut g := Gen.new()
+	for literal in [r"c''", r'c""', r"c'\x41'", r'c"\x41"'] {
+		g.source = literal
+		// The scanner excludes `c` from a parsed C string's span.
+		quote_only := flat.Node{
+			kind: .char_literal
+			value: 'c:A'
+			pos: token.new_span(1, 1, literal.len)
+		}
+		assert g.string_literal_text(&quote_only) == literal
+		// Also accept nodes whose span already includes the prefix.
+		with_prefix := flat.Node{
+			kind: .char_literal
+			value: 'c:A'
+			pos: token.new_span(1, 0, literal.len)
+		}
+		assert g.string_literal_text(&with_prefix) == literal
+	}
+	// Do not borrow a different preceding byte for a synthesized node.
+	g.source = r'x"\x41"'
+	no_prefix := flat.Node{
+		kind: .char_literal
+		value: 'c:A'
+		pos: token.new_span(1, 1, g.source.len)
+	}
+	assert g.string_literal_text(&no_prefix) == "c'A'"
+	// Empty and out-of-bounds spans must still use the safe fallback.
+	for start in [0, g.source.len, g.source.len + 1] {
+		missing := flat.Node{
+			kind: .char_literal
+			value: 'c:A'
+			pos: token.new_span(1, start, start)
+		}
+		assert g.string_literal_text(&missing) == "c'A'"
 	}
 }
 


### PR DESCRIPTION
## Summary

Preserve the source spelling of non-interpolated string literals instead of decoding and re-escaping them when formatting. This follows the approach used by Go's printer for ordinary string literals: emit the original literal token and format the surrounding code.

Motivated by the literal-spelling churn visible in #28483. Both `'x=\0'` and `'x=\x00'` should remain as written; formatting should not choose between their equivalent spellings.

## Changes

- Reuse the literal's existing source span in `string_literal_text`, preserving quotes, escapes, multiline contents, and `r`/`js` prefixes.
- Check the expected prefix and quote delimiters before using the source span. Empty or non-literal spans still use the existing escaping fallback.
- Route C-string literals through the same source-preserving path, including map-key width calculation. This also keeps the existing `"text".str` → `c"text"` rewrite stable on subsequent formatting passes.
- Recover the `c` prefix excluded from parsed C-string spans: back up one byte only when the node is a C string and the source starts at a quote immediately preceded by `c`, with bounds checks. This addresses the review of the initial implementation in commit 5c701951233657fac2b592c54ca56b2be200163a.
- Keep the safe `\x00` fallback introduced by #28309 for synthesized literals without usable source text. In particular, NUL followed by `41` must not become `\041`.
- Document the policy in `vlib/v3/gen/v/README.md`.

No scanner/parser changes and no changes to escape decoding or compiler semantics. Interpolated strings and attributes retain their existing formatting paths; preserving interpolation text while still formatting embedded expressions is outside this PR's scope.

## Regression coverage

Add ten test functions in `string_literal_spelling_test.v` covering:

- the original SCRAM NUL examples, hex NUL, and octal-adjacent cases;
- hexadecimal/Unicode spelling, decoded-backslash examples, and escaped dollars;
- single/double quotes and raw, JavaScript, and C prefixes, including empty C strings and escaped quotes;
- C-string spans starting at the quote, spans already including the prefix, and missing/invalid spans;
- formatting surrounding code while preserving the literal;
- map-key alignment using the spelling actually emitted;
- C-string selector rewriting, including the JavaScript-backend exception;
- multiline contents and safe source-less fallback.

Source-based tests check parser diagnostics, exact output, and formatting a second time. The review fix adds coverage without weakening the existing assertions.

## Validation

**The V build, tests, and formatter verification have not been run locally.** The editing environment has no V executable, and attempting to clone the repository locally failed with `Could not resolve host: github.com`. The changes were pushed through the GitHub connection and the final implementation diff was inspected, but this is not a substitute for compiling and running the tests. CI validation is still needed.

Pending validation with a rebuilt compiler:

```sh
./v -g -keepc -o ./vnew cmd/v
./vnew test vlib/v3/gen/v
./vnew test cmd/tools/vfmt_test.v
./vnew test vlib/crypto/scram
./vnew fmt -verify vlib/v3/gen/v
```

Reference for the Go approach: https://go.dev/src/go/printer/printer.go (`*ast.BasicLit` prints `x.Value`).