### PR TITLE
pref: prefer system tcc when bundled tcc is unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ when no compatible bundled `thirdparty/tcc` binary is available on the host.
 The [Tiny C Compiler (tcc)](https://repo.or.cz/w/tinycc.git) is downloaded for you by `make` if
 there is a compatible version for your system, and installed under the V `thirdparty` directory.
 
+For regular non-production builds, V prefers a working bundled TCC, then a working `tcc` from
+`PATH`, before using the platform compiler. macOS keeps the platform compiler as its default due
+to SDK compatibility; use `-cc tcc` there to select TCC explicitly.
+
 On macOS, `-cc tcc -gc boehm` uses a persistent bundled `libgc.dylib` store when the physical V
 installation path contains a comma. The store is under `$XDG_DATA_HOME/v-tcc-libgc-v1`, or
 `$HOME/.local/share/v-tcc-libgc-v1` when the XDG variable is unset or empty. V creates the fallback

--- a/README.md
+++ b/README.md
@@ -209,7 +209,9 @@ The [Tiny C Compiler (tcc)](https://repo.or.cz/w/tinycc.git) is downloaded for y
 there is a compatible version for your system, and installed under the V `thirdparty` directory.
 
 For regular non-production builds on supported hosts, V prefers a working bundled TCC, then a
-working `tcc` from `PATH`, before using the platform compiler.
+working `tcc` from `PATH`, before using the platform compiler. The system fallback is selected only
+when required V runtime artifacts are available, including the bundled `libgc.a` used by default
+glibc/Boehm builds.
 
 On macOS, `-cc tcc -gc boehm` uses a persistent bundled `libgc.dylib` store when the physical V
 installation path contains a comma. The store is under `$XDG_DATA_HOME/v-tcc-libgc-v1`, or

--- a/README.md
+++ b/README.md
@@ -208,9 +208,8 @@ when no compatible bundled `thirdparty/tcc` binary is available on the host.
 The [Tiny C Compiler (tcc)](https://repo.or.cz/w/tinycc.git) is downloaded for you by `make` if
 there is a compatible version for your system, and installed under the V `thirdparty` directory.
 
-For regular non-production builds, V prefers a working bundled TCC, then a working `tcc` from
-`PATH`, before using the platform compiler. macOS keeps the platform compiler as its default due
-to SDK compatibility; use `-cc tcc` there to select TCC explicitly.
+For regular non-production builds on supported hosts, V prefers a working bundled TCC, then a
+working `tcc` from `PATH`, before using the platform compiler.
 
 On macOS, `-cc tcc -gc boehm` uses a persistent bundled `libgc.dylib` store when the physical V
 installation path contains a comma. The store is under `$XDG_DATA_HOME/v-tcc-libgc-v1`, or

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ there is a compatible version for your system, and installed under the V `thirdp
 For regular non-production builds on supported hosts, V prefers a working bundled TCC, then a
 working `tcc` from `PATH`, before using the platform compiler. The system fallback is selected only
 when required V runtime artifacts are available, including the bundled `libgc.a` used by default
-glibc/Boehm builds.
+glibc and Windows Boehm builds.
 
 On macOS, `-cc tcc -gc boehm` uses a persistent bundled `libgc.dylib` store when the physical V
 installation path contains a comma. The store is under `$XDG_DATA_HOME/v-tcc-libgc-v1`, or

--- a/vlib/v/builder/cbuilder/cbuilder.v
+++ b/vlib/v/builder/cbuilder/cbuilder.v
@@ -88,7 +88,14 @@ pub fn gen_c(mut b builder.Builder, v_files []string) strings.Builder {
 	if b.pref.parallel_cc {
 		b.cc() // Call it just to gen b.str_args
 		util.timing_start('Parallel C compilation')
-		parallel_cc(mut b, result) or { builder.verror(err.msg()) }
+		parallel_cc(mut b, result) or {
+			util.timing_measure('Parallel C compilation')
+			ccompiler := parallel_cc_compiler_path(b)
+			if b.retry_failed_tcc_compilation(ccompiler, err.msg()) {
+				return result.res_builder
+			}
+			builder.verror(err.msg())
+		}
 		util.timing_measure('Parallel C compilation')
 	}
 

--- a/vlib/v/builder/cbuilder/parallel_cc.v
+++ b/vlib/v/builder/cbuilder/parallel_cc.v
@@ -20,13 +20,16 @@ fn parallel_cc_compiler_path(b &builder.Builder) string {
 	return cc_compiler
 }
 
-fn parallel_cc_uses_tcc(cc_kind builder.CC, ccompiler string) bool {
-	if cc_kind == .tcc {
-		return true
+fn parallel_cc_bundled_tcc_root(vroot string, ccompiler string) string {
+	if ccompiler == '' {
+		return ''
 	}
-	normalized := ccompiler.replace('\\', '/').to_lower()
-	return normalized == 'tcc' || normalized.ends_with('/tcc') || normalized.ends_with('/tcc.exe')
-		|| normalized.contains('/thirdparty/tcc/')
+	bundled_tcc := os.join_path(vroot, 'thirdparty', 'tcc', 'tcc.exe')
+	compiler_path := os.find_abs_path_of_executable(ccompiler) or { ccompiler }
+	if os.real_path(compiler_path) != os.real_path(bundled_tcc) {
+		return ''
+	}
+	return os.dir(bundled_tcc)
 }
 
 fn parallel_cc_shell_safe_linker_arg(arg string) string {
@@ -101,17 +104,18 @@ fn parallel_cc(mut b builder.Builder, result c.GenOutput) ! {
 		out_files[i].close()
 	}
 
-	cc := b.quote_compiler_name(parallel_cc_compiler_path(b))
+	ccompiler := parallel_cc_compiler_path(b)
+	cc := b.quote_compiler_name(ccompiler)
 	mut compile_args := b.get_compile_args()
 	mut linker_args := b.get_linker_args()
-	if parallel_cc_uses_tcc(b.ccoptions.cc, parallel_cc_compiler_path(b)) {
+	tcc_root_dir := parallel_cc_bundled_tcc_root(b.pref.vroot, ccompiler)
+	if tcc_root_dir != '' {
 		// vlang/tcc can have its runtime objects under `${vroot}/thirdparty/tcc/lib/tcc/`
 		// or directly under `${vroot}/thirdparty/tcc/lib/`, while its system headers
 		// can be under that install dir or `${vroot}/thirdparty/tcc/include/`.
 		// `-B` controls tcc's include search (`${B}/include`) and `-L` adds a library search path,
 		// so pass absolute paths for both. This lets tcc find them regardless of the cwd from
 		// which v was invoked, without affecting how user-supplied relative flags are resolved.
-		tcc_root_dir := os.join_path(@VEXEROOT, 'thirdparty', 'tcc')
 		tcc_lib_dir := os.join_path(tcc_root_dir, 'lib')
 		tcc_nested_dir := os.join_path(tcc_lib_dir, 'tcc')
 		tcc_install_dir := if os.is_dir(tcc_nested_dir) { tcc_nested_dir } else { tcc_lib_dir }

--- a/vlib/v/builder/cbuilder/parallel_cc_test.v
+++ b/vlib/v/builder/cbuilder/parallel_cc_test.v
@@ -1,11 +1,15 @@
 module cbuilder
 
-fn test_parallel_cc_uses_tcc_for_resolved_compiler_paths() {
-	assert parallel_cc_uses_tcc(.tcc, 'cc')
-	assert parallel_cc_uses_tcc(.unknown, 'tcc')
-	assert parallel_cc_uses_tcc(.unknown, '/tmp/v/thirdparty/tcc/tcc')
-	assert parallel_cc_uses_tcc(.unknown, 'D:\\a\\v\\v\\thirdparty\\tcc\\tcc.exe')
-	assert !parallel_cc_uses_tcc(.unknown, '/usr/bin/clang')
+import os
+
+fn test_parallel_cc_bundled_tcc_root_excludes_system_tcc() {
+	vroot := os.join_path(os.vtmp_dir(), 'parallel_cc_bundled_tcc_root')
+	bundled_tcc_root := os.join_path(vroot, 'thirdparty', 'tcc')
+	bundled_tcc := os.join_path(bundled_tcc_root, 'tcc.exe')
+	system_tcc := os.join_path(vroot, 'usr', 'bin', 'tcc')
+	assert parallel_cc_bundled_tcc_root(vroot, bundled_tcc) == bundled_tcc_root
+	assert parallel_cc_bundled_tcc_root(vroot, system_tcc) == ''
+	assert parallel_cc_bundled_tcc_root(vroot, 'clang') == ''
 }
 
 fn test_parallel_cc_projects_pkgconfig_pthread_once() {

--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -2259,6 +2259,36 @@ fn (v &Builder) retry_compilation_with(ccompiler string) os.Result {
 	return os.execute(cmd)
 }
 
+// retry_failed_tcc_compilation regenerates and compiles with a platform compiler after a TCC failure.
+pub fn (mut v Builder) retry_failed_tcc_compilation(ccompiler string, output string) bool {
+	if !is_tcc_compilation_failure(ccompiler, v.ccoptions.cc, output)
+		|| !v.pref.retry_compilation {
+		return false
+	}
+	old_ccompiler := v.pref.ccompiler
+	v.pref.default_c_compiler()
+	if v.pref.ccompiler == ccompiler || is_tcc_compiler_name(v.pref.ccompiler)
+		|| is_tcc_alias_compiler(v.pref.ccompiler) {
+		v.pref.ccompiler = first_available_ccompiler([old_ccompiler, ccompiler, v.pref.ccompiler])
+	}
+	if v.pref.ccompiler == '' || v.pref.ccompiler == ccompiler {
+		return false
+	}
+	if v.pref.is_verbose {
+		eprintln('Compilation with tcc failed. Retrying with ${v.pref.ccompiler} ...')
+	} else if !v.pref.is_quiet {
+		eprintln(term.red('warning: tcc compilation failed, falling back to ${v.pref.ccompiler}'))
+	}
+	retry_res := v.retry_compilation_with(v.pref.ccompiler)
+	if retry_res.exit_code != 0 || v.should_forward_retry_output() {
+		print(retry_res.output)
+	}
+	if retry_res.exit_code != 0 {
+		exit(retry_res.exit_code)
+	}
+	return true
+}
+
 pub fn (mut v Builder) cc() {
 	if os.executable().contains('vfmt') {
 		return
@@ -2491,29 +2521,8 @@ pub fn (mut v Builder) cc() {
 					}
 					exit(101)
 				}
-				if v.pref.retry_compilation {
-					old_ccompiler := v.pref.ccompiler
-					v.pref.default_c_compiler()
-					if v.pref.ccompiler == ccompiler || is_tcc_compiler_name(v.pref.ccompiler)
-						|| is_tcc_alias_compiler(v.pref.ccompiler) {
-						v.pref.ccompiler = first_available_ccompiler([old_ccompiler, ccompiler,
-							v.pref.ccompiler])
-					}
-					if v.pref.ccompiler != '' && v.pref.ccompiler != ccompiler {
-						if v.pref.is_verbose {
-							eprintln('Compilation with tcc failed. Retrying with ${v.pref.ccompiler} ...')
-						} else if !v.pref.is_quiet {
-							eprintln(term.red('warning: tcc compilation failed, falling back to ${v.pref.ccompiler}'))
-						}
-						retry_res := v.retry_compilation_with(v.pref.ccompiler)
-						if retry_res.exit_code != 0 || v.should_forward_retry_output() {
-							print(retry_res.output)
-						}
-						if retry_res.exit_code != 0 {
-							exit(retry_res.exit_code)
-						}
-						return
-					}
+				if v.retry_failed_tcc_compilation(ccompiler, res.output) {
+					return
 				}
 			}
 			if res.exit_code == 127 {

--- a/vlib/v/builder/cc_tcc_retry_test.v
+++ b/vlib/v/builder/cc_tcc_retry_test.v
@@ -79,6 +79,36 @@ fn test_tcc_retry_warning_is_visible() {
 	assert res.output.contains('warning: tcc compilation failed, falling back to cc'), res.output
 }
 
+fn test_parallel_tcc_failure_retries_with_platform_compiler() {
+	if os.user_os() == 'windows' {
+		return
+	}
+	test_root := os.join_path(os.vtmp_dir(), 'v_builder_parallel_tcc_retry_${os.getpid()}')
+	fake_tcc := os.join_path(test_root, 'fake-tcc')
+	source_path := os.join_path(test_root, 'main.v')
+	exe_path := os.join_path(test_root, 'main')
+	no_retry_exe_path := os.join_path(test_root, 'main_no_retry')
+	os.mkdir_all(test_root) or { panic(err) }
+	defer {
+		os.rmdir_all(test_root) or {}
+	}
+	os.write_file(fake_tcc, '#!/bin/sh\necho "tcc: error: parallel compiler failed"\nexit 1\n') or {
+		panic(err)
+	}
+	os.chmod(fake_tcc, 0o700) or { panic(err) }
+	os.write_file(source_path, 'fn main() {}\n') or { panic(err) }
+	res :=
+		execute_tcc_retry_test_command('VJOBS=2 ${os.quoted_path(@VEXE)} -old-compiler -cc ${os.quoted_path(fake_tcc)} -parallel-cc -o ${os.quoted_path(exe_path)} ${os.quoted_path(source_path)}')
+	assert res.exit_code == 0, res.output
+	assert res.output.contains('warning: tcc compilation failed, falling back to cc'), res.output
+	assert os.is_file(exe_path)
+	no_retry_res :=
+		execute_tcc_retry_test_command('VJOBS=2 ${os.quoted_path(@VEXE)} -old-compiler -cc ${os.quoted_path(fake_tcc)} -parallel-cc -no-retry-compilation -o ${os.quoted_path(no_retry_exe_path)} ${os.quoted_path(source_path)}')
+	assert no_retry_res.exit_code != 0, no_retry_res.output
+	assert no_retry_res.output.contains('failed parallel C compilation'), no_retry_res.output
+	assert !no_retry_res.output.contains('falling back to'), no_retry_res.output
+}
+
 fn test_tcc_retry_inserts_fallback_flags_before_implicit_vsh_script() {
 	script_path := os.join_path(os.vtmp_dir(), 'implicit_retry_script.vsh')
 	builder := &Builder{

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -514,36 +514,43 @@ fn (mut p Preferences) find_cc_if_cross_compiling() {
 }
 
 fn (mut p Preferences) try_to_use_tcc_by_default() {
-	preferred_tcc := default_tcc_compiler()
+	if p.backend != .c || p.output_cross_c {
+		return
+	}
 	if p.ccompiler in ['tcc', 'tinyc'] {
+		preferred_tcc := default_tcc_compiler()
 		p.ccompiler = if preferred_tcc != '' { preferred_tcc } else { 'tcc' }
 		return
 	}
-	if p.ccompiler == '' {
-		// -prealloc uses thread-local allocator state. The bundled tcc does not
-		// support TLS declarations, so use the platform C compiler by default.
-		if p.prealloc {
-			return
-		}
-		// -d no_gc_thread_local_alloc forces the bundled source libgc path. The
-		// bundled tcc cannot compile that source reliably, so use the platform C
-		// compiler by default. An explicit -cc still wins.
-		if p.needs_source_boehm_without_thread_local_alloc() {
-			return
-		}
-		// use an optimizing compiler (i.e. gcc or clang) on -prod mode
-		if p.is_prod {
-			return
-		}
-		// The macOS bundled tcc is sensitive to Apple SDK/header changes and
-		// app/framework includes. Keep it available through explicit `-cc tcc`,
-		// but default to the platform compiler on macOS.
-		if get_host_os() == .macos {
-			return
-		}
-		p.ccompiler = preferred_tcc
+	if p.ccompiler != '' {
 		return
 	}
+	// -prealloc uses thread-local allocator state. The bundled tcc does not
+	// support TLS declarations, so use the platform C compiler by default.
+	if p.prealloc {
+		return
+	}
+	// -d no_gc_thread_local_alloc forces the bundled source libgc path. The
+	// bundled tcc cannot compile that source reliably, so use the platform C
+	// compiler by default. An explicit -cc still wins.
+	if p.needs_source_boehm_without_thread_local_alloc() {
+		return
+	}
+	// use an optimizing compiler (i.e. gcc or clang) on -prod mode
+	if p.is_prod {
+		return
+	}
+	if (p.os != ._auto && p.os != get_host_os())
+		|| (p.arch != ._auto && p.arch != get_host_arch()) {
+		return
+	}
+	// The macOS bundled tcc is sensitive to Apple SDK/header changes and
+	// app/framework includes. Keep it available through explicit `-cc tcc`,
+	// but default to the platform compiler on macOS.
+	if get_host_os() == .macos {
+		return
+	}
+	p.ccompiler = default_tcc_compiler()
 }
 
 fn usable_system_tcc_compiler() string {

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -557,7 +557,8 @@ fn (mut p Preferences) try_to_use_tcc_by_default() {
 fn (p &Preferences) system_tcc_runtime_available(vroot string) bool {
 	uses_boehm := p.gc_mode in [.boehm_full, .boehm_incr, .boehm_full_opt, .boehm_incr_opt,
 		.boehm_leak]
-	if p.os != .linux || !p.is_glibc || !uses_boehm
+	needs_bundled_libgc := uses_boehm && (p.os == .windows || (p.os == .linux && p.is_glibc))
+	if !needs_bundled_libgc
 		|| 'dynamic_boehm' in p.compile_defines_all
 		|| 'use_bundled_libgc' in p.compile_defines_all {
 		return true

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -555,6 +555,10 @@ fn (mut p Preferences) try_to_use_tcc_by_default() {
 }
 
 fn (p &Preferences) system_tcc_runtime_available(vroot string) bool {
+	if p.os == .windows
+		&& !os.is_file(os.join_path(vroot, 'thirdparty', 'tcc', 'lib', 'openlibm.o')) {
+		return false
+	}
 	uses_boehm := p.gc_mode in [.boehm_full, .boehm_incr, .boehm_full_opt, .boehm_incr_opt,
 		.boehm_leak]
 	needs_bundled_libgc := uses_boehm && (p.os == .windows || (p.os == .linux && p.is_glibc))

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -547,9 +547,6 @@ fn (mut p Preferences) try_to_use_tcc_by_default() {
 }
 
 fn usable_system_tcc_compiler() string {
-	if get_host_os() != .termux {
-		return ''
-	}
 	system_tcc := os.find_abs_path_of_executable('tcc') or { return '' }
 	tcc_probe := os.execute('${os.quoted_path(system_tcc)} -v')
 	if tcc_probe.exit_code != 0 {

--- a/vlib/v/pref/default.v
+++ b/vlib/v/pref/default.v
@@ -550,7 +550,19 @@ fn (mut p Preferences) try_to_use_tcc_by_default() {
 	if get_host_os() == .macos {
 		return
 	}
-	p.ccompiler = default_tcc_compiler()
+	vroot := os.dir(vexe_path())
+	p.ccompiler = preferred_tcc_compiler(vroot, p.system_tcc_runtime_available(vroot))
+}
+
+fn (p &Preferences) system_tcc_runtime_available(vroot string) bool {
+	uses_boehm := p.gc_mode in [.boehm_full, .boehm_incr, .boehm_full_opt, .boehm_incr_opt,
+		.boehm_leak]
+	if p.os != .linux || !p.is_glibc || !uses_boehm
+		|| 'dynamic_boehm' in p.compile_defines_all
+		|| 'use_bundled_libgc' in p.compile_defines_all {
+		return true
+	}
+	return os.is_file(os.join_path(vroot, 'thirdparty', 'tcc', 'lib', 'libgc.a'))
 }
 
 fn usable_system_tcc_compiler() string {
@@ -579,9 +591,16 @@ fn usable_bundled_tcc_compiler(vroot string) string {
 pub fn default_tcc_compiler() string {
 	vexe := vexe_path()
 	vroot := os.dir(vexe)
+	return preferred_tcc_compiler(vroot, true)
+}
+
+fn preferred_tcc_compiler(vroot string, allow_system_tcc bool) string {
 	bundled_tcc := usable_bundled_tcc_compiler(vroot)
 	if bundled_tcc != '' {
 		return bundled_tcc
+	}
+	if !allow_system_tcc {
+		return ''
 	}
 	return usable_system_tcc_compiler()
 }

--- a/vlib/v/pref/default_tcc_compiler_test.v
+++ b/vlib/v/pref/default_tcc_compiler_test.v
@@ -241,7 +241,7 @@ fn test_try_to_use_tcc_by_default_requires_glibc_tcc_runtime() {
 	assert os.is_file(probe_marker)
 }
 
-fn test_system_tcc_runtime_available_requires_bundled_boehm_archive() {
+fn test_system_tcc_runtime_available_requires_bundled_runtime_artifacts() {
 	test_root := os.join_path(os.vtmp_dir(), 'v_pref_system_tcc_runtime_${os.getpid()}')
 	os.rmdir_all(test_root) or {}
 	defer {
@@ -262,7 +262,14 @@ fn test_system_tcc_runtime_available_requires_bundled_boehm_archive() {
 	os.mkdir_all(os.dir(libgc)) or { panic(err) }
 	os.write_file(libgc, '') or { panic(err) }
 	assert linux_prefs.system_tcc_runtime_available(test_root)
+	assert !windows_prefs.system_tcc_runtime_available(test_root)
+	openlibm := os.join_path(test_root, 'thirdparty', 'tcc', 'lib', 'openlibm.o')
+	os.write_file(openlibm, '') or { panic(err) }
 	assert windows_prefs.system_tcc_runtime_available(test_root)
+	assert Preferences{
+		os: .windows
+		gc_mode: .no_gc
+	}.system_tcc_runtime_available(test_root)
 	assert Preferences{
 		os: .linux
 		is_musl: true
@@ -271,6 +278,11 @@ fn test_system_tcc_runtime_available_requires_bundled_boehm_archive() {
 	assert Preferences{
 		os: .linux
 		is_glibc: true
+		gc_mode: .no_gc
+	}.system_tcc_runtime_available(test_root)
+	os.rm(openlibm) or { panic(err) }
+	assert !Preferences{
+		os: .windows
 		gc_mode: .no_gc
 	}.system_tcc_runtime_available(test_root)
 }

--- a/vlib/v/pref/default_tcc_compiler_test.v
+++ b/vlib/v/pref/default_tcc_compiler_test.v
@@ -203,6 +203,72 @@ fn test_try_to_use_tcc_by_default_does_not_probe_tcc_when_ineligible() {
 	assert !os.is_file(probe_marker)
 }
 
+fn test_try_to_use_tcc_by_default_requires_glibc_tcc_runtime() {
+	$if !linux {
+		return
+	}
+	test_root := os.join_path(os.vtmp_dir(), 'v_pref_default_tcc_runtime_${os.getpid()}')
+	os.rmdir_all(test_root) or {}
+	probe_marker := os.join_path(test_root, 'tcc_was_probed')
+	system_tcc := prepare_test_executable(test_root, 'bin/tcc', 'printf probed > ${os.quoted_path(probe_marker)}\nexit 0')
+	fake_vexe := os.join_path(test_root, 'v')
+	old_vexe := os.getenv('VEXE')
+	old_path := os.getenv('PATH')
+	os.setenv('VEXE', fake_vexe, true)
+	os.setenv('PATH', os.dir(system_tcc), true)
+	defer {
+		if old_vexe == '' {
+			os.unsetenv('VEXE')
+		} else {
+			os.setenv('VEXE', old_vexe, true)
+		}
+		os.setenv('PATH', old_path, true)
+		os.rmdir_all(test_root) or {}
+	}
+	mut prefs := Preferences{
+		os: .linux
+		is_glibc: true
+		gc_mode: .boehm_full_opt
+	}
+	prefs.try_to_use_tcc_by_default()
+	assert prefs.ccompiler == ''
+	assert !os.is_file(probe_marker)
+	libgc := os.join_path(test_root, 'thirdparty', 'tcc', 'lib', 'libgc.a')
+	os.mkdir_all(os.dir(libgc)) or { panic(err) }
+	os.write_file(libgc, '') or { panic(err) }
+	prefs.try_to_use_tcc_by_default()
+	assert prefs.ccompiler == system_tcc
+	assert os.is_file(probe_marker)
+}
+
+fn test_system_tcc_runtime_available_requires_glibc_boehm_archive() {
+	test_root := os.join_path(os.vtmp_dir(), 'v_pref_system_tcc_runtime_${os.getpid()}')
+	os.rmdir_all(test_root) or {}
+	defer {
+		os.rmdir_all(test_root) or {}
+	}
+	prefs := Preferences{
+		os: .linux
+		is_glibc: true
+		gc_mode: .boehm_full_opt
+	}
+	assert !prefs.system_tcc_runtime_available(test_root)
+	libgc := os.join_path(test_root, 'thirdparty', 'tcc', 'lib', 'libgc.a')
+	os.mkdir_all(os.dir(libgc)) or { panic(err) }
+	os.write_file(libgc, '') or { panic(err) }
+	assert prefs.system_tcc_runtime_available(test_root)
+	assert Preferences{
+		os: .linux
+		is_musl: true
+		gc_mode: .boehm_full_opt
+	}.system_tcc_runtime_available(test_root)
+	assert Preferences{
+		os: .linux
+		is_glibc: true
+		gc_mode: .no_gc
+	}.system_tcc_runtime_available(test_root)
+}
+
 fn test_try_to_use_tcc_by_default_skips_bundled_tcc_on_macos() {
 	$if !macos {
 		return

--- a/vlib/v/pref/default_tcc_compiler_test.v
+++ b/vlib/v/pref/default_tcc_compiler_test.v
@@ -143,12 +143,73 @@ fn test_try_to_use_tcc_by_default_skips_tcc_for_prealloc() {
 	assert prefs.ccompiler == ''
 }
 
+fn test_try_to_use_tcc_by_default_does_not_probe_tcc_when_ineligible() {
+	$if windows {
+		return
+	}
+	test_root := os.join_path(os.vtmp_dir(), 'v_pref_default_tcc_ineligible_test')
+	os.rmdir_all(test_root) or {}
+	probe_marker := os.join_path(test_root, 'tcc_was_probed')
+	system_tcc := prepare_test_executable(test_root, 'bin/tcc', 'printf probed > ${os.quoted_path(probe_marker)}\nexit 0')
+	fake_vexe := os.join_path(test_root, 'v')
+	old_vexe := os.getenv('VEXE')
+	old_path := os.getenv('PATH')
+	os.setenv('VEXE', fake_vexe, true)
+	os.setenv('PATH', os.dir(system_tcc), true)
+	defer {
+		if old_vexe == '' {
+			os.unsetenv('VEXE')
+		} else {
+			os.setenv('VEXE', old_vexe, true)
+		}
+		os.setenv('PATH', old_path, true)
+		os.rmdir_all(test_root) or {}
+	}
+	mut explicit_clang := Preferences{
+		ccompiler: 'clang'
+	}
+	explicit_clang.try_to_use_tcc_by_default()
+	assert explicit_clang.ccompiler == 'clang'
+	assert !os.is_file(probe_marker)
+	mut prod := Preferences{
+		is_prod: true
+	}
+	prod.try_to_use_tcc_by_default()
+	assert !os.is_file(probe_marker)
+	mut prealloc := Preferences{
+		prealloc: true
+	}
+	prealloc.try_to_use_tcc_by_default()
+	assert !os.is_file(probe_marker)
+	mut cross_target := Preferences{
+		os: if get_host_os() == .linux { OS.windows } else { OS.linux }
+	}
+	cross_target.try_to_use_tcc_by_default()
+	assert !os.is_file(probe_marker)
+	mut cross_arch := Preferences{
+		arch: if get_host_arch() == .amd64 { Arch.arm64 } else { Arch.amd64 }
+	}
+	cross_arch.try_to_use_tcc_by_default()
+	assert !os.is_file(probe_marker)
+	mut cross_c := Preferences{
+		output_cross_c: true
+	}
+	cross_c.try_to_use_tcc_by_default()
+	assert !os.is_file(probe_marker)
+	mut js_backend := Preferences{
+		backend: .js_node
+	}
+	js_backend.try_to_use_tcc_by_default()
+	assert !os.is_file(probe_marker)
+}
+
 fn test_try_to_use_tcc_by_default_skips_bundled_tcc_on_macos() {
 	$if !macos {
 		return
 	}
 	test_root := os.join_path(os.vtmp_dir(), 'v_pref_default_tcc_compiler_test')
-	prepare_test_tcc_binary(test_root, 'exit 0')
+	probe_marker := os.join_path(test_root, 'tcc_was_probed')
+	prepare_test_tcc_binary(test_root, 'printf probed > ${os.quoted_path(probe_marker)}\nexit 0')
 	fake_vexe := os.join_path(test_root, 'v')
 	old_vexe := os.getenv('VEXE')
 	os.setenv('VEXE', fake_vexe, true)
@@ -166,6 +227,7 @@ fn test_try_to_use_tcc_by_default_skips_bundled_tcc_on_macos() {
 	}
 	prefs.try_to_use_tcc_by_default()
 	assert prefs.ccompiler == ''
+	assert !os.is_file(probe_marker)
 }
 
 fn test_usable_system_tcc_compiler_finds_tcc_from_path() {

--- a/vlib/v/pref/default_tcc_compiler_test.v
+++ b/vlib/v/pref/default_tcc_compiler_test.v
@@ -241,22 +241,28 @@ fn test_try_to_use_tcc_by_default_requires_glibc_tcc_runtime() {
 	assert os.is_file(probe_marker)
 }
 
-fn test_system_tcc_runtime_available_requires_glibc_boehm_archive() {
+fn test_system_tcc_runtime_available_requires_bundled_boehm_archive() {
 	test_root := os.join_path(os.vtmp_dir(), 'v_pref_system_tcc_runtime_${os.getpid()}')
 	os.rmdir_all(test_root) or {}
 	defer {
 		os.rmdir_all(test_root) or {}
 	}
-	prefs := Preferences{
+	linux_prefs := Preferences{
 		os: .linux
 		is_glibc: true
 		gc_mode: .boehm_full_opt
 	}
-	assert !prefs.system_tcc_runtime_available(test_root)
+	windows_prefs := Preferences{
+		os: .windows
+		gc_mode: .boehm_full_opt
+	}
+	assert !linux_prefs.system_tcc_runtime_available(test_root)
+	assert !windows_prefs.system_tcc_runtime_available(test_root)
 	libgc := os.join_path(test_root, 'thirdparty', 'tcc', 'lib', 'libgc.a')
 	os.mkdir_all(os.dir(libgc)) or { panic(err) }
 	os.write_file(libgc, '') or { panic(err) }
-	assert prefs.system_tcc_runtime_available(test_root)
+	assert linux_prefs.system_tcc_runtime_available(test_root)
+	assert windows_prefs.system_tcc_runtime_available(test_root)
 	assert Preferences{
 		os: .linux
 		is_musl: true

--- a/vlib/v/pref/default_tcc_compiler_test.v
+++ b/vlib/v/pref/default_tcc_compiler_test.v
@@ -47,18 +47,21 @@ fn test_try_to_use_tcc_by_default_keeps_explicit_system_tcc_on_musl() {
 	prepare_test_tcc_binary(test_root, 'exit 1')
 	fake_vexe := os.join_path(test_root, 'v')
 	old_vexe := os.getenv('VEXE')
+	old_path := os.getenv('PATH')
 	os.setenv('VEXE', fake_vexe, true)
+	os.setenv('PATH', os.join_path(test_root, 'no_such_path'), true)
 	defer {
 		if old_vexe == '' {
 			os.unsetenv('VEXE')
 		} else {
 			os.setenv('VEXE', old_vexe, true)
 		}
+		os.setenv('PATH', old_path, true)
 		os.rmdir_all(test_root) or {}
 	}
 	mut prefs := Preferences{
 		ccompiler: 'tcc'
-		is_musl:   true
+		is_musl: true
 	}
 	prefs.try_to_use_tcc_by_default()
 	assert prefs.ccompiler == 'tcc'
@@ -72,13 +75,16 @@ fn test_try_to_use_tcc_by_default_skips_broken_bundled_tcc_on_musl() {
 	prepare_test_tcc_binary(test_root, 'exit 1')
 	fake_vexe := os.join_path(test_root, 'v')
 	old_vexe := os.getenv('VEXE')
+	old_path := os.getenv('PATH')
 	os.setenv('VEXE', fake_vexe, true)
+	os.setenv('PATH', os.join_path(test_root, 'no_such_path'), true)
 	defer {
 		if old_vexe == '' {
 			os.unsetenv('VEXE')
 		} else {
 			os.setenv('VEXE', old_vexe, true)
 		}
+		os.setenv('PATH', old_path, true)
 		os.rmdir_all(test_root) or {}
 	}
 	mut prefs := Preferences{
@@ -96,13 +102,16 @@ fn test_try_to_use_tcc_by_default_skips_broken_bundled_tcc_off_musl() {
 	prepare_test_tcc_binary(test_root, 'exit 1')
 	fake_vexe := os.join_path(test_root, 'v')
 	old_vexe := os.getenv('VEXE')
+	old_path := os.getenv('PATH')
 	os.setenv('VEXE', fake_vexe, true)
+	os.setenv('PATH', os.join_path(test_root, 'no_such_path'), true)
 	defer {
 		if old_vexe == '' {
 			os.unsetenv('VEXE')
 		} else {
 			os.setenv('VEXE', old_vexe, true)
 		}
+		os.setenv('PATH', old_path, true)
 		os.rmdir_all(test_root) or {}
 	}
 	mut prefs := Preferences{}
@@ -152,36 +161,44 @@ fn test_try_to_use_tcc_by_default_skips_bundled_tcc_on_macos() {
 		os.rmdir_all(test_root) or {}
 	}
 	mut prefs := Preferences{
-		vroot:    test_root
+		vroot: test_root
 		out_name: os.join_path(test_root, 'v')
 	}
 	prefs.try_to_use_tcc_by_default()
 	assert prefs.ccompiler == ''
 }
 
-fn test_usable_system_tcc_compiler_prefers_termux_tcc_from_path() {
+fn test_usable_system_tcc_compiler_finds_tcc_from_path() {
 	$if windows {
 		return
 	}
 	test_root := os.join_path(os.vtmp_dir(), 'v_pref_default_tcc_compiler_test')
 	system_tcc := prepare_test_executable(test_root, 'bin/tcc', 'exit 0')
 	old_path := os.getenv('PATH')
-	old_termux_version := os.getenv('TERMUX_VERSION')
 	os.setenv('PATH', os.dir(system_tcc), true)
-	os.setenv('TERMUX_VERSION', '0.118.0', true)
 	defer {
 		os.setenv('PATH', old_path, true)
-		if old_termux_version == '' {
-			os.unsetenv('TERMUX_VERSION')
-		} else {
-			os.setenv('TERMUX_VERSION', old_termux_version, true)
-		}
 		os.rmdir_all(test_root) or {}
 	}
 	assert usable_system_tcc_compiler() == system_tcc
 }
 
-fn test_default_tcc_compiler_uses_system_tcc_on_termux_when_bundled_is_missing() {
+fn test_usable_system_tcc_compiler_skips_broken_tcc_from_path() {
+	$if windows {
+		return
+	}
+	test_root := os.join_path(os.vtmp_dir(), 'v_pref_default_tcc_compiler_test')
+	system_tcc := prepare_test_executable(test_root, 'bin/tcc', 'exit 1')
+	old_path := os.getenv('PATH')
+	os.setenv('PATH', os.dir(system_tcc), true)
+	defer {
+		os.setenv('PATH', old_path, true)
+		os.rmdir_all(test_root) or {}
+	}
+	assert usable_system_tcc_compiler() == ''
+}
+
+fn test_default_tcc_compiler_uses_system_tcc_when_bundled_is_missing() {
 	$if windows {
 		return
 	}
@@ -190,10 +207,8 @@ fn test_default_tcc_compiler_uses_system_tcc_on_termux_when_bundled_is_missing()
 	system_tcc := prepare_test_executable(test_root, 'bin/tcc', 'exit 0')
 	old_vexe := os.getenv('VEXE')
 	old_path := os.getenv('PATH')
-	old_termux_version := os.getenv('TERMUX_VERSION')
 	os.setenv('VEXE', fake_vexe, true)
 	os.setenv('PATH', os.dir(system_tcc), true)
-	os.setenv('TERMUX_VERSION', '0.118.0', true)
 	defer {
 		if old_vexe == '' {
 			os.unsetenv('VEXE')
@@ -201,17 +216,17 @@ fn test_default_tcc_compiler_uses_system_tcc_on_termux_when_bundled_is_missing()
 			os.setenv('VEXE', old_vexe, true)
 		}
 		os.setenv('PATH', old_path, true)
-		if old_termux_version == '' {
-			os.unsetenv('TERMUX_VERSION')
-		} else {
-			os.setenv('TERMUX_VERSION', old_termux_version, true)
-		}
 		os.rmdir_all(test_root) or {}
 	}
 	assert default_tcc_compiler() == system_tcc
+	$if !macos {
+		mut prefs := Preferences{}
+		prefs.try_to_use_tcc_by_default()
+		assert prefs.ccompiler == system_tcc
+	}
 }
 
-fn test_try_to_use_tcc_by_default_resolves_explicit_tcc_to_system_tcc_on_termux() {
+fn test_try_to_use_tcc_by_default_resolves_explicit_tcc_to_system_tcc() {
 	$if windows {
 		return
 	}
@@ -220,10 +235,8 @@ fn test_try_to_use_tcc_by_default_resolves_explicit_tcc_to_system_tcc_on_termux(
 	system_tcc := prepare_test_executable(test_root, 'bin/tcc', 'exit 0')
 	old_vexe := os.getenv('VEXE')
 	old_path := os.getenv('PATH')
-	old_termux_version := os.getenv('TERMUX_VERSION')
 	os.setenv('VEXE', fake_vexe, true)
 	os.setenv('PATH', os.dir(system_tcc), true)
-	os.setenv('TERMUX_VERSION', '0.118.0', true)
 	defer {
 		if old_vexe == '' {
 			os.unsetenv('VEXE')
@@ -231,11 +244,6 @@ fn test_try_to_use_tcc_by_default_resolves_explicit_tcc_to_system_tcc_on_termux(
 			os.setenv('VEXE', old_vexe, true)
 		}
 		os.setenv('PATH', old_path, true)
-		if old_termux_version == '' {
-			os.unsetenv('TERMUX_VERSION')
-		} else {
-			os.setenv('TERMUX_VERSION', old_termux_version, true)
-		}
 		os.rmdir_all(test_root) or {}
 	}
 	mut prefs := Preferences{

--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -25,6 +25,12 @@ fn test_v3_default_compiler_uses_implicit_tcc() {
 	assert v3_select_implicit_c_compiler('clang', true, bundled_tcc) == 'clang'
 }
 
+fn test_v3_platform_c_compiler() {
+	assert v3_platform_c_compiler('windows') == 'gcc'
+	assert v3_platform_c_compiler('linux') == 'cc'
+	assert v3_platform_c_compiler('macos') == 'cc'
+}
+
 fn test_v3_implicit_tcc_uses_platform_compiler_for_non_c_objects() {
 	implicit_tcc := os.join_path(os.temp_dir(), 'bin', 'tcc')
 	assert c_source_object_compiler('', implicit_tcc, true) == implicit_tcc

--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -42,7 +42,7 @@ fn test_v3_default_tcc_compiler_uses_working_system_tcc() {
 		return
 	}
 	test_root := os.join_path(os.vtmp_dir(), 'v3_default_system_tcc_${os.getpid()}')
-	system_tcc := write_v3_test_tcc(test_root, 0)
+	system_tcc := write_v3_test_tcc(os.join_path(test_root, 'bin', 'tcc'), 0)
 	old_path := os.getenv_opt('PATH')
 	os.setenv('PATH', os.dir(system_tcc), true)
 	defer {
@@ -53,9 +53,12 @@ fn test_v3_default_tcc_compiler_uses_working_system_tcc() {
 		}
 		os.rmdir_all(test_root) or {}
 	}
-	bundled_tcc := os.join_path(test_root, 'missing', 'tcc.exe')
-	assert v3_default_tcc_compiler(bundled_tcc, false, true, 'linux') == system_tcc
-	assert v3_default_tcc_compiler(bundled_tcc, true, true, 'linux') == bundled_tcc
+	bundled_tcc := write_v3_test_tcc(os.join_path(test_root, 'thirdparty', 'tcc', 'tcc.exe'), 1)
+	assert !v3_usable_tcc_compiler(bundled_tcc)
+	assert v3_default_tcc_compiler(bundled_tcc, v3_usable_tcc_compiler(bundled_tcc), true, 'linux') == system_tcc
+	write_v3_test_tcc(bundled_tcc, 0)
+	assert v3_usable_tcc_compiler(bundled_tcc)
+	assert v3_default_tcc_compiler(bundled_tcc, v3_usable_tcc_compiler(bundled_tcc), true, 'linux') == bundled_tcc
 	assert v3_default_tcc_compiler(bundled_tcc, false, false, 'linux') == ''
 	assert v3_default_tcc_compiler(bundled_tcc, false, true, 'macos') == ''
 }
@@ -65,7 +68,7 @@ fn test_v3_default_tcc_compiler_skips_broken_system_tcc() {
 		return
 	}
 	test_root := os.join_path(os.vtmp_dir(), 'v3_broken_system_tcc_${os.getpid()}')
-	system_tcc := write_v3_test_tcc(test_root, 1)
+	system_tcc := write_v3_test_tcc(os.join_path(test_root, 'bin', 'tcc'), 1)
 	old_path := os.getenv_opt('PATH')
 	os.setenv('PATH', os.dir(system_tcc), true)
 	defer {
@@ -98,8 +101,7 @@ fn test_v3_regenerates_cc_fallback_after_preferred_tcc() {
 	assert v3_should_regenerate_for_cc_fallback(true, false, 0)
 }
 
-fn write_v3_test_tcc(test_root string, exit_code int) string {
-	tcc_path := os.join_path(test_root, 'bin', 'tcc')
+fn write_v3_test_tcc(tcc_path string, exit_code int) string {
 	os.mkdir_all(os.dir(tcc_path)) or { panic(err) }
 	os.write_file(tcc_path, '#!/bin/sh\nexit ${exit_code}\n') or { panic(err) }
 	os.chmod(tcc_path, 0o700) or { panic(err) }

--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -25,6 +25,17 @@ fn test_v3_default_compiler_uses_implicit_tcc() {
 	assert v3_select_implicit_c_compiler('clang', true, bundled_tcc) == 'clang'
 }
 
+fn test_v3_implicit_tcc_uses_platform_compiler_for_cpp_objects() {
+	implicit_tcc := os.join_path(os.temp_dir(), 'bin', 'tcc')
+	assert c_source_object_compiler('', implicit_tcc, true) == implicit_tcc
+	assert c_source_object_compiler('objective-c', implicit_tcc, true) == implicit_tcc
+	assert c_source_object_compiler('c++', implicit_tcc, true) == 'c++'
+	assert c_source_object_compiler('objective-c++', implicit_tcc, true) == 'c++'
+	assert c_source_object_compiler('c++', 'cc', false) == 'c++'
+	assert c_source_object_compiler('c++', 'clang', false) == 'clang'
+	assert c_source_object_compiler('c++', 'tcc', false) == 'tcc'
+}
+
 fn test_v3_bundled_tcc_probe_eligibility() {
 	linux_target := pref.Target{
 		os: 'linux'

--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -58,6 +58,16 @@ fn test_v3_bundled_tcc_probe_eligibility() {
 	})
 	assert !v3_should_probe_bundled_tcc(V3BundledTccProbeOptions{
 		...base
+		dump_c_flags: true
+	})
+	assert v3_should_probe_bundled_tcc(V3BundledTccProbeOptions{
+		...base
+		c_compiler: 'tcc'
+		c_compiler_explicit: true
+		dump_c_flags: true
+	})
+	assert !v3_should_probe_bundled_tcc(V3BundledTccProbeOptions{
+		...base
 		c_compiler: 'clang'
 		c_compiler_explicit: true
 	})
@@ -150,14 +160,15 @@ fn test_v3_default_tcc_compiler_uses_working_system_tcc() {
 	}
 	bundled_tcc := write_v3_test_tcc(os.join_path(test_root, 'thirdparty', 'tcc', 'tcc.exe'), 1)
 	assert !v3_usable_tcc_compiler(bundled_tcc)
-	implicit_tcc := v3_default_tcc_compiler(bundled_tcc, v3_usable_tcc_compiler(bundled_tcc), true, 'linux')
+	implicit_tcc := v3_default_tcc_compiler(bundled_tcc, v3_usable_tcc_compiler(bundled_tcc), true, false, 'linux')
 	assert implicit_tcc == system_tcc
 	assert v3_effective_c_compiler_for_codegen('c', 'cc', implicit_tcc != '', pref.host_target()) == 'tinyc'
 	write_v3_test_tcc(bundled_tcc, 0)
 	assert v3_usable_tcc_compiler(bundled_tcc)
-	assert v3_default_tcc_compiler(bundled_tcc, v3_usable_tcc_compiler(bundled_tcc), true, 'linux') == bundled_tcc
-	assert v3_default_tcc_compiler(bundled_tcc, false, false, 'linux') == ''
-	assert v3_default_tcc_compiler(bundled_tcc, false, true, 'macos') == ''
+	assert v3_default_tcc_compiler(bundled_tcc, v3_usable_tcc_compiler(bundled_tcc), true, false, 'linux') == bundled_tcc
+	assert v3_default_tcc_compiler(bundled_tcc, true, true, true, 'linux') == ''
+	assert v3_default_tcc_compiler(bundled_tcc, false, false, false, 'linux') == ''
+	assert v3_default_tcc_compiler(bundled_tcc, false, true, false, 'macos') == ''
 }
 
 fn test_v3_default_tcc_compiler_skips_broken_system_tcc() {
@@ -177,7 +188,7 @@ fn test_v3_default_tcc_compiler_skips_broken_system_tcc() {
 		os.rmdir_all(test_root) or {}
 	}
 	bundled_tcc := os.join_path(test_root, 'missing', 'tcc.exe')
-	assert v3_default_tcc_compiler(bundled_tcc, false, true, 'linux') == ''
+	assert v3_default_tcc_compiler(bundled_tcc, false, true, false, 'linux') == ''
 }
 
 fn test_v3_system_tcc_does_not_use_bundled_resources() {

--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -37,6 +37,113 @@ fn test_v3_windows_default_compiler_requires_bundled_tcc() {
 	assert v3_select_windows_default_c_compiler('cc', false, 'windows', 'linux', bundled_tcc, true) == 'cc'
 }
 
+fn test_v3_bundled_tcc_probe_eligibility() {
+	linux_target := pref.Target{
+		os: 'linux'
+		arch: 'amd64'
+	}
+	bundled_tcc := os.join_path(os.vtmp_dir(), 'v3_probe_eligibility', 'thirdparty', 'tcc', 'tcc.exe')
+	base := V3BundledTccProbeOptions{
+		backend: 'c'
+		c_compiler: 'cc'
+		host_os: 'linux'
+		host_target: linux_target
+		target: linux_target
+		bundled_tcc: bundled_tcc
+	}
+	assert v3_should_probe_bundled_tcc(base)
+	assert !v3_should_probe_bundled_tcc(V3BundledTccProbeOptions{
+		...base
+		backend: 'wasm'
+	})
+	assert !v3_should_probe_bundled_tcc(V3BundledTccProbeOptions{
+		...base
+		c_only: true
+	})
+	assert !v3_should_probe_bundled_tcc(V3BundledTccProbeOptions{
+		...base
+		is_prod: true
+	})
+	assert !v3_should_probe_bundled_tcc(V3BundledTccProbeOptions{
+		...base
+		is_c_debug: true
+	})
+	assert !v3_should_probe_bundled_tcc(V3BundledTccProbeOptions{
+		...base
+		c_compiler: 'clang'
+		c_compiler_explicit: true
+	})
+	assert !v3_should_probe_bundled_tcc(V3BundledTccProbeOptions{
+		...base
+		target: pref.Target{
+			os: 'linux'
+			arch: 'arm64'
+		}
+	})
+	assert v3_should_probe_bundled_tcc(V3BundledTccProbeOptions{
+		...base
+		is_prod: true
+		c_compiler: 'tcc'
+		c_compiler_explicit: true
+	})
+	assert v3_should_probe_bundled_tcc(V3BundledTccProbeOptions{
+		...base
+		c_compiler: bundled_tcc
+		c_compiler_explicit: true
+	})
+	assert !v3_should_probe_bundled_tcc(V3BundledTccProbeOptions{
+		...base
+		c_compiler: os.join_path(os.vtmp_dir(), 'bin', 'tcc')
+		c_compiler_explicit: true
+	})
+	windows_target := pref.Target{
+		os: 'windows'
+		arch: 'amd64'
+	}
+	assert v3_should_probe_bundled_tcc(V3BundledTccProbeOptions{
+		...base
+		is_prod: true
+		is_c_debug: true
+		host_os: 'windows'
+		host_target: windows_target
+		target: windows_target
+	})
+}
+
+fn test_v3_bundled_tcc_probe_does_not_run_when_ineligible() {
+	$if windows {
+		return
+	}
+	test_root := os.join_path(os.vtmp_dir(), 'v3_bundled_tcc_probe_${os.getpid()}')
+	probe_marker := os.join_path(test_root, 'tcc_was_probed')
+	bundled_tcc := os.join_path(test_root, 'thirdparty', 'tcc', 'tcc.exe')
+	os.mkdir_all(os.dir(bundled_tcc)) or { panic(err) }
+	os.write_file(bundled_tcc, '#!/bin/sh\nprintf probed > ${os.quoted_path(probe_marker)}\nexit 0\n') or { panic(err) }
+	os.chmod(bundled_tcc, 0o700) or { panic(err) }
+	defer {
+		os.rmdir_all(test_root) or {}
+	}
+	linux_target := pref.Target{
+		os: 'linux'
+		arch: 'amd64'
+	}
+	base := V3BundledTccProbeOptions{
+		backend: 'c'
+		c_compiler: 'cc'
+		host_os: 'linux'
+		host_target: linux_target
+		target: linux_target
+		bundled_tcc: bundled_tcc
+	}
+	assert !v3_bundled_tcc_available(V3BundledTccProbeOptions{
+		...base
+		is_prod: true
+	})
+	assert !os.is_file(probe_marker)
+	assert v3_bundled_tcc_available(base)
+	assert os.is_file(probe_marker)
+}
+
 fn test_v3_default_tcc_compiler_uses_working_system_tcc() {
 	$if windows {
 		return

--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -16,18 +16,6 @@ fn test_v3_tcc_backtrace_enabled() {
 	assert !v3_tcc_backtrace_enabled('linux', 'arm64', true)
 }
 
-fn test_v3_prefers_bundled_tcc_for_debug_selfhost() {
-	host := pref.host_target()
-	assert v3_should_prefer_bundled_tcc_for_selfhost(true, 'c', false, false, false, false, host, true)
-	assert !v3_should_prefer_bundled_tcc_for_selfhost(false, 'c', false, false, false, false, host, true)
-	assert !v3_should_prefer_bundled_tcc_for_selfhost(true, 'fastc', false, false, false, false, host, true)
-	assert !v3_should_prefer_bundled_tcc_for_selfhost(true, 'c', true, false, false, false, host, true)
-	assert !v3_should_prefer_bundled_tcc_for_selfhost(true, 'c', false, true, false, false, host, true)
-	assert !v3_should_prefer_bundled_tcc_for_selfhost(true, 'c', false, false, true, false, host, true)
-	assert !v3_should_prefer_bundled_tcc_for_selfhost(true, 'c', false, false, false, true, host, true)
-	assert !v3_should_prefer_bundled_tcc_for_selfhost(true, 'c', false, false, false, false, host, false)
-}
-
 fn test_v3_windows_default_compiler_requires_bundled_tcc() {
 	bundled_tcc := os.join_path(os.temp_dir(), 'thirdparty', 'tcc', 'tcc.exe')
 	assert v3_select_windows_default_c_compiler('cc', false, 'windows', 'windows', bundled_tcc, true) == bundled_tcc
@@ -162,7 +150,9 @@ fn test_v3_default_tcc_compiler_uses_working_system_tcc() {
 	}
 	bundled_tcc := write_v3_test_tcc(os.join_path(test_root, 'thirdparty', 'tcc', 'tcc.exe'), 1)
 	assert !v3_usable_tcc_compiler(bundled_tcc)
-	assert v3_default_tcc_compiler(bundled_tcc, v3_usable_tcc_compiler(bundled_tcc), true, 'linux') == system_tcc
+	implicit_tcc := v3_default_tcc_compiler(bundled_tcc, v3_usable_tcc_compiler(bundled_tcc), true, 'linux')
+	assert implicit_tcc == system_tcc
+	assert v3_effective_c_compiler_for_codegen('c', 'cc', implicit_tcc != '', pref.host_target()) == 'tinyc'
 	write_v3_test_tcc(bundled_tcc, 0)
 	assert v3_usable_tcc_compiler(bundled_tcc)
 	assert v3_default_tcc_compiler(bundled_tcc, v3_usable_tcc_compiler(bundled_tcc), true, 'linux') == bundled_tcc
@@ -200,12 +190,12 @@ fn test_v3_system_tcc_does_not_use_bundled_resources() {
 	assert bundled_resources.base_arg.contains('thirdparty')
 }
 
-fn test_v3_regenerates_cc_fallback_after_preferred_tcc() {
-	assert !v3_should_regenerate_for_cc_fallback(false, false, 0)
-	assert !v3_should_regenerate_for_cc_fallback(false, true, 1)
-	assert !v3_should_regenerate_for_cc_fallback(true, true, 0)
-	assert v3_should_regenerate_for_cc_fallback(true, true, 1)
-	assert v3_should_regenerate_for_cc_fallback(true, false, 0)
+fn test_v3_regenerates_cc_fallback_after_implicit_tcc() {
+	assert !v3_should_regenerate_after_implicit_tcc(false, false, 0)
+	assert !v3_should_regenerate_after_implicit_tcc(false, true, 1)
+	assert !v3_should_regenerate_after_implicit_tcc(true, true, 0)
+	assert v3_should_regenerate_after_implicit_tcc(true, true, 1)
+	assert v3_should_regenerate_after_implicit_tcc(true, false, 0)
 }
 
 fn write_v3_test_tcc(tcc_path string, exit_code int) string {

--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -16,13 +16,15 @@ fn test_v3_tcc_backtrace_enabled() {
 	assert !v3_tcc_backtrace_enabled('linux', 'arm64', true)
 }
 
-fn test_v3_windows_default_compiler_requires_bundled_tcc() {
+fn test_v3_windows_default_compiler_uses_implicit_tcc() {
 	bundled_tcc := os.join_path(os.temp_dir(), 'thirdparty', 'tcc', 'tcc.exe')
-	assert v3_select_windows_default_c_compiler('cc', false, 'windows', 'windows', bundled_tcc, true) == bundled_tcc
-	assert v3_select_windows_default_c_compiler('cc', false, 'windows', 'windows', bundled_tcc, false) == 'cc'
-	assert v3_select_windows_default_c_compiler('clang', true, 'windows', 'windows', bundled_tcc, true) == 'clang'
-	assert v3_select_windows_default_c_compiler('cc', false, 'linux', 'windows', bundled_tcc, true) == 'cc'
-	assert v3_select_windows_default_c_compiler('cc', false, 'windows', 'linux', bundled_tcc, true) == 'cc'
+	system_tcc := os.join_path(os.temp_dir(), 'bin', 'tcc.exe')
+	assert v3_select_windows_default_c_compiler('cc', false, 'windows', 'windows', bundled_tcc) == bundled_tcc
+	assert v3_select_windows_default_c_compiler('cc', false, 'windows', 'windows', system_tcc) == system_tcc
+	assert v3_select_windows_default_c_compiler('cc', false, 'windows', 'windows', '') == 'cc'
+	assert v3_select_windows_default_c_compiler('clang', true, 'windows', 'windows', bundled_tcc) == 'clang'
+	assert v3_select_windows_default_c_compiler('cc', false, 'linux', 'windows', bundled_tcc) == 'cc'
+	assert v3_select_windows_default_c_compiler('cc', false, 'windows', 'linux', bundled_tcc) == 'cc'
 }
 
 fn test_v3_bundled_tcc_probe_eligibility() {

--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -37,12 +37,73 @@ fn test_v3_windows_default_compiler_requires_bundled_tcc() {
 	assert v3_select_windows_default_c_compiler('cc', false, 'windows', 'linux', bundled_tcc, true) == 'cc'
 }
 
+fn test_v3_default_tcc_compiler_uses_working_system_tcc() {
+	$if windows {
+		return
+	}
+	test_root := os.join_path(os.vtmp_dir(), 'v3_default_system_tcc_${os.getpid()}')
+	system_tcc := write_v3_test_tcc(test_root, 0)
+	old_path := os.getenv_opt('PATH')
+	os.setenv('PATH', os.dir(system_tcc), true)
+	defer {
+		if value := old_path {
+			os.setenv('PATH', value, true)
+		} else {
+			os.unsetenv('PATH')
+		}
+		os.rmdir_all(test_root) or {}
+	}
+	bundled_tcc := os.join_path(test_root, 'missing', 'tcc.exe')
+	assert v3_default_tcc_compiler(bundled_tcc, false, true, 'linux') == system_tcc
+	assert v3_default_tcc_compiler(bundled_tcc, true, true, 'linux') == bundled_tcc
+	assert v3_default_tcc_compiler(bundled_tcc, false, false, 'linux') == ''
+	assert v3_default_tcc_compiler(bundled_tcc, false, true, 'macos') == ''
+}
+
+fn test_v3_default_tcc_compiler_skips_broken_system_tcc() {
+	$if windows {
+		return
+	}
+	test_root := os.join_path(os.vtmp_dir(), 'v3_broken_system_tcc_${os.getpid()}')
+	system_tcc := write_v3_test_tcc(test_root, 1)
+	old_path := os.getenv_opt('PATH')
+	os.setenv('PATH', os.dir(system_tcc), true)
+	defer {
+		if value := old_path {
+			os.setenv('PATH', value, true)
+		} else {
+			os.unsetenv('PATH')
+		}
+		os.rmdir_all(test_root) or {}
+	}
+	bundled_tcc := os.join_path(test_root, 'missing', 'tcc.exe')
+	assert v3_default_tcc_compiler(bundled_tcc, false, true, 'linux') == ''
+}
+
+fn test_v3_system_tcc_does_not_use_bundled_resources() {
+	vroot := os.join_path(os.temp_dir(), 'v3_system_tcc_resources')
+	bundled_tcc := os.join_path(vroot, 'thirdparty', 'tcc', 'tcc.exe')
+	system_tcc := os.join_path(os.path_separator, 'usr', 'bin', 'tcc')
+	resources := v3_tcc_resource_flags_for_compiler(vroot, system_tcc, bundled_tcc, false)
+	assert resources == V3TccResourceFlags{}
+	bundled_resources := v3_tcc_resource_flags_for_compiler(vroot, bundled_tcc, bundled_tcc, true)
+	assert bundled_resources.base_arg.contains('thirdparty')
+}
+
 fn test_v3_regenerates_cc_fallback_after_preferred_tcc() {
 	assert !v3_should_regenerate_for_cc_fallback(false, false, 0)
 	assert !v3_should_regenerate_for_cc_fallback(false, true, 1)
 	assert !v3_should_regenerate_for_cc_fallback(true, true, 0)
 	assert v3_should_regenerate_for_cc_fallback(true, true, 1)
 	assert v3_should_regenerate_for_cc_fallback(true, false, 0)
+}
+
+fn write_v3_test_tcc(test_root string, exit_code int) string {
+	tcc_path := os.join_path(test_root, 'bin', 'tcc')
+	os.mkdir_all(os.dir(tcc_path)) or { panic(err) }
+	os.write_file(tcc_path, '#!/bin/sh\nexit ${exit_code}\n') or { panic(err) }
+	os.chmod(tcc_path, 0o700) or { panic(err) }
+	return tcc_path
 }
 
 fn test_v3_tcc_flag_plan_skips_backtrace_on_macos_arm64() {

--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -191,11 +191,13 @@ fn test_v3_system_tcc_does_not_use_bundled_resources() {
 }
 
 fn test_v3_regenerates_cc_fallback_after_implicit_tcc() {
-	assert !v3_should_regenerate_after_implicit_tcc(false, false, 0)
-	assert !v3_should_regenerate_after_implicit_tcc(false, true, 1)
-	assert !v3_should_regenerate_after_implicit_tcc(true, true, 0)
-	assert v3_should_regenerate_after_implicit_tcc(true, true, 1)
-	assert v3_should_regenerate_after_implicit_tcc(true, false, 0)
+	assert !v3_should_regenerate_after_implicit_tcc(true, false, false, 0)
+	assert !v3_should_regenerate_after_implicit_tcc(true, false, true, 1)
+	assert !v3_should_regenerate_after_implicit_tcc(true, true, true, 0)
+	assert v3_should_regenerate_after_implicit_tcc(true, true, true, 1)
+	assert v3_should_regenerate_after_implicit_tcc(true, true, false, 0)
+	assert !v3_should_regenerate_after_implicit_tcc(false, true, true, 1)
+	assert !v3_should_regenerate_after_implicit_tcc(false, true, false, 0)
 }
 
 fn write_v3_test_tcc(tcc_path string, exit_code int) string {

--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -80,11 +80,21 @@ fn test_v3_bundled_tcc_probe_eligibility() {
 		...base
 		dump_c_flags: true
 	})
+	assert !v3_should_probe_bundled_tcc(V3BundledTccProbeOptions{
+		...base
+		parallel_cc: true
+	})
 	assert v3_should_probe_bundled_tcc(V3BundledTccProbeOptions{
 		...base
 		c_compiler: 'tcc'
 		c_compiler_explicit: true
 		dump_c_flags: true
+	})
+	assert v3_should_probe_bundled_tcc(V3BundledTccProbeOptions{
+		...base
+		c_compiler: 'tcc'
+		c_compiler_explicit: true
+		parallel_cc: true
 	})
 	assert !v3_should_probe_bundled_tcc(V3BundledTccProbeOptions{
 		...base

--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -33,16 +33,17 @@ fn test_v3_platform_c_compiler() {
 
 fn test_v3_implicit_tcc_uses_platform_compiler_for_non_c_objects() {
 	implicit_tcc := os.join_path(os.temp_dir(), 'bin', 'tcc')
-	assert c_source_object_compiler('', implicit_tcc, true) == implicit_tcc
-	assert c_source_object_compiler('objective-c', implicit_tcc, true) == 'cc'
-	assert c_source_object_compiler('c++', implicit_tcc, true) == 'c++'
-	assert c_source_object_compiler('objective-c++', implicit_tcc, true) == 'c++'
-	assert c_source_object_compiler('objective-c', 'cc', false) == 'cc'
-	assert c_source_object_compiler('c++', 'cc', false) == 'c++'
-	assert c_source_object_compiler('objective-c', 'clang', false) == 'clang'
-	assert c_source_object_compiler('c++', 'clang', false) == 'clang'
-	assert c_source_object_compiler('objective-c', 'tcc', false) == 'tcc'
-	assert c_source_object_compiler('c++', 'tcc', false) == 'tcc'
+	assert c_source_object_compiler('', implicit_tcc, true, 'linux') == implicit_tcc
+	assert c_source_object_compiler('objective-c', implicit_tcc, true, 'linux') == 'cc'
+	assert c_source_object_compiler('objective-c', implicit_tcc, true, 'windows') == 'gcc'
+	assert c_source_object_compiler('c++', implicit_tcc, true, 'linux') == 'c++'
+	assert c_source_object_compiler('objective-c++', implicit_tcc, true, 'linux') == 'c++'
+	assert c_source_object_compiler('objective-c', 'cc', false, 'linux') == 'cc'
+	assert c_source_object_compiler('c++', 'cc', false, 'linux') == 'c++'
+	assert c_source_object_compiler('objective-c', 'clang', false, 'linux') == 'clang'
+	assert c_source_object_compiler('c++', 'clang', false, 'linux') == 'clang'
+	assert c_source_object_compiler('objective-c', 'tcc', false, 'linux') == 'tcc'
+	assert c_source_object_compiler('c++', 'tcc', false, 'linux') == 'tcc'
 }
 
 fn test_v3_bundled_tcc_probe_eligibility() {
@@ -84,6 +85,17 @@ fn test_v3_bundled_tcc_probe_eligibility() {
 		...base
 		parallel_cc: true
 	})
+	windows_target := pref.Target{
+		os: 'windows'
+		arch: 'amd64'
+	}
+	assert v3_should_probe_bundled_tcc(V3BundledTccProbeOptions{
+		...base
+		parallel_cc: true
+		host_os: 'windows'
+		host_target: windows_target
+		target: windows_target
+	})
 	assert v3_should_probe_bundled_tcc(V3BundledTccProbeOptions{
 		...base
 		c_compiler: 'tcc'
@@ -124,10 +136,6 @@ fn test_v3_bundled_tcc_probe_eligibility() {
 		c_compiler: os.join_path(os.vtmp_dir(), 'bin', 'tcc')
 		c_compiler_explicit: true
 	})
-	windows_target := pref.Target{
-		os: 'windows'
-		arch: 'amd64'
-	}
 	assert v3_should_probe_bundled_tcc(V3BundledTccProbeOptions{
 		...base
 		is_prod: true

--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -239,6 +239,20 @@ fn test_v3_system_tcc_does_not_use_bundled_resources() {
 	assert bundled_resources.base_arg.contains('thirdparty')
 }
 
+fn test_v3_system_tcc_runtime_requires_windows_openlibm() {
+	test_root := os.join_path(os.vtmp_dir(), 'v3_system_tcc_runtime_${os.getpid()}')
+	os.rmdir_all(test_root) or {}
+	defer {
+		os.rmdir_all(test_root) or {}
+	}
+	assert v3_system_tcc_runtime_available(test_root, 'linux')
+	assert !v3_system_tcc_runtime_available(test_root, 'windows')
+	openlibm := os.join_path(test_root, 'thirdparty', 'tcc', 'lib', 'openlibm.o')
+	os.mkdir_all(os.dir(openlibm)) or { panic(err) }
+	os.write_file(openlibm, '') or { panic(err) }
+	assert v3_system_tcc_runtime_available(test_root, 'windows')
+}
+
 fn test_v3_regenerates_cc_fallback_after_implicit_tcc() {
 	assert !v3_should_regenerate_after_implicit_tcc(true, false, false, 0)
 	assert !v3_should_regenerate_after_implicit_tcc(true, false, true, 1)

--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -16,15 +16,13 @@ fn test_v3_tcc_backtrace_enabled() {
 	assert !v3_tcc_backtrace_enabled('linux', 'arm64', true)
 }
 
-fn test_v3_windows_default_compiler_uses_implicit_tcc() {
+fn test_v3_default_compiler_uses_implicit_tcc() {
 	bundled_tcc := os.join_path(os.temp_dir(), 'thirdparty', 'tcc', 'tcc.exe')
 	system_tcc := os.join_path(os.temp_dir(), 'bin', 'tcc.exe')
-	assert v3_select_windows_default_c_compiler('cc', false, 'windows', 'windows', bundled_tcc) == bundled_tcc
-	assert v3_select_windows_default_c_compiler('cc', false, 'windows', 'windows', system_tcc) == system_tcc
-	assert v3_select_windows_default_c_compiler('cc', false, 'windows', 'windows', '') == 'cc'
-	assert v3_select_windows_default_c_compiler('clang', true, 'windows', 'windows', bundled_tcc) == 'clang'
-	assert v3_select_windows_default_c_compiler('cc', false, 'linux', 'windows', bundled_tcc) == 'cc'
-	assert v3_select_windows_default_c_compiler('cc', false, 'windows', 'linux', bundled_tcc) == 'cc'
+	assert v3_select_implicit_c_compiler('cc', false, bundled_tcc) == bundled_tcc
+	assert v3_select_implicit_c_compiler('cc', false, system_tcc) == system_tcc
+	assert v3_select_implicit_c_compiler('cc', false, '') == 'cc'
+	assert v3_select_implicit_c_compiler('clang', true, bundled_tcc) == 'clang'
 }
 
 fn test_v3_bundled_tcc_probe_eligibility() {

--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -25,14 +25,17 @@ fn test_v3_default_compiler_uses_implicit_tcc() {
 	assert v3_select_implicit_c_compiler('clang', true, bundled_tcc) == 'clang'
 }
 
-fn test_v3_implicit_tcc_uses_platform_compiler_for_cpp_objects() {
+fn test_v3_implicit_tcc_uses_platform_compiler_for_non_c_objects() {
 	implicit_tcc := os.join_path(os.temp_dir(), 'bin', 'tcc')
 	assert c_source_object_compiler('', implicit_tcc, true) == implicit_tcc
-	assert c_source_object_compiler('objective-c', implicit_tcc, true) == implicit_tcc
+	assert c_source_object_compiler('objective-c', implicit_tcc, true) == 'cc'
 	assert c_source_object_compiler('c++', implicit_tcc, true) == 'c++'
 	assert c_source_object_compiler('objective-c++', implicit_tcc, true) == 'c++'
+	assert c_source_object_compiler('objective-c', 'cc', false) == 'cc'
 	assert c_source_object_compiler('c++', 'cc', false) == 'c++'
+	assert c_source_object_compiler('objective-c', 'clang', false) == 'clang'
 	assert c_source_object_compiler('c++', 'clang', false) == 'clang'
+	assert c_source_object_compiler('objective-c', 'tcc', false) == 'tcc'
 	assert c_source_object_compiler('c++', 'tcc', false) == 'tcc'
 }
 

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -1212,9 +1212,9 @@ fn c_source_language(source_file string, source_language string) string {
 	return ''
 }
 
-fn c_source_object_compiler(language string, c_compiler string, use_platform_non_c_compiler bool) string {
+fn c_source_object_compiler(language string, c_compiler string, use_platform_non_c_compiler bool, target_os string) string {
 	if use_platform_non_c_compiler && language == 'objective-c' {
-		return 'cc'
+		return v3_platform_c_compiler(target_os)
 	}
 	if language in ['c++', 'objective-c++']
 		&& (c_compiler == 'cc' || use_platform_non_c_compiler) {
@@ -1233,7 +1233,7 @@ fn compile_cached_c_source_object(obj_path string, source_file string, source_la
 	} else {
 		c_standard_flag(c99)
 	}
-	compiler := c_source_object_compiler(language, c_compiler, use_platform_non_c_compiler)
+	compiler := c_source_object_compiler(language, c_compiler, use_platform_non_c_compiler, target.os)
 	mut args := [std_flag]
 	args << target_args
 	if pic_flag.len > 0 {
@@ -6659,7 +6659,7 @@ fn v3_should_probe_bundled_tcc(options V3BundledTccProbeOptions) bool {
 		}
 		return os.real_path(compiler_path) == os.real_path(options.bundled_tcc)
 	}
-	if options.dump_c_flags || options.parallel_cc {
+	if options.dump_c_flags || (options.parallel_cc && options.target.os != 'windows') {
 		return false
 	}
 	// Windows uses its bundled TCC as the platform default, including modes that
@@ -9256,7 +9256,8 @@ pub fn run(args []string) {
 		bundled_tcc: bundled_tcc
 	})
 	allow_system_tcc := backend == 'c' && !c_only && !is_prod && !is_c_debug
-		&& !c_compiler_explicit && !parallel_cc && target.os == host_target.os
+		&& !c_compiler_explicit && (!parallel_cc || target.os == 'windows')
+		&& target.os == host_target.os
 		&& target.arch == host_target.arch
 	implicit_tcc := v3_default_tcc_compiler(bundled_tcc, bundled_tcc_available, allow_system_tcc, dump_c_flags.len > 0, host_os)
 	c_compiler = v3_select_implicit_c_compiler(c_compiler, c_compiler_explicit, implicit_tcc)

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -11556,7 +11556,13 @@ pub fn run(args []string) {
 			object_optimization_flags := v3_prod_c_object_optimization_flags(is_prod, no_prod_options, is_shared, parallel_cc, effective_tcc)
 			resolved_c_flags = prepare_c_flags_for_link(generated_c_flags, environment_c_flags, object_optimization_flags, prefs.c99, pic_flag, target_args, prefs.target, c_compiler, use_implicit_tcc_semantics, cc_dir, mut c_object_cache_stats) or {
 				message := err.msg()
-				if request_macos_v3_c_error_fallback_from_message(macos_v3_fallback_file, macos_v3_c_error_dir, c_compiler, message, [
+				if v3_should_regenerate_after_implicit_tcc(retry_compilation, use_implicit_tcc_semantics, false, 0) {
+					v3_regenerate_after_implicit_tcc(args, c_compiler_arg_index, cc_dir, verbose, show_cc)
+					return
+				}
+				if use_implicit_tcc_semantics {
+					clear_macos_v3_compiler_error_fallback(macos_v3_fallback_file)
+				} else if request_macos_v3_c_error_fallback_from_message(macos_v3_fallback_file, macos_v3_c_error_dir, c_compiler, message, [
 					published_c_source,
 					cache_plan_file,
 					cc_src,
@@ -12175,19 +12181,7 @@ pub fn run(args []string) {
 			used_tcc = result.exit_code == 0
 		}
 		if v3_should_regenerate_after_implicit_tcc(retry_compilation, use_implicit_tcc_semantics, tried_tcc, result.exit_code) {
-			fallback := 'cc'
-			if verbose || show_cc {
-				eprintln('warning: regenerating the tcc-targeted unit with ${fallback}')
-			}
-			retry_args := v3_retry_compilation_args(args, c_compiler_arg_index, fallback)
-			cleanup_c_build_dir(cc_dir)
-			retry_result := cmdexec.run(os.executable(), retry_args)
-			if retry_result.output.len > 0 {
-				print(retry_result.output)
-			}
-			if retry_result.exit_code != 0 {
-				exit(retry_result.exit_code)
-			}
+			v3_regenerate_after_implicit_tcc(args, c_compiler_arg_index, cc_dir, verbose, show_cc)
 			return
 		}
 		if !retry_compilation && use_implicit_tcc_semantics
@@ -12486,6 +12480,22 @@ fn v3_retry_compilation_args(args []string, c_compiler_arg_index int, fallback s
 		}
 	}
 	return public_args
+}
+
+fn v3_regenerate_after_implicit_tcc(args []string, c_compiler_arg_index int, cc_dir string, verbose bool, show_cc bool) {
+	fallback := 'cc'
+	if verbose || show_cc {
+		eprintln('warning: regenerating the tcc-targeted unit with ${fallback}')
+	}
+	retry_args := v3_retry_compilation_args(args, c_compiler_arg_index, fallback)
+	cleanup_c_build_dir(cc_dir)
+	retry_result := cmdexec.run(os.executable(), retry_args)
+	if retry_result.output.len > 0 {
+		print(retry_result.output)
+	}
+	if retry_result.exit_code != 0 {
+		exit(retry_result.exit_code)
+	}
 }
 
 fn checker_fixture_include_target_message(raw string) (string, string) {

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -6744,10 +6744,10 @@ fn v3_effective_c_compiler_for_codegen(backend string, c_compiler string, use_im
 	return effective_c_compiler_name(c_compiler, target)
 }
 
-fn v3_select_windows_default_c_compiler(c_compiler string, c_compiler_explicit bool, host_os string, target_os string, bundled_tcc string, bundled_tcc_available bool) string {
+fn v3_select_windows_default_c_compiler(c_compiler string, c_compiler_explicit bool, host_os string, target_os string, implicit_tcc string) string {
 	if !c_compiler_explicit && host_os == 'windows' && target_os == 'windows'
-		&& bundled_tcc_available {
-		return bundled_tcc
+		&& implicit_tcc != '' {
+		return implicit_tcc
 	}
 	return c_compiler
 }
@@ -9241,7 +9241,7 @@ pub fn run(args []string) {
 	allow_system_tcc := backend == 'c' && !c_only && !is_prod && !is_c_debug
 		&& !c_compiler_explicit && target.os == host_target.os && target.arch == host_target.arch
 	implicit_tcc := v3_default_tcc_compiler(bundled_tcc, bundled_tcc_available, allow_system_tcc, dump_c_flags.len > 0, host_os)
-	c_compiler = v3_select_windows_default_c_compiler(c_compiler, c_compiler_explicit, host_os, target.os, bundled_tcc, bundled_tcc_available)
+	c_compiler = v3_select_windows_default_c_compiler(c_compiler, c_compiler_explicit, host_os, target.os, implicit_tcc)
 	// Generate for the compiler that receives the first build attempt. If implicit
 	// TCC cannot be used, regenerate below before invoking the `cc` fallback.
 	use_implicit_tcc_semantics := backend == 'c' && !c_compiler_explicit && implicit_tcc != ''
@@ -9258,8 +9258,8 @@ pub fn run(args []string) {
 		clear_macos_v3_compiler_error_fallback(macos_v3_fallback_file)
 		return
 	}
-	// Windows selects its bundled TCC without an explicit `-cc`. Compiler flags
-	// follow that effective compiler, while retry policy still follows user intent.
+	// Windows selects its implicit bundled or system TCC without an explicit `-cc`.
+	// Compiler flags follow that effective compiler, while retry policy still follows user intent.
 	effective_tcc := backend in ['c', 'fastc'] && effective_c_compiler == 'tinyc'
 	explicit_tcc := c_compiler_explicit && effective_tcc
 	add_v3_tcc_compat_defines(mut user_defines, target.os, target.arch, is_shared, effective_tcc)

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -6610,6 +6610,13 @@ fn default_cc_identity() string {
 	return '${cc_path}\t${metadata}\t${version.exit_code}\t${version.output.replace('\n', ' ')}'
 }
 
+fn v3_usable_tcc_compiler(tcc_path string) bool {
+	if !os.is_executable(tcc_path) {
+		return false
+	}
+	return cmdexec.run(tcc_path, ['-v']).exit_code == 0
+}
+
 fn v3_usable_system_tcc_compiler(host_os string) string {
 	// Match the V1 system-TCC fallback on macOS: a PATH-installed TCC remains
 	// opt-in because SDK and framework headers can require Clang compatibility.
@@ -6617,8 +6624,7 @@ fn v3_usable_system_tcc_compiler(host_os string) string {
 		return ''
 	}
 	system_tcc := os.find_abs_path_of_executable('tcc') or { return '' }
-	tcc_probe := cmdexec.run(system_tcc, ['-v'])
-	if tcc_probe.exit_code != 0 {
+	if !v3_usable_tcc_compiler(system_tcc) {
 		return ''
 	}
 	return system_tcc
@@ -9169,7 +9175,7 @@ pub fn run(args []string) {
 		resolve_vroot_for_input(prefs.vroot, input_file)
 	}
 	bundled_tcc := os.join_path(prefs.vroot, 'thirdparty', 'tcc', 'tcc.exe')
-	bundled_tcc_available := os.is_executable(bundled_tcc)
+	bundled_tcc_available := v3_usable_tcc_compiler(bundled_tcc)
 	host_os := os.user_os()
 	host_target := pref.host_target()
 	allow_system_tcc := backend == 'c' && !c_only && !is_prod && !is_c_debug

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -6730,6 +6730,13 @@ fn effective_c_compiler_name(compiler string, target pref.Target) string {
 	return if target.os in ['macos', 'ios'] { 'clang' } else { 'gcc' }
 }
 
+fn v3_effective_c_compiler_for_codegen(backend string, c_compiler string, use_implicit_tcc_semantics bool, target pref.Target) string {
+	if backend == 'arm64' || use_implicit_tcc_semantics {
+		return 'tinyc'
+	}
+	return effective_c_compiler_name(c_compiler, target)
+}
+
 fn v3_select_windows_default_c_compiler(c_compiler string, c_compiler_explicit bool, host_os string, target_os string, bundled_tcc string, bundled_tcc_available bool) string {
 	if !c_compiler_explicit && host_os == 'windows' && target_os == 'windows'
 		&& bundled_tcc_available {
@@ -6738,17 +6745,8 @@ fn v3_select_windows_default_c_compiler(c_compiler string, c_compiler_explicit b
 	return c_compiler
 }
 
-fn v3_should_prefer_bundled_tcc_for_selfhost(building_v bool, backend string, c_only bool, is_prod bool, is_c_debug bool, c_compiler_explicit bool, target pref.Target, bundled_tcc_available bool) bool {
-	if !building_v || backend != 'c' || c_only || is_prod || is_c_debug || c_compiler_explicit
-		|| !bundled_tcc_available {
-		return false
-	}
-	host := pref.host_target()
-	return target.os == host.os && target.arch == host.arch
-}
-
-fn v3_should_regenerate_for_cc_fallback(prefer_bundled_tcc bool, tried_tcc bool, tcc_exit_code int) bool {
-	return prefer_bundled_tcc && (!tried_tcc || tcc_exit_code != 0)
+fn v3_should_regenerate_after_implicit_tcc(use_implicit_tcc_semantics bool, tried_tcc bool, tcc_exit_code int) bool {
+	return use_implicit_tcc_semantics && (!tried_tcc || tcc_exit_code != 0)
 }
 
 struct V3TestBuildConstraint {
@@ -9236,18 +9234,10 @@ pub fn run(args []string) {
 		&& !c_compiler_explicit && target.os == host_target.os && target.arch == host_target.arch
 	implicit_tcc := v3_default_tcc_compiler(bundled_tcc, bundled_tcc_available, allow_system_tcc, host_os)
 	c_compiler = v3_select_windows_default_c_compiler(c_compiler, c_compiler_explicit, host_os, target.os, bundled_tcc, bundled_tcc_available)
-	// The non-production C path tries bundled TCC before its `cc` fallback. Select
-	// TinyCC compile-time branches for a self-host too, so system headers and inline
-	// assembly intended for Clang do not prevent that first attempt.
-	prefer_bundled_tcc := retry_compilation
-		&& v3_should_prefer_bundled_tcc_for_selfhost(building_v, backend, c_only, is_prod, is_c_debug, c_compiler_explicit, target, bundled_tcc_available)
-	effective_c_compiler := if backend == 'arm64' {
-		'tinyc'
-	} else if prefer_bundled_tcc {
-		'tinyc'
-	} else {
-		effective_c_compiler_name(c_compiler, target)
-	}
+	// Generate for the compiler that receives the first build attempt. If implicit
+	// TCC cannot be used, regenerate below before invoking the `cc` fallback.
+	use_implicit_tcc_semantics := backend == 'c' && !c_compiler_explicit && implicit_tcc != ''
+	effective_c_compiler := v3_effective_c_compiler_for_codegen(backend, c_compiler, use_implicit_tcc_semantics, target)
 	incompatible_direct_test := v3_direct_test_input_is_incompatible(is_test_command, input_file, backend, target, effective_c_compiler, is_prod, user_defines)
 	if incompatible_direct_test {
 		// Directory test discovery already excludes incompatible backend/platform files.
@@ -12165,9 +12155,9 @@ pub fn run(args []string) {
 			show_v3_c_compiler_output(show_c_output, tcc_path, result)
 			used_tcc = result.exit_code == 0
 		}
-		if v3_should_regenerate_for_cc_fallback(prefer_bundled_tcc, tried_tcc, result.exit_code) {
+		if v3_should_regenerate_after_implicit_tcc(use_implicit_tcc_semantics, tried_tcc, result.exit_code) {
 			fallback := 'cc'
-			eprintln('warning: bundled tcc could not build the generated unit, regenerating with ${fallback}')
+			eprintln('warning: regenerating the tcc-targeted unit with ${fallback}')
 			retry_args := v3_retry_compilation_args(args, c_compiler_arg_index, fallback)
 			cleanup_c_build_dir(cc_dir)
 			retry_result := cmdexec.run(os.executable(), retry_args)

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -6703,6 +6703,13 @@ fn v3_default_tcc_compiler(bundled_tcc string, bundled_tcc_available bool, allow
 	return v3_usable_system_tcc_compiler(host_os)
 }
 
+fn v3_system_tcc_runtime_available(vroot string, target_os string) bool {
+	if target_os != 'windows' {
+		return true
+	}
+	return os.is_file(os.join_path(vroot, 'thirdparty', 'tcc', 'lib', 'openlibm.o'))
+}
+
 fn effective_c_compiler_name(compiler string, target pref.Target) string {
 	compiler_path := os.find_abs_path_of_executable(compiler) or { compiler }
 	resolved_path := os.real_path(compiler_path)
@@ -9259,6 +9266,7 @@ pub fn run(args []string) {
 		&& !c_compiler_explicit && (!parallel_cc || target.os == 'windows')
 		&& target.os == host_target.os
 		&& target.arch == host_target.arch
+		&& v3_system_tcc_runtime_available(prefs.vroot, target.os)
 	implicit_tcc := v3_default_tcc_compiler(bundled_tcc, bundled_tcc_available, allow_system_tcc, dump_c_flags.len > 0, host_os)
 	c_compiler = v3_select_implicit_c_compiler(c_compiler, c_compiler_explicit, implicit_tcc)
 	// Generate for the compiler that receives the first build attempt. If implicit

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -254,7 +254,10 @@ fn tcc_atomic_arg(prefs &pref.Preferences, tcc_path string, tcc_includes string)
 	}
 	os.mkdir_all(cache_dir) or { return atomic_s }
 	build_path := '${object_path}.tmp.${os.getpid()}'
-	mut args := ['-std=gnu11', tcc_includes]
+	mut args := ['-std=gnu11']
+	if tcc_includes != '' {
+		args << tcc_includes
+	}
 	if wrapv_flag.len > 0 {
 		args << wrapv_flag
 	}
@@ -1117,8 +1120,11 @@ fn v3_cached_tcc_executable_path(manager &modulecache.Manager, source_identity s
 		hash = c_hash_bytes(hash, identity.bytes())
 		hash = c_hash_bytes(hash, [u8(0xff)])
 	}
-	mut inputs := os.walk_ext(tcc_lib_dir, '.h')
-	inputs << os.walk_ext(tcc_lib_dir, '.a')
+	mut inputs := []string{}
+	if tcc_lib_dir != '' {
+		inputs = os.walk_ext(tcc_lib_dir, '.h')
+		inputs << os.walk_ext(tcc_lib_dir, '.a')
+	}
 	for arg in tcc_args {
 		clean := arg.trim_space()
 		if os.is_file(clean) {
@@ -2361,6 +2367,13 @@ fn v3_tcc_resource_flags(vroot string) V3TccResourceFlags {
 		include_arg: '-I${include_dir}'
 		library_arg: '-L${install_dir}'
 	}
+}
+
+fn v3_tcc_resource_flags_for_compiler(vroot string, tcc_path string, bundled_tcc string, bundled_tcc_available bool) V3TccResourceFlags {
+	if !bundled_tcc_available || os.real_path(tcc_path) != os.real_path(bundled_tcc) {
+		return V3TccResourceFlags{}
+	}
+	return v3_tcc_resource_flags(vroot)
 }
 
 fn v3_tcc_host_system_flags(target_os string, macos_sdk_root string) []string {
@@ -6597,6 +6610,30 @@ fn default_cc_identity() string {
 	return '${cc_path}\t${metadata}\t${version.exit_code}\t${version.output.replace('\n', ' ')}'
 }
 
+fn v3_usable_system_tcc_compiler(host_os string) string {
+	// Match the V1 system-TCC fallback on macOS: a PATH-installed TCC remains
+	// opt-in because SDK and framework headers can require Clang compatibility.
+	if host_os == 'macos' {
+		return ''
+	}
+	system_tcc := os.find_abs_path_of_executable('tcc') or { return '' }
+	tcc_probe := cmdexec.run(system_tcc, ['-v'])
+	if tcc_probe.exit_code != 0 {
+		return ''
+	}
+	return system_tcc
+}
+
+fn v3_default_tcc_compiler(bundled_tcc string, bundled_tcc_available bool, allow_system_tcc bool, host_os string) string {
+	if bundled_tcc_available {
+		return bundled_tcc
+	}
+	if !allow_system_tcc {
+		return ''
+	}
+	return v3_usable_system_tcc_compiler(host_os)
+}
+
 fn effective_c_compiler_name(compiler string, target pref.Target) string {
 	compiler_path := os.find_abs_path_of_executable(compiler) or { compiler }
 	resolved_path := os.real_path(compiler_path)
@@ -9133,7 +9170,12 @@ pub fn run(args []string) {
 	}
 	bundled_tcc := os.join_path(prefs.vroot, 'thirdparty', 'tcc', 'tcc.exe')
 	bundled_tcc_available := os.is_executable(bundled_tcc)
-	c_compiler = v3_select_windows_default_c_compiler(c_compiler, c_compiler_explicit, os.user_os(), target.os, bundled_tcc, bundled_tcc_available)
+	host_os := os.user_os()
+	host_target := pref.host_target()
+	allow_system_tcc := backend == 'c' && !c_only && !is_prod && !is_c_debug
+		&& !c_compiler_explicit && target.os == host_target.os && target.arch == host_target.arch
+	implicit_tcc := v3_default_tcc_compiler(bundled_tcc, bundled_tcc_available, allow_system_tcc, host_os)
+	c_compiler = v3_select_windows_default_c_compiler(c_compiler, c_compiler_explicit, host_os, target.os, bundled_tcc, bundled_tcc_available)
 	// The non-production C path tries bundled TCC before its `cc` fallback. Select
 	// TinyCC compile-time branches for a self-host too, so system headers and inline
 	// assembly intended for Clang do not prevent that first attempt.
@@ -9462,7 +9504,6 @@ pub fn run(args []string) {
 	}
 	minimal_literal_output := !is_prof
 		&& input_uses_minimal_literal_output_builtin(input_file, prefs, is_test_command, is_checker_fixture)
-	host_target := pref.host_target()
 	mut use_parallel_c_compilation := parallel_cc && backend == 'c' && !c_only && !effective_tcc
 		&& !is_o && target.os != 'windows' && coverage_dir.len == 0 && profile_file.len == 0
 		&& v3_parallel_cc_monolithic_define !in user_defines
@@ -11926,19 +11967,24 @@ pub fn run(args []string) {
 		mut tcc_cache_hit := false
 		mut used_tcc := false
 		if cached_dev_dylib.len > 0 && tcc_main_file.len > 0 && !link_uses_non_c_language
-			&& !is_c_debug {
+			&& !is_c_debug && implicit_tcc != '' {
 			tried_tcc = true
-			tcc_dir := os.join_path_single(os.join_path_single(prefs.vroot, 'thirdparty'), 'tcc')
-			tcc_path := os.join_path_single(tcc_dir, 'tcc.exe')
-			tcc_resources := v3_tcc_resource_flags(prefs.vroot)
-			mut tcc_args := [c_standard, tcc_resources.base_arg, tcc_resources.include_arg,
-				tcc_resources.library_arg, '-w', '-Werror=implicit-function-declaration']
+			tcc_path := implicit_tcc
+			tcc_resources := v3_tcc_resource_flags_for_compiler(prefs.vroot, tcc_path, bundled_tcc, bundled_tcc_available)
+			mut tcc_args := [c_standard]
+			if tcc_resources.base_arg != '' {
+				tcc_args << [tcc_resources.base_arg, tcc_resources.include_arg,
+					tcc_resources.library_arg]
+			}
+			tcc_args << ['-w', '-Werror=implicit-function-declaration']
 			tcc_sdk_root := if prefs.normalized_target_os() == 'macos' {
 				macos_sdk_root_cache.get()
 			} else {
 				''
 			}
-			tcc_args << v3_tcc_host_system_flags(prefs.normalized_target_os(), tcc_sdk_root)
+			if tcc_resources.base_arg != '' {
+				tcc_args << v3_tcc_host_system_flags(prefs.normalized_target_os(), tcc_sdk_root)
+			}
 			if v3_tcc_backtrace_enabled(prefs.normalized_target_os(), prefs.normalized_target_arch(), is_shared) {
 				tcc_args << '-bt25'
 			}
@@ -11997,19 +12043,17 @@ pub fn run(args []string) {
 			&& (!tcc_link_has_incompatible_objects || cache_full_tcc_source.len > 0)
 			&& target_args.len == 0 && (!c_compiler_explicit || explicit_tcc)
 			&& (!cache_state.manager.enabled || cache_full_tcc_source.len > 0) && !is_c_debug
-			&& dump_c_flags.len == 0 {
+			&& dump_c_flags.len == 0 && (explicit_tcc || implicit_tcc != '') {
 			tried_tcc = true
-			tcc_dir := os.join_path_single(os.join_path_single(prefs.vroot, 'thirdparty'), 'tcc')
-			bundled_tcc_path := os.join_path_single(tcc_dir, 'tcc.exe')
 			tcc_path := if explicit_tcc && c_compiler in ['tcc', 'tinyc']
-				&& os.is_executable(bundled_tcc_path) {
-				bundled_tcc_path
+				&& bundled_tcc_available {
+				bundled_tcc
 			} else if explicit_tcc {
 				c_compiler
 			} else {
-				bundled_tcc_path
+				implicit_tcc
 			}
-			tcc_resources := v3_tcc_resource_flags(prefs.vroot)
+			tcc_resources := v3_tcc_resource_flags_for_compiler(prefs.vroot, tcc_path, bundled_tcc, bundled_tcc_available)
 			mut tcc_args := environment_c_flags.clone()
 			if link_c_standard.len > 0 {
 				tcc_args << link_c_standard
@@ -12017,14 +12061,18 @@ pub fn run(args []string) {
 			if pic_flag.len > 0 {
 				tcc_args << pic_flag
 			}
-			tcc_args << [tcc_resources.base_arg, tcc_resources.include_arg,
-				tcc_resources.library_arg]
+			if tcc_resources.base_arg != '' {
+				tcc_args << [tcc_resources.base_arg, tcc_resources.include_arg,
+					tcc_resources.library_arg]
+			}
 			tcc_sdk_root := if prefs.normalized_target_os() == 'macos' {
 				macos_sdk_root_cache.get()
 			} else {
 				''
 			}
-			tcc_args << v3_tcc_host_system_flags(prefs.normalized_target_os(), tcc_sdk_root)
+			if tcc_resources.base_arg != '' {
+				tcc_args << v3_tcc_host_system_flags(prefs.normalized_target_os(), tcc_sdk_root)
+			}
 			if v3_tcc_backtrace_enabled(prefs.normalized_target_os(), prefs.normalized_target_arch(), is_shared) {
 				tcc_args << '-bt25'
 			}

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -6745,8 +6745,8 @@ fn v3_select_windows_default_c_compiler(c_compiler string, c_compiler_explicit b
 	return c_compiler
 }
 
-fn v3_should_regenerate_after_implicit_tcc(use_implicit_tcc_semantics bool, tried_tcc bool, tcc_exit_code int) bool {
-	return use_implicit_tcc_semantics && (!tried_tcc || tcc_exit_code != 0)
+fn v3_should_regenerate_after_implicit_tcc(retry_compilation bool, use_implicit_tcc_semantics bool, tried_tcc bool, tcc_exit_code int) bool {
+	return retry_compilation && use_implicit_tcc_semantics && (!tried_tcc || tcc_exit_code != 0)
 }
 
 struct V3TestBuildConstraint {
@@ -12155,9 +12155,11 @@ pub fn run(args []string) {
 			show_v3_c_compiler_output(show_c_output, tcc_path, result)
 			used_tcc = result.exit_code == 0
 		}
-		if v3_should_regenerate_after_implicit_tcc(use_implicit_tcc_semantics, tried_tcc, result.exit_code) {
+		if v3_should_regenerate_after_implicit_tcc(retry_compilation, use_implicit_tcc_semantics, tried_tcc, result.exit_code) {
 			fallback := 'cc'
-			eprintln('warning: regenerating the tcc-targeted unit with ${fallback}')
+			if verbose || show_cc {
+				eprintln('warning: regenerating the tcc-targeted unit with ${fallback}')
+			}
 			retry_args := v3_retry_compilation_args(args, c_compiler_arg_index, fallback)
 			cleanup_c_build_dir(cc_dir)
 			retry_result := cmdexec.run(os.executable(), retry_args)
@@ -12168,6 +12170,18 @@ pub fn run(args []string) {
 				exit(retry_result.exit_code)
 			}
 			return
+		}
+		if !retry_compilation && use_implicit_tcc_semantics
+			&& (!tried_tcc || result.exit_code != 0) {
+			if tried_tcc {
+				eprintln('C compilation error (from ${os.file_name(implicit_tcc)}):')
+				eprintln(result.output)
+			} else {
+				eprintln('C compilation error: implicit tcc could not be used for this build')
+			}
+			clear_macos_v3_compiler_error_fallback(macos_v3_fallback_file)
+			cleanup_c_build_dir(cc_dir)
+			exit(1)
 		}
 		if is_prod || !tried_tcc || result.exit_code != 0 {
 			used_tcc = false

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -6637,6 +6637,7 @@ struct V3BundledTccProbeOptions {
 	c_compiler          string
 	c_compiler_explicit bool
 	dump_c_flags        bool
+	parallel_cc         bool
 	host_os             string
 	host_target         pref.Target
 	target              pref.Target
@@ -6658,7 +6659,7 @@ fn v3_should_probe_bundled_tcc(options V3BundledTccProbeOptions) bool {
 		}
 		return os.real_path(compiler_path) == os.real_path(options.bundled_tcc)
 	}
-	if options.dump_c_flags {
+	if options.dump_c_flags || options.parallel_cc {
 		return false
 	}
 	// Windows uses its bundled TCC as the platform default, including modes that
@@ -9248,13 +9249,15 @@ pub fn run(args []string) {
 		c_compiler: c_compiler
 		c_compiler_explicit: c_compiler_explicit
 		dump_c_flags: dump_c_flags.len > 0
+		parallel_cc: parallel_cc
 		host_os: host_os
 		host_target: host_target
 		target: target
 		bundled_tcc: bundled_tcc
 	})
 	allow_system_tcc := backend == 'c' && !c_only && !is_prod && !is_c_debug
-		&& !c_compiler_explicit && target.os == host_target.os && target.arch == host_target.arch
+		&& !c_compiler_explicit && !parallel_cc && target.os == host_target.os
+		&& target.arch == host_target.arch
 	implicit_tcc := v3_default_tcc_compiler(bundled_tcc, bundled_tcc_available, allow_system_tcc, dump_c_flags.len > 0, host_os)
 	c_compiler = v3_select_implicit_c_compiler(c_compiler, c_compiler_explicit, implicit_tcc)
 	// Generate for the compiler that receives the first build attempt. If implicit

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -6763,6 +6763,10 @@ fn v3_select_implicit_c_compiler(c_compiler string, c_compiler_explicit bool, im
 	return c_compiler
 }
 
+fn v3_platform_c_compiler(host_os string) string {
+	return if host_os == 'windows' { 'gcc' } else { 'cc' }
+}
+
 fn v3_should_regenerate_after_implicit_tcc(retry_compilation bool, use_implicit_tcc_semantics bool, tried_tcc bool, tcc_exit_code int) bool {
 	return retry_compilation && use_implicit_tcc_semantics && (!tried_tcc || tcc_exit_code != 0)
 }
@@ -12252,7 +12256,7 @@ pub fn run(args []string) {
 			show_v3_c_compiler_output(show_c_output, c_compiler, result)
 			if result.exit_code != 0 {
 				if retry_compilation && v3_is_tcc_compilation_failure(c_compiler, result.output) {
-					fallback := 'cc'
+					fallback := v3_platform_c_compiler(host_os)
 					eprintln('warning: tcc compilation failed, falling back to ${fallback}')
 					retry_args := v3_retry_compilation_args(args, c_compiler_arg_index, fallback)
 					cleanup_c_build_dir(cc_dir)
@@ -12483,7 +12487,7 @@ fn v3_retry_compilation_args(args []string, c_compiler_arg_index int, fallback s
 }
 
 fn v3_regenerate_after_implicit_tcc(args []string, c_compiler_arg_index int, cc_dir string, verbose bool, show_cc bool) {
-	fallback := 'cc'
+	fallback := v3_platform_c_compiler(os.user_os())
 	if verbose || show_cc {
 		eprintln('warning: regenerating the tcc-targeted unit with ${fallback}')
 	}

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -323,7 +323,7 @@ fn add_c_language_runtime_link_flags(mut prepared []string, original []string, l
 	}
 }
 
-fn prepare_c_flags_for_link(flags []string, environment_c_flags []string, optimization_flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, c_compiler string, use_platform_cpp_compiler bool, uncached_dir string, mut stats CObjectCacheStats) ![]string {
+fn prepare_c_flags_for_link(flags []string, environment_c_flags []string, optimization_flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, c_compiler string, use_platform_non_c_compiler bool, uncached_dir string, mut stats CObjectCacheStats) ![]string {
 	// Nothing to cache: without object-file or native-source flags the link
 	// plan adds no value, and preparing it costs a compiler-identity probe
 	// (subprocess) plus plan-file signatures on every build.
@@ -350,7 +350,7 @@ fn prepare_c_flags_for_link(flags []string, environment_c_flags []string, optimi
 	support_flags << c_object_compile_support_flags(flags)
 	cache_dir := os.join_path(os.vtmp_dir(), 'v3_thirdparty_objs')
 	os.mkdir_all(cache_dir)!
-	plan_path := c_link_plan_path(cache_dir, flags, support_flags, c99, pic_flag, target_args, target, c_compiler, use_platform_cpp_compiler, mut stats)
+	plan_path := c_link_plan_path(cache_dir, flags, support_flags, c99, pic_flag, target_args, target, c_compiler, use_platform_non_c_compiler, mut stats)
 	// Tracing intentionally walks the object manifests so every requested
 	// object's cache decision remains visible.
 	if os.getenv('V3_CACHE_TRACE') == '' {
@@ -390,13 +390,13 @@ fn prepare_c_flags_for_link(flags []string, environment_c_flags []string, optimi
 			} else {
 				''
 			}
-			object_path := ensure_c_object_file(clean, active_language, support_flags, c99, pic_flag, target_args, target, c_compiler, use_platform_cpp_compiler, uncached_dir, mut stats)!
+			object_path := ensure_c_object_file(clean, active_language, support_flags, c99, pic_flag, target_args, target, c_compiler, use_platform_non_c_compiler, uncached_dir, mut stats)!
 			append_c_link_object(mut prepared, object_path, active_language)
 			add_c_language_runtime_link_flags(mut prepared, flags, adjacent_language, target)
 		} else if clean.ends_with('.mm') {
 			stats.requests++
 			language := c_source_language(clean, active_language)
-			object_path := ensure_c_source_object(clean, active_language, support_flags, c99, pic_flag, target_args, target, c_compiler, use_platform_cpp_compiler, uncached_dir, mut stats)!
+			object_path := ensure_c_source_object(clean, active_language, support_flags, c99, pic_flag, target_args, target, c_compiler, use_platform_non_c_compiler, uncached_dir, mut stats)!
 			append_c_link_object(mut prepared, object_path, active_language)
 			if c_generated_native_source_context(clean, uncached_dir) {
 				os.rm(clean) or {}
@@ -422,13 +422,13 @@ fn prepare_c_flags_for_link(flags []string, environment_c_flags []string, optimi
 	return prepared
 }
 
-fn c_link_plan_path(cache_dir string, flags []string, support_flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, compiler string, use_platform_cpp_compiler bool, mut stats CObjectCacheStats) string {
+fn c_link_plan_path(cache_dir string, flags []string, support_flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, compiler string, use_platform_non_c_compiler bool, mut stats CObjectCacheStats) string {
 	compiler_path, compiler_version := c_object_compiler_identity(compiler, mut stats)
 	mut hash := u64(1469598103934665603)
 	for identity in ['v3-c-link-plan-v3', os.getwd(), flags.join('\x00'), support_flags.join('\x00'),
 		c99.str(), pic_flag, target_args.join('\x00'), compiler_path, compiler_version, target.os,
 		target.arch, target.abi, target.endian, target.pointer_bits.str(), target.object_format,
-		use_platform_cpp_compiler.str()] {
+		use_platform_non_c_compiler.str()] {
 		hash = c_hash_bytes(hash, identity.bytes())
 		hash = c_hash_bytes(hash, [u8(0xff)])
 	}
@@ -1178,7 +1178,7 @@ fn c_flags_need_objective_c(flags []string) bool {
 	return false
 }
 
-fn ensure_c_object_file(obj_path string, source_language string, support_flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, c_compiler string, use_platform_cpp_compiler bool, uncached_dir string, mut stats CObjectCacheStats) !string {
+fn ensure_c_object_file(obj_path string, source_language string, support_flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, c_compiler string, use_platform_non_c_compiler bool, uncached_dir string, mut stats CObjectCacheStats) !string {
 	if os.exists(obj_path) {
 		stats.direct_objects++
 		return obj_path
@@ -1186,14 +1186,14 @@ fn ensure_c_object_file(obj_path string, source_language string, support_flags [
 	source_file := c_source_from_object_file(obj_path) or {
 		return error('missing C object ${obj_path}, and no adjacent .c/.cc/.cpp/.m/.mm/.S source was found')
 	}
-	return compile_cached_c_source_object(obj_path, source_file, source_language, support_flags, c99, pic_flag, target_args, target, c_compiler, use_platform_cpp_compiler, uncached_dir, mut stats)
+	return compile_cached_c_source_object(obj_path, source_file, source_language, support_flags, c99, pic_flag, target_args, target, c_compiler, use_platform_non_c_compiler, uncached_dir, mut stats)
 }
 
-fn ensure_c_source_object(source_file string, source_language string, support_flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, c_compiler string, use_platform_cpp_compiler bool, uncached_dir string, mut stats CObjectCacheStats) !string {
+fn ensure_c_source_object(source_file string, source_language string, support_flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, c_compiler string, use_platform_non_c_compiler bool, uncached_dir string, mut stats CObjectCacheStats) !string {
 	if !os.exists(source_file) {
 		return error('missing C source ${source_file}')
 	}
-	return compile_cached_c_source_object('${source_file}.o', source_file, source_language, support_flags, c99, pic_flag, target_args, target, c_compiler, use_platform_cpp_compiler, uncached_dir, mut stats)
+	return compile_cached_c_source_object('${source_file}.o', source_file, source_language, support_flags, c99, pic_flag, target_args, target, c_compiler, use_platform_non_c_compiler, uncached_dir, mut stats)
 }
 
 fn c_source_language(source_file string, source_language string) string {
@@ -1212,15 +1212,18 @@ fn c_source_language(source_file string, source_language string) string {
 	return ''
 }
 
-fn c_source_object_compiler(language string, c_compiler string, use_platform_cpp_compiler bool) string {
+fn c_source_object_compiler(language string, c_compiler string, use_platform_non_c_compiler bool) string {
+	if use_platform_non_c_compiler && language == 'objective-c' {
+		return 'cc'
+	}
 	if language in ['c++', 'objective-c++']
-		&& (c_compiler == 'cc' || use_platform_cpp_compiler) {
+		&& (c_compiler == 'cc' || use_platform_non_c_compiler) {
 		return 'c++'
 	}
 	return c_compiler
 }
 
-fn compile_cached_c_source_object(obj_path string, source_file string, source_language string, support_flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, c_compiler string, use_platform_cpp_compiler bool, uncached_dir string, mut stats CObjectCacheStats) !string {
+fn compile_cached_c_source_object(obj_path string, source_file string, source_language string, support_flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, c_compiler string, use_platform_non_c_compiler bool, uncached_dir string, mut stats CObjectCacheStats) !string {
 	cache_dir := os.join_path(os.vtmp_dir(), 'v3_thirdparty_objs')
 	os.mkdir_all(cache_dir)!
 	language := c_source_language(source_file, source_language)
@@ -1230,7 +1233,7 @@ fn compile_cached_c_source_object(obj_path string, source_file string, source_la
 	} else {
 		c_standard_flag(c99)
 	}
-	compiler := c_source_object_compiler(language, c_compiler, use_platform_cpp_compiler)
+	compiler := c_source_object_compiler(language, c_compiler, use_platform_non_c_compiler)
 	mut args := [std_flag]
 	args << target_args
 	if pic_flag.len > 0 {

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -6744,9 +6744,8 @@ fn v3_effective_c_compiler_for_codegen(backend string, c_compiler string, use_im
 	return effective_c_compiler_name(c_compiler, target)
 }
 
-fn v3_select_windows_default_c_compiler(c_compiler string, c_compiler_explicit bool, host_os string, target_os string, implicit_tcc string) string {
-	if !c_compiler_explicit && host_os == 'windows' && target_os == 'windows'
-		&& implicit_tcc != '' {
+fn v3_select_implicit_c_compiler(c_compiler string, c_compiler_explicit bool, implicit_tcc string) string {
+	if !c_compiler_explicit && implicit_tcc != '' {
 		return implicit_tcc
 	}
 	return c_compiler
@@ -9241,7 +9240,7 @@ pub fn run(args []string) {
 	allow_system_tcc := backend == 'c' && !c_only && !is_prod && !is_c_debug
 		&& !c_compiler_explicit && target.os == host_target.os && target.arch == host_target.arch
 	implicit_tcc := v3_default_tcc_compiler(bundled_tcc, bundled_tcc_available, allow_system_tcc, dump_c_flags.len > 0, host_os)
-	c_compiler = v3_select_windows_default_c_compiler(c_compiler, c_compiler_explicit, host_os, target.os, implicit_tcc)
+	c_compiler = v3_select_implicit_c_compiler(c_compiler, c_compiler_explicit, implicit_tcc)
 	// Generate for the compiler that receives the first build attempt. If implicit
 	// TCC cannot be used, regenerate below before invoking the `cc` fallback.
 	use_implicit_tcc_semantics := backend == 'c' && !c_compiler_explicit && implicit_tcc != ''
@@ -9258,8 +9257,8 @@ pub fn run(args []string) {
 		clear_macos_v3_compiler_error_fallback(macos_v3_fallback_file)
 		return
 	}
-	// Windows selects its implicit bundled or system TCC without an explicit `-cc`.
-	// Compiler flags follow that effective compiler, while retry policy still follows user intent.
+	// Compiler flags and native inputs follow the implicit bundled or system TCC,
+	// while retry policy still follows user intent.
 	effective_tcc := backend in ['c', 'fastc'] && effective_c_compiler == 'tinyc'
 	explicit_tcc := c_compiler_explicit && effective_tcc
 	add_v3_tcc_compat_defines(mut user_defines, target.os, target.arch, is_shared, effective_tcc)

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -323,7 +323,7 @@ fn add_c_language_runtime_link_flags(mut prepared []string, original []string, l
 	}
 }
 
-fn prepare_c_flags_for_link(flags []string, environment_c_flags []string, optimization_flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, c_compiler string, uncached_dir string, mut stats CObjectCacheStats) ![]string {
+fn prepare_c_flags_for_link(flags []string, environment_c_flags []string, optimization_flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, c_compiler string, use_platform_cpp_compiler bool, uncached_dir string, mut stats CObjectCacheStats) ![]string {
 	// Nothing to cache: without object-file or native-source flags the link
 	// plan adds no value, and preparing it costs a compiler-identity probe
 	// (subprocess) plus plan-file signatures on every build.
@@ -350,7 +350,7 @@ fn prepare_c_flags_for_link(flags []string, environment_c_flags []string, optimi
 	support_flags << c_object_compile_support_flags(flags)
 	cache_dir := os.join_path(os.vtmp_dir(), 'v3_thirdparty_objs')
 	os.mkdir_all(cache_dir)!
-	plan_path := c_link_plan_path(cache_dir, flags, support_flags, c99, pic_flag, target_args, target, c_compiler, mut stats)
+	plan_path := c_link_plan_path(cache_dir, flags, support_flags, c99, pic_flag, target_args, target, c_compiler, use_platform_cpp_compiler, mut stats)
 	// Tracing intentionally walks the object manifests so every requested
 	// object's cache decision remains visible.
 	if os.getenv('V3_CACHE_TRACE') == '' {
@@ -390,13 +390,13 @@ fn prepare_c_flags_for_link(flags []string, environment_c_flags []string, optimi
 			} else {
 				''
 			}
-			object_path := ensure_c_object_file(clean, active_language, support_flags, c99, pic_flag, target_args, target, c_compiler, uncached_dir, mut stats)!
+			object_path := ensure_c_object_file(clean, active_language, support_flags, c99, pic_flag, target_args, target, c_compiler, use_platform_cpp_compiler, uncached_dir, mut stats)!
 			append_c_link_object(mut prepared, object_path, active_language)
 			add_c_language_runtime_link_flags(mut prepared, flags, adjacent_language, target)
 		} else if clean.ends_with('.mm') {
 			stats.requests++
 			language := c_source_language(clean, active_language)
-			object_path := ensure_c_source_object(clean, active_language, support_flags, c99, pic_flag, target_args, target, c_compiler, uncached_dir, mut stats)!
+			object_path := ensure_c_source_object(clean, active_language, support_flags, c99, pic_flag, target_args, target, c_compiler, use_platform_cpp_compiler, uncached_dir, mut stats)!
 			append_c_link_object(mut prepared, object_path, active_language)
 			if c_generated_native_source_context(clean, uncached_dir) {
 				os.rm(clean) or {}
@@ -422,12 +422,13 @@ fn prepare_c_flags_for_link(flags []string, environment_c_flags []string, optimi
 	return prepared
 }
 
-fn c_link_plan_path(cache_dir string, flags []string, support_flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, compiler string, mut stats CObjectCacheStats) string {
+fn c_link_plan_path(cache_dir string, flags []string, support_flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, compiler string, use_platform_cpp_compiler bool, mut stats CObjectCacheStats) string {
 	compiler_path, compiler_version := c_object_compiler_identity(compiler, mut stats)
 	mut hash := u64(1469598103934665603)
 	for identity in ['v3-c-link-plan-v3', os.getwd(), flags.join('\x00'), support_flags.join('\x00'),
 		c99.str(), pic_flag, target_args.join('\x00'), compiler_path, compiler_version, target.os,
-		target.arch, target.abi, target.endian, target.pointer_bits.str(), target.object_format] {
+		target.arch, target.abi, target.endian, target.pointer_bits.str(), target.object_format,
+		use_platform_cpp_compiler.str()] {
 		hash = c_hash_bytes(hash, identity.bytes())
 		hash = c_hash_bytes(hash, [u8(0xff)])
 	}
@@ -1177,7 +1178,7 @@ fn c_flags_need_objective_c(flags []string) bool {
 	return false
 }
 
-fn ensure_c_object_file(obj_path string, source_language string, support_flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, c_compiler string, uncached_dir string, mut stats CObjectCacheStats) !string {
+fn ensure_c_object_file(obj_path string, source_language string, support_flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, c_compiler string, use_platform_cpp_compiler bool, uncached_dir string, mut stats CObjectCacheStats) !string {
 	if os.exists(obj_path) {
 		stats.direct_objects++
 		return obj_path
@@ -1185,14 +1186,14 @@ fn ensure_c_object_file(obj_path string, source_language string, support_flags [
 	source_file := c_source_from_object_file(obj_path) or {
 		return error('missing C object ${obj_path}, and no adjacent .c/.cc/.cpp/.m/.mm/.S source was found')
 	}
-	return compile_cached_c_source_object(obj_path, source_file, source_language, support_flags, c99, pic_flag, target_args, target, c_compiler, uncached_dir, mut stats)
+	return compile_cached_c_source_object(obj_path, source_file, source_language, support_flags, c99, pic_flag, target_args, target, c_compiler, use_platform_cpp_compiler, uncached_dir, mut stats)
 }
 
-fn ensure_c_source_object(source_file string, source_language string, support_flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, c_compiler string, uncached_dir string, mut stats CObjectCacheStats) !string {
+fn ensure_c_source_object(source_file string, source_language string, support_flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, c_compiler string, use_platform_cpp_compiler bool, uncached_dir string, mut stats CObjectCacheStats) !string {
 	if !os.exists(source_file) {
 		return error('missing C source ${source_file}')
 	}
-	return compile_cached_c_source_object('${source_file}.o', source_file, source_language, support_flags, c99, pic_flag, target_args, target, c_compiler, uncached_dir, mut stats)
+	return compile_cached_c_source_object('${source_file}.o', source_file, source_language, support_flags, c99, pic_flag, target_args, target, c_compiler, use_platform_cpp_compiler, uncached_dir, mut stats)
 }
 
 fn c_source_language(source_file string, source_language string) string {
@@ -1211,7 +1212,15 @@ fn c_source_language(source_file string, source_language string) string {
 	return ''
 }
 
-fn compile_cached_c_source_object(obj_path string, source_file string, source_language string, support_flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, c_compiler string, uncached_dir string, mut stats CObjectCacheStats) !string {
+fn c_source_object_compiler(language string, c_compiler string, use_platform_cpp_compiler bool) string {
+	if language in ['c++', 'objective-c++']
+		&& (c_compiler == 'cc' || use_platform_cpp_compiler) {
+		return 'c++'
+	}
+	return c_compiler
+}
+
+fn compile_cached_c_source_object(obj_path string, source_file string, source_language string, support_flags []string, c99 bool, pic_flag string, target_args []string, target pref.Target, c_compiler string, use_platform_cpp_compiler bool, uncached_dir string, mut stats CObjectCacheStats) !string {
 	cache_dir := os.join_path(os.vtmp_dir(), 'v3_thirdparty_objs')
 	os.mkdir_all(cache_dir)!
 	language := c_source_language(source_file, source_language)
@@ -1221,7 +1230,7 @@ fn compile_cached_c_source_object(obj_path string, source_file string, source_la
 	} else {
 		c_standard_flag(c99)
 	}
-	compiler := if is_cpp && c_compiler == 'cc' { 'c++' } else { c_compiler }
+	compiler := c_source_object_compiler(language, c_compiler, use_platform_cpp_compiler)
 	mut args := [std_flag]
 	args << target_args
 	if pic_flag.len > 0 {
@@ -11542,7 +11551,7 @@ pub fn run(args []string) {
 		}
 		if !c_only || (dump_c_flags.len > 0 && generate_c_project.len == 0) {
 			object_optimization_flags := v3_prod_c_object_optimization_flags(is_prod, no_prod_options, is_shared, parallel_cc, effective_tcc)
-			resolved_c_flags = prepare_c_flags_for_link(generated_c_flags, environment_c_flags, object_optimization_flags, prefs.c99, pic_flag, target_args, prefs.target, c_compiler, cc_dir, mut c_object_cache_stats) or {
+			resolved_c_flags = prepare_c_flags_for_link(generated_c_flags, environment_c_flags, object_optimization_flags, prefs.c99, pic_flag, target_args, prefs.target, c_compiler, use_implicit_tcc_semantics, cc_dir, mut c_object_cache_stats) or {
 				message := err.msg()
 				if request_macos_v3_c_error_fallback_from_message(macos_v3_fallback_file, macos_v3_c_error_dir, c_compiler, message, [
 					published_c_source,

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -6617,6 +6617,49 @@ fn v3_usable_tcc_compiler(tcc_path string) bool {
 	return cmdexec.run(tcc_path, ['-v']).exit_code == 0
 }
 
+struct V3BundledTccProbeOptions {
+	backend             string
+	c_only              bool
+	is_prod             bool
+	is_c_debug          bool
+	c_compiler          string
+	c_compiler_explicit bool
+	host_os             string
+	host_target         pref.Target
+	target              pref.Target
+	bundled_tcc         string
+}
+
+fn v3_should_probe_bundled_tcc(options V3BundledTccProbeOptions) bool {
+	if options.backend != 'c' || options.c_only
+		|| options.target.os != options.host_target.os
+		|| options.target.arch != options.host_target.arch {
+		return false
+	}
+	if options.c_compiler_explicit {
+		if options.c_compiler in ['tcc', 'tinyc'] {
+			return true
+		}
+		compiler_path := os.find_abs_path_of_executable(options.c_compiler) or {
+			options.c_compiler
+		}
+		return os.real_path(compiler_path) == os.real_path(options.bundled_tcc)
+	}
+	// Windows uses its bundled TCC as the platform default, including modes that
+	// use an optimizing or debug compiler by default on other hosts.
+	if options.host_os == 'windows' && options.target.os == 'windows' {
+		return true
+	}
+	return !options.is_prod && !options.is_c_debug
+}
+
+fn v3_bundled_tcc_available(options V3BundledTccProbeOptions) bool {
+	if !v3_should_probe_bundled_tcc(options) {
+		return false
+	}
+	return v3_usable_tcc_compiler(options.bundled_tcc)
+}
+
 fn v3_usable_system_tcc_compiler(host_os string) string {
 	// Match the V1 system-TCC fallback on macOS: a PATH-installed TCC remains
 	// opt-in because SDK and framework headers can require Clang compatibility.
@@ -9175,9 +9218,20 @@ pub fn run(args []string) {
 		resolve_vroot_for_input(prefs.vroot, input_file)
 	}
 	bundled_tcc := os.join_path(prefs.vroot, 'thirdparty', 'tcc', 'tcc.exe')
-	bundled_tcc_available := v3_usable_tcc_compiler(bundled_tcc)
 	host_os := os.user_os()
 	host_target := pref.host_target()
+	bundled_tcc_available := v3_bundled_tcc_available(V3BundledTccProbeOptions{
+		backend: backend
+		c_only: c_only
+		is_prod: is_prod
+		is_c_debug: is_c_debug
+		c_compiler: c_compiler
+		c_compiler_explicit: c_compiler_explicit
+		host_os: host_os
+		host_target: host_target
+		target: target
+		bundled_tcc: bundled_tcc
+	})
 	allow_system_tcc := backend == 'c' && !c_only && !is_prod && !is_c_debug
 		&& !c_compiler_explicit && target.os == host_target.os && target.arch == host_target.arch
 	implicit_tcc := v3_default_tcc_compiler(bundled_tcc, bundled_tcc_available, allow_system_tcc, host_os)
@@ -9223,7 +9277,7 @@ pub fn run(args []string) {
 	prefs.compile_values = compile_values.clone()
 	prefs.module_search_paths = expand_v3_module_search_paths(module_search_path_spec, prefs.vroot)
 	if explicit_tcc && c_compiler in ['tcc', 'tinyc'] {
-		if os.is_executable(bundled_tcc) {
+		if bundled_tcc_available {
 			c_compiler = bundled_tcc
 		}
 	}

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -6624,6 +6624,7 @@ struct V3BundledTccProbeOptions {
 	is_c_debug          bool
 	c_compiler          string
 	c_compiler_explicit bool
+	dump_c_flags        bool
 	host_os             string
 	host_target         pref.Target
 	target              pref.Target
@@ -6644,6 +6645,9 @@ fn v3_should_probe_bundled_tcc(options V3BundledTccProbeOptions) bool {
 			options.c_compiler
 		}
 		return os.real_path(compiler_path) == os.real_path(options.bundled_tcc)
+	}
+	if options.dump_c_flags {
+		return false
 	}
 	// Windows uses its bundled TCC as the platform default, including modes that
 	// use an optimizing or debug compiler by default on other hosts.
@@ -6673,7 +6677,10 @@ fn v3_usable_system_tcc_compiler(host_os string) string {
 	return system_tcc
 }
 
-fn v3_default_tcc_compiler(bundled_tcc string, bundled_tcc_available bool, allow_system_tcc bool, host_os string) string {
+fn v3_default_tcc_compiler(bundled_tcc string, bundled_tcc_available bool, allow_system_tcc bool, dump_c_flags bool, host_os string) string {
+	if dump_c_flags {
+		return ''
+	}
 	if bundled_tcc_available {
 		return bundled_tcc
 	}
@@ -9225,6 +9232,7 @@ pub fn run(args []string) {
 		is_c_debug: is_c_debug
 		c_compiler: c_compiler
 		c_compiler_explicit: c_compiler_explicit
+		dump_c_flags: dump_c_flags.len > 0
 		host_os: host_os
 		host_target: host_target
 		target: target
@@ -9232,7 +9240,7 @@ pub fn run(args []string) {
 	})
 	allow_system_tcc := backend == 'c' && !c_only && !is_prod && !is_c_debug
 		&& !c_compiler_explicit && target.os == host_target.os && target.arch == host_target.arch
-	implicit_tcc := v3_default_tcc_compiler(bundled_tcc, bundled_tcc_available, allow_system_tcc, host_os)
+	implicit_tcc := v3_default_tcc_compiler(bundled_tcc, bundled_tcc_available, allow_system_tcc, dump_c_flags.len > 0, host_os)
 	c_compiler = v3_select_windows_default_c_compiler(c_compiler, c_compiler_explicit, host_os, target.os, bundled_tcc, bundled_tcc_available)
 	// Generate for the compiler that receives the first build attempt. If implicit
 	// TCC cannot be used, regenerate below before invoking the `cc` fallback.

--- a/vlib/v3/driver/parallel_cc_test.v
+++ b/vlib/v3/driver/parallel_cc_test.v
@@ -45,8 +45,8 @@ fn test_v3_parallel_cc_compiles_and_runs_multiple_c_units() {
 		output := os.join_path_single(root, 'main')
 		os.write_file(header, 'int v3_parallel_implementation(void) { return 21; }\n')!
 		os.write_file(source, '#insert "@DIR/implementation.h"\n\nfn C.v3_parallel_implementation() int\n\nfn twice(value int) int { return value * 2 }\nfn main() { println(twice(C.v3_parallel_implementation())) }\n')!
-		build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-parallel-cc', '-nocache', '-showcc',
-			'-o', output, source])
+		build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-cc', 'cc', '-parallel-cc', '-nocache',
+			'-showcc', '-o', output, source])
 		assert build.exit_code == 0, build.output
 		assert build.output.contains('unit_0.c')
 		assert build.output.contains('unit_1.c')
@@ -70,8 +70,8 @@ fn test_v3_parallel_cc_keeps_test_binaries_in_one_unit() {
 		// The harness counters `assert` writes are `static` definitions inside the
 		// program body, so a split unit that only references them would not
 		// compile. The build has to stay in one translation unit.
-		build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-parallel-cc', '-nocache', '-showcc',
-			'-o', output, source])
+		build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-cc', 'cc', '-parallel-cc', '-nocache',
+			'-showcc', '-o', output, source])
 		assert build.exit_code == 0, build.output
 		assert !build.output.contains('unit_1.c'), build.output
 		run_result := cmdexec.run(output, [])
@@ -92,8 +92,8 @@ fn test_v3_parallel_cc_does_not_shadow_user_parallel_header() {
 		output := os.join_path_single(root, 'main')
 		os.write_file(header, '#ifndef V3_USER_PARALLEL_H\n#define V3_USER_PARALLEL_H\nstatic inline int v3_user_parallel_header_value(void) { return 42; }\n#endif\n')!
 		os.write_file(source, '#flag -I @DIR\n#include "parallel.h"\n\nfn C.v3_user_parallel_header_value() int\n\nfn main() { println(C.v3_user_parallel_header_value()) }\n')!
-		build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-parallel-cc', '-nocache', '-showcc',
-			'-o', output, source])
+		build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-cc', 'cc', '-parallel-cc', '-nocache',
+			'-showcc', '-o', output, source])
 		assert build.exit_code == 0, build.output
 		assert build.output.contains('unit_0.c')
 		run_result := cmdexec.run(output, [])
@@ -115,8 +115,8 @@ fn test_v3_parallel_cc_falls_back_for_native_static_state() {
 		output := os.join_path_single(root, 'main')
 		os.write_file(header, 'static int v3_parallel_state;\nstatic inline int v3_parallel_next(void) { return ++v3_parallel_state; }\n')!
 		os.write_file(source, '#flag -I @DIR\n#include "state.h"\n\nfn C.v3_parallel_next() int\n\nfn first() int { return C.v3_parallel_next() }\nfn second() int { return C.v3_parallel_next() }\nfn main() { println(first())\nprintln(second()) }\n')!
-		build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-parallel-cc', '-nocache', '-showcc',
-			'-o', output, source])
+		build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-cc', 'cc', '-parallel-cc', '-nocache',
+			'-showcc', '-o', output, source])
 		assert build.exit_code == 0, build.output
 		assert !build.output.contains('unit_0.c'), build.output
 		assert build.output.contains('src.c'), build.output
@@ -139,8 +139,8 @@ fn test_v3_parallel_cc_falls_back_for_native_function_local_static_state() {
 		output := os.join_path_single(root, 'main')
 		os.write_file(header, 'static inline int v3_parallel_local_next(void) {\n\tstatic int state;\n\treturn ++state;\n}\n')!
 		os.write_file(source, '#flag -I @DIR\n#include "state.h"\n\nfn C.v3_parallel_local_next() int\n\nfn first() int { return C.v3_parallel_local_next() }\nfn second() int { return C.v3_parallel_local_next() }\nfn main() { println(first())\nprintln(second()) }\n')!
-		build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-parallel-cc', '-nocache', '-showcc',
-			'-o', output, source])
+		build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-cc', 'cc', '-parallel-cc', '-nocache',
+			'-showcc', '-o', output, source])
 		assert build.exit_code == 0, build.output
 		assert !build.output.contains('unit_0.c'), build.output
 		assert build.output.contains('src.c'), build.output
@@ -169,8 +169,8 @@ fn test_v3_parallel_cc_falls_back_for_macro_generated_function_local_static_stat
 DEF(v3_parallel_macro_next)
 ')!
 		os.write_file(source, '#flag -I @DIR\n#include "state.h"\n\nfn C.v3_parallel_macro_next() int\n\nfn first() int { return C.v3_parallel_macro_next() }\nfn second() int { return C.v3_parallel_macro_next() }\nfn main() { println(first())\nprintln(second()) }\n')!
-		build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-parallel-cc', '-nocache', '-showcc',
-			'-o', output, source])
+		build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-cc', 'cc', '-parallel-cc', '-nocache',
+			'-showcc', '-o', output, source])
 		assert build.exit_code == 0, build.output
 		assert !build.output.contains('unit_0.c'), build.output
 		assert build.output.contains('src.c'), build.output
@@ -194,8 +194,8 @@ fn test_v3_parallel_cc_falls_back_for_coverage_and_profile_state() {
 			output := os.join_path_single(root, 'main_${mode}')
 			state_path := os.join_path_single(root, mode)
 			option := if mode == 'coverage' { '-coverage' } else { '-profile' }
-			build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-parallel-cc', option, state_path,
-				'-nocache', '-showcc', '-o', output, source])
+			build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-cc', 'cc', '-parallel-cc',
+				option, state_path, '-nocache', '-showcc', '-o', output, source])
 			assert build.exit_code == 0, build.output
 			assert !build.output.contains('unit_0.c'), build.output
 			assert build.output.contains('src.c'), build.output

--- a/vlib/v3/driver/parallel_cc_test.v
+++ b/vlib/v3/driver/parallel_cc_test.v
@@ -45,8 +45,8 @@ fn test_v3_parallel_cc_compiles_and_runs_multiple_c_units() {
 		output := os.join_path_single(root, 'main')
 		os.write_file(header, 'int v3_parallel_implementation(void) { return 21; }\n')!
 		os.write_file(source, '#insert "@DIR/implementation.h"\n\nfn C.v3_parallel_implementation() int\n\nfn twice(value int) int { return value * 2 }\nfn main() { println(twice(C.v3_parallel_implementation())) }\n')!
-		build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-cc', 'cc', '-parallel-cc', '-nocache',
-			'-showcc', '-o', output, source])
+		build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-parallel-cc', '-nocache', '-showcc',
+			'-o', output, source])
 		assert build.exit_code == 0, build.output
 		assert build.output.contains('unit_0.c')
 		assert build.output.contains('unit_1.c')
@@ -70,8 +70,8 @@ fn test_v3_parallel_cc_keeps_test_binaries_in_one_unit() {
 		// The harness counters `assert` writes are `static` definitions inside the
 		// program body, so a split unit that only references them would not
 		// compile. The build has to stay in one translation unit.
-		build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-cc', 'cc', '-parallel-cc', '-nocache',
-			'-showcc', '-o', output, source])
+		build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-parallel-cc', '-nocache', '-showcc',
+			'-o', output, source])
 		assert build.exit_code == 0, build.output
 		assert !build.output.contains('unit_1.c'), build.output
 		run_result := cmdexec.run(output, [])
@@ -92,8 +92,8 @@ fn test_v3_parallel_cc_does_not_shadow_user_parallel_header() {
 		output := os.join_path_single(root, 'main')
 		os.write_file(header, '#ifndef V3_USER_PARALLEL_H\n#define V3_USER_PARALLEL_H\nstatic inline int v3_user_parallel_header_value(void) { return 42; }\n#endif\n')!
 		os.write_file(source, '#flag -I @DIR\n#include "parallel.h"\n\nfn C.v3_user_parallel_header_value() int\n\nfn main() { println(C.v3_user_parallel_header_value()) }\n')!
-		build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-cc', 'cc', '-parallel-cc', '-nocache',
-			'-showcc', '-o', output, source])
+		build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-parallel-cc', '-nocache', '-showcc',
+			'-o', output, source])
 		assert build.exit_code == 0, build.output
 		assert build.output.contains('unit_0.c')
 		run_result := cmdexec.run(output, [])
@@ -115,8 +115,8 @@ fn test_v3_parallel_cc_falls_back_for_native_static_state() {
 		output := os.join_path_single(root, 'main')
 		os.write_file(header, 'static int v3_parallel_state;\nstatic inline int v3_parallel_next(void) { return ++v3_parallel_state; }\n')!
 		os.write_file(source, '#flag -I @DIR\n#include "state.h"\n\nfn C.v3_parallel_next() int\n\nfn first() int { return C.v3_parallel_next() }\nfn second() int { return C.v3_parallel_next() }\nfn main() { println(first())\nprintln(second()) }\n')!
-		build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-cc', 'cc', '-parallel-cc', '-nocache',
-			'-showcc', '-o', output, source])
+		build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-parallel-cc', '-nocache', '-showcc',
+			'-o', output, source])
 		assert build.exit_code == 0, build.output
 		assert !build.output.contains('unit_0.c'), build.output
 		assert build.output.contains('src.c'), build.output
@@ -139,8 +139,8 @@ fn test_v3_parallel_cc_falls_back_for_native_function_local_static_state() {
 		output := os.join_path_single(root, 'main')
 		os.write_file(header, 'static inline int v3_parallel_local_next(void) {\n\tstatic int state;\n\treturn ++state;\n}\n')!
 		os.write_file(source, '#flag -I @DIR\n#include "state.h"\n\nfn C.v3_parallel_local_next() int\n\nfn first() int { return C.v3_parallel_local_next() }\nfn second() int { return C.v3_parallel_local_next() }\nfn main() { println(first())\nprintln(second()) }\n')!
-		build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-cc', 'cc', '-parallel-cc', '-nocache',
-			'-showcc', '-o', output, source])
+		build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-parallel-cc', '-nocache', '-showcc',
+			'-o', output, source])
 		assert build.exit_code == 0, build.output
 		assert !build.output.contains('unit_0.c'), build.output
 		assert build.output.contains('src.c'), build.output
@@ -169,8 +169,8 @@ fn test_v3_parallel_cc_falls_back_for_macro_generated_function_local_static_stat
 DEF(v3_parallel_macro_next)
 ')!
 		os.write_file(source, '#flag -I @DIR\n#include "state.h"\n\nfn C.v3_parallel_macro_next() int\n\nfn first() int { return C.v3_parallel_macro_next() }\nfn second() int { return C.v3_parallel_macro_next() }\nfn main() { println(first())\nprintln(second()) }\n')!
-		build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-cc', 'cc', '-parallel-cc', '-nocache',
-			'-showcc', '-o', output, source])
+		build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-parallel-cc', '-nocache', '-showcc',
+			'-o', output, source])
 		assert build.exit_code == 0, build.output
 		assert !build.output.contains('unit_0.c'), build.output
 		assert build.output.contains('src.c'), build.output
@@ -194,8 +194,8 @@ fn test_v3_parallel_cc_falls_back_for_coverage_and_profile_state() {
 			output := os.join_path_single(root, 'main_${mode}')
 			state_path := os.join_path_single(root, mode)
 			option := if mode == 'coverage' { '-coverage' } else { '-profile' }
-			build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-cc', 'cc', '-parallel-cc',
-				option, state_path, '-nocache', '-showcc', '-o', output, source])
+			build := cmdexec.run(v3_parallel_cc_test_compiler(), ['-parallel-cc', option, state_path,
+				'-nocache', '-showcc', '-o', output, source])
 			assert build.exit_code == 0, build.output
 			assert !build.output.contains('unit_0.c'), build.output
 			assert build.output.contains('src.c'), build.output


### PR DESCRIPTION
## Summary

- use a working `tcc` from `PATH` by default when bundled TCC is unavailable
- require bundled libgc and openlibm runtime artifacts before selecting system TCC where needed
- wire the same bundled-first/system-second selection into the default V3 C-backend path
- propagate implicit bundled/system TCC selection into V3 TinyCC compile-time and codegen semantics
- use the selected implicit TCC for native-input preprocessing and `#flag` source compilation
- route implicit-TCC Objective-C objects through the platform C compiler and C++/Objective-C++ objects through `c++`
- keep `cc`-only caching disabled whenever implicit TCC is the actual compiler
- regenerate V3 C output for the platform compiler before falling back from an implicit TCC
- regenerate V3 when implicit TCC rejects an adjacent native C or assembly source
- honor `-no-retry-compilation` when an implicit V3 TCC attempt fails
- exclude compiler-flag dumps and supported V3 parallel builds from implicit TCC probing and selection
- probe bundled and system TCC candidates before selecting them
- defer TCC probes until the current V1 or V3 build mode is eligible to select TCC
- keep bundled TCC resource roots off system TCC in V1 parallel builds and V3 builds
- regenerate failed V1 parallel-TCC builds with the platform compiler under the normal retry policy
- keep explicit compiler selection, production behavior, and the macOS system-TCC safety exclusion
- add regression coverage for working and broken bundled/system TCC installations in V1 and V3
- document the default C compiler selection order and runtime requirement

Fixes #28492

## Testing

- `./vnew vlib/v/pref/default_tcc_compiler_test.v`
- `./vnew -old-compiler vlib/v/pref/default_tcc_compiler_test.v`
- `./vnew -silent test vlib/v/pref/` (4 passed)
- `./vnew -old-compiler -silent test vlib/v/pref/` (4 passed)
- `./vnew vlib/v3/driver/c_compiler_flags_test.v`
- `./vnew -new-compiler vlib/v/tests/project_with_cpp_code/compiling_cpp_files_with_a_cplusplus_compiler_test.c.v`
- `./vnew -silent vlib/v3/driver/parallel_cc_test.v`
- `./vnew -silent test vlib/v3/driver/` (9 passed)
- `./vnew -silent -no-retry-compilation -dump-c-flags - -o /tmp/v3_dump_flags_test
  examples/hello_world.v` (single platform-compiler plan)
- `./vnew -silent -no-retry-compilation vlib/v3/driver/c_compiler_flags_test.v`
  (expected TCC failure with no fallback/retry)
- `./vnew -silent test vlib/v/builder/cbuilder/` (1 passed)
- `./vnew -old-compiler -silent test vlib/v/builder/cbuilder/` (1 passed)
- `./vnew -old-compiler -silent vlib/v/builder/cc_tcc_retry_test.v`
- `./vnew -old-compiler -silent test vlib/v/builder/` (15 passed, 1 skipped)
- `VFLAGS='-old-compiler' ./vnew -old-compiler -silent vlib/v/builder/parallel_cc_failure_test.v`
- `./vnew -old-compiler -silent vlib/v/compiler_errors_test.v` (1703 passed, 5 skipped)
- `./vnew check-md README.md`

The broader `./vnew -old-compiler -silent test vlib/v/` run reached 2385/2393 before an existing
profile test remained stuck for more than 17 minutes. It also reported unrelated V3/V1 and local
macOS TCC/libgc baseline failures. The default V3 compiler-errors failure reproduces on unmodified
`origin/master`.

The default-dispatched `parallel_cc_failure_test.v` duplicate-symbol expectation also fails on
unmodified `origin/master`; forcing its child compilations through V1 passes.







