### PR TITLE
tools: make check-md treat ```vml fences as non-V code blocks

### DIFF
--- a/cmd/tools/vcheck-md.v
+++ b/cmd/tools/vcheck-md.v
@@ -328,6 +328,8 @@ fn eline(file_path string, lnumber int, column int, message string) string {
 }
 
 const default_command = 'compile'
+// fence languages that begin with `v` but hold something other than V source
+const non_v_fence_languages = ['vml']
 
 struct VCodeExample {
 mut:
@@ -438,7 +440,7 @@ fn (mut f MDFile) check() CheckResult {
 }
 
 fn (mut f MDFile) parse_line(lnumber int, line string) {
-	if line.starts_with('```v') {
+	if line.starts_with('```v') && line.replace('```', '').trim_space() !in non_v_fence_languages {
 		if f.state == .markdown {
 			f.state = .vexample
 			mut command := line.replace('```v', '').trim_space()

--- a/cmd/tools/vcheck_test.v
+++ b/cmd/tools/vcheck_test.v
@@ -365,3 +365,34 @@ fn write_text_file(path string, content string) ! {
 	os.mkdir_all(os.dir(path))!
 	os.write_file(path, content)!
 }
+
+fn test_check_md_vml_fence_is_not_a_v_example() {
+	md_dir := os.join_path(os.vtmp_dir(), 'vcheck_vml_fence_${os.getpid()}')
+	os.rmdir_all(md_dir) or {}
+	os.mkdir_all(md_dir)!
+	defer {
+		os.rmdir_all(md_dir) or {}
+	}
+	md_path := os.join_path(md_dir, 'vml.md')
+	// VML markup is not V source, so a ```vml fence must not be extracted as a V example,
+	// and the parser must still pick up the V example that follows it.
+	write_text_file(md_path, '# VML fence
+
+```vml
+Screen {
+    Column {
+        Button { text: "Save" on_tap: app.save() }
+    }
+}
+```
+
+```v ignore
+fn after_vml() {}
+```
+')!
+	res :=
+		os.execute('${os.quoted_path(vexe)} check-md -hide-warnings -silent ${os.quoted_path(md_path)}')
+	assert res.exit_code == 0, res.output
+	assert !res.output.contains('unrecognized command'), res.output
+	assert res.output.contains('Checked .md files: 1 | Ex.: 1 |'), res.output
+}


### PR DESCRIPTION
#fixes 28456

### Problem

`v check-md` fails on master:

```
doc/docs.md:7260:1: error: unrecognized command: "ml", use one of: wip/ignore/compile/...
```

`parse_line` treats every fence beginning with ```` ```v ```` as a V example and derives the check command from whatever follows the `v`, so the ```` ```vml ```` fence added with the VML docs is parsed as command `ml`. Because the block is also extracted as a V example, its contents are additionally run through `v fmt`, producing a phantom formatting error on every run.

This is currently failing the `check-markdown` job on every open PR, regardless of what the PR touches.

### Fix

Route fence languages that begin with `v` but are not V source (`vml` for now) through the ordinary non-V code-block path in `parse_line`, so they are neither counted as examples nor formatted or compiled. The list is a small const so further cases can be added without touching the parser.

I chose this over adding a no-op `'ml' {}` arm next to the existing `'mod' {}` one: that would clear the error but still push VML content through `v fmt` before the `match` is reached, leaving the phantom fmt error in place. VML isn't V syntax, so it shouldn't enter the example pipeline at all.

### Tests

New `test_check_md_vml_fence_is_not_a_v_example` in `cmd/tools/vcheck_test.v`: a ```` ```vml ```` block followed by a real ```` ```v ```` example. Asserts exit 0, no `unrecognized command`, and `Ex.: 1` (only the V example counted). Verified it fails on master with the exact error above before the fix.

`v check-md doc/docs.md` on master, before → after: the line-7260 error is gone, `Ex.` drops 344 → 343, `Fmt errors` drops 1 → 0. The remaining compile errors in that file are pre-existing and unrelated.

`v fmt -verify` clean on both files.

🧙 Built with [WOZCODE](https://wozcode.com)

Fixes: #28456 