### PR TITLE
v3: reduce self-build stage time and memory use

### DIFF
--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -358,15 +358,24 @@ $if !windows {
 		return unsafe { nil }
 	}
 
-	// optional_support_thread fuses the declaration-signature, multi-return and
-	// unresolved-call optional scans on a helper while the other predispatch
-	// workers traverse the same immutable AST.
+	// Declaration signatures and unresolved calls use independent read-only inputs;
+	// collect their optional typedefs on separate lanes and join before dispatch.
 	fn optional_support_thread(arg voidptr) voidptr {
 		mut w := unsafe { &FlatGen(arg) }
 		osw := time.new_stopwatch()
 		scope := cgen_worker_scope_begin(w.scope_parallel_workers)
-		w.collect_optional_typedefs()
+		w.collect_declaration_signature_types()
+		w.optional_types_ready = true
 		w.timing_profile('  [ttime]       fs opt types   ${f64(osw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		w.worker_scope = scope
+		cgen_worker_scope_leave(scope)
+		return unsafe { nil }
+	}
+
+	fn unresolved_call_optional_thread(arg voidptr) voidptr {
+		mut w := unsafe { &FlatGen(arg) }
+		scope := cgen_worker_scope_begin(w.scope_parallel_workers)
+		w.collect_unresolved_call_optional_types()
 		w.worker_scope = scope
 		cgen_worker_scope_leave(scope)
 		return unsafe { nil }
@@ -1360,6 +1369,17 @@ fn (mut g FlatGen) publish_optional_support(mut worker FlatGen) {
 		g.parallel_worker_scopes << worker.worker_scope
 		worker.worker_scope = unsafe { nil }
 	}
+}
+
+fn (mut g FlatGen) publish_unresolved_call_optional_types(mut worker FlatGen) {
+	for name, payload in worker.needed_optional_types {
+		// This scan follows declarations in the serial pipeline, including when
+		// two payload spellings map to the same optional typedef name.
+		g.needed_optional_types[name.clone()] = payload.clone()
+	}
+	// Only the typedef spellings escape this scan; release its parsing scratch.
+	cgen_worker_scope_free(worker.worker_scope)
+	worker.worker_scope = unsafe { nil }
 }
 
 fn (mut g FlatGen) publish_interface_impl_scan(mut worker FlatGen) {
@@ -3063,12 +3083,16 @@ fn (mut g FlatGen) run_pre_dispatch_parallel(no_parallel bool) bool {
 		mut optional_worker := g.new_parallel_worker(2)
 		optional_worker.tc.verbose = g.tc.verbose
 		optional_worker.c_name_cache = &CNameCache{}
+		mut call_optional_worker := g.new_parallel_worker(3)
+		call_optional_worker.c_name_cache = &CNameCache{}
 		fail := os.getenv('V3_TEST_PTHREAD_CREATE_FAIL')
 		if fail.len > 0 {
 			// prepare_pre_dispatch_master can submit its own selection/cost batches to
 			// this pool. Do not run it as the caller-side task of an outer Pool.run:
 			// the untagged completion channel would let the nested batch consume the
 			// support tasks' completions and return while its payloads are still live.
+			g.prepare_pre_dispatch_master()
+			optional_worker.fn_gen_items = g.fn_gen_items.clone()
 			g.a.worker_pool.run([
 				workers.Task{
 					run: fixed_storage_scan_thread
@@ -3085,8 +3109,12 @@ fn (mut g FlatGen) run_pre_dispatch_parallel(no_parallel bool) bool {
 					arg: voidptr(optional_worker)
 					force_sync: fail == 'cgen:all' || fail == 'cgen:pre:all'
 				},
+				workers.Task{
+					run: unresolved_call_optional_thread
+					arg: voidptr(call_optional_worker)
+					force_sync: fail == 'cgen:all' || fail == 'cgen:pre:all'
+				},
 			])
-			g.prepare_pre_dispatch_master()
 			g.refine_fn_item_costs(no_parallel, false)
 		} else {
 			// Item selection only reads the AST and immutable checker tables, so let
@@ -3095,8 +3123,13 @@ fn (mut g FlatGen) run_pre_dispatch_parallel(no_parallel bool) bool {
 			mut psw := time.new_stopwatch()
 			fixed_storage_thread := spawn fixed_storage_scan_thread(voidptr(fs_worker))
 			fixed_array_thread := spawn fixed_array_support_thread(voidptr(fixed_array_worker))
-			optional_thread := spawn optional_support_thread(voidptr(optional_worker))
+			call_optional_thread := spawn unresolved_call_optional_thread(voidptr(call_optional_worker))
 			g.prepare_pre_dispatch_master()
+			// Reuse the selected declarations instead of selecting every function
+			// again on the optional-support thread. Cost refinement writes the
+			// master's item array, so the helper needs its own snapshot.
+			optional_worker.fn_gen_items = g.fn_gen_items.clone()
+			optional_thread := spawn optional_support_thread(voidptr(optional_worker))
 			g.timing_profile('  [ttime]     cg prep master ${f64(psw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 			psw.restart()
 			g.refine_fn_item_costs(no_parallel, true)
@@ -3105,11 +3138,13 @@ fn (mut g FlatGen) run_pre_dispatch_parallel(no_parallel bool) bool {
 			_ = fixed_storage_thread.wait()
 			_ = fixed_array_thread.wait()
 			_ = optional_thread.wait()
+			_ = call_optional_thread.wait()
 			g.timing_profile('  [ttime]     cg fs wait     ${f64(psw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		}
 		g.publish_fixed_storage_scan(mut fs_worker)
 		g.publish_fixed_array_support(mut fixed_array_worker)
 		g.publish_optional_support(mut optional_worker)
+		g.publish_unresolved_call_optional_types(mut call_optional_worker)
 		if g.parallel_prepared && !g.prep_externs_pending {
 			// Item-body and top-level C-extern refs are fully collected (fused
 			// prep + exact-cost pass or its serial fallback); the pre-dispatch

--- a/vlib/v3/gen/c/struct.v
+++ b/vlib/v3/gen/c/struct.v
@@ -3888,14 +3888,18 @@ fn (g &FlatGen) find_struct_decl(type_name string) ?StructDeclInfo {
 // a private instance (new_parallel_worker_config).
 struct StructDeclPrefCache {
 mut:
-	module           string
-	entries          map[string]StructDeclInfo
-	misses           map[string]bool
-	field_entries    map[string][]types.StructField
-	field_misses     map[string]bool
-	field_last_name  string
-	field_last_value []types.StructField
-	field_last_state i8
+	module             string
+	entries            map[string]StructDeclInfo
+	misses             map[string]bool
+	field_entries      map[string][]types.StructField
+	field_misses       map[string]bool
+	field_last_name    string
+	field_last_value   []types.StructField
+	field_last_state   i8
+	type_recent_owners [256]string
+	type_recent_fields [256]string
+	type_recent_values [256]types.Type
+	type_recent_states [256]i8
 }
 
 fn (mut cache StructDeclPrefCache) select_module(module_name string) {
@@ -3910,6 +3914,7 @@ fn (mut cache StructDeclPrefCache) select_module(module_name string) {
 	cache.field_last_name = ''
 	cache.field_last_value = []types.StructField{}
 	cache.field_last_state = 0
+	cache.type_recent_states = [256]i8{}
 }
 
 fn (g &FlatGen) find_struct_decl_preferred(type_name string) ?StructDeclInfo {
@@ -4093,14 +4098,55 @@ fn (g &FlatGen) struct_init_resolved_decl_name(type_name string) string {
 
 // struct_field_type supports struct field type handling for FlatGen.
 fn (g &FlatGen) struct_field_type(type_name string, field_name string) ?types.Type {
-	fields := g.struct_fields_for_type(type_name) or { return none }
-	for f in fields {
-		if f.name == field_name {
-			if shared_alias_ptr := g.shared_alias_pointer_type(f.typ) {
-				return shared_alias_ptr
-			}
-			return f.typ
+	typ := g.struct_field_type_cached(type_name, field_name)?
+	if shared_alias_ptr := g.shared_alias_pointer_type(typ) {
+		return shared_alias_ptr
+	}
+	return typ
+}
+
+@[direct_array_access]
+fn (g &FlatGen) struct_field_type_cached(type_name string, field_name string) ?types.Type {
+	mut cache := g.struct_decl_pref_cache
+	cache_enabled := g.cache_struct_fields && !isnil(cache)
+	mut slot := 0
+	if cache_enabled {
+		cache.select_module(g.tc.cur_module)
+		// The complete owner/field comparison keeps sampled-key collisions harmless.
+		mut hash := u32(type_name.len * 31 + field_name.len)
+		if type_name.len > 0 {
+			hash = hash * 16777619 ^ u32(type_name[type_name.len - 1])
 		}
+		if field_name.len > 0 {
+			hash = hash * 16777619 ^ u32(field_name[0])
+			hash = hash * 16777619 ^ u32(field_name[field_name.len - 1])
+		}
+		slot = int(hash & 255)
+		if cache.type_recent_states[slot] != 0
+			&& cache.type_recent_owners[slot] == type_name
+			&& cache.type_recent_fields[slot] == field_name {
+			if cache.type_recent_states[slot] < 0 {
+				return none
+			}
+			return cache.type_recent_values[slot]
+		}
+	}
+	fields := g.struct_fields_for_type(type_name) or { return none }
+	for field in fields {
+		if field.name == field_name {
+			if cache_enabled {
+				cache.type_recent_owners[slot] = type_name
+				cache.type_recent_fields[slot] = field_name
+				cache.type_recent_values[slot] = field.typ
+				cache.type_recent_states[slot] = 1
+			}
+			return field.typ
+		}
+	}
+	if cache_enabled {
+		cache.type_recent_owners[slot] = type_name
+		cache.type_recent_fields[slot] = field_name
+		cache.type_recent_states[slot] = -1
 	}
 	return none
 }

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -726,6 +726,11 @@ fn (mut g FlatGen) collect_optional_typedefs() {
 		return
 	}
 	g.collect_declaration_signature_types()
+	g.collect_unresolved_call_optional_types()
+	g.optional_types_ready = true
+}
+
+fn (mut g FlatGen) collect_unresolved_call_optional_types() {
 	// Calls without a resolved expression type are the only optional-type source
 	// not covered by the shared declaration-signature scan.
 	mut seen_type_ids := []bool{len: 65536}
@@ -759,7 +764,6 @@ fn (mut g FlatGen) collect_optional_typedefs() {
 			g.collect_optional_typedef_type(g.parse_node_type(&node))
 		}
 	}
-	g.optional_types_ready = true
 }
 
 fn cgen_type_text_is_complete(text string) bool {

--- a/vlib/v3/gen/c/types_test.v
+++ b/vlib/v3/gen/c/types_test.v
@@ -6,6 +6,61 @@ import v3.parser
 import v3.pref
 import v3.types
 
+fn test_field_type_cache_preserves_collisions_and_module_context() {
+	mut ast := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&ast)
+	tc.structs['one.Box'] = [
+		types.StructField{ name: 'abba', typ: types.Type(types.int_) },
+		types.StructField{ name: 'acca', typ: types.Type(types.string_) },
+	]
+	tc.structs['two.Box'] = [
+		types.StructField{ name: 'abba', typ: types.Type(types.bool_) },
+	]
+	mut g := FlatGen.new()
+	g.a = &ast
+	g.tc = &tc
+	g.cache_struct_fields = true
+	g.struct_decl_pref_cache = &StructDeclPrefCache{}
+	for _ in 0 .. 3 {
+		tc.cur_module = 'one'
+		assert g.struct_field_type('Box'.clone(), 'abba'.clone())? == types.Type(types.int_)
+		assert g.struct_field_type('Box', 'acca')? == types.Type(types.string_)
+		assert g.struct_field_type('Box', 'adda') == none
+		tc.cur_module = 'two'
+		assert g.struct_field_type('Box', 'abba')? == types.Type(types.bool_)
+		assert g.struct_field_type('Box', 'acca') == none
+	}
+}
+
+fn test_optional_scan_lanes_preserve_declaration_and_unresolved_call_types() {
+	$if !windows {
+		mut ast := flat.FlatAst.new()
+		ast.add_node(flat.Node{ kind: .call, typ: '?string' })
+		ast.add_node(flat.Node{ kind: .call, typ: '?([]' })
+		mut tc := types.TypeChecker.new(&ast)
+		tc.fn_ret_types['resolved'] = types.Type(types.OptionType{ base_type: types.Type(types.int_) })
+		mut serial := FlatGen.new()
+		serial.a = &ast
+		serial.tc = &tc
+		serial.collect_optional_typedefs()
+		mut split := FlatGen.new()
+		split.a = &ast
+		split.tc = &tc
+		split.scope_parallel_workers = true
+		mut declarations := split.new_parallel_worker(0)
+		mut calls := split.new_parallel_worker(1)
+		optional_support_thread(voidptr(declarations))
+		unresolved_call_optional_thread(voidptr(calls))
+		split.publish_optional_support(mut declarations)
+		split.publish_unresolved_call_optional_types(mut calls)
+		assert split.needed_optional_types == serial.needed_optional_types
+		assert split.needed_optional_types.len == 2
+		assert split.optional_types_ready
+		assert split.decl_types_ready
+		assert split.multi_return_types_ready
+	}
+}
+
 fn test_void_pointer_predicate_preserves_alias_and_named_type_rules() {
 	void_alias := types.Type(types.Alias{ name: 'Nothing', base_type: types.Type(types.void_) })
 	for typ in [types.Type(types.voidptr_), types.Type(types.Pointer{ base_type: void_alias }),

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -25,6 +25,9 @@ const selfhost_transform_clone_budget_bytes = u64(2_600_000_000)
 // Shared-base workers share the AST but retain private checker and transform
 // scratch. Eight lanes keep large user builds below the ordinary memory ceiling.
 const max_shared_transform_jobs = 8
+// Compiler builds use bounded batches and can fill more cores without cloning
+// the base AST. Ordinary import graphs retain the smaller scratch budget.
+const max_shared_selfhost_transform_jobs = 12
 // One chunk per lane bounds the number of private worker views kept until merge.
 const shared_transform_chunks_per_job = 1
 // Normal function lowering needs part of the shared append pool too. Limit
@@ -2256,7 +2259,7 @@ fn (mut t Transformer) run_parallel_transform(items []FnWorkItem, base_nodes int
 		// exact per-item subtree ranges, and skip_generics (the generic passes
 		// scan and mutate arbitrary AST regions, which the shared design forbids).
 		if t.skip_generics && !isnil(t.tc) && t.tc.top_level_idx.len > 0 {
-			shared_jobs := shared_transform_job_count(t.a.worker_pool.size() + 1, items.len)
+			shared_jobs := shared_transform_job_count(t.a.worker_pool.size() + 1, items.len, t.building_v)
 			if shared_jobs > 1 {
 				return t.run_parallel_transform_shared(items, base_nodes, base_children, shared_jobs)
 			}
@@ -2396,13 +2399,14 @@ fn (mut t Transformer) mark_parallel_worker_maps_shared() {
 
 // shared_transform_job_count caps the shared-base worker count: no clones, so
 // only core count and item count matter.
-fn shared_transform_job_count(n_runtime_jobs int, n_items int) int {
+fn shared_transform_job_count(n_runtime_jobs int, n_items int, building_v bool) int {
 	if n_runtime_jobs <= 0 || n_items <= 0 {
 		return 0
 	}
 	mut n := n_runtime_jobs
-	if n > max_shared_transform_jobs {
-		n = max_shared_transform_jobs
+	limit := if building_v { max_shared_selfhost_transform_jobs } else { max_shared_transform_jobs }
+	if n > limit {
+		n = limit
 	}
 	if n > n_items {
 		n = n_items

--- a/vlib/v3/transform/type_propagation.v
+++ b/vlib/v3/transform/type_propagation.v
@@ -1166,6 +1166,10 @@ fn (t &Transformer) normalize_type_alias(typ string) string {
 	result := t.normalize_type_alias_uncached(typ)
 	c.entries[typ] = result
 	c.put_recent(typ, result)
+	// Builtin spellings are independent of the importing file and module.
+	if result == typ && is_plain_builtin_alias_type(typ) {
+		c.canonical_types[recent_slot] = typ
+	}
 	return result
 }
 

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -380,11 +380,11 @@ mut:
 	parse_value_recent_context [2048]u64
 	parse_value_recent_values  [2048]Type
 	parse_value_recent_set     [2048]bool
-	// Exact canonical text-id cache used by post-transform consumers. A lazy
-	// 65536-slot table avoids collisions for every compact FlatAst text id.
+	// Bounded canonical text-id cache. Workers touch only a fraction of the
+	// 65536 possible ids; retain the exact id to distinguish slot collisions.
 	parse_text_id_context []u64
 	parse_text_id_values  []Type
-	parse_text_id_set     []bool
+	parse_text_ids        []u16
 	// Alias targets can contain callbacks whose signatures mention the alias
 	// itself (for example `type Handlers = map[string]fn (Handlers)`). Keep the
 	// active expansion chain private to each checker/cache so parsing such a
@@ -416,12 +416,12 @@ mut:
 	symbol_recent_set           [2048]bool
 	struct_field_entries        map[string]Type
 	struct_field_misses         map[string]bool
-	struct_field_last_struct    usize
-	struct_field_last_field     usize
-	struct_field_last_struct_n  int
-	struct_field_last_field_n   int
-	struct_field_last_value     Type = Type(void_)
-	struct_field_last_state     i8
+	struct_field_shared         map[string]Type // immutable declaration types, without local TypeIds
+	struct_field_complete       map[string]bool // direct fields cover every lookup for these owners
+	struct_field_recent_structs [256]string
+	struct_field_recent_fields  [256]string
+	struct_field_recent_values  [256]Type
+	struct_field_recent_states  [256]i8
 	struct_field_fn_diagnostics map[string]string
 	sum_variant_pattern_entries map[string]string
 	recv_pattern_entries        map[string]GenericReceiverMethodPatternMatch
@@ -942,6 +942,8 @@ mut:
 	// checker workers. Transformed or appended nodes use the scan fallback in
 	// direct_parent_id.
 	direct_parent_ids           []flat.NodeId
+	preflight_node_ids          []i32
+	preflight_index_nodes_len   int = -1
 	rewritten_parent_ids        []flat.NodeId
 	value_used_nodes            []bool
 	fn_check_costs              []i32
@@ -1301,6 +1303,8 @@ fn (tc &TypeChecker) fork_program_view(ast &flat.FlatAst, direct_dependencies_by
 		rewritten_parent_ids: tc.rewritten_parent_ids
 		value_used_nodes: tc.value_used_nodes
 		direct_parent_index_trusted: tc.direct_parent_index_trusted
+		preflight_node_ids: tc.preflight_node_ids
+		preflight_index_nodes_len: tc.preflight_index_nodes_len
 		has_goto_nodes: tc.has_goto_nodes
 		declaration_attributes: tc.declaration_attributes
 		type_declaration_ids: tc.type_declaration_ids
@@ -1564,6 +1568,9 @@ pub fn (mut tc TypeChecker) set_fresh_type_cache(parse_enabled bool) {
 		cache.clear_c_type_entries()
 		cache.struct_field_entries.clear()
 		cache.struct_field_misses.clear()
+		cache.struct_field_shared = map[string]Type{}
+		cache.struct_field_complete = map[string]bool{}
+		cache.struct_field_recent_states = [256]i8{}
 		cache.recv_pattern_entries.clear()
 		cache.recv_pattern_misses.clear()
 		cache.ierror_compat_entries.clear()
@@ -1619,6 +1626,7 @@ pub fn (tc &TypeChecker) type_cache_parse_enabled() bool {
 	return !isnil(tc.type_cache) && tc.type_cache.parse_enabled
 }
 
+// clear_field_lookup_cache invalidates field types after declaration metadata changes.
 pub fn (tc &TypeChecker) clear_field_lookup_cache() {
 	mut cache := tc.type_cache
 	if isnil(cache) {
@@ -1626,6 +1634,9 @@ pub fn (tc &TypeChecker) clear_field_lookup_cache() {
 	}
 	cache.struct_field_entries.clear()
 	cache.struct_field_misses.clear()
+	cache.struct_field_shared = map[string]Type{}
+	cache.struct_field_complete = map[string]bool{}
+	cache.struct_field_recent_states = [256]i8{}
 }
 
 // clear_c_type_cache invalidates C spellings after monomorphization changes
@@ -1685,10 +1696,25 @@ pub fn (mut tc TypeChecker) free_parallel_transform_caches() {
 
 // reset_node_caches updates reset node caches state for types.
 fn (mut tc TypeChecker) reset_node_caches(n int) {
-	tc.resolved_call_names = []string{len: n}
-	tc.resolved_call_set = []bool{len: n}
-	tc.resolved_fn_value_names = []string{len: n}
-	tc.resolved_fn_value_set = []bool{len: n}
+	for group in 0 .. 3 {
+		tc.reset_node_cache_group(n, group)
+	}
+}
+
+// Independent arrays can be initialized on separate persistent worker arenas.
+fn (mut tc TypeChecker) reset_node_cache_group(n int, group int) {
+	if group == 0 {
+		// Only set slots are read; zeroed strings also match the representation
+		// used when transform grows these caches. Avoid a default-string fill.
+		tc.resolved_call_names = unsafe { []string{len: n} }
+		tc.resolved_call_set = []bool{len: n}
+		return
+	}
+	if group == 1 {
+		tc.resolved_fn_value_names = unsafe { []string{len: n} }
+		tc.resolved_fn_value_set = []bool{len: n}
+		return
+	}
 	tc.statement_nodes = []bool{len: n}
 	// No init fill: every read of expr_type_values is guarded by expr_type_set,
 	// so unset slots are never returned, and skipping the ~1M-element fill loop
@@ -1712,12 +1738,40 @@ fn (mut tc TypeChecker) init_direct_parent_index(a &flat.FlatAst) {
 	tc.strings_builder_candidates = []i32{cap: 1024}
 	tc.synthetic_top_level_type_ids = []i32{cap: 2048}
 	tc.has_goto_nodes = false
+	tc.preflight_node_ids = []i32{}
+	tc.preflight_index_nodes_len = -1
 }
 
-@[direct_array_access]
+struct DirectParentEdge {
+	child      flat.NodeId
+	parent     flat.NodeId
+	value_used bool
+}
+
+struct DirectParentChunk {
+mut:
+	external_edges     []DirectParentEdge
+	preflight_node_ids []i32
+	synthetic_type_ids []i32
+	has_goto_nodes     bool
+}
+
 fn (mut tc TypeChecker) fill_direct_parent_edges(a &flat.FlatAst) {
+	chunk := tc.fill_direct_parent_edges_range(a, 0, a.nodes.len)
+	tc.merge_direct_parent_chunk(chunk)
+	tc.preflight_index_nodes_len = a.nodes.len
+}
+
+// Ranges start immediately after a declaration, where the running cost resets.
+@[direct_array_access]
+fn (mut tc TypeChecker) fill_direct_parent_edges_range(a &flat.FlatAst, start int, end int) DirectParentChunk {
+	mut chunk := DirectParentChunk{}
 	mut fn_cost := 0
-	for parent_idx, node in a.nodes {
+	for parent_idx in start .. end {
+		node := a.nodes[parent_idx]
+		if node.kind in [.for_in_stmt, .comptime_for] {
+			chunk.preflight_node_ids << parent_idx
+		}
 		// Node count alone severely underestimates index-heavy and control-flow
 		// functions, which leaves one parallel checker worker running last.
 		mut node_cost := 1 + int(node.children_count) * 2
@@ -1732,21 +1786,29 @@ fn (mut tc TypeChecker) fill_direct_parent_edges(a &flat.FlatAst) {
 		}
 		fn_cost += node_cost
 		if node.kind == .goto_stmt {
-			tc.has_goto_nodes = true
+			chunk.has_goto_nodes = true
 		}
 		if node.kind == .struct_decl
 			&& (is_anonymous_struct_name(node.value) || node.value.contains('@local@')) {
-			tc.synthetic_top_level_type_ids << parent_idx
+			chunk.synthetic_type_ids << parent_idx
 		}
 		for child_idx in 0 .. node.children_count {
 			child := a.child(&node, child_idx)
 			idx := int(child)
-			if idx >= 0 && idx < tc.value_used_nodes.len
-				&& node.kind !in [.expr_stmt, .block, .match_branch, .fn_decl, .comptime_for] {
+			if idx < 0 || idx >= a.nodes.len {
+				continue
+			}
+			value_used := node.kind !in [.expr_stmt, .block, .match_branch, .fn_decl, .comptime_for]
+			if idx < start || idx >= end {
+				// Each lane writes only its own child slots. Replay cross-range
+				// references after joining, preserving the first parent in source order.
+				chunk.external_edges << DirectParentEdge{child, flat.NodeId(parent_idx), value_used}
+				continue
+			}
+			if value_used {
 				tc.value_used_nodes[idx] = true
 			}
-			if idx >= 0 && idx < tc.direct_parent_ids.len
-				&& tc.direct_parent_ids[idx] == flat.empty_node {
+			if tc.direct_parent_ids[idx] == flat.empty_node {
 				tc.direct_parent_ids[idx] = flat.NodeId(parent_idx)
 			}
 		}
@@ -1758,6 +1820,42 @@ fn (mut tc TypeChecker) fill_direct_parent_edges(a &flat.FlatAst) {
 			fn_cost = 0
 		}
 	}
+	return chunk
+}
+
+fn (mut tc TypeChecker) merge_direct_parent_chunk(chunk DirectParentChunk) {
+	for edge in chunk.external_edges {
+		old_parent := tc.direct_parent_ids[int(edge.child)]
+		if old_parent == flat.empty_node || edge.parent < old_parent {
+			tc.direct_parent_ids[int(edge.child)] = edge.parent
+		}
+		if edge.value_used {
+			tc.value_used_nodes[int(edge.child)] = true
+		}
+	}
+	tc.preflight_node_ids << chunk.preflight_node_ids
+	tc.synthetic_top_level_type_ids << chunk.synthetic_type_ids
+	tc.has_goto_nodes = tc.has_goto_nodes || chunk.has_goto_nodes
+}
+
+// preflight_nodes reuses the parsed-tree scan while its parent index is valid.
+// Standalone checker clients and rewritten ASTs retain the full-scan fallback.
+fn (tc &TypeChecker) preflight_nodes(kind flat.NodeKind) []i32 {
+	mut ids := []i32{}
+	if tc.direct_parent_index_trusted && tc.preflight_index_nodes_len == tc.a.nodes.len {
+		for id in tc.preflight_node_ids {
+			if tc.a.nodes[id].kind == kind {
+				ids << id
+			}
+		}
+	} else {
+		for id, node in tc.a.nodes {
+			if node.kind == kind {
+				ids << id
+			}
+		}
+	}
+	return ids
 }
 
 fn (mut tc TypeChecker) collect_direct_parent_metadata(a &flat.FlatAst) {
@@ -2812,6 +2910,7 @@ fn (mut tc TypeChecker) collect_index_child(a &flat.FlatAst, i int, idx_file str
 	return idx_module
 }
 
+// collect indexes source declarations and resolves their types before body checking.
 pub fn (mut tc TypeChecker) collect(a &flat.FlatAst) {
 	mut ck_c_sw := time.new_stopwatch()
 	mut ck_part_sw := time.new_stopwatch()
@@ -3095,22 +3194,22 @@ fn is_plain_type_symbol(type_text string) bool {
 	return true
 }
 
-fn (mut tc TypeChecker) register_declaration_visibility(node flat.Node) {
+fn (mut tc TypeChecker) register_declaration_visibility(node flat.Node, module_name string) {
 	visibility := DeclarationVisibility{
-		module_name: tc.cur_module
+		module_name: module_name
 		kind: node.kind
 		is_pub: node.op == .arrow
 	}
 	match node.kind {
 		.fn_decl {
-			name := checker_qualified_fn_name(tc.cur_module, node.value)
+			name := checker_qualified_fn_name(module_name, node.value)
 			tc.declaration_visibility[name] = visibility
-			if tc.cur_module == 'builtin' && visibility.is_pub {
+			if module_name == 'builtin' && visibility.is_pub {
 				tc.declaration_visibility['builtin.${node.value}'] = visibility
 			}
 		}
 		.struct_decl, .type_decl, .interface_decl, .enum_decl {
-			name := qualify_decl_name_in_module(node.value, tc.cur_module)
+			name := qualify_decl_name_in_module(node.value, module_name)
 			tc.declaration_visibility[name] = visibility
 		}
 		.const_decl {
@@ -3119,7 +3218,7 @@ fn (mut tc TypeChecker) register_declaration_visibility(node flat.Node) {
 				if field.kind != .const_field {
 					continue
 				}
-				name := qualify_decl_name_in_module(field.value, tc.cur_module)
+				name := qualify_decl_name_in_module(field.value, module_name)
 				tc.declaration_visibility[name] = visibility
 			}
 		}
@@ -3129,9 +3228,9 @@ fn (mut tc TypeChecker) register_declaration_visibility(node flat.Node) {
 				if field.kind != .field_decl || field.value.starts_with('C.') {
 					continue
 				}
-				name := qualify_decl_name_in_module(field.value, tc.cur_module)
+				name := qualify_decl_name_in_module(field.value, module_name)
 				tc.declaration_visibility[name] = DeclarationVisibility{
-					module_name: tc.cur_module
+					module_name: module_name
 					kind: .global_decl
 					is_pub: visibility.is_pub || field.op == .arrow
 				}
@@ -3141,12 +3240,33 @@ fn (mut tc TypeChecker) register_declaration_visibility(node flat.Node) {
 	}
 }
 
+fn (mut tc TypeChecker) collect_declaration_visibility() {
+	mut file_modules := tc.file_modules.clone()
+	mut file := tc.cur_file
+	mut module_name := tc.cur_module
+	for idx in tc.top_level_idx {
+		node := tc.a.nodes[idx]
+		if node.kind == .file {
+			file = node.value
+			module_name = file_modules[file] or { '' }
+		} else if node.kind == .module_decl {
+			module_name = node.value
+			if file.len > 0 && file !in file_modules {
+				file_modules[file] = module_name
+			}
+		} else {
+			tc.register_declaration_visibility(node, module_name)
+		}
+	}
+}
+
 // collect_after_index runs collection passes 1 and 2 plus the resolution tail
 // over the already-built top-level index (shared by the fast file-index path
 // and the full-scan fallback in collect()).
 fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 	mut ck_c_sw := time.new_stopwatch()
-	if !tc.prepare_collect_declaration_indexes_parallel(a) {
+	parallel_declaration_indexes := tc.prepare_collect_declaration_indexes_parallel(a)
+	if !parallel_declaration_indexes {
 		tc.build_enclosing_generic_param_index(a)
 		tc.build_type_declaration_index(a)
 		tc.build_fn_declaration_indexes(a)
@@ -3158,7 +3278,9 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 	for tl_idx in tc.top_level_idx {
 		node := a.nodes[tl_idx]
 		node_ref := a.node(flat.NodeId(tl_idx))
-		tc.register_declaration_visibility(node)
+		if !parallel_declaration_indexes {
+			tc.register_declaration_visibility(node, tc.cur_module)
+		}
 		match node.kind {
 			.file {
 				tc.enter_file(node.value)
@@ -3749,6 +3871,9 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 	tc.resolve_const_types()
 	tc.build_const_suffixes()
 	tc.build_struct_embed_index()
+	if tc.building_v_fast {
+		tc.cache_direct_struct_field_types()
+	}
 	tc.timing_profile('  [ttime]     ck c resolve   ${f64(ck_c_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 	if !isnil(tc.visible_mutation_cache) {
 		mut visible_mutation_cache := tc.visible_mutation_cache
@@ -3757,6 +3882,39 @@ fn (mut tc TypeChecker) collect_after_index(a &flat.FlatAst) {
 	$if ownership ? {
 		tc.ownership_after_collect()
 	}
+}
+
+// Seed the frozen cache once instead of making every checker batch walk the
+// same large compiler structs. Generic applications still need substitution.
+fn (tc &TypeChecker) cache_direct_struct_field_types() {
+	if isnil(tc.type_cache) {
+		return
+	}
+	mut cache := tc.type_cache
+	mut fields_by_name := map[string]Type{}
+	mut complete_owners := map[string]bool{}
+	for owner, fields in tc.structs {
+		if owner.contains('[') {
+			continue
+		}
+		mut complete := true
+		embeds_indexed := owner in tc.struct_embed_receivers
+		// Match the direct-field walk's first-declaration precedence.
+		for i := fields.len - 1; i >= 0; i-- {
+			field := fields[i]
+			fields_by_name['${owner}\n${field.name}'] = field.typ
+			if field.is_embed || (!embeds_indexed && embedded_field_type(field) != none) {
+				complete = false
+			}
+		}
+		if complete {
+			complete_owners[owner] = true
+		}
+	}
+	cache.struct_field_shared = fields_by_name.move()
+	cache.struct_field_complete = complete_owners.move()
+	cache.struct_field_misses.clear()
+	cache.struct_field_recent_states = [256]i8{}
 }
 
 fn source_field_decl_is_mut(field flat.Node) bool {
@@ -15483,8 +15641,9 @@ fn (tc &TypeChecker) comptime_struct_update_source_pos(node flat.Node) ?token.Po
 fn (mut tc TypeChecker) check_comptime_struct_updates_preflight() {
 	message := 'cannot use struct update syntax in compile time expressions'
 	tc.ct_update_pos = map[int]token.Pos{}
-	for node in tc.a.nodes {
-		if node.kind != .comptime_for || node.children_count == 0 {
+	for id in tc.preflight_nodes(.comptime_for) {
+		node := tc.a.nodes[id]
+		if node.children_count == 0 {
 			continue
 		}
 		body_id := tc.a.child(&node, 0)
@@ -15587,10 +15746,8 @@ fn (mut tc TypeChecker) check_comptime_for_source_type(id flat.NodeId, node flat
 }
 
 fn (mut tc TypeChecker) check_comptime_for_source_types_preflight() {
-	for index, node in tc.a.nodes {
-		if node.kind == .comptime_for {
-			tc.check_comptime_for_source_type(flat.NodeId(index), node)
-		}
+	for index in tc.preflight_nodes(.comptime_for) {
+		tc.check_comptime_for_source_type(flat.NodeId(index), tc.a.nodes[index])
 	}
 }
 

--- a/vlib/v3/types/checker_comptime.v
+++ b/vlib/v3/types/checker_comptime.v
@@ -12614,8 +12614,9 @@ fn (mut tc TypeChecker) check_loop_var_const_conflict(id flat.NodeId) bool {
 }
 
 fn (mut tc TypeChecker) check_for_in_const_conflicts_preflight() {
-	for i, node in tc.a.nodes {
-		if node.kind != .for_in_stmt || node.value.int() < 3 || node.children_count < 2 {
+	for i in tc.preflight_nodes(.for_in_stmt) {
+		node := tc.a.nodes[i]
+		if node.value.int() < 3 || node.children_count < 2 {
 			continue
 		}
 		file := tc.a.source_files[node.pos.id] or { continue }

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -141,24 +141,28 @@ struct UnusedFnVarCandidate {
 }
 
 struct CollectIndexPrepArgs {
-	tc   voidptr
-	a    &flat.FlatAst
-	kind u8 // 0 = parent edges, 1 = threads condition, 2 = node-cache reset
-	n    int
+	tc    voidptr
+	a     &flat.FlatAst
+	kind  u8 // 0 = parent edges, 1 = threads condition, 2..4 = caches, 5 = metadata
+	n     int
+	start int
+	end   int
+mut:
+	parent_chunk DirectParentChunk
 }
 
 struct CollectDeclarationIndexArgs {
 	tc   voidptr
 	a    &flat.FlatAst
-	kind u8 // 0 = generic params, 1 = type declarations, 2 = function declarations
+	kind u8 // 0 = generic params, 1 = type declarations, 2 = functions, 3 = visibility
 }
 
 fn collect_index_prep_thread(arg voidptr) voidptr {
-	a := unsafe { &CollectIndexPrepArgs(arg) }
+	mut a := unsafe { &CollectIndexPrepArgs(arg) }
 	mut tc := unsafe { &TypeChecker(a.tc) }
 	match a.kind {
 		0 {
-			tc.fill_direct_parent_edges(a.a)
+			a.parent_chunk = tc.fill_direct_parent_edges_range(a.a, a.start, a.end)
 		}
 		1 {
 			scope := check_worker_scope_begin(true)
@@ -166,8 +170,11 @@ fn collect_index_prep_thread(arg voidptr) voidptr {
 			check_worker_scope_leave(scope)
 			check_worker_scope_free(scope)
 		}
+		5 {
+			tc.collect_direct_parent_metadata(a.a)
+		}
 		else {
-			tc.reset_node_caches(a.n)
+			tc.reset_node_cache_group(a.n, int(a.kind) - 2)
 		}
 	}
 	return unsafe { nil }
@@ -179,53 +186,62 @@ fn collect_declaration_index_thread(arg voidptr) voidptr {
 	match a.kind {
 		0 { tc.build_enclosing_generic_param_index(a.a) }
 		1 { tc.build_type_declaration_index(a.a) }
-		else { tc.build_fn_declaration_indexes(a.a) }
+		2 { tc.build_fn_declaration_indexes(a.a) }
+		else { tc.collect_declaration_visibility() }
 	}
 	return unsafe { nil }
 }
 
-// prepare_collect_index_parallel overlaps three independent index-front-end
-// tasks. Persistent arrays are initialized and reset on the caller's arena;
-// helper tasks only fill those arrays or return the scalar threads condition.
+// prepare_collect_index_parallel overlaps independent index tasks. Each cache
+// group owns its arrays, and all allocations survive in persistent arenas.
 fn (mut tc TypeChecker) prepare_collect_index_parallel(a &flat.FlatAst) bool {
 	if !tc.building_v_fast || os.getenv('V3_NO_PAR_CHECK_INDEX_PREP') != '' || isnil(a.worker_pool)
 		|| a.worker_pool.size() < 2 || a.nodes.len < 65536 {
 		return false
 	}
 	tc.init_direct_parent_index(a)
-	mut args := [
-		CollectIndexPrepArgs{
-			tc:   voidptr(tc)
-			a:    a
-			kind: 0
-		},
-		CollectIndexPrepArgs{
-			tc:   voidptr(tc)
-			a:    a
-			kind: 1
-		},
-		CollectIndexPrepArgs{
-			tc:   voidptr(tc)
-			a:    a
-			kind: 2
-			n:    a.nodes.len
-		},
-	]
-	a.worker_pool.run([
-		workers.Task{ run: collect_index_prep_thread, arg: unsafe { voidptr(&args[0]) } },
-		workers.Task{ run: collect_index_prep_thread, arg: unsafe { voidptr(&args[1]) } },
-		workers.Task{
-			run:        collect_index_prep_thread
-			arg:        unsafe { voidptr(&args[2]) }
-			force_sync: true
-		},
-	])
-	tc.collect_direct_parent_metadata(a)
+	mut args := []CollectIndexPrepArgs{cap: 9}
+	mut start := 0
+	for job in 0 .. 4 {
+		mut end := if job == 3 { a.nodes.len } else { a.nodes.len * (job + 1) / 4 }
+		if end < start {
+			continue
+		}
+		// Finish a declaration so the next lane starts with a zero function cost.
+		for end < a.nodes.len {
+			kind := a.nodes[end].kind
+			end++
+			if kind in [.file, .module_decl, .struct_decl, .type_decl, .interface_decl, .enum_decl,
+				.import_decl, .const_decl, .global_decl, .fn_decl, .c_fn_decl] {
+				break
+			}
+		}
+		args << CollectIndexPrepArgs{ tc: voidptr(tc), a: a, kind: 0, start: start, end: end }
+		start = end
+	}
+	for kind in [u8(1), 5, 2, 3, 4] {
+		args << CollectIndexPrepArgs{ tc: voidptr(tc), a: a, kind: kind, n: a.nodes.len }
+	}
+	mut tasks := []workers.Task{cap: args.len}
+	for i in 0 .. args.len {
+		tasks << workers.Task{
+			run: collect_index_prep_thread
+			arg: unsafe { voidptr(&args[i]) }
+			force_sync: i == args.len - 1
+		}
+	}
+	a.worker_pool.run(tasks)
+	for arg in args {
+		if arg.kind == 0 {
+			tc.merge_direct_parent_chunk(arg.parent_chunk)
+		}
+	}
+	tc.preflight_index_nodes_len = a.nodes.len
 	tc.direct_parent_index_trusted = true
 	return true
 }
 
-// prepare_collect_declaration_indexes_parallel builds the three independent
+// prepare_collect_declaration_indexes_parallel builds independent
 // read-only-AST declaration indexes on separate persistent lanes.
 fn (mut tc TypeChecker) prepare_collect_declaration_indexes_parallel(a &flat.FlatAst) bool {
 	if !tc.building_v_fast || !tc.scope_parallel_check_workers
@@ -249,6 +265,11 @@ fn (mut tc TypeChecker) prepare_collect_declaration_indexes_parallel(a &flat.Fla
 			a:    a
 			kind: 2
 		},
+		CollectDeclarationIndexArgs{
+			tc: voidptr(tc)
+			a: a
+			kind: 3
+		},
 	]
 	a.worker_pool.run([
 		workers.Task{
@@ -260,8 +281,12 @@ fn (mut tc TypeChecker) prepare_collect_declaration_indexes_parallel(a &flat.Fla
 			arg: unsafe { voidptr(&args[1]) }
 		},
 		workers.Task{
-			run:        collect_declaration_index_thread
-			arg:        unsafe { voidptr(&args[2]) }
+			run: collect_declaration_index_thread
+			arg: unsafe { voidptr(&args[2]) }
+		},
+		workers.Task{
+			run: collect_declaration_index_thread
+			arg: unsafe { voidptr(&args[3]) }
 			force_sync: true
 		},
 	])
@@ -1209,10 +1234,16 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 				chunk_target = items.len
 			}
 		}
-		mut chunks := split_check_items(items, chunk_target)
-		chunk_count := chunks.len
 		fail := os.getenv('V3_TEST_PTHREAD_CREATE_FAIL')
 		dynamic_dispatch := tc.scope_parallel_check_workers && tc.building_v_fast && fail.len == 0
+		// Dynamic workers record their actual assignments after dispatch; the
+		// static partition would only allocate and sort buckets that get replaced.
+		mut chunks := if dynamic_dispatch {
+			[][]CheckWorkItem{len: chunk_target}
+		} else {
+			split_check_items(items, chunk_target)
+		}
+		chunk_count := chunks.len
 		mut dynamic_chunks := [][]CheckWorkItem{}
 		mut chunk_queue := chan int{cap: 1}
 		if dynamic_dispatch {
@@ -1484,20 +1515,44 @@ fn split_check_items(items []CheckWorkItem, n int) [][]CheckWorkItem {
 	}
 	mut sorted := items.clone()
 	sorted.sort(a.rank > b.rank)
+	mut least_loaded := []int{len: n, init: index}
+	restore_check_load_heap(mut least_loaded, loads)
 	for it in sorted {
-		mut best := 0
-		for b in 1 .. n {
-			if loads[b] < loads[best] {
-				best = b
-			}
-		}
+		best := least_loaded[0]
 		buckets[best] << it
 		loads[best] += i64(it.cost) + 1
+		restore_check_load_heap(mut least_loaded, loads)
 	}
 	for mut bucket in buckets {
 		bucket.sort(a.fn_idx < b.fn_idx)
 	}
 	return buckets
+}
+
+// Only the root's load changes. Break equal-load ties by bucket index, exactly
+// as the original linear search, so scheduling and merge order stay unchanged.
+@[direct_array_access]
+fn restore_check_load_heap(mut order []int, loads []i64) {
+	if order.len < 2 {
+		return
+	}
+	root := order[0]
+	mut parent := 0
+	for parent * 2 + 1 < order.len {
+		mut child := parent * 2 + 1
+		right := child + 1
+		if right < order.len && (loads[order[right]] < loads[order[child]]
+			|| (loads[order[right]] == loads[order[child]] && order[right] < order[child])) {
+			child = right
+		}
+		if loads[root] < loads[order[child]]
+			|| (loads[root] == loads[order[child]] && root < order[child]) {
+			break
+		}
+		order[parent] = order[child]
+		parent = child
+	}
+	order[parent] = root
 }
 
 // merge_own_sparse_caches replays the master's out-of-range cache writes
@@ -2792,6 +2847,12 @@ fn (tc &TypeChecker) fork_for_parallel_check() &TypeChecker {
 		w.type_interner = new_type_interner()
 		w.symbols = new_symbol_interner()
 		w.type_cache.base = unsafe { nil }
+		if !isnil(precomputed) {
+			// Only immutable semantic values cross the arena boundary. The full
+			// cache also contains TypeIds belonging to another private interner.
+			unsafe { w.type_cache.struct_field_shared = precomputed.struct_field_shared }
+			unsafe { w.type_cache.struct_field_complete = precomputed.struct_field_complete }
+		}
 	}
 	return w
 }
@@ -2804,13 +2865,13 @@ fn (tc &TypeChecker) precomputed_check_cache() &TypeCache {
 		return unsafe { nil }
 	}
 	if tc.type_cache.source_error_embed_indexed || tc.type_cache.short_type_name_index_built
-		|| tc.type_cache.local_fn_decl_indexed_len > 0 {
+		|| tc.type_cache.local_fn_decl_indexed_len > 0 || tc.type_cache.struct_field_shared.len > 0 {
 		return tc.type_cache
 	}
 	mut fallback := tc.type_cache.base
 	for !isnil(fallback) {
 		if fallback.source_error_embed_indexed || fallback.short_type_name_index_built
-			|| fallback.local_fn_decl_indexed_len > 0 {
+			|| fallback.local_fn_decl_indexed_len > 0 || fallback.struct_field_shared.len > 0 {
 			return fallback
 		}
 		fallback = fallback.base
@@ -2856,9 +2917,19 @@ fn check_clone_chunk_thread(arg voidptr) voidptr {
 
 fn (mut tc TypeChecker) intern_expr_type_misses(indexes []int) {
 	for idx in indexes {
-		_, canonical := tc.intern_type(clone_owned_type(tc.expr_type_values[idx]))
-		tc.expr_type_values[idx] = canonical
+		tc.expr_type_values[idx] = tc.promote_check_type(tc.expr_type_values[idx])
 	}
+}
+
+// A batch repeats the same types on thousands of nodes. Clone only the first
+// instance into the accumulator's arena, before releasing the batch's storage.
+// The accumulator is private to this lane (or the joined master during merge).
+fn (tc &TypeChecker) promote_check_type(typ Type) Type {
+	if canonical := tc.probe_intern_type(typ) {
+		return canonical
+	}
+	_, canonical := tc.intern_type(clone_owned_type(typ))
+	return canonical
 }
 
 fn par_check_clone_enabled() bool {
@@ -2875,8 +2946,7 @@ fn (mut tc TypeChecker) clone_parallel_worker_node_caches(items []CheckWorkItem)
 				tc.resolved_fn_value_names[idx] = tc.resolved_fn_value_names[idx].clone()
 			}
 			if idx < tc.expr_type_set.len && tc.expr_type_set[idx] {
-				_, canonical := tc.intern_type(clone_owned_type(tc.expr_type_values[idx]))
-				tc.expr_type_values[idx] = canonical
+				tc.expr_type_values[idx] = tc.promote_check_type(tc.expr_type_values[idx])
 			}
 		}
 	}
@@ -2987,8 +3057,7 @@ fn (mut tc TypeChecker) merge_parallel_check_worker_scoped(w &TypeChecker, scope
 	}
 	for idx, typ in w.sparse_expr_type_values {
 		owned_type := if scoped {
-			_, canonical := tc.intern_type(clone_owned_type(typ))
-			canonical
+			tc.promote_check_type(typ)
 		} else {
 			typ
 		}

--- a/vlib/v3/types/checker_parallel_test.v
+++ b/vlib/v3/types/checker_parallel_test.v
@@ -6,6 +6,152 @@ import v3.flat
 import v3.parser
 import v3.pref
 
+fn test_check_heap_partitions_match_linear_load_selection() {
+	for count in [0, 1, 2, 33, 256, 1500] {
+		mut items := []CheckWorkItem{}
+		mut total := i64(0)
+		for i in 0 .. count {
+			cost := (i * 31) % 97
+			items << CheckWorkItem{ fn_idx: i, cost: cost, rank: i64(i % 13) }
+			total += i64(cost) + 1
+		}
+		for n in [1, 2, 3, 17, 136] {
+			mut expected := [][]CheckWorkItem{len: n}
+			mut loads := []i64{len: n}
+			if n > 1 {
+				loads[0] = -total * check_master_bias_pct / i64(100 * n)
+			}
+			mut sorted := items.clone()
+			sorted.sort(a.rank > b.rank)
+			for item in sorted {
+				mut best := 0
+				for bucket in 1 .. n {
+					if loads[bucket] < loads[best] {
+						best = bucket
+					}
+				}
+				expected[best] << item
+				loads[best] += i64(item.cost) + 1
+			}
+			for mut bucket in expected {
+				bucket.sort(a.fn_idx < b.fn_idx)
+			}
+			assert split_check_items(items, n) == expected
+		}
+	}
+}
+
+fn test_visibility_index_preserves_file_context_and_builtin_aliases() {
+	mut a := flat.FlatAst.new()
+	a.add_val(.file, 'one.v')
+	a.add_val(.module_decl, 'alpha')
+	a.add_node(flat.Node{ kind: .fn_decl, value: 'entry', op: .arrow })
+	a.add_val(.file, 'one.v')
+	a.add_val(.fn_decl, 'trailing')
+	a.add_val(.file, 'two.v')
+	a.add_val(.module_decl, 'builtin')
+	a.add_node(flat.Node{ kind: .fn_decl, value: 'helper', op: .arrow })
+	mut tc := TypeChecker.new(&a)
+	for i in 0 .. a.nodes.len {
+		tc.top_level_idx << i
+	}
+	tc.cur_module = 'original'
+	tc.cur_file = 'original.v'
+	tc.collect_declaration_visibility()
+	assert tc.declaration_visibility['alpha.entry'].is_pub
+	assert tc.declaration_visibility['alpha.trailing'].module_name == 'alpha'
+	assert tc.declaration_visibility['helper'].is_pub
+	assert tc.declaration_visibility['builtin.helper'].is_pub
+	assert tc.cur_module == 'original'
+	assert tc.cur_file == 'original.v'
+	assert tc.file_modules.len == 0
+}
+
+fn test_checker_type_promotion_survives_batch_arena_release() {
+	$if prealloc {
+		a := flat.FlatAst.new()
+		tc := TypeChecker.new(&a)
+		scope := unsafe { prealloc_scope_begin() }
+		borrowed := Type(FnType{
+			params: [Type(Struct{ name: 'ScopedItem'.clone() })]
+			return_type: Type(Array{ elem_type: Type(string_) })
+		})
+		unsafe { prealloc_scope_leave(scope) }
+		first := tc.promote_check_type(borrowed)
+		second := tc.promote_check_type(borrowed)
+		if first is FnType && second is FnType {
+			assert !unsafe { prealloc_scope_owns(scope, first.params.data) }
+			assert first.params.data == second.params.data
+		} else {
+			assert false
+		}
+		unsafe { prealloc_scope_free_after(scope) }
+		assert first.name() == 'fn(ScopedItem) []string'
+		assert second.name() == first.name()
+	}
+}
+
+fn test_parent_index_ranges_preserve_cross_range_edges_and_function_costs() {
+	mut a := flat.FlatAst.new()
+	a.add(.ident)
+	for kind, children in {
+		flat.NodeKind.paren:        [flat.NodeId(0), flat.NodeId(5)]
+		flat.NodeKind.fn_decl:      [flat.NodeId(1)]
+		flat.NodeKind.expr_stmt:    [flat.NodeId(0)]
+		flat.NodeKind.comptime_for: [flat.NodeId(5)]
+	} {
+		start := a.begin_children()
+		for child in children {
+			a.add_child(child)
+		}
+		a.add_node(flat.Node{ kind: kind, children_start: start, children_count: children.len })
+	}
+	a.add(.ident)
+	start := a.begin_children()
+	a.add_child(flat.NodeId(5))
+	a.add_node(flat.Node{ kind: .paren, children_start: start, children_count: 1 })
+	a.add(.for_in_stmt)
+	a.add_val(.struct_decl, 'Box@local@1')
+	a.add(.goto_stmt)
+	a.add(.fn_decl)
+	mut serial := TypeChecker.new(&a)
+	serial.building_v_fast = true
+	serial.build_direct_parent_index(&a)
+	mut split := TypeChecker.new(&a)
+	split.building_v_fast = true
+	split.init_direct_parent_index(&a)
+	// Visit the later range first to exercise source-order parent selection.
+	later := split.fill_direct_parent_edges_range(&a, 3, a.nodes.len)
+	earlier := split.fill_direct_parent_edges_range(&a, 0, 3)
+	split.merge_direct_parent_chunk(earlier)
+	split.merge_direct_parent_chunk(later)
+	assert split.direct_parent_ids == serial.direct_parent_ids
+	assert split.direct_parent_ids[5] == flat.NodeId(1)
+	assert split.value_used_nodes == serial.value_used_nodes
+	assert split.fn_check_costs == serial.fn_check_costs
+	assert split.preflight_node_ids == serial.preflight_node_ids
+	assert split.synthetic_top_level_type_ids == serial.synthetic_top_level_type_ids
+	assert split.has_goto_nodes == serial.has_goto_nodes
+}
+
+fn test_preflight_index_falls_back_after_ast_growth_or_invalidation() {
+	mut a := flat.FlatAst.new()
+	a.add(.ident)
+	loop := a.add(.for_in_stmt)
+	comptime_loop := a.add(.comptime_for)
+	mut tc := TypeChecker.new(&a)
+	tc.build_direct_parent_index(&a)
+	assert tc.preflight_nodes(.for_in_stmt) == [i32(loop)]
+	assert tc.preflight_nodes(.comptime_for) == [i32(comptime_loop)]
+	added := a.add(.comptime_for)
+	assert tc.preflight_nodes(.comptime_for) == [i32(comptime_loop), i32(added)]
+	tc.build_direct_parent_index(&a)
+	a.nodes[int(loop)].kind = .comptime_for
+	tc.direct_parent_index_trusted = false
+	assert tc.preflight_nodes(.for_in_stmt).len == 0
+	assert tc.preflight_nodes(.comptime_for) == [i32(loop), i32(comptime_loop), i32(added)]
+}
+
 fn test_fast_file_index_collects_translated_module_attribute() {
 	old_no_file_idx := os.getenv_opt('V3_NO_FILE_IDX')
 	os.unsetenv('V3_NO_FILE_IDX')

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -10649,12 +10649,20 @@ pub fn (mut tc TypeChecker) prepare_interface_requirement_indexes() {
 	// Default interface methods are stored with ordinary function signatures.
 	// Index them once instead of scanning the full signature table separately
 	// for every interface (and again for each embedded-interface traversal).
+	mut receiver_names := map[string]string{}
 	for key, _ in tc.fn_ret_types {
 		dot := key.last_index_u8(`.`)
 		if dot <= 0 {
 			continue
 		}
-		receiver := tc.interface_metadata_name(key[..dot])
+		raw_receiver := key[..dot]
+		// Most signatures repeat an ordinary struct receiver. Resolve its
+		// interface metadata once for this immutable declaration table.
+		receiver := receiver_names[raw_receiver] or {
+			resolved := tc.interface_metadata_name(raw_receiver)
+			receiver_names[raw_receiver] = resolved
+			resolved
+		}
 		mut methods := direct_methods[receiver] or { continue }
 		method := key[dot + 1..]
 		if method !in methods {
@@ -10979,16 +10987,16 @@ pub fn (tc &TypeChecker) struct_fields_for_type(struct_name string) []StructFiel
 	return tc.struct_fields_for_init(struct_name)
 }
 
+@[direct_array_access]
 fn (tc &TypeChecker) struct_field_type(struct_name string, field_name string) ?Type {
 	if !isnil(tc.type_cache) {
 		cache := tc.type_cache
-		if cache.struct_field_last_state != 0
-			&& cache.struct_field_last_struct == usize(struct_name.str)
-			&& cache.struct_field_last_field == usize(field_name.str)
-			&& cache.struct_field_last_struct_n == struct_name.len
-			&& cache.struct_field_last_field_n == field_name.len {
-			if cache.struct_field_last_state > 0 {
-				return cache.struct_field_last_value
+		slot := struct_field_cache_slot(struct_name, field_name)
+		if cache.struct_field_recent_states[slot] != 0
+			&& cache.struct_field_recent_structs[slot] == struct_name
+			&& cache.struct_field_recent_fields[slot] == field_name {
+			if cache.struct_field_recent_states[slot] > 0 {
+				return cache.struct_field_recent_values[slot]
 			}
 			return none
 		}
@@ -10997,11 +11005,19 @@ fn (tc &TypeChecker) struct_field_type(struct_name string, field_name string) ?T
 	if !isnil(tc.type_cache) {
 		mut fallback := tc.type_cache.base
 		for !isnil(fallback) {
+			if typ := fallback.struct_field_shared[cache_key] {
+				tc.remember_struct_field_type(struct_name, field_name, typ, true)
+				return typ
+			}
 			if typ := fallback.struct_field_entries[cache_key] {
 				tc.remember_struct_field_type(struct_name, field_name, typ, true)
 				return typ
 			}
 			if fallback.struct_field_misses[cache_key] {
+				tc.remember_struct_field_type(struct_name, field_name, Type(void_), false)
+				return none
+			}
+			if fallback.struct_field_complete[struct_name] {
 				tc.remember_struct_field_type(struct_name, field_name, Type(void_), false)
 				return none
 			}
@@ -11011,7 +11027,12 @@ fn (tc &TypeChecker) struct_field_type(struct_name string, field_name string) ?T
 			tc.remember_struct_field_type(struct_name, field_name, typ, true)
 			return typ
 		}
-		if tc.type_cache.struct_field_misses[cache_key] {
+		if typ := tc.type_cache.struct_field_shared[cache_key] {
+			tc.remember_struct_field_type(struct_name, field_name, typ, true)
+			return typ
+		}
+		if tc.type_cache.struct_field_misses[cache_key]
+			|| tc.type_cache.struct_field_complete[struct_name] {
 			tc.remember_struct_field_type(struct_name, field_name, Type(void_), false)
 			return none
 		}
@@ -11033,19 +11054,33 @@ fn (tc &TypeChecker) struct_field_type(struct_name string, field_name string) ?T
 	return none
 }
 
+// Sample both spellings; every cache hit compares the full names.
+@[direct_array_access; inline]
+fn struct_field_cache_slot(struct_name string, field_name string) int {
+	mut hash := u32(struct_name.len)
+	if struct_name.len > 0 {
+		hash = hash * 16777619 ^ u32(struct_name[struct_name.len / 2])
+		hash = hash * 16777619 ^ u32(struct_name[struct_name.len - 1])
+	}
+	hash = hash * 16777619 ^ u32(field_name.len)
+	if field_name.len > 0 {
+		hash = hash * 16777619 ^ u32(field_name[0])
+		hash = hash * 16777619 ^ u32(field_name[field_name.len - 1])
+	}
+	return int(hash & 255)
+}
+
+@[direct_array_access]
 fn (tc &TypeChecker) remember_struct_field_type(struct_name string, field_name string, typ Type, found bool) {
 	if isnil(tc.type_cache) {
 		return
 	}
 	mut cache := tc.type_cache
-	struct_ptr := usize(struct_name.str)
-	field_ptr := usize(field_name.str)
-	cache.struct_field_last_struct = struct_ptr
-	cache.struct_field_last_field = field_ptr
-	cache.struct_field_last_struct_n = struct_name.len
-	cache.struct_field_last_field_n = field_name.len
-	cache.struct_field_last_value = typ
-	cache.struct_field_last_state = if found { i8(1) } else { i8(-1) }
+	slot := struct_field_cache_slot(struct_name, field_name)
+	cache.struct_field_recent_structs[slot] = struct_name
+	cache.struct_field_recent_fields[slot] = field_name
+	cache.struct_field_recent_values[slot] = typ
+	cache.struct_field_recent_states[slot] = if found { i8(1) } else { i8(-1) }
 }
 
 // struct_field_type_name returns the canonical type name for a struct field.
@@ -12358,6 +12393,47 @@ fn (tc &TypeChecker) lexical_smartcast_type(id flat.NodeId, key string) ?Type {
 	return tc.lexical_smartcast_type_in_parents(id, key, false)
 }
 
+// Reject unrelated conditions before resolving their types or allocating bindings.
+// Identifier conditions can refer to a saved boolean expression, so stay conservative.
+fn (tc &TypeChecker) condition_may_smartcast_key(id flat.NodeId, key string) bool {
+	if !tc.valid_node_id(id) {
+		return false
+	}
+	node := tc.a.node(id)
+	match node.kind {
+		.ident {
+			return true
+		}
+		.paren, .prefix {
+			return node.children_count > 0
+				&& tc.condition_may_smartcast_key(tc.a.child(node, 0), key)
+		}
+		.is_expr {
+			return node.children_count > 0 && tc.expr_key(tc.a.child(node, 0)) == key
+		}
+		.infix {
+			if node.children_count < 2 {
+				return false
+			}
+			lhs := tc.a.child(node, 0)
+			rhs := tc.a.child(node, 1)
+			if node.op in [.logical_and, .logical_or] {
+				return tc.condition_may_smartcast_key(lhs, key) || tc.condition_may_smartcast_key(rhs, key)
+			}
+			if node.op in [.eq, .ne] {
+				if tc.a.node(rhs).kind in [.none_expr, .nil_literal] {
+					return tc.expr_key(lhs) == key
+				}
+				if tc.a.node(lhs).kind in [.none_expr, .nil_literal] {
+					return tc.expr_key(rhs) == key
+				}
+			}
+		}
+		else {}
+	}
+	return false
+}
+
 // Walk the parent chain once, returning the nearest valid narrowing. Separate
 // if/for/match walks repeated the same parent lookups and evaluated outer
 // conditions even when a closer branch already determined the type.
@@ -12383,7 +12459,7 @@ fn (tc &TypeChecker) lexical_smartcast_type_in_parents(id flat.NodeId, key strin
 					break
 				}
 			}
-			if branch_index >= 1 {
+			if branch_index >= 1 && tc.condition_may_smartcast_key(tc.a.child(parent, 0), key) {
 				cond_id := tc.a.child(parent, 0)
 				bindings := if branch_index == 1 {
 					tc.extract_smartcasts(cond_id)
@@ -12410,7 +12486,7 @@ fn (tc &TypeChecker) lexical_smartcast_type_in_parents(id flat.NodeId, key strin
 			// rest of the body (the dynamic pass deletes the smartcast on assignment).
 			// Only reconstruct the condition smartcast when no preceding body statement,
 			// nor the statement holding `id`, writes `key`.
-			if body_index >= 3 {
+			if body_index >= 3 && tc.condition_may_smartcast_key(tc.a.child(parent, 1), key) {
 				for binding in tc.extract_smartcasts(tc.a.child(parent, 1)) {
 					if binding.name == key
 						&& !tc.for_body_writes_key_before(parent, body_index, current, key) {
@@ -12805,21 +12881,21 @@ pub fn (tc &TypeChecker) parse_type_ref(typ string, text_id u16) Type {
 		}
 	}
 	mut cache := unsafe { tc.type_cache }
-	if cache.parse_text_id_set.len == 0 {
-		cache.parse_text_id_context = []u64{len: 65536}
-		cache.parse_text_id_values = unsafe { []Type{len: 65536} }
-		cache.parse_text_id_set = []bool{len: 65536}
+	if cache.parse_text_ids.len == 0 {
+		cache.parse_text_id_context = []u64{len: 4096}
+		cache.parse_text_id_values = unsafe { []Type{len: 4096} }
+		cache.parse_text_ids = []u16{len: 4096}
 	}
-	slot := int(text_id)
+	slot := int(text_id) & 4095
 	context_hash := parse_type_cache_context_hash(mut cache, tc.cur_file, tc.cur_module, tc.fn_context.generic_params, tc.resolution_type_mode)
-	if cache.parse_text_id_set[slot] && cache.parse_text_id_context[slot] == context_hash {
+	if cache.parse_text_ids[slot] == text_id && cache.parse_text_id_context[slot] == context_hash {
 		cache.parse_hits++
 		return cache.parse_text_id_values[slot]
 	}
 	result := tc.parse_type(typ)
 	cache.parse_text_id_context[slot] = context_hash
 	cache.parse_text_id_values[slot] = result
-	cache.parse_text_id_set[slot] = true
+	cache.parse_text_ids[slot] = text_id
 	return result
 }
 
@@ -14691,7 +14767,8 @@ fn (mut memo BodyResolveMemo) begin(lo int, hi int) {
 	memo.hi = hi
 	memo.call_generation++
 	if memo.types.len < span {
-		memo.types = []Type{len: span, init: Type(void_)}
+		// A type is read only after its filled byte is set for this function.
+		memo.types = unsafe { []Type{len: span} }
 		memo.filled = []u8{len: span}
 	} else {
 		unsafe { vmemset(memo.filled.data, 0, span) }

--- a/vlib/v3/types/type_cache_test.v
+++ b/vlib/v3/types/type_cache_test.v
@@ -2,6 +2,87 @@ module types
 
 import v3.flat
 
+fn test_seeded_field_types_preserve_direct_precedence_and_generic_substitution() {
+	a := flat.FlatAst.new()
+	mut tc := TypeChecker.new(&a)
+	tc.structs['Inner'] = [StructField{ name: 'value', typ: Type(bool_) }]
+	tc.structs['Outer'] = [
+		StructField{ name: 'Inner', typ: Type(Struct{ name: 'Inner' }), is_embed: true },
+		StructField{ name: 'value', typ: Type(int_) },
+		StructField{ name: 'value', typ: Type(string_) },
+	]
+	tc.structs['Box'] = [StructField{ name: 'item', typ: unknown_type('T') }]
+	tc.structs['Promoted'] = [
+		StructField{ name: 'Inner', typ: Type(Struct{ name: 'Inner' }) },
+	]
+	tc.struct_generic_params['Box'] = ['T']
+	mut expected := []string{}
+	for owner in ['Outer', 'Box[int]', 'Box[string]'] {
+		field := if owner == 'Outer' { 'value' } else { 'item' }
+		expected << tc.struct_field_type_name(owner, field)?
+	}
+	tc.clear_field_lookup_cache()
+	tc.cache_direct_struct_field_types()
+	tc.scope_parallel_check_workers = true
+	mut worker := tc.fork_for_parallel_check()
+	assert worker.type_cache.struct_field_shared.len == tc.type_cache.struct_field_shared.len
+	assert worker.type_cache.struct_field_shared.len > 0
+	assert worker.type_cache.struct_field_complete['Inner']
+	assert !worker.type_cache.struct_field_complete['Outer']
+	assert !worker.type_cache.struct_field_complete['Promoted']
+	assert worker.struct_field_type('Inner', 'missing') == none
+	assert worker.struct_field_type('Promoted', 'value')? == Type(bool_)
+	for i, owner in ['Outer', 'Box[int]', 'Box[string]'] {
+		field := if owner == 'Outer' { 'value' } else { 'item' }
+		assert worker.struct_field_type_name(owner, field)? == expected[i]
+	}
+	worker.clear_field_lookup_cache()
+	assert tc.type_cache.struct_field_shared.len > 0
+	assert tc.type_cache.struct_field_complete['Inner']
+	tc.structs['Inner'] << StructField{ name: 'missing', typ: Type(string_) }
+	tc.clear_field_lookup_cache()
+	assert tc.struct_field_type('Inner', 'missing')? == Type(string_)
+}
+
+fn test_field_cache_handles_collisions_missing_fields_and_invalidation() {
+	a := flat.FlatAst.new()
+	mut tc := TypeChecker.new(&a)
+	tc.structs['Box'] = [
+		StructField{ name: 'abba', typ: Type(int_) },
+		StructField{ name: 'acca', typ: Type(string_) },
+	]
+	for _ in 0 .. 3 {
+		assert tc.struct_field_type('Box'.clone(), 'abba'.clone())? == Type(int_)
+		assert tc.struct_field_type('Box', 'acca')? == Type(string_)
+		assert tc.struct_field_type('Box', 'adda') == none
+	}
+	tc.structs['Box'] = [StructField{ name: 'adda', typ: Type(bool_) }]
+	tc.clear_field_lookup_cache()
+	assert tc.struct_field_type('Box', 'adda')? == Type(bool_)
+	assert tc.struct_field_type('Box', 'acca') == none
+}
+
+fn test_type_text_id_cache_keeps_colliding_ids_and_file_context_distinct() {
+	a := flat.FlatAst.new()
+	mut tc := TypeChecker.new(&a)
+	tc.type_cache.parse_enabled = true
+	tc.cur_module = 'app'
+	tc.cur_file = 'one.v'
+	tc.structs['one.Item'] = []StructField{}
+	tc.structs['two.Item'] = []StructField{}
+	tc.register_file_import('dep', 'one')
+	for _ in 0 .. 3 {
+		assert tc.parse_type_ref('dep.Item', 1).name() == 'one.Item'
+		assert tc.parse_type_ref('string', 4097).name() == 'string'
+		assert tc.parse_type_ref('bool', 65535).name() == 'bool'
+	}
+	tc.cur_file = 'two.v'
+	tc.register_file_import('dep', 'two')
+	assert tc.parse_type_ref('dep.Item', 1).name() == 'two.Item'
+	tc.cur_file = 'one.v'
+	assert tc.parse_type_ref('dep.Item', 1).name() == 'one.Item'
+}
+
 fn test_parse_type_cache_keeps_context_components_without_joined_keys() {
 	a := flat.FlatAst.new()
 	mut tc := TypeChecker.new(&a)

--- a/vlib/v3/types/universe.v
+++ b/vlib/v3/types/universe.v
@@ -90,12 +90,15 @@ pub const byteptr_ = Pointer{
 
 // is_builtin_type_name reports whether name is one of V's builtin type names.
 pub fn is_builtin_type_name(name string) bool {
-	return name == 'bool' || name == 'int' || name == 'i8' || name == 'i16' || name == 'i32'
-		|| name == 'i64' || name == 'u8' || name == 'byte' || name == 'u16' || name == 'u32'
-		|| name == 'u64' || name == 'f32' || name == 'f64' || name == 'string' || name == 'char'
-		|| name == 'rune' || name == 'isize' || name == 'usize' || name == 'void'
-		|| name == 'voidptr' || name == 'array' || name == 'map' || name == 'charptr'
-		|| name == 'byteptr' || name == 'nil' || name == 'none'
+	return match name.len {
+		2 { name in ['i8', 'u8'] }
+		3 { name in ['int', 'i16', 'i32', 'i64', 'u16', 'u32', 'u64', 'f32', 'f64', 'map', 'nil'] }
+		4 { name in ['bool', 'byte', 'char', 'rune', 'void', 'none'] }
+		5 { name in ['isize', 'usize', 'array'] }
+		6 { name == 'string' }
+		7 { name in ['voidptr', 'charptr', 'byteptr'] }
+		else { false }
+	}
 }
 
 // builtin_type_value returns the Type for a known builtin type name.


### PR DESCRIPTION
Cold V3 self-builds repeat field/type lookups, scan the parsed AST for multiple indexes,
and spend time assigning functions to worker buckets. Reduce that work and overlap
independent setup and C generation tasks, without intended changes to language semantics,
diagnostics, CLI behavior, or generated output.

- Parallelize checker array initialization and parent/declaration indexing; reuse the
  parsed-node index for comptime preflight checks.
- Share immutable field metadata, bound type-text caches with exact collision tags,
  cache field lookups, and reuse owned canonical types during worker arena promotion.
- Replace linear bucket selection with a heap that preserves load ties and partitions;
  skip the unused static partition during dynamic dispatch.
- Use up to 12 transform jobs for compiler self-builds, cache builtin alias normalization,
  and split optional-type scans while reusing selected function declarations in C generation.

## Performance

Five paired self-build runs, alternating baseline and optimized executables against the
same source tree, on an Apple M5 Max (18 cores, 128 GB RAM). Baseline compiler:
`316db75a07`. Both executables were built with `-gc none -prealloc -prod`.

| Metric | Baseline median | Optimized median | Change |
| --- | ---: | ---: | ---: |
| Checker | 130.40 ms | 108.91 ms | -16.5% |
| Transform | 176.32 ms | 141.25 ms | -19.9% |
| Cgen | 169.29 ms | 155.73 ms | -8.0% |
| Peak memory | 2,162 MB | 2,087 MB | -75 MB |
| RSS after cgen | 1,321 MB | 1,215 MB | -106 MB |

The transform target of 150 ms was met in all five optimized runs. The checker target
of 100 ms and cgen target of 150 ms remain unmet. Other benchmark batches had substantial
outliers from concurrent compiler jobs and macOS indexing.

Reproduce from the repository root:

```sh
./v -g -keepc -o ./vnew cmd/v
./vnew -gc none -prealloc -prod -o vlib/v3/v3 vlib/v3/v3.v
cd vlib/v3
./v3 -nocache -building-v -o v4 v3.v
```

## Validation

- Types, C generation, and transform unit suites: **44 passed, 3 failed**. All three
  failures were reproduced on the baseline: `types/storage_source_test.v`,
  `types/checker_scoped_transform_test.v`, and `transform/transform_parallel_test.v`.
  Their expectations were not changed.
- Focused cache, interface, and checker tests passed. Added coverage for cache collisions,
  embedded/generic field lookup, invalidation, arena lifetime, parent-index boundaries,
  and scheduler partition equivalence.
- Nine integration files passed, covering parallel determinism and worker failures,
  C generation, self-host expansion/transform, and smartcasts. Parallel determinism and
  worker-failure tests were also rerun after the scheduler change and passed.
- Optimized `v3` built `v4`; `v4` built `v5`; `v5` compiled and ran Hello World.
- Touched V files formatted; `git diff --check` passed. `test-all` was not run.
