### PR TITLE
parser: fix comment after a blank line before `pub mut:`/`mut:` breaking struct/interface parsing in `.parse_comments` mode (fix #28500)

### DIFF
--- a/vlib/v/fmt/tests/struct_decl_comment_before_section_expected.vv
+++ b/vlib/v/fmt/tests/struct_decl_comment_before_section_expected.vv
@@ -1,0 +1,35 @@
+// The comment after a blank line, right before a section keyword,
+// should stay with the previous field.
+pub struct Linker {
+	macho int
+	// frameworks to link
+pub mut:
+	frameworks []string
+	// private, mutable
+mut:
+	count int
+	// public, immutable
+pub:
+	name string
+	// global
+__global:
+	flag bool
+	// module
+module:
+	handle voidptr
+}
+
+pub interface Reader {
+	name string
+	// mutable part
+mut:
+	count int
+	read() int
+}
+
+pub interface Writer {
+	flush()
+	// after a method
+mut:
+	write() int
+}

--- a/vlib/v/fmt/tests/struct_decl_comment_before_section_input.vv
+++ b/vlib/v/fmt/tests/struct_decl_comment_before_section_input.vv
@@ -1,0 +1,42 @@
+// The comment after a blank line, right before a section keyword,
+// should stay with the previous field.
+pub struct Linker {
+	macho int
+
+	// frameworks to link
+pub mut:
+	frameworks []string
+
+	// private, mutable
+mut:
+	count int
+
+	// public, immutable
+pub:
+	name string
+
+	// global
+__global:
+	flag bool
+
+	// module
+module:
+	handle voidptr
+}
+
+pub interface Reader {
+	name string
+
+	// mutable part
+mut:
+	count int
+	read() int
+}
+
+pub interface Writer {
+	flush()
+
+	// after a method
+mut:
+	write() int
+}

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -163,6 +163,20 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 				end_comments = p.eat_comments(same_line: true)
 				break
 			}
+			mut pre_field_comments := p.eat_comments()
+			if pre_field_comments.len > 0
+				&& ((p.tok.kind == .key_pub && p.peek_tok.kind in [.key_mut, .colon])
+				|| (p.tok.kind in [.key_mut, .key_global, .key_module] && p.peek_tok.kind == .colon)) {
+				// A comment that is separated from the previous field by a blank line, and is
+				// followed by a section keyword (like `pub mut:`), was not eaten as the follow up
+				// comment of that field; it still belongs to it, not to the first field of the new section.
+				if ast_fields.len > 0 {
+					ast_fields.last().next_comments << pre_field_comments
+				} else {
+					pre_comments << pre_field_comments
+				}
+				pre_field_comments = []
+			}
 			if p.tok.kind == .key_pub && p.peek_tok.kind in [.key_mut, .colon] {
 				p.next()
 				if p.tok.kind == .key_mut {
@@ -225,7 +239,7 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 				is_field_mut = false
 				is_field_global = false
 			}
-			pre_field_comments := p.eat_comments()
+			pre_field_comments << p.eat_comments()
 			mut next_field_comments := []ast.Comment{}
 			field_start_pos := p.tok.pos()
 			mut is_field_volatile := false
@@ -896,6 +910,25 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 			continue
 		}
 
+		mut comments := p.eat_comments()
+		if comments.len > 0 && p.tok.kind == .key_mut && p.peek_tok.kind == .colon {
+			// A comment that is separated from the previous field/method by a blank line, and is
+			// followed by `mut:`, was not eaten as the follow up comment of that field/method;
+			// it still belongs to it, not to the first field/method of the `mut:` section.
+			if methods.len > 0 && (fields.len == 0 || methods.last().pos.pos > fields.last().pos.pos) {
+				methods.last().next_comments << comments
+			} else if fields.len > 0 {
+				mut last_comments := fields.last().comments.clone()
+				last_comments << comments
+				fields[fields.len - 1] = ast.StructField{
+					...fields.last()
+					comments: last_comments
+				}
+			} else {
+				pre_comments << comments
+			}
+			comments = []
+		}
 		if p.tok.kind == .key_mut {
 			if is_mut {
 				p.error_with_pos('redefinition of `mut` section', p.tok.pos())
@@ -916,7 +949,7 @@ fn (mut p Parser) interface_decl() ast.InterfaceDecl {
 			}
 			return ast.InterfaceDecl{}
 		}
-		mut comments := p.eat_comments()
+		comments << p.eat_comments()
 		if p.peek_tok.kind == .lpar {
 			// interface methods
 			method_start_pos := p.tok.pos()

--- a/vlib/v/parser/struct.v
+++ b/vlib/v/parser/struct.v
@@ -164,9 +164,10 @@ fn (mut p Parser) struct_decl(is_anon bool) ast.StructDecl {
 				break
 			}
 			mut pre_field_comments := p.eat_comments()
-			if pre_field_comments.len > 0
-				&& ((p.tok.kind == .key_pub && p.peek_tok.kind in [.key_mut, .colon])
-				|| (p.tok.kind in [.key_mut, .key_global, .key_module] && p.peek_tok.kind == .colon)) {
+			kw, next := p.tok.kind, p.peek_tok.kind
+			is_section_keyword := (kw == .key_pub && next in [.key_mut, .colon])
+				|| (kw in [.key_mut, .key_global, .key_module] && next == .colon)
+			if pre_field_comments.len > 0 && is_section_keyword {
 				// A comment that is separated from the previous field by a blank line, and is
 				// followed by a section keyword (like `pub mut:`), was not eaten as the follow up
 				// comment of that field; it still belongs to it, not to the first field of the new section.


### PR DESCRIPTION
Fixes #28500

### Problem

In `.parse_comments` mode (used by `v vet` and `vlib/v/parser/v_parser_test.v`), a struct field followed by a blank line, then a comment, then a section keyword failed to parse:

```v
pub struct Linker {
	macho int

	// frameworks to link
pub mut:
	frameworks []string
}
```

```
min.v:5:5: error: cannot use `mut` on struct field type
```

After a field, trailing comments are eaten with `eat_comments(follow_up: true)`, which stops at a blank line. The next loop iteration checked for section keywords (`pub mut:`, `mut:`, `pub:`, `__global:`, `module:`) *before* eating any comments, so the current token was still the comment, the section check failed, and `pub mut:` was parsed as a field named `pub` of type `mut`.

`vlib/v3/gen/arm64/linker.v` contains this pattern several times, so `v_parser_test.v` fails on master as soon as CI gets past the format gate (see #28483).

### Fix

- `struct_decl`: eat leading comments at the top of each field iteration. If a section keyword follows, attach the comments to the previous field's `next_comments` (the same owner the no-blank-line case already uses), so vfmt keeps them in front of the keyword; otherwise they stay the next field's `pre_comments` exactly as before.
- `interface_decl`: had the identical gap for its `mut:` section (`expecting type declaration`); same fix, attaching to the last parsed field/method.

### Tests

- New `vlib/v/fmt/tests/struct_decl_comment_before_section_{input,expected}.vv` covering all five struct section keywords and interface `mut:` after a field and after a method. Fails without the parser change, passes with it.
- `v test vlib/v/parser vlib/v/fmt cmd/tools/vvet` all pass; `v_parser_test.v` now parses `linker.v` with 0 errors; `v vet` is clean on the repro.

🧙 Built with [WOZCODE](https://wozcode.com)
