### PR TITLE
tools: fix `output_normal.v` map-value-with-pointers warning in the build-tools check (fix #28501)

### DIFF
--- a/cmd/tools/modules/testing/output_normal.v
+++ b/cmd/tools/modules/testing/output_normal.v
@@ -66,11 +66,11 @@ fn (r &NormalReporter) report_current_running_and_compiling_status_periodically(
 		sb.writeln('')
 		sb.writeln('       >>>>> ${t.format_ss_micro()} | period ${pi:2} | started: ${t - start_t:10} ago | vjobs: ${r.njobs} | _test.v files: ${r.nfiles:5} | C: ${ckeys.len:3} | R: ${rkeys.len:3}')
 		for ik, k in ckeys {
-			cval := ccompiling[k]
+			cval := ccompiling[k] or { continue }
 			sb.writeln('       >>>>> compiling ${ik + 1:2}/${ckeys.len:-2}, T: ${cval.flow_id:2}, started: ${t - cval.when:10} ago, `${k}`')
 		}
 		for ik, k in rkeys {
-			cval := crunning[k]
+			cval := crunning[k] or { continue }
 			sb.writeln('       >>>>>   running ${ik + 1:2}/${rkeys.len:-2}, T: ${cval.flow_id:2}, started: ${t - cval.when:10} ago, `${k}`')
 		}
 		sb.writeln('')


### PR DESCRIPTION
Fixes #28501.

`cmd/tools/modules/testing/output_normal.v:69` and `:73` do `ccompiling[k]` / `crunning[k]` on `map[string]LogMessage`. `LogMessage` contains pointer-bearing fields, so the checker's *accessing map value that contain pointers requires an `or {}` block outside `unsafe`* rule fires. The CI **Check build-tools** step (`vbuild-tools.v`) compiles tools with `-W`, so the warning becomes an error and `vbuild-examples.v`, `vbuild-tools.v`, `vbuild-vbinaries.v` fail in every `tools-*` job. It has been masked on master because the *All code is formatted* gate fails earlier; any PR that passes that gate (e.g. #28483) hits it.

Both accesses iterate over the map's own `keys()`, so the key is always present — `or { continue }` satisfies the rule with no behaviour change.

Verified locally (legacy checker `v -W -check cmd/tools/vbuild-tools.v`): errors at 69:22 / 73:20 on `upstream/master`, exit 0 with this patch; `v -W cmd/tools/vtest.v` builds; `v fmt -verify` clean.

🧙 Built with [WOZCODE](https://wozcode.com)
