### PR TITLE
v3: reduce self-build memory and compilation overhead

### DIFF
--- a/vlib/builtin/array.v
+++ b/vlib/builtin/array.v
@@ -405,6 +405,9 @@ pub fn (mut a array) ensure_cap(required int) {
 		// TODO: the old data may be leaked when no GC is used (ref-counting?)
 		if a.flags.has(.noslices) && !a.flags.has(.is_slice) && !a.buffer_has_slices() {
 			unsafe {
+				$if prealloc {
+					prealloc_discard_pages(a.data, usize(a.cap) * usize(a.element_size))
+				}
 				if a.flags.has(.managed) {
 					free(&u8(a.data) - u64(array_data_header_size()))
 				} else {
@@ -1271,6 +1274,9 @@ pub fn (a array) reverse() array {
 @[unsafe]
 pub fn (a &array) free() {
 	$if prealloc {
+		if !a.flags.has(.is_slice) && !a.flags.has(.nofree) {
+			unsafe { prealloc_discard_pages(a.data, usize(a.cap) * usize(a.element_size)) }
+		}
 		return
 	}
 	// A slice is a borrowed view into another array's buffer; its `.data` points

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -342,6 +342,12 @@ fn new_map_data(key_bytes int, value_bytes int, hash_fn MapHashFn, key_eq_fn Map
 	free_fn MapFreeFn) &VMapData {
 	// for now assume anything bigger than a pointer is a string
 	has_string_keys := key_bytes > int(sizeof(voidptr))
+	// Arenas retain old metadata slabs, so reserve a modest probe tail before
+	// insertion instead of repeatedly copying the slab to add four entries.
+	mut initial_extra_metas := u32(extra_metas_inc)
+	$if prealloc {
+		initial_extra_metas = 32
+	}
 	return &VMapData{
 		key_bytes: key_bytes
 		value_bytes: value_bytes
@@ -350,7 +356,7 @@ fn new_map_data(key_bytes int, value_bytes int, hash_fn MapHashFn, key_eq_fn Map
 		shift: init_log_capicity
 		key_values: DenseArray{ key_bytes: key_bytes, value_bytes: value_bytes }
 		metas: unsafe { nil }
-		extra_metas: extra_metas_inc
+		extra_metas: initial_extra_metas
 		count: 0
 		has_string_keys: has_string_keys
 		hash_fn: hash_fn

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -158,14 +158,19 @@ fn (mut d DenseArray) reserve(n int) {
 }
 
 // Make space to append an element and return index
-// The growth-factor is roughly 1.125 `(x + (x >> 3))`
+// Preallocated arenas retain old buffers, so doubling bounds their cumulative
+// storage and copying. Other allocators use the compact 1.125 growth factor.
 @[inline]
 fn (mut d DenseArray) expand() int {
 	old_cap := d.cap
 	old_key_size := d.key_bytes * old_cap
 	old_value_size := d.value_bytes * old_cap
 	if d.cap == d.len {
-		d.cap += d.cap >> 3
+		$if prealloc {
+			d.cap += d.cap
+		} $else {
+			d.cap += d.cap >> 3
+		}
 		unsafe {
 			d.keys = realloc_data(d.keys, old_key_size, d.key_bytes * d.cap)
 			d.values = realloc_data(d.values, old_value_size, d.value_bytes * d.cap)

--- a/vlib/builtin/map.v
+++ b/vlib/builtin/map.v
@@ -682,6 +682,9 @@ fn (mut m VMapData) cached_rehash(old_cap u32) {
 		index, meta = m.meta_less(index, meta)
 		m.meta_greater(index, meta, kv_index)
 	}
+	$if prealloc {
+		unsafe { prealloc_discard_pages(old_metas, usize(sizeof(u32)) * usize(old_cap + 2 + old_extra_metas)) }
+	}
 	unsafe { free(old_metas) }
 }
 
@@ -1052,6 +1055,9 @@ pub fn (m &map) free() {
 
 @[unsafe]
 fn (m &VMapData) free() {
+	$if prealloc {
+		unsafe { prealloc_discard_pages(m.metas, usize(sizeof(u32)) * usize(m.even_index + 2 + m.extra_metas)) }
+	}
 	unsafe { free(m.metas) }
 	unsafe {
 		m.metas = nil
@@ -1082,10 +1088,16 @@ fn (m &VMapData) free() {
 			m.key_values.all_deleted = nil
 		}
 		if m.key_values.keys != nil {
+			$if prealloc {
+				prealloc_discard_pages(m.key_values.keys, usize(m.key_values.cap) * usize(m.key_bytes))
+			}
 			free(m.key_values.keys)
 			m.key_values.keys = nil
 		}
 		if m.key_values.values != nil {
+			$if prealloc {
+				prealloc_discard_pages(m.key_values.values, usize(m.key_values.cap) * usize(m.value_bytes))
+			}
 			free(m.key_values.values)
 			m.key_values.values = nil
 		}

--- a/vlib/builtin/prealloc.c.v
+++ b/vlib/builtin/prealloc.c.v
@@ -34,7 +34,8 @@ const prealloc_block_size = 16 * 1024 * 1024
 // size of the first chunk for a scoped prealloc arena. Request-scoped arenas
 // should not force a 16MB libc allocation for every request.
 const prealloc_scope_block_size = 256 * 1024
-const prealloc_recycle_cache_slots = 512
+// Bound retained scope blocks to 16 MiB per thread, including compiler workers.
+const prealloc_recycle_cache_slots = 64
 
 // `malloc` has to return memory suitably aligned for any V value. Keep the
 // default at the common max alignment used by libc malloc on current targets.

--- a/vlib/builtin/prealloc.c.v
+++ b/vlib/builtin/prealloc.c.v
@@ -6,6 +6,7 @@ module builtin
 $if !freestanding && !vinix {
 	$if !windows {
 		#include <sys/mman.h>
+		#include <unistd.h>
 	}
 }
 
@@ -15,6 +16,41 @@ fn C.v_prealloc_atomic_store_i32(ptr &i32, val int) int
 fn C.v_prealloc_atomic_cas_i32(ptr &i32, expected int, desired int) int
 fn C.v_prealloc_atomic_add_i64(ptr &i64, delta i64) i64
 fn C.v_prealloc_atomic_load_i64(ptr &i64) i64
+
+fn C.madvise(addr voidptr, length usize, advice int) int
+
+// prealloc_discard_pages releases physical backing for dead arena storage on
+// macOS and Linux. Only complete pages inside the range are discarded; their
+// addresses remain reserved and writable until the containing arena is freed.
+// No surviving value may depend on the contents of this range.
+@[unsafe]
+pub fn prealloc_discard_pages(start voidptr, size usize) {
+	$if prealloc && !freestanding && !vinix && ( macos || linux ) {
+		if size < 65_536 || start == unsafe { nil } {
+			return
+		}
+		page_bytes := C.sysconf(C._SC_PAGESIZE)
+		if page_bytes <= 0 {
+			return
+		}
+		page_size := usize(page_bytes)
+		lo := (usize(start) + page_size - 1) / page_size * page_size
+		hi := (usize(start) + size) / page_size * page_size
+		if hi <= lo {
+			return
+		}
+		$if macos {
+			// Darwin's MADV_DONTNEED keeps dirty pages resident. Replace only
+			// the dead pages, preserving neighboring allocations and addresses.
+			p := C.mmap(voidptr(lo), hi - lo, C.PROT_READ | C.PROT_WRITE, C.MAP_PRIVATE | C.MAP_ANONYMOUS | C.MAP_FIXED, -1, 0)
+			if p == C.MAP_FAILED {
+				panic('could not release unused arena pages')
+			}
+		} $else {
+			C.madvise(voidptr(lo), hi - lo, C.MADV_DONTNEED)
+		}
+	}
+}
 
 // With -prealloc, V calls libc's malloc to get chunks, each at least 16MB
 // in size, as needed. Once a chunk is available, all malloc() calls within
@@ -34,8 +70,8 @@ const prealloc_block_size = 16 * 1024 * 1024
 // size of the first chunk for a scoped prealloc arena. Request-scoped arenas
 // should not force a 16MB libc allocation for every request.
 const prealloc_scope_block_size = 256 * 1024
-// Bound retained scope blocks to 8 MiB per thread, including compiler workers.
-const prealloc_recycle_cache_slots = 32
+// Bound retained scope blocks to 4 MiB per thread, including compiler workers.
+const prealloc_recycle_cache_slots = 16
 
 // `malloc` has to return memory suitably aligned for any V value. Keep the
 // default at the common max alignment used by libc malloc on current targets.
@@ -955,6 +991,10 @@ fn prealloc_realloc(old_data &u8, old_size isize, new_size isize) &u8 {
 	new_ptr := unsafe { vmemory_block_malloc(new_size, 0) }
 	min_size := if old_size < new_size { old_size } else { new_size }
 	unsafe { C.memcpy(new_ptr, old_data, min_size) }
+	// realloc invalidates the old buffer once its contents have been copied.
+	if old_size > 0 {
+		unsafe { prealloc_discard_pages(old_data, usize(old_size)) }
+	}
 	return new_ptr
 }
 

--- a/vlib/builtin/prealloc.c.v
+++ b/vlib/builtin/prealloc.c.v
@@ -34,8 +34,8 @@ const prealloc_block_size = 16 * 1024 * 1024
 // size of the first chunk for a scoped prealloc arena. Request-scoped arenas
 // should not force a 16MB libc allocation for every request.
 const prealloc_scope_block_size = 256 * 1024
-// Bound retained scope blocks to 16 MiB per thread, including compiler workers.
-const prealloc_recycle_cache_slots = 64
+// Bound retained scope blocks to 8 MiB per thread, including compiler workers.
+const prealloc_recycle_cache_slots = 32
 
 // `malloc` has to return memory suitably aligned for any V value. Keep the
 // default at the common max alignment used by libc malloc on current targets.
@@ -46,7 +46,7 @@ __global g_prealloc_allocation_count i64
 __global g_prealloc_allocated_bytes i64
 
 // prealloc_recyclable_block_size reports whether a block belongs to one of
-// the scope size classes (256K..4M, the geometric scope growth ladder) that
+// the scope size classes (256K..1M, the geometric scope growth ladder) that
 // the per-thread recycle cache retains.
 fn prealloc_recyclable_block_size(size isize) bool {
 	base := isize(prealloc_scope_block_size)
@@ -69,10 +69,7 @@ mut:
 
 @[inline]
 fn prealloc_recycle_cache_limit() int {
-	$if v3_backend ? {
-		return prealloc_recycle_cache_slots
-	}
-	return 64
+	return prealloc_recycle_cache_slots
 }
 
 // PreallocStats is a process-wide snapshot of instrumented arena allocations.

--- a/vlib/builtin/prealloc_discard_test.v
+++ b/vlib/builtin/prealloc_discard_test.v
@@ -1,10 +1,10 @@
-module builtin
-
 fn test_prealloc_discard_preserves_neighbors_and_writable_reservation() {
 	mut bytes := []u8{len: 300_013, init: 0xa5}
 	start := 10_003
 	end := 210_017
-	unsafe { prealloc_discard_pages(&bytes[start], usize(end - start)) }
+	$if prealloc {
+		unsafe { prealloc_discard_pages(&bytes[start], usize(end - start)) }
+	}
 	for i in 0 .. start {
 		assert bytes[i] == 0xa5
 	}
@@ -39,8 +39,11 @@ fn test_prealloc_realloc_preserves_contents_and_neighbor_allocation() {
 fn test_noslices_growth_preserves_tracked_slice() {
 	mut bytes := []u8{len: 131_101, init: 0xa5}
 	unsafe { bytes.flags.set(.noslices) }
-	borrowed := bytes[0..bytes.len]
+	// Keep a borrowed view so growth must preserve the original buffer.
+	borrowed := unsafe { bytes[0..bytes.len] }
+	assert borrowed.data == bytes.data
 	bytes << []u8{len: 131_101, init: 0x3c}
+	assert borrowed.data != bytes.data
 	assert borrowed.len == 131_101
 	for byte in borrowed {
 		assert byte == 0xa5

--- a/vlib/builtin/prealloc_discard_test.v
+++ b/vlib/builtin/prealloc_discard_test.v
@@ -1,0 +1,49 @@
+module builtin
+
+fn test_prealloc_discard_preserves_neighbors_and_writable_reservation() {
+	mut bytes := []u8{len: 300_013, init: 0xa5}
+	start := 10_003
+	end := 210_017
+	unsafe { prealloc_discard_pages(&bytes[start], usize(end - start)) }
+	for i in 0 .. start {
+		assert bytes[i] == 0xa5
+	}
+	for i in end .. bytes.len {
+		assert bytes[i] == 0xa5
+	}
+	for i in start .. end {
+		bytes[i] = u8(i)
+	}
+	for i in start .. end {
+		assert bytes[i] == u8(i)
+	}
+}
+
+fn test_prealloc_realloc_preserves_contents_and_neighbor_allocation() {
+	$if prealloc {
+		scope := unsafe { prealloc_scope_begin() }
+		data := unsafe { malloc(131_101) }
+		unsafe { vmemset(data, 0xa5, 131_101) }
+		neighbor := []u8{len: 65_539, init: 0x3c}
+		grown := unsafe { realloc_data(data, 131_101, 262_207) }
+		for i in 0 .. 131_101 {
+			assert unsafe { grown[i] } == 0xa5
+		}
+		for byte in neighbor {
+			assert byte == 0x3c
+		}
+		unsafe { prealloc_scope_end(scope) }
+	}
+}
+
+fn test_noslices_growth_preserves_tracked_slice() {
+	mut bytes := []u8{len: 131_101, init: 0xa5}
+	unsafe { bytes.flags.set(.noslices) }
+	borrowed := bytes[0..bytes.len]
+	bytes << []u8{len: 131_101, init: 0x3c}
+	assert borrowed.len == 131_101
+	for byte in borrowed {
+		assert byte == 0xa5
+	}
+	assert bytes[131_101] == 0x3c
+}

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -68,8 +68,9 @@ collected profile. It removes its temporary binaries and profiles when finished.
 
 Use `./v3-pgo -nocache -building-v -o v4 v3.v` for the self-build benchmark. Profile-guided gains
 are separate from ordinary `-prod` builds and depend on the workload. Rebuild the profile when
-compiler sources change. `CC` and `LLVM_PROFDATA` select the Clang and profile tools; macOS also
-supports finding `llvm-profdata` through `xcrun`. `V3_PGO_CFLAGS` adds flags to the final build.
+compiler sources change. `CC` and `LLVM_PROFDATA` select the Clang and profile tools. Relative
+tool paths resolve from the caller's working directory. macOS also supports finding
+`llvm-profdata` through `xcrun`. `V3_PGO_CFLAGS` adds flags to the final build.
 
 ## Target selection
 

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -58,6 +58,19 @@ not retry with V1, except for `-new-compiler -cc msvc` on Windows. V3 does not y
 command lines, so that combination intentionally launches `v1_fallback.exe` instead of exercising
 V3.
 
+## Profile-guided compiler build
+
+On macOS or Linux with Clang and a matching `llvm-profdata`, build an optimized standalone
+compiler with `./build_pgo.sh ./v3 ./v3-pgo` from this directory. The first argument is an existing
+V3 compiler; the second is the output path. Both arguments are optional. The script builds an
+instrumented compiler, trains it on three uncached self-compilations, and rebuilds with the
+collected profile. It removes its temporary binaries and profiles when finished.
+
+Use `./v3-pgo -nocache -building-v -o v4 v3.v` for the self-build benchmark. Profile-guided gains
+are separate from ordinary `-prod` builds and depend on the workload. Rebuild the profile when
+compiler sources change. `CC` and `LLVM_PROFDATA` select the Clang and profile tools; macOS also
+supports finding `llvm-profdata` through `xcrun`. `V3_PGO_CFLAGS` adds flags to the final build.
+
 ## Target selection
 
 The C backend accepts `-os <name>` and `-arch <name>`. The target controls source-file suffix

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -302,6 +302,15 @@ created by lowering. V1 and V2 do not need a separate step because their checker
 updates the typed AST/table that later stages keep using directly; v3's flat AST
 keeps those per-node caches outside the nodes.
 
+Resolved call and function-value caches use `types.CachedName` pointers, allocating a string
+header only for occupied slots. The existing set bits guard reads. `types.cached_name()` creates
+an immutable entry; `types.promote_cached_name()` preserves both its header and string bytes
+when a worker or transform arena is released. Text interning uses per-pass `flat.TextProbeCache`
+scratch on the stack, while canonical text remains owned by the AST.
+After parallel transform merges its append regions, `FlatAst.discard_unused_capacity()`
+releases unused AST pages on macOS and Linux in preallocated builds. It preserves the virtual
+reservation and live nodes, so later appends keep their existing capacity.
+
 Imports are resolved recursively: after parsing the input file, the driver
 collects `import_decl` nodes, resolves module paths, parses module files, and
 repeats until no new imports are found.

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -311,6 +311,13 @@ After parallel transform merges its append regions, `FlatAst.discard_unused_capa
 releases unused AST pages on macOS and Linux in preallocated builds. It preserves the virtual
 reservation and live nodes, so later appends keep their existing capacity.
 
+Preallocated builds use `prealloc_discard_pages()` to return complete pages from obsolete
+reallocation buffers and freed containers while preserving the surrounding arena. Array growth
+does this only when the existing ownership checks permit releasing the old buffer. Scope block
+recycling retains at most 4 MiB per thread. Self-host transform helpers keep merge bookkeeping in
+separate arenas and publish escaping AST text into their parent arenas; the bookkeeping is freed
+after joining. The completed master transform also releases its private indexes and rewrite logs.
+
 Imports are resolved recursively: after parsing the input file, the driver
 collects `import_decl` nodes, resolves module paths, parses module files, and
 repeats until no new imports are found.

--- a/vlib/v3/build_pgo.sh
+++ b/vlib/v3/build_pgo.sh
@@ -18,8 +18,13 @@ if [[ -z "${LLVM_PROFDATA:-}" ]] && ! command -v "$profdata" >/dev/null 2>&1 \
     && command -v xcrun >/dev/null 2>&1; then
     profdata="$(xcrun --find llvm-profdata)"
 fi
-command -v "$clang" >/dev/null || { echo "Clang executable not found: $clang" >&2; exit 1; }
-command -v "$profdata" >/dev/null || { echo "profile tool not found: $profdata" >&2; exit 1; }
+clang_path="$(command -v "$clang")" || { echo "Clang executable not found: $clang" >&2; exit 1; }
+profdata_path="$(command -v "$profdata")" || { echo "profile tool not found: $profdata" >&2; exit 1; }
+# Resolve overrides and relative PATH entries before changing directories.
+clang="$clang_path"
+profdata="$profdata_path"
+[[ "$clang" = /* ]] || clang="$PWD/$clang"
+[[ "$profdata" = /* ]] || profdata="$PWD/$profdata"
 case "$("$clang" --version)" in
     *clang*) ;;
     *) echo "profile-guided builds require Clang: $clang" >&2; exit 1 ;;

--- a/vlib/v3/build_pgo.sh
+++ b/vlib/v3/build_pgo.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Build a standalone V3 compiler with Clang's profile-guided optimization.
+set -euo pipefail
+
+if (( $# > 2 )); then
+    echo "usage: $0 [bootstrap-compiler [output]]" >&2
+    exit 1
+fi
+
+script_dir="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+bootstrap="${1:-$script_dir/v3}"
+output="${2:-$script_dir/v3-pgo}"
+[[ "$bootstrap" = /* ]] || bootstrap="$PWD/$bootstrap"
+[[ "$output" = /* ]] || output="$PWD/$output"
+clang="${CC:-clang}"
+profdata="${LLVM_PROFDATA:-llvm-profdata}"
+if [[ -z "${LLVM_PROFDATA:-}" ]] && ! command -v "$profdata" >/dev/null 2>&1 \
+    && command -v xcrun >/dev/null 2>&1; then
+    profdata="$(xcrun --find llvm-profdata)"
+fi
+command -v "$clang" >/dev/null || { echo "Clang executable not found: $clang" >&2; exit 1; }
+command -v "$profdata" >/dev/null || { echo "profile tool not found: $profdata" >&2; exit 1; }
+case "$("$clang" --version)" in
+    *clang*) ;;
+    *) echo "profile-guided builds require Clang: $clang" >&2; exit 1 ;;
+esac
+if [[ ! -x "$bootstrap" ]]; then
+    echo "bootstrap compiler is not executable: $bootstrap" >&2
+    exit 1
+fi
+
+# A fresh directory prevents profiles from unrelated compiler revisions mixing.
+# Its path has no shell metacharacters when passed through V's -cflags parser.
+pgo_dir="$(mktemp -d /tmp/v3-pgo.XXXXXXXX)"
+trap 'rm -rf -- "$pgo_dir"' EXIT
+mkdir "$pgo_dir/profiles"
+cd -- "$script_dir"
+common=(-gc none -prealloc -prod -nocache -building-v -silent -cc "$clang")
+
+printf '%s\n' 'Building the instrumented compiler...'
+"$bootstrap" "${common[@]}" \
+    -cflags "-fprofile-generate=$pgo_dir/profiles -fprofile-update=atomic" \
+    -o "$pgo_dir/instrumented" v3.v
+
+for run in 1 2 3; do
+    printf 'Collecting self-compilation profile %s/3...\n' "$run"
+    LLVM_PROFILE_FILE="$pgo_dir/profiles/default-%m.profraw" \
+        "$pgo_dir/instrumented" -nocache -building-v -silent \
+        -o "$pgo_dir/training.c" v3.v
+done
+"$profdata" merge "$pgo_dir"/profiles/*.profraw -o "$pgo_dir/merged.profdata"
+
+printf '%s\n' 'Building the optimized compiler...'
+"$bootstrap" "${common[@]}" \
+    -cflags "-fprofile-use=$pgo_dir/merged.profdata ${V3_PGO_CFLAGS:-}" \
+    -o "$output" v3.v
+printf 'Built %s\n' "$output"

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -15917,7 +15917,7 @@ struct SyntheticInsertion {
 	node flat.Node
 }
 
-// insert_synthetic_imports rebuilds a.nodes with each synthetic import spliced in
+// insert_synthetic_imports shifts a.nodes in place with each synthetic import spliced in
 // before its recorded original-array position, so the next resolver pass scans a
 // module's synthetic import right after that module's own region — in the same
 // order serial one-module-at-a-time resolution appended and scanned it, before
@@ -15932,26 +15932,37 @@ fn insert_synthetic_imports(mut a flat.FlatAst, insertions []SyntheticInsertion)
 		return
 	}
 	old_len := a.nodes.len
-	mut new_nodes := []flat.Node{cap: old_len + insertions.len}
-	mut start := 0
+	mut imports := []flat.Node{cap: insertions.len}
 	for insertion in insertions {
-		// Copy each unchanged region once instead of appending every AST node.
-		new_nodes << a.nodes[start..insertion.pos]
-		new_nodes << canonical_node_texts(mut a, insertion.node)
-		start = insertion.pos
+		imports << canonical_node_texts(mut a, insertion.node)
 	}
-	new_nodes << a.nodes[start..]
-	for i in 0 .. new_nodes.len {
-		mut node := new_nodes[i]
+	// Keep the parser's reserved capacity. Rebuilding this array for a handful
+	// of imports retains the old slab under -prealloc and forces later parse
+	// waves to allocate and copy it again.
+	unsafe { a.nodes.grow_len(insertions.len) }
+	mut end := old_len
+	for i := insertions.len - 1; i >= 0; i-- {
+		insertion := insertions[i]
+		if end > insertion.pos {
+			// Move backwards by region: source and destination may overlap, and
+			// earlier regions must remain intact until their own move.
+			unsafe {
+				vmemmove(&a.nodes[insertion.pos + i + 1], &a.nodes[insertion.pos], isize(end - insertion.pos) * isize(sizeof(flat.Node)))
+			}
+		}
+		a.nodes[insertion.pos + i] = imports[i]
+		end = insertion.pos
+	}
+	for i in 0 .. a.nodes.len {
+		mut node := a.nodes[i]
 		if node.kind == .directive && node.value.starts_with('@attributes:') {
 			target_idx := node.value['@attributes:'.len..].int()
 			if target_idx >= 0 && target_idx < old_len {
 				node.value = '@attributes:${target_idx + synthetic_index_shift(insertions, target_idx)}'
-				new_nodes[i] = canonical_node_texts(mut a, node)
+				a.nodes[i] = canonical_node_texts(mut a, node)
 			}
 		}
 	}
-	a.nodes = new_nodes
 	for i, idx in a.file_node_ids {
 		a.file_node_ids[i] = idx + synthetic_index_shift(insertions, idx)
 	}

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -6273,7 +6273,7 @@ fn promote_scoped_ast_nodes_flagged(mut ast flat.FlatAst, base_nodes int, new_en
 // canonicalize_scoped_node_cached is canonicalize_scoped_node with a pointer
 // probe over the caller's cache arrays: owned texts repeat the same shared
 // string instances heavily, so most content-hash intern lookups are skipped.
-fn canonicalize_scoped_node_cached(mut ast flat.FlatAst, idx int, scope voidptr, mut cache_ptrs []voidptr, mut cache_vals []string) {
+fn canonicalize_scoped_node_cached(mut ast flat.FlatAst, idx int, scope voidptr, mut cache_ptrs [4096]voidptr, mut cache_vals [4096]string) {
 	if idx < 0 || idx >= ast.nodes.len {
 		return
 	}
@@ -6509,16 +6509,10 @@ fn promote_scoped_checker_node_caches(mut tc types.TypeChecker, a &flat.FlatAst,
 	if !transform.promote_scoped_checker_node_caches_parallel(mut tc, a, scope, generated_start) {
 		for idx in 0 .. tc.resolved_call_names.len {
 			if idx < tc.resolved_call_set.len && tc.resolved_call_set[idx] {
-				name := tc.resolved_call_names[idx]
-				if name.len > 0 && scoped_value_owned(scope, name.str) {
-					tc.resolved_call_names[idx] = name.clone()
-				}
+				tc.resolved_call_names[idx] = types.promote_cached_name(tc.resolved_call_names[idx], scope)
 			}
 			if idx < tc.resolved_fn_value_set.len && tc.resolved_fn_value_set[idx] {
-				name := tc.resolved_fn_value_names[idx]
-				if name.len > 0 && scoped_value_owned(scope, name.str) {
-					tc.resolved_fn_value_names[idx] = name.clone()
-				}
+				tc.resolved_fn_value_names[idx] = types.promote_cached_name(tc.resolved_fn_value_names[idx], scope)
 			}
 			if idx >= generated_start && idx < tc.expr_type_set.len && tc.expr_type_set[idx] {
 				tc.expr_type_values[idx] = types.clone_owned_type(tc.expr_type_values[idx])
@@ -7217,7 +7211,7 @@ fn restore_transformed_fn_value_types(mut tc types.TypeChecker, a &flat.FlatAst,
 		if idx >= tc.resolved_fn_value_set.len || !tc.resolved_fn_value_set[idx] {
 			continue
 		}
-		name := tc.resolved_fn_value_names[idx]
+		name := tc.resolved_fn_value_names[idx].value
 		params := tc.fn_param_types[name] or { continue }
 		ret := tc.fn_ret_types[name] or { continue }
 		tc.expr_type_values[idx] = types.FnType{
@@ -10824,11 +10818,10 @@ pub fn run(args []string) {
 					if !fused_text_promote {
 						mut scoped_text_flags := []u8{len: a.nodes.len}
 						if transform.scan_scoped_text_flags_parallel(a, transform_scope, mut scoped_text_flags) {
-							mut canon_cache_ptrs := unsafe { []voidptr{len: 4096} }
-							mut canon_cache_vals := []string{len: 4096}
+							mut canon_cache := flat.TextProbeCache{}
 							for idx, flag in scoped_text_flags {
 								if flag != 0 {
-									canonicalize_scoped_node_cached(mut a, idx, transform_scope, mut canon_cache_ptrs, mut canon_cache_vals)
+									canonicalize_scoped_node_cached(mut a, idx, transform_scope, mut canon_cache.ptrs, mut canon_cache.values)
 								}
 							}
 						} else {
@@ -10910,7 +10903,8 @@ pub fn run(args []string) {
 					for idx in 0 .. pre_tc.resolved_call_names.len {
 						if idx < pre_tc.resolved_call_set.len && pre_tc.resolved_call_set[idx] {
 							name := pre_tc.resolved_call_names[idx]
-							if name.len > 0 && scoped_value_owned(transform_scope, name.str) {
+							if scoped_value_owned(transform_scope, name)
+								|| scoped_value_owned(transform_scope, name.value.str) {
 								leaked_rc++
 								if first_leak < 0 {
 									first_leak = idx
@@ -10920,7 +10914,8 @@ pub fn run(args []string) {
 						if idx < pre_tc.resolved_fn_value_set.len
 							&& pre_tc.resolved_fn_value_set[idx] {
 							name := pre_tc.resolved_fn_value_names[idx]
-							if name.len > 0 && scoped_value_owned(transform_scope, name.str) {
+							if scoped_value_owned(transform_scope, name)
+								|| scoped_value_owned(transform_scope, name.value.str) {
 								leaked_fv++
 							}
 						}
@@ -10997,6 +10992,10 @@ pub fn run(args []string) {
 		if !building_v && !uses_generics && transformed_used_fns_need_monomorphize(used_fns) {
 			uses_generics = true
 			skip_transform_generics = false
+		}
+		if scope_prealloc_transform {
+			// Worker views have joined and their live regions are now compacted.
+			unsafe { a.discard_unused_capacity() }
 		}
 		if incremental_cache_hit {
 			b.step_parallel('transform (incremental)', transform_was_parallel)

--- a/vlib/v3/driver/implicit_import_test.v
+++ b/vlib/v3/driver/implicit_import_test.v
@@ -209,6 +209,46 @@ fn test_synthetic_import_insertion_remaps_declaration_attribute_targets() {
 	assert ast.nodes[3].value == '@attributes:2'
 }
 
+fn test_synthetic_import_insertion_reuses_capacity_and_remaps_edges() {
+	// Exercise both an existing reservation and growth past a full buffer.
+	for capacity in [6, 32] {
+		mut ast := flat.FlatAst.new()
+		ast.nodes = []flat.Node{cap: capacity}
+		for name in ['a', 'b', 'c', 'd', 'e', 'f'] {
+			ast.add_node(flat.Node{ kind: .ident, value: name })
+		}
+		ast.children = [flat.NodeId(0), 1, 2, 3, 4, 5, flat.empty_node]
+		ast.nodes[5].children_start = 0
+		ast.nodes[5].children_count = i32(ast.children.len)
+		ast.user_code_start = 2
+		data := ast.nodes.data
+		insert_synthetic_imports(mut ast, [
+			SyntheticInsertion{ pos: 0, node: flat.Node{ kind: .import_decl, value: 'first' } },
+			SyntheticInsertion{ pos: 2, node: flat.Node{ kind: .import_decl, value: 'second' } },
+			SyntheticInsertion{ pos: 2, node: flat.Node{ kind: .import_decl, value: 'third' } },
+			SyntheticInsertion{ pos: 6, node: flat.Node{ kind: .import_decl, value: 'last' } },
+		])
+		assert ast.nodes.map(it.value) == ['first', 'a', 'b', 'second', 'third', 'c', 'd', 'e',
+			'f', 'last']
+		assert ast.children == [flat.NodeId(1), 2, 5, 6, 7, 8, flat.empty_node]
+		assert ast.nodes[8].children_start == 0
+		assert ast.nodes[8].children_count == ast.children.len
+		assert ast.user_code_start == 5
+		assert ast.text_values[ast.text_values.len - 4..] == ['first', 'second', 'third', 'last']
+		if capacity == 32 {
+			assert ast.nodes.data == data
+			assert ast.nodes.cap == capacity
+		}
+		// A later import wave must retain the same reservation as well.
+		grown_data := ast.nodes.data
+		insert_synthetic_imports(mut ast, [
+			SyntheticInsertion{ pos: 10, node: flat.Node{ kind: .import_decl, value: 'next' } },
+		])
+		assert ast.nodes.data == grown_data
+		assert ast.nodes.last().value == 'next'
+	}
+}
+
 fn test_synthetic_import_insertion_preserves_file_index_and_import_order() {
 	root := os.join_path(os.vtmp_dir(), 'v3_synthetic_file_index_${os.getpid()}')
 	os.mkdir_all(root)!

--- a/vlib/v3/flat/flat.v
+++ b/vlib/v3/flat/flat.v
@@ -839,7 +839,7 @@ pub fn (mut a FlatAst) add_child(id NodeId) {
 }
 
 // child supports child handling for FlatAst.
-@[inline]
+@[direct_array_access; inline]
 pub fn (a &FlatAst) child(node &Node, index int) NodeId {
 	child_index := node.children_start + index
 	if index < 0 || index >= node.children_count || child_index < 0 || child_index >= a.children.len {
@@ -850,7 +850,7 @@ pub fn (a &FlatAst) child(node &Node, index int) NodeId {
 }
 
 // child_node supports child node handling for FlatAst.
-@[inline]
+@[direct_array_access; inline]
 pub fn (a &FlatAst) child_node(node &Node, index int) &Node {
 	id := a.child(node, index)
 	if int(id) < 0 || int(id) >= a.nodes.len {
@@ -861,7 +861,7 @@ pub fn (a &FlatAst) child_node(node &Node, index int) &Node {
 }
 
 // node supports node handling for FlatAst.
-@[inline]
+@[direct_array_access; inline]
 pub fn (a &FlatAst) node(id NodeId) &Node {
 	if int(id) < 0 || int(id) >= a.nodes.len {
 		return &empty_node_value

--- a/vlib/v3/flat/flat.v
+++ b/vlib/v3/flat/flat.v
@@ -522,6 +522,15 @@ pub fn (mut a FlatAst) intern_node_texts_from(start int) {
 	a.intern_node_texts_range(start, a.nodes.len)
 }
 
+// TextProbeCache holds per-pass scratch on the stack. Its strings borrow
+// canonical text owned by the AST; the cache itself never escapes the pass.
+pub struct TextProbeCache {
+pub mut:
+	ptrs   [4096]voidptr
+	values [4096]string
+	ids    [4096]u16
+}
+
 // intern_node_texts_range canonicalizes managed payloads in nodes[start..end).
 // The bounded form serves the parallel parse merge, where later chunks are
 // already present in the node array but must be interned in chunk order.
@@ -533,14 +542,12 @@ pub fn (mut a FlatAst) intern_node_texts_range(start int, end int) {
 	// Node texts repeat heavily by exact string instance (already-interned
 	// strings share `.str`), so a direct-mapped pointer probe skips the
 	// content-hash table lookup for the overwhelming majority of nodes.
-	// Nothing is freed during this pass, so pointer keys stay valid.
-	mut cache_ptrs := unsafe { []voidptr{len: 4096} }
-	mut cache_vals := []string{len: 4096}
-	mut type_cache_ptrs := unsafe { []voidptr{len: 4096} }
-	mut type_cache_vals := []string{len: 4096}
-	mut type_cache_ids := []u16{len: 4096}
+	// Nothing is freed during this pass, so pointer keys stay valid. Fixed
+	// arrays keep this per-pass scratch off the compilation arena.
+	mut value_cache := TextProbeCache{}
+	mut type_cache := TextProbeCache{}
 	for idx in first .. end {
-		a.intern_node_texts_one(idx, mut cache_ptrs, mut cache_vals, mut type_cache_ptrs, mut type_cache_vals, mut type_cache_ids)
+		a.intern_node_texts_one(idx, mut value_cache.ptrs, mut value_cache.values, mut type_cache.ptrs, mut type_cache.values, mut type_cache.ids)
 	}
 }
 
@@ -552,17 +559,14 @@ pub fn (mut a FlatAst) intern_node_texts_at(indexes []int) {
 	if indexes.len == 0 {
 		return
 	}
-	mut cache_ptrs := unsafe { []voidptr{len: 4096} }
-	mut cache_vals := []string{len: 4096}
-	mut type_cache_ptrs := unsafe { []voidptr{len: 4096} }
-	mut type_cache_vals := []string{len: 4096}
-	mut type_cache_ids := []u16{len: 4096}
+	mut value_cache := TextProbeCache{}
+	mut type_cache := TextProbeCache{}
 	for idx in indexes {
-		a.intern_node_texts_one(idx, mut cache_ptrs, mut cache_vals, mut type_cache_ptrs, mut type_cache_vals, mut type_cache_ids)
+		a.intern_node_texts_one(idx, mut value_cache.ptrs, mut value_cache.values, mut type_cache.ptrs, mut type_cache.values, mut type_cache.ids)
 	}
 }
 
-fn (mut a FlatAst) intern_node_texts_one(idx int, mut cache_ptrs []voidptr, mut cache_vals []string, mut type_cache_ptrs []voidptr, mut type_cache_vals []string, mut type_cache_ids []u16) {
+fn (mut a FlatAst) intern_node_texts_one(idx int, mut cache_ptrs [4096]voidptr, mut cache_vals [4096]string, mut type_cache_ptrs [4096]voidptr, mut type_cache_vals [4096]string, mut type_cache_ids [4096]u16) {
 	a.nodes[idx].value = a.intern_text_ptr_cached(a.nodes[idx].value, mut cache_ptrs, mut cache_vals)
 	type_id, canonical_type := a.intern_type_text_ptr_cached(a.nodes[idx].typ, mut type_cache_ptrs, mut type_cache_vals, mut type_cache_ids)
 	a.nodes[idx].typ = canonical_type
@@ -582,7 +586,7 @@ fn (mut a FlatAst) intern_node_texts_one(idx int, mut cache_ptrs []voidptr, mut 
 // intern_type_text_ptr_cached canonicalizes a node type spelling and returns
 // its compact identity. Programs with more than 65535 texts use 0 and retain
 // the existing string-keyed fallback.
-pub fn (mut a FlatAst) intern_type_text_ptr_cached(value string, mut cache_ptrs []voidptr, mut cache_vals []string, mut cache_ids []u16) (u16, string) {
+pub fn (mut a FlatAst) intern_type_text_ptr_cached(value string, mut cache_ptrs [4096]voidptr, mut cache_vals [4096]string, mut cache_ids [4096]u16) (u16, string) {
 	if value.len == 0 {
 		return 0, ''
 	}
@@ -602,7 +606,7 @@ pub fn (mut a FlatAst) intern_type_text_ptr_cached(value string, mut cache_ptrs 
 // rebinds `value` to its canonical copy when the text table already holds the
 // content and reports a miss otherwise, never mutating the table. Safe on
 // worker threads only while no thread inserts into the table.
-pub fn (a &FlatAst) probe_text_ptr_cached(value string, mut cache_ptrs []voidptr, mut cache_vals []string) (string, bool) {
+pub fn (a &FlatAst) probe_text_ptr_cached(value string, mut cache_ptrs [4096]voidptr, mut cache_vals [4096]string) (string, bool) {
 	if value.len == 0 {
 		return '', true
 	}
@@ -621,7 +625,7 @@ pub fn (a &FlatAst) probe_text_ptr_cached(value string, mut cache_ptrs []voidptr
 
 // probe_type_text_ptr_cached is the compact-id form used while parallel parse
 // workers probe the frozen master text table.
-pub fn (a &FlatAst) probe_type_text_ptr_cached(value string, mut cache_ptrs []voidptr, mut cache_vals []string, mut cache_ids []u16) (u16, string, bool) {
+pub fn (a &FlatAst) probe_type_text_ptr_cached(value string, mut cache_ptrs [4096]voidptr, mut cache_vals [4096]string, mut cache_ids [4096]u16) (u16, string, bool) {
 	if value.len == 0 {
 		return 0, '', true
 	}
@@ -640,7 +644,8 @@ pub fn (a &FlatAst) probe_type_text_ptr_cached(value string, mut cache_ptrs []vo
 	return 0, value, false
 }
 
-pub fn (mut a FlatAst) intern_text_ptr_cached(value string, mut cache_ptrs []voidptr, mut cache_vals []string) string {
+// intern_text_ptr_cached interns text using a caller-owned scratch cache.
+pub fn (mut a FlatAst) intern_text_ptr_cached(value string, mut cache_ptrs [4096]voidptr, mut cache_vals [4096]string) string {
 	if value.len == 0 {
 		return ''
 	}

--- a/vlib/v3/flat/flat_memory.c.v
+++ b/vlib/v3/flat/flat_memory.c.v
@@ -1,0 +1,59 @@
+module flat
+
+$if macos || linux {
+	#include <sys/mman.h>
+	#include <unistd.h>
+}
+
+fn C.madvise(addr voidptr, length usize, advice int) int
+
+// discard_unused_capacity releases resident pages beyond the live AST after
+// parallel workers have joined and their append regions have been compacted.
+// The virtual reservation stays writable, so later appends retain their capacity.
+// No surviving view may read or write beyond this AST's live array lengths.
+@[unsafe]
+pub fn (a &FlatAst) discard_unused_capacity() {
+	$if prealloc {
+		// Only full pages inside unused array capacity are discarded. Live nodes,
+		// array headers, and neighboring arena allocations remain untouched.
+		if a.nodes.cap > a.nodes.len {
+			unsafe {
+				discard_unused_pages(&u8(a.nodes.data) + usize(a.nodes.len) * sizeof(Node), usize(a.nodes.cap - a.nodes.len) * sizeof(Node))
+			}
+		}
+		if a.children.cap > a.children.len {
+			unsafe {
+				discard_unused_pages(&u8(a.children.data) + usize(a.children.len) * sizeof(NodeId), usize(a.children.cap - a.children.len) * sizeof(NodeId))
+			}
+		}
+	}
+}
+
+@[unsafe]
+fn discard_unused_pages(start voidptr, size usize) {
+	$if macos || linux {
+		if size < 1024 * 1024 {
+			return
+		}
+		page_bytes := C.sysconf(C._SC_PAGESIZE)
+		if page_bytes <= 0 {
+			return
+		}
+		page_size := usize(page_bytes)
+		lo := (usize(start) + page_size - 1) / page_size * page_size
+		hi := (usize(start) + size) / page_size * page_size
+		if hi <= lo {
+			return
+		}
+		$if macos {
+			// Darwin's MADV_DONTNEED retains these dirty pages. Replacing only
+			// the dead tail drops its physical backing while preserving addresses.
+			p := C.mmap(voidptr(lo), hi - lo, C.PROT_READ | C.PROT_WRITE, C.MAP_PRIVATE | C.MAP_ANONYMOUS | C.MAP_FIXED, -1, 0)
+			if p == C.MAP_FAILED {
+				panic('could not release unused AST pages')
+			}
+		} $else {
+			C.madvise(voidptr(lo), hi - lo, C.MADV_DONTNEED)
+		}
+	}
+}

--- a/vlib/v3/flat/flat_memory.c.v
+++ b/vlib/v3/flat/flat_memory.c.v
@@ -1,12 +1,5 @@
 module flat
 
-$if macos || linux {
-	#include <sys/mman.h>
-	#include <unistd.h>
-}
-
-fn C.madvise(addr voidptr, length usize, advice int) int
-
 // discard_unused_capacity releases resident pages beyond the live AST after
 // parallel workers have joined and their append regions have been compacted.
 // The virtual reservation stays writable, so later appends retain their capacity.
@@ -18,42 +11,13 @@ pub fn (a &FlatAst) discard_unused_capacity() {
 		// array headers, and neighboring arena allocations remain untouched.
 		if a.nodes.cap > a.nodes.len {
 			unsafe {
-				discard_unused_pages(&u8(a.nodes.data) + usize(a.nodes.len) * sizeof(Node), usize(a.nodes.cap - a.nodes.len) * sizeof(Node))
+				prealloc_discard_pages(&u8(a.nodes.data) + usize(a.nodes.len) * sizeof(Node), usize(a.nodes.cap - a.nodes.len) * sizeof(Node))
 			}
 		}
 		if a.children.cap > a.children.len {
 			unsafe {
-				discard_unused_pages(&u8(a.children.data) + usize(a.children.len) * sizeof(NodeId), usize(a.children.cap - a.children.len) * sizeof(NodeId))
+				prealloc_discard_pages(&u8(a.children.data) + usize(a.children.len) * sizeof(NodeId), usize(a.children.cap - a.children.len) * sizeof(NodeId))
 			}
-		}
-	}
-}
-
-@[unsafe]
-fn discard_unused_pages(start voidptr, size usize) {
-	$if macos || linux {
-		if size < 1024 * 1024 {
-			return
-		}
-		page_bytes := C.sysconf(C._SC_PAGESIZE)
-		if page_bytes <= 0 {
-			return
-		}
-		page_size := usize(page_bytes)
-		lo := (usize(start) + page_size - 1) / page_size * page_size
-		hi := (usize(start) + size) / page_size * page_size
-		if hi <= lo {
-			return
-		}
-		$if macos {
-			// Darwin's MADV_DONTNEED retains these dirty pages. Replacing only
-			// the dead tail drops its physical backing while preserving addresses.
-			p := C.mmap(voidptr(lo), hi - lo, C.PROT_READ | C.PROT_WRITE, C.MAP_PRIVATE | C.MAP_ANONYMOUS | C.MAP_FIXED, -1, 0)
-			if p == C.MAP_FAILED {
-				panic('could not release unused AST pages')
-			}
-		} $else {
-			C.madvise(voidptr(lo), hi - lo, C.MADV_DONTNEED)
 		}
 	}
 }

--- a/vlib/v3/flat/flat_test.v
+++ b/vlib/v3/flat/flat_test.v
@@ -117,3 +117,24 @@ fn test_promote_transform_texts_rebuilds_scoped_table_growth() {
 		}
 	}
 }
+
+fn test_ast_accessors_preserve_bounds_validation() {
+	mut a := FlatAst.new()
+	id := a.add_val(.ident, 'valid')
+	a.children << id
+	parent := Node{ children_count: 1 }
+	assert a.child(&parent, 0) == id
+	assert a.child_node(&parent, 0).value == 'valid'
+	assert a.node(id).value == 'valid'
+	assert a.child(&parent, -1) == empty_node
+	assert a.child(&parent, 1) == empty_node
+	assert a.child_node(&parent, -1).kind == .empty
+	assert a.child_node(&parent, 1).kind == .empty
+	assert a.node(empty_node).kind == .empty
+	assert a.node(NodeId(a.nodes.len)).kind == .empty
+	outside := Node{ children_start: 4, children_count: 1 }
+	assert a.child(&outside, 0) == empty_node
+	assert a.child_node(&outside, 0).kind == .empty
+	a.children[0] = NodeId(a.nodes.len)
+	assert a.child_node(&parent, 0).kind == .empty
+}

--- a/vlib/v3/flat/flat_test.v
+++ b/vlib/v3/flat/flat_test.v
@@ -1,5 +1,63 @@
 module flat
 
+fn discard_capacity_on_worker() bool {
+	test_discard_unused_capacity_preserves_live_nodes_and_later_appends()
+	$if prealloc {
+		// Releasing the original arena must also work after its unused pages
+		// have been replaced, including the root arena's libc-backed blocks.
+		unsafe { prealloc_thread_cleanup() }
+	}
+	return true
+}
+
+fn test_discard_unused_capacity_allows_arena_teardown() {
+	$if prealloc {
+		handle := spawn discard_capacity_on_worker()
+		assert handle.wait()
+	}
+}
+
+fn test_discard_unused_capacity_preserves_live_nodes_and_later_appends() {
+	mut a := FlatAst.new()
+	// Dirty the full backing, then discard the former worker append regions.
+	a.nodes = []Node{len: 50_000, init: Node{ kind: .ident, value: 'live', typ: 'int' }}
+	a.children = []NodeId{len: 400_000, init: NodeId(17)}
+	a.nodes.trim(73)
+	a.children.trim(113)
+	neighbor := []u8{len: 40_000, init: 0xab}
+	node_data := a.nodes.data
+	child_data := a.children.data
+	node_cap := a.nodes.cap
+	child_cap := a.children.cap
+	unsafe { a.discard_unused_capacity() }
+	assert a.nodes.len == 73
+	assert a.children.len == 113
+	for node in a.nodes {
+		assert node.kind == .ident
+		assert node.value == 'live'
+		assert node.typ == 'int'
+	}
+	for child in a.children {
+		assert child == NodeId(17)
+	}
+	for byte in neighbor {
+		assert byte == 0xab
+	}
+	for i in 0 .. 30_000 {
+		a.nodes << Node{ kind: .int_literal, value: '42' }
+		a.children << NodeId(i)
+	}
+	assert a.nodes.data == node_data
+	assert a.children.data == child_data
+	assert a.nodes.cap == node_cap
+	assert a.children.cap == child_cap
+	for i in 0 .. 30_000 {
+		assert a.nodes[73 + i].kind == .int_literal
+		assert a.nodes[73 + i].value == '42'
+		assert a.children[113 + i] == NodeId(i)
+	}
+}
+
 fn test_node_kind_has_one_canonical_representation() {
 	mut ast := FlatAst.new()
 	id := ast.add_node(Node{
@@ -85,6 +143,37 @@ fn test_clone_text_table_owned_detaches_scoped_storage() {
 		assert values[0] == 'scoped_text_0'
 		assert values[255] == 'scoped_text_255'
 		assert ids['scoped_text_128'] == TextId(129)
+	}
+}
+
+fn test_text_intern_passes_detach_reused_source_storage() {
+	mut ast := FlatAst.new()
+	mut source := []u8{len: 5}
+	// Simulate parser scratch being reused between independent intern passes.
+	borrowed := unsafe { tos(source.data, source.len) }
+	names := ['alpha', 'bravo', 'cider']
+	for i, name in names {
+		for j in 0 .. source.len {
+			source[j] = name[j]
+		}
+		ast.add_node(Node{
+			value: borrowed
+			typ: borrowed
+			payload: node_payload([borrowed])
+		})
+		if i % 2 == 0 {
+			ast.intern_node_texts_range(i, i + 1)
+		} else {
+			ast.intern_node_texts_at([i])
+		}
+	}
+	for i, name in names {
+		node := ast.nodes[i]
+		assert node.value == name
+		assert node.typ == name
+		assert node.generic_params() == [name]
+		assert ast.text(TextId(node.type_text_id())) == name
+		assert node.value.str == node.typ.str
 	}
 }
 

--- a/vlib/v3/gen/c/attributes_test.v
+++ b/vlib/v3/gen/c/attributes_test.v
@@ -35,11 +35,29 @@ fn test_noinline_attribute_is_preserved_for_generic_specialization() {
 
 	assert g.fn_decl_c_attribute(template_id) == ''
 	assert g.fn_decl_c_attribute(specialization_id) == ''
-	assert g.fn_decl_c_noinline_prefix(template_id) == '__attribute__((noinline)) '
-	assert g.fn_decl_c_noinline_prefix(specialization_id) == '__attribute__((noinline)) '
+	assert g.fn_decl_inlining_prefix(template_id) == '__attribute__((noinline)) '
+	assert g.fn_decl_inlining_prefix(specialization_id) == '__attribute__((noinline)) '
 
 	g.ccompiler = 'msvc'
 	assert g.fn_decl_c_attribute(specialization_id) == ''
-	assert g.fn_decl_c_noinline_prefix(specialization_id) == ''
-	assert g.fn_decl_msvc_noinline_prefix(specialization_id) == '__declspec(noinline) '
+	assert g.fn_decl_inlining_prefix(specialization_id) == '__declspec(noinline) '
+}
+
+fn test_inline_hint_preserves_external_linkage_and_specialization_attributes() {
+	mut g := cgen_attribute_test_gen()
+	g.ccompiler = 'clang'
+	pos := token.new_span(1, 20, 40)
+	source := g.a.add_node(flat.Node{ kind: .fn_decl, value: 'helper', pos: pos })
+	specialized := g.a.add_node(flat.Node{ kind: .fn_decl, value: 'helper_T_int', pos: pos })
+	g.a.specialized_fn_nodes[int(specialized)] = true
+	g.decl_attrs[int(source)] = ['inline']
+	g.decl_attrs_by_source_position[flat_fn_source_position_key(g.a.nodes[int(source)])] = [
+		'inline',
+	]
+	assert g.fn_decl_inlining_prefix(source) == 'inline '
+	assert g.fn_decl_inlining_prefix(specialized) == 'inline '
+	g.ccompiler = 'msvc'
+	assert g.fn_decl_inlining_prefix(specialized) == '__inline '
+	g.decl_attrs[int(source)] = ['inline', 'noinline']
+	assert g.fn_decl_inlining_prefix(source) == '__declspec(noinline) '
 }

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -15467,6 +15467,13 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			g.gen_or_expr(node)
 		}
 		.block {
+			old_unsafe_depth := g.unsafe_depth
+			if node.value == 'unsafe' {
+				g.unsafe_depth++
+			}
+			defer {
+				g.unsafe_depth = old_unsafe_depth
+			}
 			if node.children_count > 1 {
 				// Lowered collection expressions can introduce a lexical defer inside a
 				// GNU statement expression. Keep it visible to returns/propagations in
@@ -19374,7 +19381,11 @@ fn (mut g FlatGen) builtin_abi_decls() {
 	g.writeln('#define pthread_rwlockattr_setkind_np(attr, kind) (0)')
 	g.writeln('#endif')
 	g.filelock_compat_decls()
-	g.writeln('#define array_new(elem_size, len, cap) __new_array((len), (cap), (elem_size))')
+	// Empty array headers need no allocation. Keep this small wrapper inline so
+	// aggregate defaults fold to constants even when __new_array stays out of line.
+	g.writeln('array __new_array(${g.int_ct} len, ${g.int_ct} cap, ${g.int_ct} elem_size);')
+	g.writeln('static inline array __v3_internal_symbol_array_new(${g.int_ct} elem_size, ${g.int_ct} len, ${g.int_ct} cap) { if (len == 0 && cap == 0) return (array){.element_size = elem_size, .flags = ArrayFlags__managed}; return __new_array(len, cap, elem_size); }')
+	g.writeln('#define array_new(elem_size, len, cap) __v3_internal_symbol_array_new((elem_size), (len), (cap))')
 	g.writeln('#define array_push array__push')
 	g.writeln('void array__push_many(array* a, void* val, ${g.int_ct} size);')
 	g.writeln('#define array_push_many_ptr(a, val, size) array__push_many((a), (void*)(val), (size))')
@@ -22188,8 +22199,7 @@ fn (g &FlatGen) collect_string_plus_parts(id flat.NodeId, mut parts []flat.NodeI
 	parts << id
 }
 
-// Nested string concatenation owns each intermediate result. Emit the chain as
-// ordered statements and release every superseded accumulator.
+// Evaluate concatenation operands in order, then copy them into one allocation.
 fn (mut g FlatGen) gen_owned_string_plus_chain(id flat.NodeId) {
 	mut parts := []flat.NodeId{}
 	g.collect_string_plus_parts(id, mut parts)
@@ -22197,23 +22207,7 @@ fn (mut g FlatGen) gen_owned_string_plus_chain(id flat.NodeId) {
 		g.gen_call(id, g.a.nodes[int(id)])
 		return
 	}
-	tmp := g.tmp_count
-	g.tmp_count++
-	g.write('({')
-	for i, part in parts {
-		g.write(' string __str_plus_part_${tmp}_${i} = ')
-		g.gen_expr_as_string(part)
-		g.write(';')
-	}
-	g.write(' string __str_plus_acc_${tmp}_1 = string__plus(__str_plus_part_${tmp}_0, __str_plus_part_${tmp}_1);')
-	mut previous := '__str_plus_acc_${tmp}_1'
-	for i := 2; i < parts.len; i++ {
-		next := '__str_plus_acc_${tmp}_${i}'
-		g.write(' string ${next} = string__plus(${previous}, __str_plus_part_${tmp}_${i});')
-		g.write(' string__free(&${previous});')
-		previous = next
-	}
-	g.write(' ${previous}; })')
+	g.gen_string_join_parts(parts, false)
 }
 
 fn (g &FlatGen) is_runtime_assignable(id flat.NodeId) bool {
@@ -22715,6 +22709,7 @@ fn (g &FlatGen) op_str(op flat.Op) string {
 	}
 }
 
+@[inline]
 fn (mut g FlatGen) write(s string) {
 	if g.line_start {
 		g.write_indent()
@@ -22729,6 +22724,7 @@ fn (mut g FlatGen) write(s string) {
 	g.line_start = s[s.len - 1] == `\n`
 }
 
+@[inline]
 fn (mut g FlatGen) writeln(s string) {
 	if s.len > 0 {
 		if g.line_start {
@@ -22740,6 +22736,7 @@ fn (mut g FlatGen) writeln(s string) {
 	g.line_start = true
 }
 
+@[inline]
 fn (mut g FlatGen) write_indent() {
 	for _ in 0 .. g.indent {
 		g.sb.write_string('\t')

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -21944,7 +21944,14 @@ fn (mut g FlatGen) const_emission_order_owned() []string {
 		return g.const_emission_order()
 	}
 	scope := cgen_worker_scope_begin(true)
+	// Dependency discovery resolves receiver types. Keep those memo writes in
+	// the same disposable arena as the traversal, away from the live checker.
+	master_tc := g.tc
+	g.tc = g.clone_parallel_type_checker()
+	saved_lookup_caches := g.begin_scratch_lookup_caches()
 	scoped_names := g.const_emission_order()
+	g.restore_scratch_lookup_caches(saved_lookup_caches)
+	g.tc = master_tc
 	cgen_worker_scope_leave(scope)
 	names := clone_cgen_string_list(scoped_names)
 	cgen_worker_scope_free(scope)

--- a/vlib/v3/gen/c/const_deps_test.v
+++ b/vlib/v3/gen/c/const_deps_test.v
@@ -42,6 +42,29 @@ fn const_deps_test_method_call(mut a flat.FlatAst, receiver string, method strin
 	return add_const_deps_test_node(mut a, .call, '', [callee])
 }
 
+fn test_scoped_const_order_does_not_populate_live_checker_cache() {
+	mut a := flat.FlatAst.new()
+	call := const_deps_test_method_call(mut a, '[]int', 'clone')
+	mut tc := types.TypeChecker.new(&a)
+	tc.set_fresh_type_cache(true)
+	mut g := FlatGen.new()
+	g.a = &a
+	g.tc = &tc
+	g.scope_parallel_workers = true
+	g.const_vals['value'] = call
+	g.const_init_order = ['value']
+	before := tc.type_cache_stats()
+	assert g.const_emission_order_owned() == ['value']
+	assert g.tc == &tc
+	assert tc.type_cache_stats() == before
+	// Sorting again must work after the previous dependency arena was freed.
+	assert g.const_emission_order_owned() == ['value']
+	// The fixture must actually exercise type memoization during traversal.
+	assert g.const_emission_order() == ['value']
+	assert tc.type_cache_stats().parse_misses > before.parse_misses
+	assert tc.parse_type('[]int').name() == '[]int'
+}
+
 fn test_const_helper_shadows_follow_lexical_scope_and_declaration_order() {
 	mut a := flat.FlatAst.new()
 	dep_value := add_const_deps_test_node(mut a, .int_literal, '41', [])

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -1909,26 +1909,23 @@ fn (g &FlatGen) fn_decl_c_attribute(node_id flat.NodeId) string {
 	return ' __attribute__((${c_attrs.join(', ')}))'
 }
 
-fn (g &FlatGen) fn_decl_c_noinline_prefix(node_id flat.NodeId) string {
-	if g.ccompiler == 'msvc' {
-		return ''
-	}
+// Keep the external declaration and let the C optimizer choose which hinted
+// calls to inline. In particular, cached modules still need a callable symbol.
+fn (g &FlatGen) fn_decl_inlining_prefix(node_id flat.NodeId) string {
+	mut inline_hint := false
 	for raw_attr in g.fn_decl_attributes(node_id) {
-		if raw_attr.all_before(':').trim_space() == 'noinline' {
-			return '__attribute__((noinline)) '
+		attr := raw_attr.all_before(':').trim_space()
+		if attr == 'noinline' {
+			return if g.ccompiler == 'msvc' {
+				'__declspec(noinline) '
+			} else {
+				'__attribute__((noinline)) '
+			}
 		}
+		inline_hint = inline_hint || attr == 'inline'
 	}
-	return ''
-}
-
-fn (g &FlatGen) fn_decl_msvc_noinline_prefix(node_id flat.NodeId) string {
-	if g.ccompiler != 'msvc' {
-		return ''
-	}
-	for raw_attr in g.fn_decl_attributes(node_id) {
-		if raw_attr.all_before(':').trim_space() == 'noinline' {
-			return '__declspec(noinline) '
-		}
+	if inline_hint {
+		return if g.ccompiler == 'msvc' { '__inline ' } else { 'inline ' }
 	}
 	return ''
 }
@@ -4740,8 +4737,7 @@ fn (mut g FlatGen) gen_fn_in_module(node_id flat.NodeId, node flat.Node, module_
 	} else {
 		ret_type := g.fn_node_return_type(node, module_name)
 		g.set_cur_fn_ret(ret_type)
-		g.write(g.fn_decl_msvc_noinline_prefix(node_id))
-		g.write(g.fn_decl_c_noinline_prefix(node_id))
+		g.write(g.fn_decl_inlining_prefix(node_id))
 		if export_name := g.export_fn_name_in_module(module_name, node.value) {
 			if export_name == generated_fn_name {
 				g.write(g.exported_symbol_attribute())

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -970,6 +970,12 @@ fn (g &FlatGen) fn_node_is_open_generic_template(node flat.Node, module_name str
 }
 
 fn (g &FlatGen) is_program_specialization_fn_node(node flat.Node, node_index int, module_name string) bool {
+	if g.a.specialized_fn_nodes[node_index] {
+		return true
+	}
+	if g.tc.specialized_generic_fns.len == 0 {
+		return false
+	}
 	qfn := g.qualified_fn_name_in_module_c(module_name, node.value)
 	return g.is_program_specialization_fn_node_with_qfn(node, node_index, qfn)
 }
@@ -2399,12 +2405,15 @@ fn (g &FlatGen) is_explicit_generic_method_call_selector(fn_node &flat.Node, res
 }
 
 fn (g &FlatGen) method_name_by_receiver_param_type(receiver_type types.Type, method string) ?string {
+	if method.contains('.') {
+		return none
+	}
+	suffix := '.${method}'
 	clean_receiver := concrete_receiver_type(receiver_type)
 	receiver_ct := g.tc.c_type(clean_receiver)
 	mut candidates := []string{}
 	for name, params in g.fn_decl_param_types {
-		if !name.contains('.') || name.contains('__') || name.all_after_last('.') != method
-			|| params.len == 0 {
+		if params.len == 0 || !name.ends_with(suffix) || name.contains('__') {
 			continue
 		}
 		param_receiver := concrete_receiver_type(params[0])

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -17,7 +17,7 @@ const min_flat_cgen_parallel_items = 128
 // expression. Keep self-host body batches narrow so those values are released
 // throughout cgen instead of accumulating across hundreds of functions.
 const scoped_cgen_worker_batches = 256
-const flat_cgen_chunks_per_job = 6
+const flat_cgen_chunks_per_job = 8
 
 // FlatCgenChunkArgs represents flat cgen chunk args data used by c.
 struct FlatCgenChunkArgs {
@@ -365,6 +365,67 @@ $if !windows {
 		osw := time.new_stopwatch()
 		scope := cgen_worker_scope_begin(w.scope_parallel_workers)
 		w.collect_declaration_signature_types()
+		w.optional_types_ready = true
+		w.timing_profile('  [ttime]       fs opt types   ${f64(osw.elapsed().microseconds()) / 1000.0:7.2f} ms')
+		w.worker_scope = scope
+		cgen_worker_scope_leave(scope)
+		return unsafe { nil }
+	}
+
+	struct OptionalSelectionArgs {
+		worker voidptr
+		items  chan []FlatFnGenItem
+	}
+
+	fn checker_signature_support_thread(arg voidptr) voidptr {
+		mut w := unsafe { &FlatGen(arg) }
+		scope := cgen_worker_scope_begin(w.scope_parallel_workers)
+		w.collect_checker_declaration_signature_types()
+		w.worker_scope = scope
+		cgen_worker_scope_leave(scope)
+		return unsafe { nil }
+	}
+
+	// Start declaration discovery while the master selects functions. The channel
+	// publishes a stable snapshot before this lane reads the selected signatures.
+	fn optional_support_selection_thread(arg voidptr) voidptr {
+		a := unsafe { &OptionalSelectionArgs(arg) }
+		mut w := unsafe { &FlatGen(a.worker) }
+		osw := time.new_stopwatch()
+		scope := cgen_worker_scope_begin(w.scope_parallel_workers)
+		old_module := w.tc.cur_module
+		old_file := w.tc.cur_file
+		if !w.decl_types_ready {
+			w.collect_specialized_declaration_signature_types()
+			// Checker signatures and expression types do not depend on selection.
+			// Give that scan its own checker/cache state while selected items arrive.
+			mut metadata := w.new_parallel_worker(0)
+			metadata.c_name_cache = &CNameCache{}
+			metadata.generic_app_cache = &GenericAppCache{}
+			metadata.needed_optional_types = map[string]string{}
+			metadata_thread := spawn checker_signature_support_thread(voidptr(metadata))
+			w.fn_gen_items = <-a.items
+			w.collect_selected_declaration_signature_types()
+			metadata_thread.wait()
+			// Preserve the serial precedence: source specializations, selected
+			// signatures, then checker metadata. Tuple emission deduplicates names.
+			for name, payload in metadata.needed_optional_types {
+				w.needed_optional_types[name] = payload
+			}
+			w.multi_return_types << metadata.multi_return_types
+			for name, enabled in metadata.multi_return_type_names {
+				w.multi_return_type_names[name] = enabled
+			}
+			if metadata.worker_scope != unsafe { nil } {
+				w.parallel_worker_scopes << metadata.worker_scope
+			}
+			w.decl_types_ready = true
+			w.multi_return_types_ready = true
+		} else {
+			w.fn_gen_items = <-a.items
+		}
+		w.tc.cur_module = old_module
+		w.tc.cur_file = old_file
 		w.optional_types_ready = true
 		w.timing_profile('  [ttime]       fs opt types   ${f64(osw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		w.worker_scope = scope
@@ -1365,6 +1426,8 @@ fn (mut g FlatGen) publish_optional_support(mut worker FlatGen) {
 	g.multi_return_type_names = worker.multi_return_type_names.move()
 	g.multi_return_types_ready = worker.multi_return_types_ready
 	g.decl_types_ready = worker.decl_types_ready
+	g.parallel_worker_scopes << worker.parallel_worker_scopes
+	worker.parallel_worker_scopes = []voidptr{}
 	if worker.worker_scope != unsafe { nil } {
 		g.parallel_worker_scopes << worker.worker_scope
 		worker.worker_scope = unsafe { nil }
@@ -3075,17 +3138,21 @@ fn (mut g FlatGen) run_pre_dispatch_parallel(no_parallel bool) bool {
 		}
 		mut fs_worker := g.new_parallel_worker(0)
 		fs_worker.tc.verbose = g.tc.verbose
-		// These helpers can intern C names concurrently. Give each a detached cache
-		// instead of racing through the shared master cache backing.
+		// These helpers resolve C names and generic applications concurrently with
+		// selection. Keep their mutable caches separate from the master and each other.
 		fs_worker.c_name_cache = &CNameCache{}
+		fs_worker.generic_app_cache = &GenericAppCache{}
 		mut fixed_array_worker := g.new_parallel_worker(1)
 		fixed_array_worker.tc.verbose = g.tc.verbose
 		fixed_array_worker.c_name_cache = &CNameCache{}
+		fixed_array_worker.generic_app_cache = &GenericAppCache{}
 		mut optional_worker := g.new_parallel_worker(2)
 		optional_worker.tc.verbose = g.tc.verbose
 		optional_worker.c_name_cache = &CNameCache{}
+		optional_worker.generic_app_cache = &GenericAppCache{}
 		mut call_optional_worker := g.new_parallel_worker(3)
 		call_optional_worker.c_name_cache = &CNameCache{}
+		call_optional_worker.generic_app_cache = &GenericAppCache{}
 		fail := os.getenv('V3_TEST_PTHREAD_CREATE_FAIL')
 		if fail.len > 0 {
 			// prepare_pre_dispatch_master can submit its own selection/cost batches to
@@ -3125,12 +3192,16 @@ fn (mut g FlatGen) run_pre_dispatch_parallel(no_parallel bool) bool {
 			fixed_storage_thread := spawn fixed_storage_scan_thread(voidptr(fs_worker))
 			fixed_array_thread := spawn fixed_array_support_thread(voidptr(fixed_array_worker))
 			call_optional_thread := spawn unresolved_call_optional_thread(voidptr(call_optional_worker))
+			selection_args := OptionalSelectionArgs{
+				worker: voidptr(optional_worker)
+				items: chan []FlatFnGenItem{ cap: 1 }
+			}
+			optional_thread := spawn optional_support_selection_thread(voidptr(&selection_args))
 			g.prepare_pre_dispatch_master()
 			// Reuse the selected declarations instead of selecting every function
 			// again on the optional-support thread. Cost refinement writes the
 			// master's item array, so the helper needs its own snapshot.
-			optional_worker.fn_gen_items = g.fn_gen_items.clone()
-			optional_thread := spawn optional_support_thread(voidptr(optional_worker))
+			selection_args.items <- g.fn_gen_items.clone()
 			g.timing_profile('  [ttime]     cg prep master ${f64(psw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 			psw.restart()
 			g.refine_fn_item_costs(no_parallel, true)

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -17,7 +17,7 @@ const min_flat_cgen_parallel_items = 128
 // expression. Keep self-host body batches narrow so those values are released
 // throughout cgen instead of accumulating across hundreds of functions.
 const scoped_cgen_worker_batches = 256
-const flat_cgen_chunks_per_job = 8
+const flat_cgen_chunks_per_job = 16
 
 // FlatCgenChunkArgs represents flat cgen chunk args data used by c.
 struct FlatCgenChunkArgs {

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -2024,7 +2024,7 @@ fn (g &FlatGen) parallel_cached_expr_type(id flat.NodeId, node &flat.Node) ?type
 	}
 	if node.kind == .call && idx < g.tc.resolved_call_set.len && idx < g.tc.resolved_call_names.len
 		&& g.tc.resolved_call_set[idx] {
-		name := g.tc.resolved_call_names[idx]
+		name := g.tc.resolved_call_names[idx].value
 		if t := g.tc.fn_ret_types[name] {
 			return t
 		}
@@ -2144,7 +2144,7 @@ fn (g &FlatGen) parallel_cached_expr_type_with_cache(id flat.NodeId, node &flat.
 		|| idx >= g.tc.resolved_call_names.len || !g.tc.resolved_call_set[idx] {
 		return none
 	}
-	name := g.tc.resolved_call_names[idx]
+	name := g.tc.resolved_call_names[idx].value
 	slot := int((u64(voidptr(name.str)) >> 4 ^ u64(name.len)) & 4095)
 	if cache.seen[slot] && cache.ptrs[slot] == voidptr(name.str) && cache.lens[slot] == name.len {
 		if cache.found[slot] {

--- a/vlib/v3/gen/c/parallel_worker_test.v
+++ b/vlib/v3/gen/c/parallel_worker_test.v
@@ -214,7 +214,7 @@ fn test_parallel_checker_clone_preserves_sparse_transform_caches() {
 	}, flat.Node{
 		kind: .ident
 	}]
-	tc.resolved_call_names = ['source_call']
+	tc.resolved_call_names = [types.cached_name('source_call')]
 	tc.resolved_call_set = [true]
 	tc.expr_type_values = [types.Type(types.int_)]
 	tc.expr_type_set = [true]

--- a/vlib/v3/gen/c/stmt.v
+++ b/vlib/v3/gen/c/stmt.v
@@ -6881,7 +6881,13 @@ fn (mut g FlatGen) gen_decl_assign(node flat.Node) {
 			}
 			g.gen_decl_lhs(lhs_id)
 			g.write(' = ')
-			g.gen_decl_init_expr(rhs_id, rhs, v_type, ct, !lhs_is_defer_capture)
+			if node.value == '__v3_zeroed_stack_value_decl' && !lhs_is_defer_capture
+				&& !g.has_zero_sized_leading_init_slot(v_type) {
+				// An internal staging value is assigned on every path that reads it.
+				g.write('{0}')
+			} else {
+				g.gen_decl_init_expr(rhs_id, rhs, v_type, ct, !lhs_is_defer_capture)
+			}
 			g.writeln(';')
 			if lhs.kind == .ident {
 				owner := g.tc.cur_scope.insert_with_owner(lhs.value, v_type)

--- a/vlib/v3/gen/c/stmt_test.v
+++ b/vlib/v3/gen/c/stmt_test.v
@@ -695,3 +695,29 @@ fn test_inline_asm_x86_registers_include_avx512_mask_registers() {
 	assert !is_c_inline_asm_x86_register('r999')
 	assert lower_c_inline_asm_template('mov ax, cs', 'amd64', map[string]bool{}, false) == 'mov %cs, %ax'
 }
+
+fn test_unsafe_value_block_scopes_direct_array_access() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	mut g := FlatGen.new()
+	g.a = &a
+	g.tc = &tc
+	array_type := types.Type(types.Array{ elem_type: types.Type(types.int_) })
+	values := stmt_test_node(mut a, .ident, 'values', [])
+	index := stmt_test_node(mut a, .int_literal, '1', [])
+	element := stmt_test_node(mut a, .index, '', [values, index])
+	tc.cur_scope.insert('values', array_type)
+	tc.register_synth_type(values, array_type)
+	tc.register_synth_type(element, types.Type(types.int_))
+	expression := stmt_test_node(mut a, .expr_stmt, '', [element])
+	block := stmt_test_node(mut a, .block, 'unsafe', [expression])
+	g.gen_expr(block)
+	unchecked := g.sb.str()
+	assert unchecked.contains('.data'), unchecked
+	assert !unchecked.contains('array_get('), unchecked
+	assert g.unsafe_depth == 0
+	g.sb.clear()
+	g.gen_expr(element)
+	checked := g.sb.str()
+	assert checked.contains('array_get('), checked
+}

--- a/vlib/v3/gen/c/str_intp.v
+++ b/vlib/v3/gen/c/str_intp.v
@@ -5,6 +5,10 @@ import v3.types
 
 // gen_string_interp emits string interp output for c.
 fn (mut g FlatGen) gen_string_interp(node flat.Node) {
+	if node.value == '__v3_string_join' {
+		g.gen_string_join(node)
+		return
+	}
 	n := node.children_count
 	if n == 0 {
 		sid := g.intern_string('')
@@ -86,6 +90,28 @@ fn (mut g FlatGen) gen_string_interp(node flat.Node) {
 		}
 	}
 	g.write('})')
+}
+
+// Lowered operands are already strings. Separate assignments preserve source
+// evaluation order, including calls that mutate a value used by a later part.
+fn (mut g FlatGen) gen_string_join(node flat.Node) {
+	g.gen_string_join_parts(g.a.children_of(&node), true)
+}
+
+fn (mut g FlatGen) gen_string_join_parts(parts []flat.NodeId, interpolation bool) {
+	name := '__v3_internal_symbol_join_${g.tmp_count}'
+	g.tmp_count++
+	g.write('({ string ${name}[${parts.len}]; ')
+	for i, part in parts {
+		g.write('${name}[${i}] = ')
+		if interpolation {
+			g.gen_string_interp_child_expr(part)
+		} else {
+			g.gen_expr_as_string(part)
+		}
+		g.write('; ')
+	}
+	g.write('string_plus_many(${parts.len}, ${name}); })')
 }
 
 fn (g &FlatGen) string_interp_child_type(child_id flat.NodeId, child flat.Node) types.Type {

--- a/vlib/v3/gen/c/str_intp_test.v
+++ b/vlib/v3/gen/c/str_intp_test.v
@@ -83,3 +83,32 @@ fn test_ierror_interpolation_uses_dynamic_message_dispatch() {
 	g.gen_string_interp(a.nodes[int(interp_id)])
 	assert g.sb.str() == 'string_plus_many(1, (string[1]){({ IError _ierror_msg0 = err; IError__msg(&_ierror_msg0); })})'
 }
+
+fn test_lowered_string_join_keeps_source_identifiers_out_of_its_temporary_namespace() {
+	mut a := flat.FlatAst.new()
+	name := '__v3_internal_symbol_join_0'
+	part := a.add_node(flat.Node{
+		kind: .ident
+		value: name
+		typ: 'string'
+	})
+	a.children << part
+	a.children << part
+	mut tc := types.TypeChecker.new(&a)
+	tc.cur_scope.insert(name, types.Type(types.string_))
+	mut g := FlatGen.new()
+	g.a = &a
+	g.tc = &tc
+	g.gen_string_interp(flat.Node{
+		kind: .string_interp
+		value: '__v3_string_join'
+		typ: 'string'
+		children_count: 2
+	})
+	output := g.sb.str()
+	assert output.contains('string ${name}[2];')
+	assert output.contains('${name}[0] = ${g.cname(name)};')
+	assert output.contains('${name}[1] = ${g.cname(name)};')
+	assert g.cname(name) != name
+	assert output.contains('string_plus_many(2, ${name})')
+}

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -740,7 +740,7 @@ fn (mut g FlatGen) collect_unresolved_call_optional_types() {
 			continue
 		}
 		if idx < g.tc.resolved_call_set.len && g.tc.resolved_call_set[idx] {
-			name := g.tc.resolved_call_names[idx]
+			name := g.tc.resolved_call_names[idx].value
 			if name in g.tc.fn_ret_types {
 				// collect_declaration_signature_types() already processed this exact
 				// return entry; only calls without checker return metadata need their

--- a/vlib/v3/gen/c/types.v
+++ b/vlib/v3/gen/c/types.v
@@ -799,6 +799,17 @@ fn (mut g FlatGen) collect_declaration_signature_types() {
 	if g.decl_types_ready {
 		return
 	}
+	old_module := g.tc.cur_module
+	old_file := g.tc.cur_file
+	defer {
+		g.tc.cur_module = old_module
+		g.tc.cur_file = old_file
+	}
+	g.collect_specialized_declaration_signature_types()
+	g.finish_declaration_signature_types()
+}
+
+fn (mut g FlatGen) collect_specialized_declaration_signature_types() {
 	// Specialized generic-interface wrappers are synthesized from the interface
 	// declaration instead of appearing as standalone AST declarations. Discover
 	// their applications here as well so tuple and option return ABIs are defined
@@ -817,12 +828,6 @@ fn (mut g FlatGen) collect_declaration_signature_types() {
 				g.collect_declaration_signature_type_for_context(param, true)
 			}
 		}
-	}
-	old_module := g.tc.cur_module
-	old_file := g.tc.cur_file
-	defer {
-		g.tc.cur_module = old_module
-		g.tc.cur_file = old_file
 	}
 	// Parallel monomorph workers can append concrete declarations before their
 	// checker signature maps are merged. Read those declaration nodes directly too,
@@ -869,12 +874,19 @@ fn (mut g FlatGen) collect_declaration_signature_types() {
 			g.collect_declaration_signature_type_for_context(g.fn_node_effective_param_type(param, raw_type), concrete_optional)
 		}
 	}
+}
+
+fn (mut g FlatGen) finish_declaration_signature_types() {
 	// The selected function list excludes open generic templates and carries the
 	// exact module/file context later used by forward_decls(). Collect those known
 	// concrete signatures without the conservative placeholder-name filter: in a
 	// large program it can mistake short nominal payloads such as `Token` or `Type`
 	// for generic parameters and omit their optional wrapper typedefs.
 	g.collect_selected_declaration_signature_types()
+	g.collect_checker_declaration_signature_types()
+}
+
+fn (mut g FlatGen) collect_checker_declaration_signature_types() {
 	mut seen := &PreseedTypeSeen{}
 	for name, ret in g.tc.fn_ret_types {
 		// Generic template signatures keep unspecialized placeholder types

--- a/vlib/v3/gen/c/types_test.v
+++ b/vlib/v3/gen/c/types_test.v
@@ -6,6 +6,78 @@ import v3.parser
 import v3.pref
 import v3.types
 
+fn test_optional_selection_handoff_preserves_signature_context_and_types() {
+	$if !windows && !v3_no_parallel ? {
+		mut ast := flat.FlatAst.new()
+		fn_id := ast.add_node(flat.Node{ kind: .fn_decl, value: 'load', typ: '?Data' })
+		pair_id := ast.add_node(flat.Node{ kind: .fn_decl, value: 'pair', typ: '(int, string)' })
+		ast.specialized_fn_nodes[int(fn_id)] = true
+		ast.specialized_fn_modules[int(fn_id)] = 'payload'
+		ast.specialized_fn_files[int(fn_id)] = 'payload.v'
+		mut tc := types.TypeChecker.new(&ast)
+		tc.structs['payload.Data'] = []types.StructField{}
+		tc.struct_modules['payload.Data'] = 'payload'
+		tc.fn_ret_types['payload.pair'] = types.Type(types.MultiReturn{ types: [
+			types.Type(types.int_),
+			types.Type(types.string_),
+		] })
+		tc.cur_module = 'caller'
+		tc.cur_file = 'caller.v'
+		mut serial := FlatGen.new()
+		serial.scope_parallel_workers = true
+		serial.a = &ast
+		serial.tc = &tc
+		items := [
+			FlatFnGenItem{ node_id: fn_id, module: 'payload', file: 'payload.v', c_name: 'load' },
+			FlatFnGenItem{ node_id: pair_id, module: 'payload', file: 'payload.v', c_name: 'pair' },
+		]
+		serial.fn_gen_items = items
+		mut worker := serial.new_parallel_worker(0)
+		serial.collect_declaration_signature_types()
+		args := OptionalSelectionArgs{ worker: voidptr(worker), items: chan []FlatFnGenItem{ cap: 1 } }
+		thread := spawn optional_support_selection_thread(voidptr(&args))
+		args.items <- items.clone()
+		thread.wait()
+		assert worker.needed_optional_types == serial.needed_optional_types
+		assert 'Optional_payload__Data' in worker.needed_optional_types
+		assert worker.optional_types_ready
+		assert worker.decl_types_ready
+		assert worker.multi_return_types_ready
+		assert worker.tc.cur_module == 'caller'
+		assert worker.tc.cur_file == 'caller.v'
+		assert worker.multi_return_type_names == serial.multi_return_type_names
+		mut serial_emitted := map[string]bool{}
+		mut parallel_emitted := map[string]bool{}
+		serial.walk_multi_return_typedefs(mut serial_emitted, false)
+		worker.walk_multi_return_typedefs(mut parallel_emitted, false)
+		assert serial_emitted.len == 1
+		assert worker.sb.str() == serial.sb.str()
+		serial.publish_optional_support(mut worker)
+		$if prealloc {
+			assert serial.parallel_worker_scopes.len == 2
+		}
+		serial.free_parallel_worker_scopes()
+	}
+}
+
+fn test_receiver_param_method_scan_preserves_suffix_and_tie_breaking() {
+	mut ast := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&ast)
+	mut g := FlatGen.new()
+	g.a = &ast
+	g.tc = &tc
+	receiver := types.Type(types.Struct{ name: 'Box' })
+	for name in ['z.Box.show', 'a.Box.show', 'mod.Box.show', 'mod.Box.shower', '__hidden.Box.show'] {
+		g.fn_decl_param_types[name] = [receiver]
+	}
+	tc.cur_module = 'mod'
+	assert g.method_name_by_receiver_param_type(receiver, 'show')? == 'mod.Box.show'
+	tc.cur_module = 'elsewhere'
+	assert g.method_name_by_receiver_param_type(receiver, 'show')? == 'a.Box.show'
+	assert g.method_name_by_receiver_param_type(receiver, 'Box.show') == none
+	assert g.method_name_by_receiver_param_type(receiver, 'missing') == none
+}
+
 fn test_field_type_cache_preserves_collisions_and_module_context() {
 	mut ast := flat.FlatAst.new()
 	mut tc := types.TypeChecker.new(&ast)

--- a/vlib/v3/gen/c/types_test.v
+++ b/vlib/v3/gen/c/types_test.v
@@ -196,7 +196,7 @@ fn test_json_helper_scan_requires_legacy_json_module() {
 		flat.Node{ kind: .ident, value: 'pointer', typ: '&int' }]
 	ast.children = [flat.NodeId(1), flat.NodeId(2)]
 	mut tc := types.TypeChecker.new(&ast)
-	tc.resolved_call_names = ['json.encode', '', '']
+	tc.resolved_call_names = [types.cached_name('json.encode'), unsafe { nil }, unsafe { nil }]
 	tc.resolved_call_set = [true, false, false]
 	tc.expr_type_values = [types.Type(types.void_), types.Type(types.void_),
 		types.Type(types.Pointer{ base_type: types.Type(types.int_) })]

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -142,9 +142,16 @@ pub mut:
 // reserve_selfhost_ast prepares the shared AST for a compiler-sized input
 // without retaining successively doubled backing arrays during transform.
 pub fn (mut p Parser) reserve_selfhost_ast() {
-	selfhost_ast_capacity := 2_097_152 // 2 MiB
-	p.a.nodes.ensure_cap(selfhost_ast_capacity)
-	p.a.children.ensure_cap(selfhost_ast_capacity)
+	// Reserve transform headroom without ensure_cap rounding the node slab up
+	// to four million entries. Parallel transform partitions this capacity, so
+	// extra room also spreads worker writes across more physical pages.
+	selfhost_node_capacity := 3_145_728
+	if p.a.nodes.cap < selfhost_node_capacity {
+		old_nodes := p.a.nodes
+		p.a.nodes = []flat.Node{cap: selfhost_node_capacity}
+		p.a.nodes << old_nodes
+	}
+	p.a.children.ensure_cap(4_194_304)
 }
 
 // ExportRecord captures one accepted `@[export: name]` registration in file

--- a/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/parser/parser_parallel_notd_v3_no_parallel.v
@@ -973,11 +973,8 @@ fn parse_merge_copy_thread(arg voidptr) voidptr {
 			cid
 		}
 	}
-	mut cache_ptrs := unsafe { []voidptr{len: 4096} }
-	mut cache_vals := []string{len: 4096}
-	mut type_cache_ptrs := unsafe { []voidptr{len: 4096} }
-	mut type_cache_vals := []string{len: 4096}
-	mut type_cache_ids := []u16{len: 4096}
+	mut value_cache := flat.TextProbeCache{}
+	mut type_cache := flat.TextProbeCache{}
 	for k in 0 .. w.a.nodes.len {
 		mut node := w.a.nodes[k]
 		if node.children_count != 0 {
@@ -993,10 +990,10 @@ fn parse_merge_copy_thread(arg voidptr) voidptr {
 		// are rebound here; missing texts go to the ordered serial tail so the
 		// canonical table's insertion order matches the serial merge.
 		mut all_hit := true
-		node.value, all_hit = p.a.probe_text_ptr_cached(node.value, mut cache_ptrs, mut cache_vals)
+		node.value, all_hit = p.a.probe_text_ptr_cached(node.value, mut value_cache.ptrs, mut value_cache.values)
 		mut hit := true
 		mut type_id := u16(0)
-		type_id, node.typ, hit = p.a.probe_type_text_ptr_cached(node.typ, mut type_cache_ptrs, mut type_cache_vals, mut type_cache_ids)
+		type_id, node.typ, hit = p.a.probe_type_text_ptr_cached(node.typ, mut type_cache.ptrs, mut type_cache.values, mut type_cache.ids)
 		node.set_type_text_id(type_id)
 		all_hit = all_hit && hit
 		params := node.generic_params()
@@ -1004,7 +1001,7 @@ fn parse_merge_copy_thread(arg voidptr) voidptr {
 			mut canonical_params := []string{cap: params.len}
 			mut params_hit := true
 			for item in params {
-				canonical, item_hit := p.a.probe_text_ptr_cached(item, mut cache_ptrs, mut cache_vals)
+				canonical, item_hit := p.a.probe_text_ptr_cached(item, mut value_cache.ptrs, mut value_cache.values)
 				canonical_params << canonical
 				params_hit = params_hit && item_hit
 			}

--- a/vlib/v3/tests/post_merge_review_fixes_test.v
+++ b/vlib/v3/tests/post_merge_review_fixes_test.v
@@ -2356,12 +2356,131 @@ fn test_dynamic_enum_array_literal_keeps_enum_element_width() {
 	assert out == '0\n1'
 }
 
-fn test_nested_string_plus_releases_intermediate_storage() {
+fn test_empty_array_headers_preserve_growth_and_argument_evaluation() {
+	v3_bin := build_v3()
+	source := 'struct EmptyArrays {
+mut:
+	words []string
+	values []u16
+}
+
+struct HeaderCalls {
+mut:
+	count int
+}
+
+fn v3_array_new() int { return 5 }
+fn __v3_internal_symbol_array_new() int { return 6 }
+
+fn zero(mut calls HeaderCalls) int {
+	calls.count++
+	return 0
+}
+
+fn main() {
+	assert v3_array_new() == 5
+	assert __v3_internal_symbol_array_new() == 6
+	mut calls := HeaderCalls{}
+	mut values := []int{len: zero(mut calls), cap: zero(mut calls)}
+	assert calls.count == 2
+	assert values.len == 0 && values.cap == 0
+	values << 42
+	assert values == [42]
+	mut empty := []int{}
+	mut copied := empty.clone()
+	empty << 1
+	copied << 2
+	assert empty == [1] && copied == [2]
+	mut fields := EmptyArrays{}
+	fields.words << "value"
+	fields.values << u16(513)
+	assert fields.words == ["value"]
+	assert fields.values[0] == 513
+	println("ok")
+}
+'
+	assert run_good_with_flags(v3_bin, 'empty_array_headers_prealloc', '-gc none -prealloc -nocache', source) == 'ok'
+	assert run_good_with_flags(v3_bin, 'empty_array_headers_malloc', '-gc none -no-prealloc -nocache', source) == 'ok'
+}
+
+fn test_or_staging_does_not_construct_unused_defaults() {
+	v3_bin := build_v3()
+	source := '@[has_globals]
+module main
+
+__global default_calls int
+
+fn initial_value() int {
+	default_calls++
+	return 99
+}
+
+struct StagedValue {
+	value int = initial_value()
+	items []int
+	labels map[string]string
+}
+
+fn maybe_value(ok bool) !StagedValue {
+	if !ok { return error("missing") }
+	return StagedValue{value: 7, items: [3], labels: {"k": "v"}}
+}
+
+fn choose_value(ok bool) StagedValue {
+	return maybe_value(ok) or { StagedValue{value: 8, items: [4]} }
+}
+
+fn early_return(ok bool) int {
+	value := maybe_value(ok) or { return -1 }
+	return value.value
+}
+
+fn maybe_pair(ok bool) !(StagedValue, string) {
+	if !ok { return error("missing") }
+	return StagedValue{value: 11}, "pair"
+}
+
+fn main() {
+	a := choose_value(true)
+	assert a.value == 7 && a.items == [3] && a.labels["k"] == "v"
+	b := choose_value(false)
+	assert b.value == 8 && b.items == [4] && b.labels.len == 0
+	assert early_return(true) == 7
+	assert early_return(false) == -1
+	mut total := 0
+	for i in 0 .. 3 {
+		value := maybe_value(i == 1) or { continue }
+		total += value.value
+	}
+	assert total == 7
+	c, text := maybe_pair(true) or { StagedValue{value: 12}, "fallback" }
+	assert c.value == 11 && text == "pair"
+	d, fallback := maybe_pair(false) or { StagedValue{value: 12}, "fallback" }
+	assert d.value == 12 && fallback == "fallback"
+	values := {"found": StagedValue{value: 13}}
+	found := values["found"] or { StagedValue{value: 14} }
+	missing := values["missing"] or { StagedValue{value: 14} }
+	assert found.value == 13 && missing.value == 14
+	selected := if total == 7 { StagedValue{value: 15} } else { StagedValue{value: 16} }
+	assert selected.value == 15
+	assert default_calls == 0
+	ordinary := StagedValue{}
+	assert ordinary.value == 99
+	assert default_calls == 1
+	println("ok")
+}
+'
+	assert run_good(v3_bin, 'or_staging_defaults', source) == 'ok'
+	heap_source := source.replace('struct StagedValue {', '@[heap]\nstruct StagedValue {')
+	assert run_good(v3_bin, 'or_staging_heap_defaults', heap_source) == 'ok'
+}
+
+fn test_interpolation_joins_without_intermediate_storage() {
 	v3_bin := build_v3()
 	source := "fn concat_path(dir string, name string) string {\n\treturn '\${dir}/\${name}'\n}\n\nfn main() {\n\tname := 'file'\n\tprintln(concat_path('root', name))\n}\n"
 	c_source := gen_c(v3_bin, 'nested_string_plus_owned_intermediate', source)
 	assert !c_source.contains('string__plus(string__plus(dir,'), c_source
-	assert c_source.contains('string__free(&__str_plus_acc_'), c_source
+	assert c_source.contains(', __v3_internal_symbol_join_'), c_source
 	out := run_good(v3_bin, 'nested_string_plus_owned_intermediate_run', source)
 	assert out == 'root/file'
 }
@@ -10409,4 +10528,45 @@ fn main() {
 '
 	}, 'main.v')
 	assert out == 'true'
+}
+
+fn test_inline_helpers_keep_callable_symbols_in_cached_and_uncached_builds() {
+	v3_bin := build_v3()
+	files := {
+		'v.mod':           'Module { name: "inline_symbols" }'
+		'helper/helper.v': 'module helper
+
+@[inline]
+pub fn twice(n int) int {
+	return n * 2
+}
+
+@[inline]
+pub fn identity[T](value T) T {
+	return value
+}
+'
+		'main.v':          'module main
+import helper
+
+fn invoke(f fn (int) int, n int) int {
+	return f(n)
+}
+
+fn main() {
+	assert invoke(helper.twice, 21) == 42
+	assert helper.identity[int](7) == 7
+	println("ok")
+}
+'
+	}
+	assert run_good_project_with_flags(v3_bin, 'inline_uncached', '-nocache', files, 'main.v') == 'ok'
+	assert run_good_cached_project(v3_bin, 'inline_cached', files, 'main.v') == 'ok'
+	root := '${tmp_test_path('inline_cached')}_project'
+	warm_bin := tmp_test_path('inline_cached_warm')
+	warm := os.execute('${v3_bin} ${os.join_path(root, 'main.v')} -o ${warm_bin}')
+	assert warm.exit_code == 0, warm.output
+	run := os.execute(warm_bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'ok'
 }

--- a/vlib/v3/tests/string_interpolation_stringify_codegen_test.v
+++ b/vlib/v3/tests/string_interpolation_stringify_codegen_test.v
@@ -318,3 +318,66 @@ fn test_string_plus_does_not_stringify_non_strings() {
 	assert map_result.output.contains('operator `+` cannot concatenate `string` and `map[string]int`'), map_result.output
 	assert !map_result.output.contains('C compilation failed'), map_result.output
 }
+
+fn test_joined_interpolation_preserves_order_and_formatted_parts() {
+	v3_bin := string_interp_build_v3()
+	src := "const prefix = 'hello'
+const greeting = '\${prefix} world!'
+
+struct Counter {
+mut:
+	n int
+}
+
+fn (mut c Counter) next() int {
+	c.n++
+	return c.n
+}
+
+fn (mut c Counter) values() []int {
+	c.n++
+	return [c.n]
+}
+
+fn (mut c Counter) maybe() ?int {
+	c.n++
+	return c.n
+}
+
+fn decorate(text string) string {
+	return '<\${text}> / \${text}'
+}
+
+fn main() {
+	mut c := Counter{}
+	assert '\${c.next()}:\${c.next()}:\${c.next()}' == '1:2:3'
+	assert c.n == 3
+	// Array and optional conversions introduce statements before the join.
+	assert '\${c.next()} / \${c.values()} / \${c.next()}' == '4 / [5] / 6'
+	assert '\${c.next()} / \${c.maybe()} / \${c.next()}' == '7 / Option(8) / 9'
+	assert c.n == 9
+	assert '\${c.next():04d} / \${c.next():x} / \${c.next():3d}' == '0010 / b /  12'
+	assert c.next().str() + (c.next().str() + c.next().str()) == '131415'
+	assert c.n == 15
+	assert greeting == 'hello world!'
+	__v3_internal_symbol_join_0 := 'reserved'
+	assert '<\${__v3_internal_symbol_join_0}>' == '<reserved>'
+	text := 'Привет'
+	assert decorate(text) == '<Привет> / Привет'
+	zero := u8(0).ascii_str()
+	joined := 'a\${zero}b\${text}'
+	assert joined.len == 3 + text.len
+	assert joined[0] == 97 && joined[1] == 0 && joined[2] == 98
+	assert joined[3..] == text
+	assert text + zero + text == 'Привет' + zero + 'Привет'
+	assert text == 'Привет'
+	println('ok')
+}
+"
+	bin := os.join_path(os.temp_dir(), 'v3_string_join_order_${os.getpid()}')
+	compile := compile_v3_input(v3_bin, 'v3_string_join_order', src, bin)
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(bin)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space() == 'ok'
+}

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -6626,8 +6626,8 @@ fn (mut t Transformer) fn_span_interp_estimate(lo int, hi int) (int, bool) {
 }
 
 fn (mut t Transformer) string_interp_expansion_estimates(node flat.Node) (int, bool) {
-	// transform_string_interp joins every part after the first with string__plus.
-	// Each join appends two nodes and three child IDs, so charge the larger pool.
+	// Reserve conservatively for a join and its converted operands. Keeping the
+	// former pairwise-join bound also covers late, partially lowered expansions.
 	mut estimate := if node.children_count > 1 { 3 * (int(node.children_count) - 1) } else { 0 }
 	mut may_hoist := false
 	mut needs_deferred_lowering := false

--- a/vlib/v3/transform/fn_test.v
+++ b/vlib/v3/transform/fn_test.v
@@ -109,7 +109,7 @@ fn test_cloned_worker_merge_replays_relocated_children_and_body_roots() {
 			children_count: 1
 		}
 		worker_ast.children[base_slot] = new_leaf
-		worker.inplace_child_log << InplaceChildRewrite{ slot: base_slot, child: new_leaf }
+		worker.inplace_child_log << InplaceChildRewrite{ slot: i32(base_slot), child: new_leaf }
 		a.add_node(flat.Node{ kind: .int_literal, value: '3' })
 		a.add_child(leaf)
 		merged_leaf := flat.NodeId(a.nodes.len)
@@ -1029,18 +1029,18 @@ fn test_merged_resolution_cache_initializes_gaps_and_preserves_entries() {
 	t.set_resolved_fn_value_entry(2, 'main.callback')
 	t.set_resolved_call_entry(4096, 'main.last')
 	t.set_resolved_fn_value_entry(8192, 'main.final_callback')
-	assert tc.resolved_call_names[1] == 'main.first'
+	assert tc.resolved_call_names[1].value == 'main.first'
 	assert tc.resolved_call_set[1]
-	assert tc.resolved_call_names[4096] == 'main.last'
+	assert tc.resolved_call_names[4096].value == 'main.last'
 	assert tc.resolved_call_set[4096]
-	assert tc.resolved_fn_value_names[2] == 'main.callback'
+	assert tc.resolved_fn_value_names[2].value == 'main.callback'
 	assert tc.resolved_fn_value_set[2]
-	assert tc.resolved_fn_value_names[8192] == 'main.final_callback'
+	assert tc.resolved_fn_value_names[8192].value == 'main.final_callback'
 	assert tc.resolved_fn_value_set[8192]
 	for i in 3 .. 4096 {
-		assert tc.resolved_call_names[i] == ''
+		assert isnil(tc.resolved_call_names[i])
 		assert !tc.resolved_call_set[i]
-		assert tc.resolved_fn_value_names[i] == ''
+		assert isnil(tc.resolved_fn_value_names[i])
 		assert !tc.resolved_fn_value_set[i]
 	}
 }

--- a/vlib/v3/transform/fn_test.v
+++ b/vlib/v3/transform/fn_test.v
@@ -3,6 +3,39 @@ module transform
 import v3.flat
 import v3.types
 
+fn test_selfhost_return_alias_cache_preserves_module_and_worker_context() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	tc.type_aliases['one.Value'] = 'int'
+	tc.structs['two.Value'] = []types.StructField{}
+	mut t := new_transformer(mut a, &tc, map[string]bool{})
+	t.building_v = true
+	t.skip_generics = true
+	t.raw_return_alias_cache = &ContextBoolLookupCache{}
+	t.build_generic_alias_name_index()
+	for module_name in ['one', 'two', 'one', 'two'] {
+		t.cur_module = module_name
+		for typ in ['Value', '?Value', '[]Value', 'map[string]Value', ' int '] {
+			expected := t.raw_return_type_contains_alias_uncached(typ)
+			assert t.raw_return_type_contains_alias(typ) == expected
+			assert t.raw_return_type_contains_alias(typ.clone()) == expected
+		}
+		assert t.raw_return_type_contains_alias('?Value') == (module_name == 'one')
+	}
+	assert t.raw_return_alias_cache.entries.len > 0
+	mut worker := t.fork_scoped_batch_worker(&a, &tc)
+	assert worker.raw_return_alias_cache != t.raw_return_alias_cache
+	worker.cur_module = 'one'
+	assert worker.raw_return_type_contains_alias('?Value')
+	assert !t.raw_return_type_contains_alias('?Value')
+	// General builds continue to observe declaration changes between queries.
+	t.building_v = false
+	t.cur_module = 'one'
+	assert !t.raw_return_type_contains_alias('Late')
+	tc.type_aliases['one.Late'] = 'string'
+	assert t.raw_return_type_contains_alias('Late')
+}
+
 fn test_enum_autostr_call_marks_synthesized_helper_used() {
 	mut a := flat.FlatAst.new()
 	mut tc := types.TypeChecker.new(&a)

--- a/vlib/v3/transform/fn_test.v
+++ b/vlib/v3/transform/fn_test.v
@@ -3,6 +3,23 @@ module transform
 import v3.flat
 import v3.types
 
+fn test_zeroed_staging_values_keep_heap_structs_on_the_stack() {
+	mut a := flat.FlatAst.new()
+	decl := a.add_node(flat.Node{ kind: .struct_decl, value: 'HeapValue' })
+	mut tc := types.TypeChecker.new(&a)
+	tc.structs['HeapValue'] = []types.StructField{}
+	tc.type_declaration_ids['HeapValue'] = [int(decl)]
+	tc.declaration_attributes[int(decl)] = ['heap']
+	mut t := new_transformer(mut a, &tc, map[string]bool{})
+	assert t.heap_attr_struct_type('HeapValue')
+	staging := t.make_staging_value_decl('staging', 'HeapValue')
+	t.transform_decl_assign_stmt(staging, a.nodes[int(staging)])
+	assert 'staging' !in t.heaped_amp_locals
+	ordinary := t.make_decl_assign_typed('ordinary', t.zero_value_for_type('HeapValue'), 'HeapValue')
+	t.transform_decl_assign_stmt(ordinary, a.nodes[int(ordinary)])
+	assert 'ordinary' in t.heaped_amp_locals
+}
+
 fn test_selfhost_return_alias_cache_preserves_module_and_worker_context() {
 	mut a := flat.FlatAst.new()
 	mut tc := types.TypeChecker.new(&a)

--- a/vlib/v3/transform/if.v
+++ b/vlib/v3/transform/if.v
@@ -521,7 +521,7 @@ fn (mut t Transformer) try_expand_if_expr_value_for_type(id flat.NodeId, node fl
 	t.pending_stmts.clear()
 
 	mut prelude := []flat.NodeId{}
-	prelude << t.make_decl_assign_typed(tmp_name, t.zero_value_for_type(actual_result_type), actual_result_type)
+	prelude << t.make_staging_value_decl(tmp_name, actual_result_type)
 	for stmt in t.build_if_value_chain(id, tmp_name, actual_result_type) {
 		prelude << stmt
 	}

--- a/vlib/v3/transform/map.v
+++ b/vlib/v3/transform/map.v
@@ -2058,7 +2058,7 @@ fn (mut t Transformer) transform_map_index_or_expr(id flat.NodeId, node flat.Nod
 			t.make_ident(key_name),
 		], 'void'))
 	}
-	prelude << t.make_decl_assign_typed(val_name, t.zero_value_for_type(result_type), result_type)
+	prelude << t.make_staging_value_decl(val_name, result_type)
 	move_found_value := !isnil(t.tc) && t.tc.ownership_index_read_moves_value(expr_id)
 		&& t.tc.ownership_type_requires_destruction(t.tc.parse_type(info.value_type))
 

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -3462,13 +3462,26 @@ fn (mut t Transformer) ensure_node_context_map_capacity() {
 	if t.node_context_read_only {
 		return
 	}
-	if t.node_module_map_cache.len < t.a.nodes.len {
-		t.node_module_map_cache.ensure_cap(t.a.nodes.cap)
-		t.node_module_map_cache << []u32{len: t.a.nodes.len - t.node_module_map_cache.len}
+	grow_node_context_cache(mut t.node_module_map_cache, t.a.nodes.len, t.a.nodes.cap)
+	grow_node_context_cache(mut t.node_file_map_cache, t.a.nodes.len, t.a.nodes.cap)
+}
+
+fn grow_node_context_cache(mut cache []u32, size int, capacity int) {
+	old_len := cache.len
+	if old_len >= size {
+		return
 	}
-	if t.node_file_map_cache.len < t.a.nodes.len {
-		t.node_file_map_cache.ensure_cap(t.a.nodes.cap)
-		t.node_file_map_cache << []u32{len: t.a.nodes.len - t.node_file_map_cache.len}
+	if cache.cap < capacity {
+		// Use the AST's reserved size without rounding each side table up again.
+		mut grown := []u32{cap: capacity}
+		grown << cache
+		// Transfer the new backing; this local has no other surviving reference.
+		cache = unsafe { grown }
+	}
+	// Extend in place instead of retaining a temporary zero-filled array.
+	unsafe {
+		cache.grow_len(size - old_len)
+		vmemset(&cache[old_len], 0, isize(size - old_len) * isize(sizeof(u32)))
 	}
 }
 
@@ -5887,7 +5900,7 @@ fn (mut t Transformer) clear_resolved_call(id flat.NodeId) {
 		return
 	}
 	if idx >= 0 && idx < t.tc.resolved_call_names.len {
-		t.tc.resolved_call_names[idx] = ''
+		t.tc.resolved_call_names[idx] = unsafe { nil }
 		t.tc.resolved_call_set[idx] = false
 	}
 }
@@ -10938,7 +10951,7 @@ fn (mut t Transformer) copy_cloned_resolution_forked(src_idx int, dst_idx int) {
 		''
 	}
 	if call_name.len == 0 && src_idx < t.tc.resolved_call_set.len && t.tc.resolved_call_set[src_idx] {
-		call_name = t.tc.resolved_call_names[src_idx]
+		call_name = t.tc.resolved_call_names[src_idx].value
 	}
 	if call_name.len > 0 && !t.cloned_call_has_exact_generic_callee(dst_idx)
 		&& !t.resolved_call_is_generic_fn(call_name) {
@@ -10951,7 +10964,7 @@ fn (mut t Transformer) copy_cloned_resolution_forked(src_idx int, dst_idx int) {
 	}
 	if fn_value.len == 0 && src_idx < t.tc.resolved_fn_value_set.len
 		&& t.tc.resolved_fn_value_set[src_idx] {
-		fn_value = t.tc.resolved_fn_value_names[src_idx]
+		fn_value = t.tc.resolved_fn_value_names[src_idx].value
 	}
 	if fn_value.len > 0 {
 		overlay.resolved_fn_values[dst_idx] = fn_value

--- a/vlib/v3/transform/monomorphize_test.v
+++ b/vlib/v3/transform/monomorphize_test.v
@@ -3,6 +3,22 @@ module transform
 import v3.flat
 import v3.types
 
+fn test_node_context_cache_growth_preserves_ids_and_initializes_new_slots() {
+	mut cache := []u32{}
+	grow_node_context_cache(mut cache, 3, 8)
+	cache[0] = 7
+	cache[2] = 9
+	grow_node_context_cache(mut cache, 6, 8)
+	assert cache == [u32(7), 0, 9, 0, 0, 0]
+	cache[5] = 11
+	grow_node_context_cache(mut cache, 12, 16)
+	assert cache[..6] == [u32(7), 0, 9, 0, 0, 11]
+	assert cache[6..] == [u32(0), 0, 0, 0, 0, 0]
+	grow_node_context_cache(mut cache, 2, 16)
+	assert cache.len == 12
+	assert cache[5] == 11
+}
+
 fn test_specialized_fn_signature_types_are_recorded_once() {
 	mut a := flat.FlatAst.new()
 	param_id := a.add_node(flat.Node{

--- a/vlib/v3/transform/or.v
+++ b/vlib/v3/transform/or.v
@@ -1444,6 +1444,14 @@ fn (mut t Transformer) make_stack_value_decl_assign_typed(name string, rhs flat.
 	return decl
 }
 
+// make_staging_value_decl reserves a temporary assigned by every continuing branch.
+// Preserve its typed initializer for other backends; C needs only zeroed storage.
+fn (mut t Transformer) make_staging_value_decl(name string, typ string) flat.NodeId {
+	decl := t.make_stack_value_decl_assign_typed(name, t.zero_value_for_type(typ), typ)
+	t.a.nodes[int(decl)].value = zeroed_stack_value_decl_marker
+	return decl
+}
+
 // zero_value_for_type supports zero value for type handling for Transformer.
 fn (mut t Transformer) zero_value_for_type(typ string) flat.NodeId {
 	mut clean := typ
@@ -1638,8 +1646,7 @@ fn (mut t Transformer) lower_or_expr_to_temp(id flat.NodeId, node flat.Node) fla
 			break
 		}
 	}
-	prelude << t.make_stack_value_decl_assign_typed(val_tmp,
-		t.zero_value_for_type(storage_value_type), storage_value_type)
+	prelude << t.make_staging_value_decl(val_tmp, storage_value_type)
 
 	opt_ident := t.make_ident(opt_tmp)
 	ok_cond := t.make_selector(opt_ident, 'ok', 'bool')

--- a/vlib/v3/transform/scoped_merge_notd_v3_no_parallel_test.v
+++ b/vlib/v3/transform/scoped_merge_notd_v3_no_parallel_test.v
@@ -1,0 +1,41 @@
+module transform
+
+import v3.flat
+import v3.types
+
+fn test_helper_merge_releases_bookkeeping_and_preserves_published_text() {
+	mut a := flat.FlatAst.new()
+	mut tc := types.TypeChecker.new(&a)
+	tc.begin_sparse_transform_node_caches(0)
+	mut master := new_transformer(mut a, &tc, map[string]bool{})
+	master.retain_worker_results = true
+	master.used_fns_log_active = true
+	mut helper := master.fork_worker(&a, tc.fork_for_parallel_transform(&a))
+	helper.merge_scratch_scope = transform_worker_scope_begin(true)
+	scope := helper.merge_scratch_scope
+	helper.used_fns['main.generated'.clone()] = true
+	helper.sum_eq_types['main.Sum'.clone()] = SumEqRequest{
+		sum_name: 'main.Sum'.clone()
+		module: 'main'.clone()
+		file: 'main.v'.clone()
+		helper_module: 'main'.clone()
+	}
+	text := helper.promote_scoped_result_text('main.resolved'.clone())
+	assert !transform_scope_owns(scope, text.str)
+	helper.tc.fork_overlay.resolved_call_names[10] = text
+	helper.generic_call_spec_cache[12] = GenericCallSpec{
+		decl_key: 'main.generic'.clone()
+		args: ['[]int'.clone()]
+	}
+	transform_worker_scope_leave(scope)
+	master.merge_worker_used_fns(helper)
+	assert !transform_scope_owns(scope, master.used_fns_log[0].str)
+	assert !transform_scope_owns(scope, master.sum_eq_types['main.Sum'].sum_name.str)
+	master.merge_worker(helper, []FnWorkItem{}, 0, 0, false)
+	assert helper.merge_scratch_scope == unsafe { nil }
+	assert master.used_fns_log == ['main.generated']
+	assert master.sum_eq_types['main.Sum'].file == 'main.v'
+	assert tc.sparse_resolved_call_names[10] == 'main.resolved'
+	assert master.generic_call_spec_cache[12].decl_key == 'main.generic'
+	assert master.generic_call_spec_cache[12].args == ['[]int']
+}

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -260,6 +260,7 @@ mut:
 	interface_type_cache          &ContextLookupCache = unsafe { nil }
 	enum_expected_cache           &LookupCache = unsafe { nil }
 	type_alias_name_cache         &ContextBoolLookupCache = unsafe { nil }
+	raw_return_alias_cache        &ContextBoolLookupCache = unsafe { nil }
 	interface_box_param_cache     &BoolLookupCache = unsafe { nil }
 	alias_receiver_method_cache   &LookupCache = unsafe { nil }
 	receiver_method_cache         &ReceiverMethodCache = unsafe { nil }
@@ -1793,6 +1794,7 @@ fn (mut t Transformer) prepare() {
 	t.type_alias_name_cache = &ContextBoolLookupCache{
 		entries: map[string]i8{}
 	}
+	t.raw_return_alias_cache = &ContextBoolLookupCache{}
 	t.prepare_interface_impl_indexes()
 	t.ierror_none_type_id = t.interface_impl_type_id('IError', 'None__') or { 0 }
 }
@@ -3803,6 +3805,7 @@ fn (t &Transformer) fork_worker_config(ast &flat.FlatAst, wtc &types.TypeChecker
 	w.type_alias_name_cache = &ContextBoolLookupCache{
 		entries: map[string]i8{}
 	}
+	w.raw_return_alias_cache = &ContextBoolLookupCache{}
 	w.alias_receiver_method_cache = &LookupCache{
 		entries: map[string]string{}
 		misses: map[string]bool{}
@@ -3942,6 +3945,7 @@ fn (t &Transformer) fork_scan_worker(wtc &types.TypeChecker) &Transformer {
 	w.type_alias_name_cache = &ContextBoolLookupCache{
 		entries: map[string]i8{}
 	}
+	w.raw_return_alias_cache = &ContextBoolLookupCache{}
 	w.alias_receiver_method_cache = &LookupCache{
 		entries: map[string]string{}
 		misses: map[string]bool{}
@@ -23107,7 +23111,29 @@ fn (t &Transformer) raw_return_type_for_fn_name(name string, node flat.Node) ?st
 }
 
 fn (t &Transformer) raw_return_type_contains_alias(typ string) bool {
-	clean := typ.trim_space()
+	// Self-host lowering keeps alias declarations fixed. Repeated return types
+	// can reuse the recursive verdict within one module and worker batch.
+	if !t.building_v || !t.skip_generics || isnil(t.raw_return_alias_cache) {
+		return t.raw_return_type_contains_alias_uncached(typ)
+	}
+	mut cache := t.raw_return_alias_cache
+	if !same_transform_text(cache.module, t.cur_module) {
+		cache.module = t.cur_module
+		cache.entries.clear()
+		cache.last_name = ''
+		cache.last_value = 0
+	}
+	cached := cache.get(typ)
+	if cached != 0 {
+		return cached > 0
+	}
+	result := t.raw_return_type_contains_alias_uncached(typ)
+	cache.put(typ, if result { i8(1) } else { i8(-1) })
+	return result
+}
+
+fn (t &Transformer) raw_return_type_contains_alias_uncached(typ string) bool {
+	clean := trimmed_transform_text(typ)
 	if clean.len == 0 {
 		return false
 	}

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -132,8 +132,9 @@ struct LocalClosureDeclCandidate {
 	name      string
 }
 
+// Rewrite logs use the same compact index width as the AST they address.
 struct InplaceChildRewrite {
-	slot  int
+	slot  i32
 	child flat.NodeId
 }
 
@@ -504,7 +505,7 @@ mut:
 	worker_scope                voidptr
 	scoped_base_nodes           int = -1
 	scoped_owned_base_nodes     map[int]bool
-	scoped_owned_base_log       []int
+	scoped_owned_base_log       []flat.NodeId
 	scoped_base_log_active      bool
 	scoped_promoted_texts       map[string]string
 	retain_worker_results       bool
@@ -1134,8 +1135,7 @@ fn transform_after_prepare(mut t Transformer, mut a flat.FlatAst, _used_fns map[
 	t.apply_ignored_comptime_for_nodes()
 	t.retain_current_worker_scope_all()
 	t.timing_profile('  [ttime] sum_eq+tail        ${f64(impl_sw.elapsed().microseconds()) / 1000.0:7.2f} ms')
-	mut owned_base_nodes := t.scoped_owned_base_nodes.keys()
-	owned_base_nodes << t.scoped_owned_base_log
+	owned_base_nodes := t.scoped_owned_base_node_ids()
 	// The per-item resolve memo was allocated inside this stage's disposable
 	// arena; drop the master checker's pointer before the driver releases it.
 	if !isnil(t.tc) {
@@ -1145,13 +1145,24 @@ fn transform_after_prepare(mut t Transformer, mut a flat.FlatAst, _used_fns map[
 	return t.used_fns, was_parallel, t.monomorph_errors, owned_base_nodes, t.retained_worker_regions
 }
 
+// Widen compact rewrite ids only when publishing the transform result.
+fn (t &Transformer) scoped_owned_base_node_ids() []int {
+	mut nodes := []int{cap: t.scoped_owned_base_nodes.len + t.scoped_owned_base_log.len}
+	for idx, _ in t.scoped_owned_base_nodes {
+		nodes << idx
+	}
+	for idx in t.scoped_owned_base_log {
+		nodes << int(idx)
+	}
+	return nodes
+}
+
 fn (mut t Transformer) retain_current_worker_scope_all() {
 	if !t.retain_worker_results || t.worker_scope == unsafe { nil } {
 		return
 	}
 	if !t.retained_worker_regions.any(it.scope == t.worker_scope) {
-		mut base_nodes := t.scoped_owned_base_nodes.keys()
-		base_nodes << t.scoped_owned_base_log
+		base_nodes := t.scoped_owned_base_node_ids()
 		t.retained_worker_regions << ScopedTransformRegion{
 			scope: t.worker_scope
 			new_start: 0
@@ -2091,7 +2102,7 @@ fn (mut t Transformer) record_inplace_child_rewrite(slot int, child flat.NodeId)
 	// append block. The master chunk already appends at the final offset.
 	if !t.defer_oor_writes && slot >= 0 && slot < t.shared_base_children {
 		t.inplace_child_log << InplaceChildRewrite{
-			slot: slot
+			slot: i32(slot)
 			child: child
 		}
 	}
@@ -2303,7 +2314,7 @@ fn (mut t Transformer) set_node_generic_params(idx int, gparams []string) {
 fn (mut t Transformer) mark_scoped_owned_base_node(idx int) {
 	if t.scope_parallel_workers && idx >= 0 && idx < t.scoped_base_nodes {
 		if t.scoped_base_log_active {
-			t.scoped_owned_base_log << idx
+			t.scoped_owned_base_log << flat.NodeId(idx)
 		} else {
 			t.scoped_owned_base_nodes[idx] = true
 		}
@@ -3886,7 +3897,7 @@ fn (t &Transformer) fork_worker_config(ast &flat.FlatAst, wtc &types.TypeChecker
 		t.scoped_base_nodes
 	}
 	w.scoped_owned_base_nodes = map[int]bool{}
-	w.scoped_owned_base_log = []int{}
+	w.scoped_owned_base_log = []flat.NodeId{}
 	w.scoped_base_log_active = false
 	w.scoped_promoted_texts = map[string]string{}
 	// Workers do not record transformed fns (that would write the master's
@@ -4643,7 +4654,7 @@ fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nod
 	}
 	if t.scope_parallel_workers && t.retain_worker_results {
 		for idx in w.scoped_owned_base_nodes.keys() {
-			t.scoped_owned_base_log << idx
+			t.scoped_owned_base_log << flat.NodeId(idx)
 		}
 		t.scoped_owned_base_log << w.scoped_owned_base_log
 	}
@@ -4653,7 +4664,7 @@ fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nod
 			t.clone_scoped_worker_node(idx, w.worker_scope)
 		}
 		for idx in w.scoped_owned_base_log {
-			t.clone_scoped_worker_node(idx, w.worker_scope)
+			t.clone_scoped_worker_node(int(idx), w.worker_scope)
 		}
 	}
 	// Replay the call/fn-value resolutions the worker recorded for its
@@ -4763,11 +4774,11 @@ fn (mut t Transformer) set_resolved_call_entry(idx int, name string) {
 		unsafe {
 			t.tc.resolved_call_names.grow_len(amount)
 			t.tc.resolved_call_set.grow_len(amount)
-			vmemset(&t.tc.resolved_call_names[start], 0, isize(amount) * isize(sizeof(string)))
+			vmemset(&t.tc.resolved_call_names[start], 0, isize(amount) * isize(sizeof(&types.CachedName)))
 			vmemset(&t.tc.resolved_call_set[set_start], 0, isize(amount))
 		}
 	}
-	t.tc.resolved_call_names[idx] = t.tc.canonical_symbol(name)
+	t.tc.resolved_call_names[idx] = types.cached_name(t.tc.canonical_symbol(name))
 	t.tc.resolved_call_set[idx] = true
 }
 
@@ -4799,11 +4810,11 @@ fn (mut t Transformer) set_resolved_fn_value_entry(idx int, name string) {
 		unsafe {
 			t.tc.resolved_fn_value_names.grow_len(amount)
 			t.tc.resolved_fn_value_set.grow_len(amount)
-			vmemset(&t.tc.resolved_fn_value_names[start], 0, isize(amount) * isize(sizeof(string)))
+			vmemset(&t.tc.resolved_fn_value_names[start], 0, isize(amount) * isize(sizeof(&types.CachedName)))
 			vmemset(&t.tc.resolved_fn_value_set[set_start], 0, isize(amount))
 		}
 	}
-	t.tc.resolved_fn_value_names[idx] = t.tc.canonical_symbol(name)
+	t.tc.resolved_fn_value_names[idx] = types.cached_name(t.tc.canonical_symbol(name))
 	t.tc.resolved_fn_value_set[idx] = true
 }
 
@@ -4832,7 +4843,7 @@ fn (mut t Transformer) clear_typechecker_node_cache_range(start int, end int) {
 			vmemset(&t.tc.resolved_call_set[start], 0, call_end - start)
 		}
 		for k in start .. call_end {
-			t.tc.resolved_call_names[k] = ''
+			t.tc.resolved_call_names[k] = unsafe { nil }
 		}
 	}
 	fn_value_end := if end < t.tc.resolved_fn_value_set.len {
@@ -4845,7 +4856,7 @@ fn (mut t Transformer) clear_typechecker_node_cache_range(start int, end int) {
 			vmemset(&t.tc.resolved_fn_value_set[start], 0, fn_value_end - start)
 		}
 		for k in start .. fn_value_end {
-			t.tc.resolved_fn_value_names[k] = ''
+			t.tc.resolved_fn_value_names[k] = unsafe { nil }
 		}
 	}
 	expr_end := if end < t.tc.expr_type_set.len { end } else { t.tc.expr_type_set.len }
@@ -4884,11 +4895,11 @@ fn (mut t Transformer) clear_typechecker_node_cache(idx int) {
 		return
 	}
 	if idx < t.tc.resolved_call_set.len {
-		t.tc.resolved_call_names[idx] = ''
+		t.tc.resolved_call_names[idx] = unsafe { nil }
 		t.tc.resolved_call_set[idx] = false
 	}
 	if idx < t.tc.resolved_fn_value_set.len {
-		t.tc.resolved_fn_value_names[idx] = ''
+		t.tc.resolved_fn_value_names[idx] = unsafe { nil }
 		t.tc.resolved_fn_value_set[idx] = false
 	}
 	if idx < t.tc.expr_type_set.len {

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -503,18 +503,20 @@ mut:
 	preserve_inplace_expr_types bool
 	inplace_child_log           []InplaceChildRewrite
 	worker_scope                voidptr
-	scoped_base_nodes           int = -1
-	scoped_owned_base_nodes     map[int]bool
-	scoped_owned_base_log       []flat.NodeId
-	scoped_base_log_active      bool
-	scoped_promoted_texts       map[string]string
-	retain_worker_results       bool
-	retained_worker_regions     []ScopedTransformRegion
-	stage_scope                 voidptr
-	scoped_monomorphize         bool
-	monomorph_worker_scopes     []voidptr
-	signature_maps_shared       bool
-	signature_maps_changed      bool
+	// Helper merge tables are disposable; published AST text uses their parent arena.
+	merge_scratch_scope     voidptr
+	scoped_base_nodes       int = -1
+	scoped_owned_base_nodes map[int]bool
+	scoped_owned_base_log   []flat.NodeId
+	scoped_base_log_active  bool
+	scoped_promoted_texts   map[string]string
+	retain_worker_results   bool
+	retained_worker_regions []ScopedTransformRegion
+	stage_scope             voidptr
+	scoped_monomorphize     bool
+	monomorph_worker_scopes []voidptr
+	signature_maps_shared   bool
+	signature_maps_changed  bool
 }
 
 // AliasCache memoizes normalize_type_alias results. It lives on the heap so the
@@ -1142,7 +1144,33 @@ fn transform_after_prepare(mut t Transformer, mut a flat.FlatAst, _used_fns map[
 		t.tc.reset_body_resolve_memo()
 	}
 	t.used_fns_log_active = used_log_was_active
+	t.release_finished_scratch()
 	return t.used_fns, was_parallel, t.monomorph_errors, owned_base_nodes, t.retained_worker_regions
+}
+
+fn (mut t Transformer) release_finished_scratch() {
+	$if prealloc {
+		if !t.building_v || !t.skip_generics || t.stage_scope == unsafe { nil } {
+			return
+		}
+		// The transformer has finished, but its arena still backs AST text.
+		// Drop only private container storage; string and node payloads survive.
+		unsafe {
+			t.node_module_map_cache.free()
+			t.node_file_map_cache.free()
+			t.source_parent_ids.free()
+			t.fn_scan_costs.free()
+			t.fn_escape_scan_flags.free()
+			t.scoped_owned_base_log.free()
+			t.inplace_child_log.free()
+			t.transformed_fns.free()
+			t.scoped_promoted_texts.free()
+			t.receiver_method_suffix_index.free()
+			t.structs.free()
+			t.fn_ret_types.free()
+			t.call_param_types_decl_index.free()
+		}
+	}
 }
 
 // Widen compact rewrite ids only when publishing the transform result.
@@ -4183,16 +4211,24 @@ fn (t &Transformer) fork_program_view(ast &flat.FlatAst, wtc &types.TypeChecker,
 fn (mut t Transformer) merge_worker_used_fns(w &Transformer) {
 	t.merge_worker_signatures(w)
 	t.merge_worker_capture_contexts(w)
-	scoped := w.worker_scope != unsafe { nil }
+	scoped := w.worker_scope != unsafe { nil } || w.merge_scratch_scope != unsafe { nil }
 	for name, used in w.used_fns {
 		if used {
-			owned_name := if scoped && !t.retain_worker_results { name.clone() } else { name }
+			owned_name := if scoped && (!t.retain_worker_results || w.merge_scratch_scope != unsafe { nil }) {
+				name.clone()
+			} else {
+				name
+			}
 			t.mark_used_fn_key(owned_name)
 		}
 	}
 	for name, used in w.used_struct_operator_fns {
 		if used && name !in t.used_struct_operator_fns {
-			owned_name := if scoped && !t.retain_worker_results { name.clone() } else { name }
+			owned_name := if scoped && (!t.retain_worker_results || w.merge_scratch_scope != unsafe { nil }) {
+				name.clone()
+			} else {
+				name
+			}
 			t.used_struct_operator_fns[owned_name] = true
 		}
 	}
@@ -4706,12 +4742,16 @@ fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nod
 			continue
 		}
 		t.generic_call_spec_cache[shifted] = GenericCallSpec{
-			decl_key: if w.worker_scope != unsafe { nil } {
+			decl_key: if w.worker_scope != unsafe { nil } || w.merge_scratch_scope != unsafe { nil } {
 				spec.decl_key.clone()
 			} else {
 				spec.decl_key
 			}
-			args: spec.args.clone()
+			args: if w.worker_scope != unsafe { nil } || w.merge_scratch_scope != unsafe { nil } {
+				spec.args.map(it.clone())
+			} else {
+				spec.args.clone()
+			}
 		}
 	}
 	for idx, missed in w.generic_call_spec_misses {
@@ -4728,7 +4768,11 @@ fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nod
 			continue
 		}
 		shifted := idx + int(node_shift)
-		owned_typ := if w.worker_scope != unsafe { nil } { typ.clone() } else { typ }
+		owned_typ := if w.worker_scope != unsafe { nil } || w.merge_scratch_scope != unsafe { nil } {
+			typ.clone()
+		} else {
+			typ
+		}
 		t.record_refined_node_type(shifted, owned_typ)
 	}
 	if w.ignored_comptime_for_nodes.len > 0 {
@@ -4757,6 +4801,12 @@ fn (mut t Transformer) merge_worker(w &Transformer, items []FnWorkItem, base_nod
 				t.ignored_comptime_for_nodes[shifted] = true
 			}
 		}
+	}
+	if w.merge_scratch_scope != unsafe { nil } {
+		// Every worker table and rewrite log has been consumed. Node payloads
+		// were published outside this arena while the helper was running.
+		transform_worker_scope_free(w.merge_scratch_scope)
+		unsafe { w.merge_scratch_scope = nil }
 	}
 }
 

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -52,6 +52,7 @@ const non_aliasing_allocation_call_marker = '__v3_non_aliasing_allocation_call'
 const source_deref_marker = '__v3_source_deref'
 const source_mut_pointer_deref_marker = '__v3_source_mut_pointer_deref'
 const stack_value_decl_marker = '__v3_stack_value_decl'
+const zeroed_stack_value_decl_marker = '__v3_zeroed_stack_value_decl'
 // Small late-reachability sets are cheaper to lower directly than through a
 // sequence of disposable scoped-worker forks. Larger sets keep bounded scratch.
 const direct_late_transform_max_names = 64
@@ -5617,10 +5618,7 @@ fn (mut t Transformer) transform_const_string_interp(_id flat.NodeId, node flat.
 		child_id := t.a.child(&node, i)
 		parts << t.transform_string_interp_part(child_id)
 	}
-	mut expr := parts[0]
-	for i in 1 .. parts.len {
-		expr = t.make_call_typed('string__plus', [expr, parts[i]], 'string')
-	}
+	expr := t.make_string_join(parts, node)
 	mut stmts := []flat.NodeId{}
 	t.drain_pending(mut stmts)
 	t.pending_stmts = outer_pending
@@ -14222,6 +14220,7 @@ fn (mut t Transformer) transform_decl_assign_stmt(id flat.NodeId, node flat.Node
 		// regardless of whether its address is later taken (`@[heap]` is an unconditional
 		// promise, not an escape-analysis trigger).
 		if src.kind == .ident && node.value != stack_value_decl_marker
+			&& node.value != zeroed_stack_value_decl_marker
 			&& src.value !in t.heaped_amp_locals && t.heap_attr_struct_type(inferred_typ) {
 			return t.heap_escaping_source_decl(node, src.value, inferred_typ)
 		}
@@ -18487,6 +18486,9 @@ fn (mut t Transformer) lower_owned_array_index_move(source_id flat.NodeId, index
 
 // transform_string_interp transforms transform string interp data for transform.
 fn (mut t Transformer) transform_string_interp(id flat.NodeId, node flat.Node) flat.NodeId {
+	if node.value == '__v3_string_join' {
+		return id
+	}
 	if node.children_count == 0 {
 		return t.make_string_literal('')
 	}
@@ -18545,12 +18547,33 @@ fn (mut t Transformer) transform_string_interp(id flat.NodeId, node flat.Node) f
 		t.pending_stmts << st
 	}
 	parts := if hoisting { temps } else { inline_parts }
-	mut result := if parts.len == 0 { t.make_string_literal('') } else { parts[0] }
-	for i in 1 .. parts.len {
-		result = t.string_plus(result, parts[i])
+	return t.make_string_join(parts, node)
+}
+
+// Keep converted operands together: a concatenation chain adds two AST nodes
+// per pair and repeatedly copies each growing prefix at runtime.
+fn (mut t Transformer) make_string_join(parts []flat.NodeId, source flat.Node) flat.NodeId {
+	if parts.len == 0 {
+		return t.make_string_literal('')
 	}
-	t.set_node_typ(int(result), 'string')
-	return result
+	if parts.len == 1 {
+		t.set_node_typ(int(parts[0]), 'string')
+		return parts[0]
+	}
+	if parts.len == 2 {
+		return t.string_plus(parts[0], parts[1])
+	}
+	t.mark_used_fn_key('string_plus_many')
+	start := t.a.children.len
+	t.a.children << parts
+	return t.a.add_node(flat.Node{
+		kind: .string_interp
+		value: '__v3_string_join'
+		typ: 'string'
+		pos: source.pos
+		children_start: start
+		children_count: parts.len
+	})
 }
 
 fn (t &Transformer) string_interp_has_unresolved_generic_part(node flat.Node) bool {

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -27,7 +27,7 @@ const selfhost_transform_clone_budget_bytes = u64(2_600_000_000)
 const max_shared_transform_jobs = 8
 // Compiler builds use bounded batches and can fill more cores without cloning
 // the base AST. Ordinary import graphs retain the smaller scratch budget.
-const max_shared_selfhost_transform_jobs = 12
+const max_shared_selfhost_transform_jobs = 18
 // One chunk per lane bounds the number of private worker views kept until merge.
 const shared_transform_chunks_per_job = 1
 // Normal function lowering needs part of the shared append pool too. Limit

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -737,16 +737,10 @@ $if !windows {
 		mut tc := unsafe { &types.TypeChecker(a.tc) }
 		for idx in a.start .. a.end {
 			if idx < tc.resolved_call_set.len && tc.resolved_call_set[idx] {
-				name := tc.resolved_call_names[idx]
-				if name.len > 0 && transform_scope_owns(a.scope, name.str) {
-					tc.resolved_call_names[idx] = name.clone()
-				}
+				tc.resolved_call_names[idx] = types.promote_cached_name(tc.resolved_call_names[idx], a.scope)
 			}
 			if idx < tc.resolved_fn_value_set.len && tc.resolved_fn_value_set[idx] {
-				name := tc.resolved_fn_value_names[idx]
-				if name.len > 0 && transform_scope_owns(a.scope, name.str) {
-					tc.resolved_fn_value_names[idx] = name.clone()
-				}
+				tc.resolved_fn_value_names[idx] = types.promote_cached_name(tc.resolved_fn_value_names[idx], a.scope)
 			}
 			if idx >= a.generated_start && idx < tc.expr_type_set.len && tc.expr_type_set[idx]
 				&& idx < tc.expr_type_values.len {
@@ -1936,7 +1930,7 @@ fn (mut t Transformer) absorb_scoped_batch(batch &Transformer, scope voidptr, ne
 			t.promote_scoped_node_to_current(idx, scope)
 		}
 		for idx in batch.scoped_owned_base_log {
-			t.promote_scoped_node_to_current(idx, scope)
+			t.promote_scoped_node_to_current(int(idx), scope)
 		}
 	} else {
 		// Generic lowering can rewrite nodes reached indirectly through late calls.
@@ -1946,7 +1940,7 @@ fn (mut t Transformer) absorb_scoped_batch(batch &Transformer, scope voidptr, ne
 		}
 	}
 	for idx in batch.scoped_owned_base_nodes.keys() {
-		t.scoped_owned_base_log << idx
+		t.scoped_owned_base_log << flat.NodeId(idx)
 	}
 	t.scoped_owned_base_log << batch.scoped_owned_base_log
 	t.inplace_child_log << batch.inplace_child_log
@@ -2631,8 +2625,7 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 			}
 		}
 		if t.retain_worker_results && t.worker_scope != unsafe { nil } {
-			mut master_base_nodes := t.scoped_owned_base_nodes.keys()
-			master_base_nodes << t.scoped_owned_base_log
+			mut master_base_nodes := t.scoped_owned_base_node_ids()
 			for write in t.deferred_base_writes {
 				master_base_nodes << write.idx
 			}
@@ -2677,8 +2670,7 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 				t.clone_deferred_worker_writes_from(deferred_start)
 				transform_worker_scope_free(ww.worker_scope)
 			} else if ww.worker_scope != unsafe { nil } {
-				mut worker_base_nodes := ww.scoped_owned_base_nodes.keys()
-				worker_base_nodes << ww.scoped_owned_base_log
+				mut worker_base_nodes := ww.scoped_owned_base_node_ids()
 				for item in chunks[ci + 1] {
 					worker_base_nodes << item.fn_idx
 				}

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -1838,6 +1838,7 @@ fn (mut t Transformer) promote_scoped_node_to_current(idx int, scope voidptr) {
 	if !needs_owned_params {
 		return
 	}
+	publication_state := transform_stage_scope_suspend(t.merge_scratch_scope)
 	mut params := []string{cap: old_params.len}
 	for param in old_params {
 		if param.len > 0 && transform_scope_owns(scope, param.str) {
@@ -1847,6 +1848,7 @@ fn (mut t Transformer) promote_scoped_node_to_current(idx int, scope voidptr) {
 		}
 	}
 	node.set_generic_params(params)
+	transform_stage_scope_resume(t.merge_scratch_scope, publication_state)
 }
 
 fn (mut t Transformer) promote_scoped_result_text(value string) string {
@@ -1879,7 +1881,9 @@ fn (mut t Transformer) promote_scoped_result_text(value string) string {
 	} else if id := t.a.text_ids[value] {
 		canonical = t.a.text_values[int(id) - 1]
 	} else {
+		publication_state := transform_stage_scope_suspend(t.merge_scratch_scope)
 		canonical = value.clone()
+		transform_stage_scope_resume(t.merge_scratch_scope, publication_state)
 		t.scoped_promoted_texts[canonical] = canonical
 	}
 	if use_cache {
@@ -1986,7 +1990,9 @@ fn (mut t Transformer) absorb_scoped_batch(batch &Transformer, scope voidptr, ne
 	for write in batch.deferred_base_writes {
 		t.deferred_base_writes << write
 	}
+	publication_state := transform_stage_scope_suspend(t.merge_scratch_scope)
 	t.clone_deferred_worker_writes_from(deferred_start)
+	transform_stage_scope_resume(t.merge_scratch_scope, publication_state)
 	if !isnil(batch.tc.fork_overlay) {
 		for idx, name in batch.tc.fork_overlay.resolved_call_names {
 			owned_name := t.promote_scoped_result_text(name)
@@ -2020,6 +2026,11 @@ fn (mut t Transformer) absorb_scoped_batch(batch &Transformer, scope voidptr, ne
 // batch prevents caches from retaining pointers into the released arena.
 fn (mut t Transformer) transform_scoped_helper_batches(items []FnWorkItem, max_batches int) {
 	t.retain_current_worker_scope_all()
+	// Only helper accumulators use this arena. The master continues using the
+	// stage arena because its semantic results survive through code generation.
+	if t.building_v && t.skip_generics && !isnil(t.tc.fork_overlay) {
+		t.merge_scratch_scope = transform_worker_scope_begin(true)
+	}
 	// NOTE (2026-08): a worker-persistent per-file normalize-result base shared
 	// across batches was implemented and measured an exact wash — items are
 	// sorted by fn_idx, so each file's work is contiguous within one worker and
@@ -2061,9 +2072,13 @@ fn (mut t Transformer) transform_scoped_helper_batches(items []FnWorkItem, max_b
 		batch.scoped_base_nodes = new_node_start
 		batch.transform_pure_items_serial(items[start..end])
 		transform_worker_scope_leave(scratch_scope)
+		publication_state := transform_stage_scope_suspend(t.merge_scratch_scope)
 		t.a.promote_transform_texts_from(text_start, scratch_scope)
+		transform_stage_scope_resume(t.merge_scratch_scope, publication_state)
 		t.absorb_scoped_batch(batch, scratch_scope, new_node_start)
+		storage_state := transform_stage_scope_suspend(t.merge_scratch_scope)
 		t.promote_scoped_ast_storage(scratch_scope)
+		transform_stage_scope_resume(t.merge_scratch_scope, storage_state)
 		for item in items[start..end] {
 			if item.fn_idx >= 0 && item.fn_idx < t.transformed_fns.len {
 				t.transformed_fns[item.fn_idx] = true
@@ -2076,10 +2091,8 @@ fn (mut t Transformer) transform_scoped_helper_batches(items []FnWorkItem, max_b
 		start = end
 		batch_idx++
 	}
-	// Promotions and merged side tables were allocated in the helper thread's
-	// persistent parent arena after each scratch scope was left. Nothing from a
-	// completed helper needs to keep a result arena alive until the end of the
-	// whole transform phase.
+	// AST payloads outlive the helper. Merge bookkeeping is released after join.
+	transform_worker_scope_leave(t.merge_scratch_scope)
 	t.worker_scope = unsafe { nil }
 }
 

--- a/vlib/v3/types/c_type_cache_identity_test.v
+++ b/vlib/v3/types/c_type_cache_identity_test.v
@@ -55,6 +55,27 @@ fn test_c_type_cache_reuses_entry_for_equal_types() {
 	assert tc.c_type(first) == tc.c_type(again)
 }
 
+fn test_c_type_cache_preserves_types_after_recent_slot_eviction() {
+	mut a := flat.FlatAst.new()
+	mut tc := TypeChecker.new(&a)
+	mut expected := []string{}
+	for size in 1 .. 2050 {
+		expected << tc.c_type(Type(ArrayFixed{
+			elem_type: Type(int_)
+			len: size
+			len_expr: 'size'
+		}))
+	}
+	for i, name in expected {
+		assert name.ends_with('_${i + 1}')
+		assert tc.c_type(Type(ArrayFixed{
+			elem_type: Type(int_)
+			len: i + 1
+			len_expr: 'size'
+		})) == name
+	}
+}
+
 fn test_private_c_struct_names_keep_the_struct_tag() {
 	mut a := flat.FlatAst.new()
 	mut tc := TypeChecker.new(&a)

--- a/vlib/v3/types/cached_name.v
+++ b/vlib/v3/types/cached_name.v
@@ -1,0 +1,28 @@
+module types
+
+// CachedName keeps a resolved name behind one pointer in the dense node caches.
+// Most AST nodes have no resolved name, so empty slots need no string header.
+@[heap]
+pub struct CachedName {
+pub:
+	value string
+}
+
+// cached_name boxes an immutable name in the current allocation arena.
+@[inline]
+pub fn cached_name(value string) &CachedName {
+	return &CachedName{ value: value }
+}
+
+// promote_cached_name moves a cached header and its bytes out of a scope that
+// has been left but not yet freed. Either allocation may belong to that scope.
+pub fn promote_cached_name(name &CachedName, scope voidptr) &CachedName {
+	$if prealloc {
+		if !isnil(name) && unsafe {
+			prealloc_scope_owns(scope, name) || prealloc_scope_owns(scope, name.value.str)
+		} {
+			return cached_name(name.value.clone())
+		}
+	}
+	return name
+}

--- a/vlib/v3/types/cached_name_test.v
+++ b/vlib/v3/types/cached_name_test.v
@@ -1,0 +1,38 @@
+module types
+
+fn test_cached_name_promotes_header_with_parent_owned_bytes() {
+	$if prealloc {
+		value := 'parent.name'.clone()
+		scope := unsafe { prealloc_scope_begin() }
+		name := cached_name(value)
+		assert unsafe { prealloc_scope_owns(scope, name) }
+		assert !unsafe { prealloc_scope_owns(scope, name.value.str) }
+		unsafe { prealloc_scope_leave(scope) }
+		promoted := promote_cached_name(name, scope)
+		assert !unsafe { prealloc_scope_owns(scope, promoted) }
+		assert !unsafe { prealloc_scope_owns(scope, promoted.value.str) }
+		unsafe { prealloc_scope_free_after(scope) }
+		assert promoted.value == 'parent.name'
+	}
+}
+
+fn test_cached_name_promotes_scoped_bytes_and_preserves_parent_names() {
+	$if prealloc {
+		parent := cached_name('parent.name'.clone())
+		scope := unsafe { prealloc_scope_begin() }
+		value := 'worker.name'.clone()
+		state := unsafe { prealloc_scope_suspend(scope) }
+		name := cached_name(value)
+		unsafe { prealloc_scope_resume(scope, state) }
+		assert !unsafe { prealloc_scope_owns(scope, name) }
+		assert unsafe { prealloc_scope_owns(scope, name.value.str) }
+		unsafe { prealloc_scope_leave(scope) }
+		promoted := promote_cached_name(name, scope)
+		assert promote_cached_name(parent, scope) == parent
+		assert !unsafe { prealloc_scope_owns(scope, promoted) }
+		assert !unsafe { prealloc_scope_owns(scope, promoted.value.str) }
+		unsafe { prealloc_scope_free_after(scope) }
+		assert promoted.value == 'worker.name'
+		assert parent.value == 'parent.name'
+	}
+}

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -344,6 +344,10 @@ fn push_type_name_candidate(mut candidates []string, name string) {
 	}
 }
 
+// Recent probes are private to each short-lived checker view; map caches
+// retain entries evicted by a collision in these bounded front caches.
+const type_cache_recent_slots = 512
+
 // TypeCache represents type cache data used by types.
 struct TypeCache {
 mut:
@@ -375,11 +379,11 @@ mut:
 	// Canonical AST type texts repeat by pointer within one checker view. Cache
 	// their parsed values directly so the common hit avoids the generic map
 	// lookup after the existing context check.
-	parse_value_recent_ptrs    [2048]usize
-	parse_value_recent_lens    [2048]int
-	parse_value_recent_context [2048]u64
-	parse_value_recent_values  [2048]Type
-	parse_value_recent_set     [2048]bool
+	parse_value_recent_ptrs    [type_cache_recent_slots]usize
+	parse_value_recent_lens    [type_cache_recent_slots]int
+	parse_value_recent_context [type_cache_recent_slots]u64
+	parse_value_recent_values  [type_cache_recent_slots]Type
+	parse_value_recent_set     [type_cache_recent_slots]bool
 	// Bounded canonical text-id cache. Workers touch only a fraction of the
 	// 65536 possible ids; retain the exact id to distinguish slot collisions.
 	parse_text_id_context []u64
@@ -397,23 +401,23 @@ mut:
 	// (`[size]int` with different resolved `size`, or same-named aliases over
 	// different bases); raw interface words and retained Type payloads are not
 	// stable either, since sum-type payload storage can reuse an address.
-	c_recent_ids  [2048]TypeId
-	c_recent_vals [2048]string
-	c_recent_set  [2048]bool
+	c_recent_ids  [type_cache_recent_slots]TypeId
+	c_recent_vals [type_cache_recent_slots]string
+	c_recent_set  [type_cache_recent_slots]bool
 	// type_name cannot use its result as its lookup key. Semantic hashes choose a
 	// slot, and an owned Type copy verifies equality.
-	name_recent_hashes [2048]u64
-	name_recent_types  [2048]Type
-	name_recent_vals   [2048]string
-	name_recent_set    [2048]bool
+	name_recent_hashes [type_cache_recent_slots]u64
+	name_recent_types  [type_cache_recent_slots]Type
+	name_recent_vals   [type_cache_recent_slots]string
+	name_recent_set    [type_cache_recent_slots]bool
 	// Per-checker symbol probes front the compilation-wide interner. Resolved
 	// names are usually repeated as the same canonical string pointer inside a
 	// worker, so these slots avoid taking the interner mutex on every call.
-	symbol_recent_ptrs          [2048]usize
-	symbol_recent_lens          [2048]int
-	symbol_recent_ids           [2048]SymbolId
-	symbol_recent_vals          [2048]string
-	symbol_recent_set           [2048]bool
+	symbol_recent_ptrs          [type_cache_recent_slots]usize
+	symbol_recent_lens          [type_cache_recent_slots]int
+	symbol_recent_ids           [type_cache_recent_slots]SymbolId
+	symbol_recent_vals          [type_cache_recent_slots]string
+	symbol_recent_set           [type_cache_recent_slots]bool
 	struct_field_entries        map[string]Type
 	struct_field_misses         map[string]bool
 	struct_field_shared         map[string]Type // immutable declaration types, without local TypeIds
@@ -791,9 +795,9 @@ pub mut:
 	comptime_static_depth   int
 	errors                  []TypeError
 	notices                 []TypeError
-	resolved_call_names     []string // node_id -> resolved function name
+	resolved_call_names     []&CachedName // node_id -> resolved function name
 	resolved_call_set       []bool
-	resolved_fn_value_names []string // node_id -> resolved function value name
+	resolved_fn_value_names []&CachedName // node_id -> resolved function value name
 	resolved_fn_value_set   []bool
 	statement_nodes         []bool
 	// Exact call/function-value dependencies recorded while each function is
@@ -1091,9 +1095,9 @@ pub fn TypeChecker.new(a &flat.FlatAst) TypeChecker {
 		// reset_node_caches (allocating them here too paid for everything
 		// twice), and extend_node_caches grows them on demand for any checker
 		// used without a collect() call.
-		resolved_call_names: []string{}
+		resolved_call_names: []&CachedName{}
 		resolved_call_set: []bool{}
-		resolved_fn_value_names: []string{}
+		resolved_fn_value_names: []&CachedName{}
 		resolved_fn_value_set: []bool{}
 		statement_nodes: []bool{}
 		method_values_by_fn: map[int][]string{}
@@ -1704,12 +1708,12 @@ fn (mut tc TypeChecker) reset_node_caches(n int) {
 // Independent arrays can be initialized on separate persistent worker arenas.
 fn (mut tc TypeChecker) reset_node_cache_group(n int, group int) {
 	if group == 0 {
-		tc.resolved_call_names = new_zeroed_string_cache(n)
+		tc.resolved_call_names = new_zeroed_name_cache(n)
 		tc.resolved_call_set = []bool{len: n}
 		return
 	}
 	if group == 1 {
-		tc.resolved_fn_value_names = new_zeroed_string_cache(n)
+		tc.resolved_fn_value_names = new_zeroed_name_cache(n)
 		tc.resolved_fn_value_set = []bool{len: n}
 		return
 	}
@@ -1724,14 +1728,14 @@ fn (mut tc TypeChecker) reset_node_cache_group(n int, group int) {
 	tc.parallel_check_sparse = false
 }
 
-fn new_zeroed_string_cache(n int) []string {
-	mut values := []string{cap: n}
+fn new_zeroed_name_cache(n int) []&CachedName {
+	mut values := []&CachedName{cap: n}
 	if n > 0 {
 		// Cache reads are guarded by set bits. Match the zero representation
 		// used during transform growth without synthesizing per-element stores.
 		unsafe {
 			values.grow_len(n)
-			vmemset(values.data, 0, isize(n) * isize(sizeof(string)))
+			vmemset(values.data, 0, isize(n) * isize(sizeof(&CachedName)))
 		}
 	}
 	return values
@@ -2191,9 +2195,9 @@ fn (mut tc TypeChecker) extend_node_caches(n int) {
 		&& n <= tc.statement_nodes.len && n <= tc.expr_type_values.len && n <= tc.checking_nodes.len {
 		return
 	}
-	extend_string_cache(mut tc.resolved_call_names, n)
+	extend_name_cache(mut tc.resolved_call_names, n)
 	extend_bool_cache(mut tc.resolved_call_set, n)
-	extend_string_cache(mut tc.resolved_fn_value_names, n)
+	extend_name_cache(mut tc.resolved_fn_value_names, n)
 	extend_bool_cache(mut tc.resolved_fn_value_set, n)
 	extend_bool_cache(mut tc.statement_nodes, n)
 	extend_type_cache(mut tc.expr_type_values, n)
@@ -2204,9 +2208,9 @@ fn (mut tc TypeChecker) extend_node_caches(n int) {
 // reserve_transform_node_caches reserves node-indexed semantic storage before
 // a scoped transform starts, keeping the escaping slabs in the compilation arena.
 pub fn (mut tc TypeChecker) reserve_transform_node_caches(n int) {
-	reserve_string_cache(mut tc.resolved_call_names, n)
+	reserve_name_cache(mut tc.resolved_call_names, n)
 	reserve_bool_cache(mut tc.resolved_call_set, n)
-	reserve_string_cache(mut tc.resolved_fn_value_names, n)
+	reserve_name_cache(mut tc.resolved_fn_value_names, n)
 	reserve_bool_cache(mut tc.resolved_fn_value_set, n)
 	reserve_bool_cache(mut tc.statement_nodes, n)
 	reserve_type_cache(mut tc.expr_type_values, n)
@@ -2229,13 +2233,13 @@ pub fn (mut tc TypeChecker) materialize_sparse_transform_node_caches(n int, capa
 	tc.extend_node_caches(n)
 	for idx, name in tc.sparse_resolved_call_names {
 		if idx >= 0 && idx < n {
-			tc.resolved_call_names[idx] = name
+			tc.resolved_call_names[idx] = cached_name(name)
 			tc.resolved_call_set[idx] = true
 		}
 	}
 	for idx, name in tc.sparse_resolved_fn_values {
 		if idx >= 0 && idx < n {
-			tc.resolved_fn_value_names[idx] = name
+			tc.resolved_fn_value_names[idx] = cached_name(name)
 			tc.resolved_fn_value_set[idx] = true
 		}
 	}
@@ -2338,7 +2342,7 @@ pub fn (mut tc TypeChecker) promote_scoped_transform_interners(type_start int, s
 	}
 }
 
-fn reserve_string_cache(mut values []string, n int) {
+fn reserve_name_cache(mut values []&CachedName, n int) {
 	if n > values.cap {
 		unsafe { values.grow_cap(n - values.cap) }
 	}
@@ -2356,9 +2360,13 @@ fn reserve_type_cache(mut values []Type, n int) {
 	}
 }
 
-fn extend_string_cache(mut values []string, n int) {
+fn extend_name_cache(mut values []&CachedName, n int) {
 	if n > values.len {
-		values << []string{len: n - values.len}
+		start := values.len
+		unsafe {
+			values.grow_len(n - start)
+			vmemset(&values[start], 0, isize(n - start) * isize(sizeof(&CachedName)))
+		}
 	}
 }
 
@@ -7582,7 +7590,8 @@ fn (mut tc TypeChecker) annotate_call_expected_exprs(id flat.NodeId, node flat.N
 	}
 	collapsed := if field_init_args > 0 { 1 } else { 0 }
 	recv_extra := if info.has_receiver { 1 } else { 0 }
-	mut actual_count := node.children_count - 1 - info.arg_offset - field_init_args + collapsed + recv_extra
+	mut actual_count := node.children_count - 1 - info.arg_offset - field_init_args + collapsed +
+		recv_extra
 	for i in 1 + info.arg_offset .. node.children_count {
 		arg_id := tc.call_arg_value(tc.a.child(&node, i))
 		arg_type := tc.cached_expr_type(arg_id) or { tc.resolve_type(arg_id) }
@@ -8218,14 +8227,14 @@ fn (tc &TypeChecker) cached_resolved_call(id flat.NodeId) ?string {
 	if tc.parallel_check_sparse {
 		if tc.in_check_range(idx) {
 			if idx < tc.resolved_call_set.len && tc.resolved_call_set[idx] {
-				return tc.resolved_call_names[idx]
+				return tc.resolved_call_names[idx].value
 			}
 			return none
 		}
 		return tc.sparse_resolved_call_names[idx] or { none }
 	}
 	if idx >= 0 && idx < tc.resolved_call_set.len && tc.resolved_call_set[idx] {
-		return tc.resolved_call_names[idx]
+		return tc.resolved_call_names[idx].value
 	}
 	return none
 }
@@ -8406,14 +8415,14 @@ pub fn (tc &TypeChecker) resolved_fn_value_name(id flat.NodeId) ?string {
 	if tc.parallel_check_sparse {
 		if tc.in_check_range(idx) {
 			if idx < tc.resolved_fn_value_set.len && tc.resolved_fn_value_set[idx] {
-				return tc.resolved_fn_value_names[idx]
+				return tc.resolved_fn_value_names[idx].value
 			}
 			return none
 		}
 		return tc.sparse_resolved_fn_values[idx] or { none }
 	}
 	if idx >= 0 && idx < tc.resolved_fn_value_set.len && tc.resolved_fn_value_set[idx] {
-		return tc.resolved_fn_value_names[idx]
+		return tc.resolved_fn_value_names[idx].value
 	}
 	return none
 }
@@ -8429,7 +8438,7 @@ pub fn (mut tc TypeChecker) clear_resolved_fn_value(id flat.NodeId) {
 		tc.fork_overlay.resolved_fn_values.delete(idx)
 	}
 	if idx < tc.resolved_fn_value_set.len {
-		tc.resolved_fn_value_names[idx] = ''
+		tc.resolved_fn_value_names[idx] = unsafe { nil }
 		tc.resolved_fn_value_set[idx] = false
 	}
 	if tc.sparse_resolved_fn_values.len > 0 {
@@ -8479,7 +8488,7 @@ fn (tc &TypeChecker) intern_symbol(name string) (SymbolId, string) {
 	mut cache := unsafe { tc.type_cache }
 	if !isnil(cache) {
 		ptr := usize(name.str)
-		slot := int((u64(ptr) >> 4 ^ u64(name.len)) & 2047)
+		slot := int((u64(ptr) >> 4 ^ u64(name.len)) & u64(type_cache_recent_slots - 1))
 		if cache.symbol_recent_set[slot] && cache.symbol_recent_ptrs[slot] == ptr
 			&& cache.symbol_recent_lens[slot] == name.len {
 			return cache.symbol_recent_ids[slot], cache.symbol_recent_vals[slot]
@@ -8627,7 +8636,7 @@ fn (mut tc TypeChecker) remember_resolved_call(id flat.NodeId, name string) {
 	tc.record_direct_dependency(symbol_id)
 	if tc.parallel_check_sparse {
 		if tc.in_check_range(idx) && idx < tc.resolved_call_names.len {
-			tc.resolved_call_names[idx] = canonical
+			tc.resolved_call_names[idx] = cached_name(canonical)
 			tc.resolved_call_set[idx] = true
 			return
 		}
@@ -8638,7 +8647,7 @@ fn (mut tc TypeChecker) remember_resolved_call(id flat.NodeId, name string) {
 		tc.extend_node_caches(tc.a.nodes.len)
 	}
 	if idx < tc.resolved_call_names.len {
-		tc.resolved_call_names[idx] = canonical
+		tc.resolved_call_names[idx] = cached_name(canonical)
 		tc.resolved_call_set[idx] = true
 	}
 }
@@ -8653,7 +8662,7 @@ fn (mut tc TypeChecker) remember_resolved_fn_value(id flat.NodeId, name string) 
 	tc.record_direct_dependency(symbol_id)
 	if tc.parallel_check_sparse {
 		if tc.in_check_range(idx) && idx < tc.resolved_fn_value_names.len {
-			tc.resolved_fn_value_names[idx] = canonical
+			tc.resolved_fn_value_names[idx] = cached_name(canonical)
 			tc.resolved_fn_value_set[idx] = true
 			return
 		}
@@ -8664,7 +8673,7 @@ fn (mut tc TypeChecker) remember_resolved_fn_value(id flat.NodeId, name string) 
 		tc.extend_node_caches(tc.a.nodes.len)
 	}
 	if idx < tc.resolved_fn_value_names.len {
-		tc.resolved_fn_value_names[idx] = canonical
+		tc.resolved_fn_value_names[idx] = cached_name(canonical)
 		tc.resolved_fn_value_set[idx] = true
 	}
 }

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -1704,14 +1704,12 @@ fn (mut tc TypeChecker) reset_node_caches(n int) {
 // Independent arrays can be initialized on separate persistent worker arenas.
 fn (mut tc TypeChecker) reset_node_cache_group(n int, group int) {
 	if group == 0 {
-		// Only set slots are read; zeroed strings also match the representation
-		// used when transform grows these caches. Avoid a default-string fill.
-		tc.resolved_call_names = unsafe { []string{len: n} }
+		tc.resolved_call_names = new_zeroed_string_cache(n)
 		tc.resolved_call_set = []bool{len: n}
 		return
 	}
 	if group == 1 {
-		tc.resolved_fn_value_names = unsafe { []string{len: n} }
+		tc.resolved_fn_value_names = new_zeroed_string_cache(n)
 		tc.resolved_fn_value_set = []bool{len: n}
 		return
 	}
@@ -1724,6 +1722,19 @@ fn (mut tc TypeChecker) reset_node_cache_group(n int, group int) {
 	tc.lexical_smartcast_misses = []bool{len: n}
 	tc.checking_nodes = []bool{len: n}
 	tc.parallel_check_sparse = false
+}
+
+fn new_zeroed_string_cache(n int) []string {
+	mut values := []string{cap: n}
+	if n > 0 {
+		// Cache reads are guarded by set bits. Match the zero representation
+		// used during transform growth without synthesizing per-element stores.
+		unsafe {
+			values.grow_len(n)
+			vmemset(values.data, 0, isize(n) * isize(sizeof(string)))
+		}
+	}
+	return values
 }
 
 fn (mut tc TypeChecker) init_direct_parent_index(a &flat.FlatAst) {
@@ -1752,6 +1763,7 @@ struct DirectParentChunk {
 mut:
 	external_edges     []DirectParentEdge
 	preflight_node_ids []i32
+	metadata_node_ids  []i32
 	synthetic_type_ids []i32
 	has_goto_nodes     bool
 }
@@ -1769,6 +1781,9 @@ fn (mut tc TypeChecker) fill_direct_parent_edges_range(a &flat.FlatAst, start in
 	mut fn_cost := 0
 	for parent_idx in start .. end {
 		node := a.nodes[parent_idx]
+		if node.kind in [.decl_assign, .directive] {
+			chunk.metadata_node_ids << parent_idx
+		}
 		if node.kind in [.for_in_stmt, .comptime_for] {
 			chunk.preflight_node_ids << parent_idx
 		}
@@ -1860,30 +1875,36 @@ fn (tc &TypeChecker) preflight_nodes(kind flat.NodeKind) []i32 {
 
 fn (mut tc TypeChecker) collect_direct_parent_metadata(a &flat.FlatAst) {
 	for parent_idx, node in a.nodes {
-		if node.kind == .decl_assign && node.children_count >= 2 {
-			lhs := a.child_node(&node, 0)
-			if lhs.kind == .ident && tc.expr_is_strings_new_builder_call(a.child(&node, 1)) {
-				tc.strings_builder_candidates << parent_idx
-			}
-		} else if node.kind == .directive {
-			if node.value.starts_with('@attributes:') {
-				decl_id := node.value['@attributes:'.len..].int()
-				if decl_id >= 0 && decl_id < a.nodes.len {
-					tc.declaration_attributes[decl_id] = node.generic_params()
-					decl := a.nodes[decl_id]
-					if decl.kind == .module_decl {
-						if source_file := a.source_files[decl.pos.id] {
-							tc.collect_module_attributes(node, source_file.name)
-						}
+		if node.kind in [.decl_assign, .directive] {
+			tc.collect_direct_parent_node_metadata(a, parent_idx, node)
+		}
+	}
+}
+
+fn (mut tc TypeChecker) collect_direct_parent_node_metadata(a &flat.FlatAst, parent_idx int, node flat.Node) {
+	if node.kind == .decl_assign && node.children_count >= 2 {
+		lhs := a.child_node(&node, 0)
+		if lhs.kind == .ident && tc.expr_is_strings_new_builder_call(a.child(&node, 1)) {
+			tc.strings_builder_candidates << parent_idx
+		}
+	} else if node.kind == .directive {
+		if node.value.starts_with('@attributes:') {
+			decl_id := node.value['@attributes:'.len..].int()
+			if decl_id >= 0 && decl_id < a.nodes.len {
+				tc.declaration_attributes[decl_id] = node.generic_params()
+				decl := a.nodes[decl_id]
+				if decl.kind == .module_decl {
+					if source_file := a.source_files[decl.pos.id] {
+						tc.collect_module_attributes(node, source_file.name)
 					}
 				}
-			} else if node.value == 'flag' && node.pos.is_valid() {
-				if source_file := a.source_files[node.pos.id] {
-					if raw_dir := checker_flag_include_dir(node.typ) {
-						resolved := tc.resolve_insert_path(raw_dir, source_file.name)
-						if resolved !in tc.insert_include_dirs_by_file[source_file.name] {
-							tc.insert_include_dirs_by_file[source_file.name] << resolved
-						}
+			}
+		} else if node.value == 'flag' && node.pos.is_valid() {
+			if source_file := a.source_files[node.pos.id] {
+				if raw_dir := checker_flag_include_dir(node.typ) {
+					resolved := tc.resolve_insert_path(raw_dir, source_file.name)
+					if resolved !in tc.insert_include_dirs_by_file[source_file.name] {
+						tc.insert_include_dirs_by_file[source_file.name] << resolved
 					}
 				}
 			}

--- a/vlib/v3/types/checker_comptime.v
+++ b/vlib/v3/types/checker_comptime.v
@@ -6441,7 +6441,20 @@ fn (tc &TypeChecker) scan_has_spawn_expr() bool {
 	mut file_nodes := map[string]flat.NodeId{}
 	mut file_imports := map[string][]string{}
 	mut module_files := map[string][]string{}
-	for idx, node in tc.a.nodes {
+	// Parser file pairs already identify the file roots. Hand-built or rewritten
+	// trees keep the full-scan fallback when that index is incomplete.
+	mut file_ids := []i32{}
+	if file_index_usable(tc.a) {
+		file_ids = tc.a.file_node_ids.clone()
+	} else {
+		for idx, node in tc.a.nodes {
+			if node.kind == .file {
+				file_ids << idx
+			}
+		}
+	}
+	for idx in file_ids {
+		node := tc.a.nodes[idx]
 		if node.kind != .file || node.children_count == 0 || node.value.len == 0 {
 			continue
 		}

--- a/vlib/v3/types/checker_ownership_d_ownership.v
+++ b/vlib/v3/types/checker_ownership_d_ownership.v
@@ -10479,7 +10479,7 @@ fn (tc &TypeChecker) ownership_call_name_in_module(id flat.NodeId, module_name s
 	call_id := tc.ownership_unwrap_expr(id)
 	idx := int(call_id)
 	if idx >= 0 && idx < tc.resolved_call_set.len && tc.resolved_call_set[idx] {
-		return tc.resolved_call_names[idx]
+		return tc.resolved_call_names[idx].value
 	}
 	if !tc.valid_node_id(call_id) {
 		return ''
@@ -11056,7 +11056,7 @@ fn (tc &TypeChecker) ownership_call_name(id flat.NodeId) string {
 	call_id := tc.ownership_unwrap_expr(id)
 	idx := int(call_id)
 	if idx >= 0 && idx < tc.resolved_call_set.len && tc.resolved_call_set[idx] {
-		return tc.resolved_call_names[idx]
+		return tc.resolved_call_names[idx].value
 	}
 	if !tc.valid_node_id(call_id) {
 		return ''

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -11,7 +11,7 @@ const min_parallel_check_items = 256
 const max_parallel_check_jobs = 26
 // Scoped workers use bounded arena batches, so let self-host checks occupy all
 // of the worker pool's cores without retaining one large arena per core.
-const max_scoped_check_jobs = 17
+const max_scoped_check_jobs = 18
 // The historical 96-batch limit remains the low-memory fallback. Prealloc
 // self-host checks default to one twelfth as many batches below, amortizing
 // checker fork/promotion setup while keeping each worker's scratch bounded.
@@ -143,7 +143,7 @@ struct UnusedFnVarCandidate {
 struct CollectIndexPrepArgs {
 	tc    voidptr
 	a     &flat.FlatAst
-	kind  u8 // 0 = parent edges, 1 = threads condition, 2..4 = caches, 5 = metadata
+	kind  u8 // 0 = parent edges, 1 = threads condition, 2..4 = caches
 	n     int
 	start int
 	end   int
@@ -169,9 +169,6 @@ fn collect_index_prep_thread(arg voidptr) voidptr {
 			tc.prepare_threads_condition()
 			check_worker_scope_leave(scope)
 			check_worker_scope_free(scope)
-		}
-		5 {
-			tc.collect_direct_parent_metadata(a.a)
 		}
 		else {
 			tc.reset_node_cache_group(a.n, int(a.kind) - 2)
@@ -200,10 +197,15 @@ fn (mut tc TypeChecker) prepare_collect_index_parallel(a &flat.FlatAst) bool {
 		return false
 	}
 	tc.init_direct_parent_index(a)
-	mut args := []CollectIndexPrepArgs{cap: 9}
+	parent_jobs := int_min(8, a.worker_pool.size() + 1)
+	mut args := []CollectIndexPrepArgs{cap: parent_jobs + 4}
 	mut start := 0
-	for job in 0 .. 4 {
-		mut end := if job == 3 { a.nodes.len } else { a.nodes.len * (job + 1) / 4 }
+	for job in 0 .. parent_jobs {
+		mut end := if job == parent_jobs - 1 {
+			a.nodes.len
+		} else {
+			a.nodes.len * (job + 1) / parent_jobs
+		}
 		if end < start {
 			continue
 		}
@@ -219,7 +221,7 @@ fn (mut tc TypeChecker) prepare_collect_index_parallel(a &flat.FlatAst) bool {
 		args << CollectIndexPrepArgs{ tc: voidptr(tc), a: a, kind: 0, start: start, end: end }
 		start = end
 	}
-	for kind in [u8(1), 5, 2, 3, 4] {
+	for kind in [u8(1), 2, 3, 4] {
 		args << CollectIndexPrepArgs{ tc: voidptr(tc), a: a, kind: kind, n: a.nodes.len }
 	}
 	mut tasks := []workers.Task{cap: args.len}
@@ -234,6 +236,11 @@ fn (mut tc TypeChecker) prepare_collect_index_parallel(a &flat.FlatAst) bool {
 	for arg in args {
 		if arg.kind == 0 {
 			tc.merge_direct_parent_chunk(arg.parent_chunk)
+			// The parent walk already found these nodes; avoid streaming the whole
+			// AST again just to collect declaration attributes and builder bindings.
+			for idx in arg.parent_chunk.metadata_node_ids {
+				tc.collect_direct_parent_node_metadata(a, idx, a.nodes[idx])
+			}
 		}
 	}
 	tc.preflight_index_nodes_len = a.nodes.len
@@ -2836,6 +2843,35 @@ mut:
 	miss []int
 }
 
+struct CheckTypePromotionCache {
+mut:
+	w0     [512]u64
+	w1     [512]u64
+	values [512]Type
+	set    [512]bool
+}
+
+// Source payloads stay alive and immutable for the entire promotion pass. Raw
+// identities are safe within that pass; never retain this cache across arena frees.
+fn (tc &TypeChecker) cached_check_type_promotion(typ Type, mut cache CheckTypePromotionCache, promote_missing bool) ?Type {
+	w0, w1, raw_slot := type_value_words(&typ)
+	slot := raw_slot & (cache.set.len - 1)
+	if cache.set[slot] && cache.w0[slot] == w0 && cache.w1[slot] == w1 {
+		return cache.values[slot]
+	}
+	canonical := tc.probe_intern_type(typ) or {
+		if !promote_missing {
+			return none
+		}
+		tc.promote_check_type(typ)
+	}
+	cache.w0[slot] = w0
+	cache.w1[slot] = w1
+	cache.values[slot] = canonical
+	cache.set[slot] = true
+	return canonical
+}
+
 // check_clone_chunk_thread promotes one chunk's node-cache payloads out of
 // the (still alive) worker scopes: name clones land in the pool thread's
 // persistent arena, and expr types are rebound via a read-only interner probe.
@@ -2845,6 +2881,7 @@ fn check_clone_chunk_thread(arg voidptr) voidptr {
 	mut a := unsafe { &CheckCloneChunkArgs(arg) }
 	mut tc := unsafe { &TypeChecker(a.tc) }
 	items := unsafe { &[]CheckWorkItem(a.items_ptr) }
+	mut cache := CheckTypePromotionCache{}
 	for item in *items {
 		for idx in item.range_lo .. item.fn_idx + 1 {
 			if idx < tc.resolved_call_set.len && tc.resolved_call_set[idx] {
@@ -2854,7 +2891,7 @@ fn check_clone_chunk_thread(arg voidptr) voidptr {
 				tc.resolved_fn_value_names[idx] = tc.resolved_fn_value_names[idx].clone()
 			}
 			if idx < tc.expr_type_set.len && tc.expr_type_set[idx] {
-				if canonical := tc.probe_intern_type(tc.expr_type_values[idx]) {
+				if canonical := tc.cached_check_type_promotion(tc.expr_type_values[idx], mut cache, false) {
 					tc.expr_type_values[idx] = canonical
 				} else {
 					a.miss << idx
@@ -2866,8 +2903,11 @@ fn check_clone_chunk_thread(arg voidptr) voidptr {
 }
 
 fn (mut tc TypeChecker) intern_expr_type_misses(indexes []int) {
+	mut cache := CheckTypePromotionCache{}
 	for idx in indexes {
-		tc.expr_type_values[idx] = tc.promote_check_type(tc.expr_type_values[idx])
+		tc.expr_type_values[idx] = tc.cached_check_type_promotion(tc.expr_type_values[idx], mut cache, true) or {
+			tc.promote_check_type(tc.expr_type_values[idx])
+		}
 	}
 }
 
@@ -2887,6 +2927,7 @@ fn par_check_clone_enabled() bool {
 }
 
 fn (mut tc TypeChecker) clone_parallel_worker_node_caches(items []CheckWorkItem) {
+	mut cache := CheckTypePromotionCache{}
 	for item in items {
 		for idx in item.range_lo .. item.fn_idx + 1 {
 			if idx < tc.resolved_call_set.len && tc.resolved_call_set[idx] {
@@ -2896,7 +2937,9 @@ fn (mut tc TypeChecker) clone_parallel_worker_node_caches(items []CheckWorkItem)
 				tc.resolved_fn_value_names[idx] = tc.resolved_fn_value_names[idx].clone()
 			}
 			if idx < tc.expr_type_set.len && tc.expr_type_set[idx] {
-				tc.expr_type_values[idx] = tc.promote_check_type(tc.expr_type_values[idx])
+				tc.expr_type_values[idx] = tc.cached_check_type_promotion(tc.expr_type_values[idx], mut cache, true) or {
+					tc.promote_check_type(tc.expr_type_values[idx])
+				}
 			}
 		}
 	}

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -1559,11 +1559,11 @@ fn restore_check_load_heap(mut order []int, loads []i64) {
 // serial flow produced with direct writes.
 fn (mut tc TypeChecker) merge_own_sparse_caches() {
 	for idx, name in tc.sparse_resolved_call_names {
-		tc.resolved_call_names[idx] = name
+		tc.resolved_call_names[idx] = cached_name(name)
 		tc.resolved_call_set[idx] = true
 	}
 	for idx, name in tc.sparse_resolved_fn_values {
-		tc.resolved_fn_value_names[idx] = name
+		tc.resolved_fn_value_names[idx] = cached_name(name)
 		tc.resolved_fn_value_set[idx] = true
 	}
 	for idx, _ in tc.sparse_statement_nodes {
@@ -2885,10 +2885,10 @@ fn check_clone_chunk_thread(arg voidptr) voidptr {
 	for item in *items {
 		for idx in item.range_lo .. item.fn_idx + 1 {
 			if idx < tc.resolved_call_set.len && tc.resolved_call_set[idx] {
-				tc.resolved_call_names[idx] = tc.resolved_call_names[idx].clone()
+				tc.resolved_call_names[idx] = cached_name(tc.resolved_call_names[idx].value.clone())
 			}
 			if idx < tc.resolved_fn_value_set.len && tc.resolved_fn_value_set[idx] {
-				tc.resolved_fn_value_names[idx] = tc.resolved_fn_value_names[idx].clone()
+				tc.resolved_fn_value_names[idx] = cached_name(tc.resolved_fn_value_names[idx].value.clone())
 			}
 			if idx < tc.expr_type_set.len && tc.expr_type_set[idx] {
 				if canonical := tc.cached_check_type_promotion(tc.expr_type_values[idx], mut cache, false) {
@@ -2931,10 +2931,10 @@ fn (mut tc TypeChecker) clone_parallel_worker_node_caches(items []CheckWorkItem)
 	for item in items {
 		for idx in item.range_lo .. item.fn_idx + 1 {
 			if idx < tc.resolved_call_set.len && tc.resolved_call_set[idx] {
-				tc.resolved_call_names[idx] = tc.resolved_call_names[idx].clone()
+				tc.resolved_call_names[idx] = cached_name(tc.resolved_call_names[idx].value.clone())
 			}
 			if idx < tc.resolved_fn_value_set.len && tc.resolved_fn_value_set[idx] {
-				tc.resolved_fn_value_names[idx] = tc.resolved_fn_value_names[idx].clone()
+				tc.resolved_fn_value_names[idx] = cached_name(tc.resolved_fn_value_names[idx].value.clone())
 			}
 			if idx < tc.expr_type_set.len && tc.expr_type_set[idx] {
 				tc.expr_type_values[idx] = tc.cached_check_type_promotion(tc.expr_type_values[idx], mut cache, true) or {
@@ -3028,7 +3028,7 @@ fn (mut tc TypeChecker) merge_parallel_check_worker_scoped(w &TypeChecker, scope
 		if tc.parallel_check_sparse {
 			tc.sparse_resolved_call_names[idx] = owned_name
 		} else {
-			tc.resolved_call_names[idx] = owned_name
+			tc.resolved_call_names[idx] = cached_name(owned_name)
 			tc.resolved_call_set[idx] = true
 		}
 	}
@@ -3037,7 +3037,7 @@ fn (mut tc TypeChecker) merge_parallel_check_worker_scoped(w &TypeChecker, scope
 		if tc.parallel_check_sparse {
 			tc.sparse_resolved_fn_values[idx] = owned_name
 		} else {
-			tc.resolved_fn_value_names[idx] = owned_name
+			tc.resolved_fn_value_names[idx] = cached_name(owned_name)
 			tc.resolved_fn_value_set[idx] = true
 		}
 	}

--- a/vlib/v3/types/checker_parallel_test.v
+++ b/vlib/v3/types/checker_parallel_test.v
@@ -6,6 +6,27 @@ import v3.flat
 import v3.parser
 import v3.pref
 
+fn test_type_promotion_cache_preserves_misses_and_distinct_live_payloads() {
+	a := flat.FlatAst.new()
+	mut tc := TypeChecker.new(&a)
+	initial_count := tc.type_count()
+	mut cache := CheckTypePromotionCache{}
+	mut originals := []Type{}
+	for i in 0 .. 600 {
+		typ := Type(Struct{ name: 'Item${i}' })
+		originals << typ
+		assert tc.cached_check_type_promotion(typ, mut cache, false) == none
+		promoted := tc.cached_check_type_promotion(typ, mut cache, true)?
+		assert promoted.name() == 'Item${i}'
+		assert tc.cached_check_type_promotion(typ, mut cache, false)? == promoted
+	}
+	// More live payloads than slots exercises eviction without losing identity.
+	for i, typ in originals {
+		assert tc.cached_check_type_promotion(typ, mut cache, false)?.name() == 'Item${i}'
+	}
+	assert tc.type_count() == initial_count + 600
+}
+
 fn test_check_heap_partitions_match_linear_load_selection() {
 	for count in [0, 1, 2, 33, 256, 1500] {
 		mut items := []CheckWorkItem{}
@@ -173,6 +194,31 @@ fn test_fast_file_index_collects_translated_module_attribute() {
 	mut tc := TypeChecker.new(a)
 	tc.collect(a)
 	assert tc.translated_files[path]
+}
+
+fn test_parent_metadata_replay_matches_full_scan() {
+	path := os.join_path(os.vtmp_dir(), 'v3_parent_metadata_${os.getpid()}.v')
+	os.write_file(path, '@[translated]\nmodule main\nimport strings\n@[inline]\nfn make_builder() { mut b := strings.new_builder(10) }\n') or { panic(err) }
+	defer { os.rm(path) or {} }
+	mut p := parser.Parser.new(pref.new_preferences())
+	a := p.parse_file(path)
+	assert p.diagnostics.len == 0, p.diagnostics.str()
+	mut serial := TypeChecker.new(a)
+	serial.init_direct_parent_index(a)
+	serial.collect_direct_parent_metadata(a)
+	mut split := TypeChecker.new(a)
+	split.init_direct_parent_index(a)
+	for part in 0 .. 3 {
+		chunk := split.fill_direct_parent_edges_range(a, a.nodes.len * part / 3, a.nodes.len * (part + 1) / 3)
+		for idx in chunk.metadata_node_ids {
+			split.collect_direct_parent_node_metadata(a, idx, a.nodes[idx])
+		}
+	}
+	assert split.declaration_attributes == serial.declaration_attributes
+	assert split.translated_files == serial.translated_files
+	assert split.translated_files[path]
+	assert split.strings_builder_candidates == serial.strings_builder_candidates
+	assert split.strings_builder_candidates.len == 1
 }
 
 fn test_checker_flag_include_dir_consumes_only_the_operand() {

--- a/vlib/v3/types/checker_parallel_test.v
+++ b/vlib/v3/types/checker_parallel_test.v
@@ -288,8 +288,8 @@ fn test_nested_parallel_checker_merge_keeps_out_of_range_caches_sparse() {
 
 	tc.parallel_check_sparse = false
 	tc.merge_own_sparse_caches()
-	assert tc.resolved_call_names[2] == 'main.answer'
-	assert tc.resolved_fn_value_names[2] == 'main.callback'
+	assert tc.resolved_call_names[2].value == 'main.answer'
+	assert tc.resolved_fn_value_names[2].value == 'main.callback'
 	assert tc.statement_nodes[2]
 	assert tc.expr_type_values[2] is Primitive
 	worker.free_parallel_check_worker_cache()

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -13130,7 +13130,7 @@ pub fn (tc &TypeChecker) type_name(t Type) string {
 @[inline]
 fn type_recent_hash_slot(typ Type) (u64, int) {
 	hash := semantic_type_hash(typ)
-	return hash, int(hash & 2047)
+	return hash, int(hash & u64(type_cache_recent_slots - 1))
 }
 
 // type_value_words exposes the transient Type representation for immediate
@@ -13295,7 +13295,7 @@ fn parse_type_cache_get_mode(mut cache TypeCache, file string, module_name strin
 
 @[inline]
 fn parse_type_cache_value_recent_slot(text string, context_hash u64) int {
-	return int(((u64(voidptr(text.str)) >> 4) ^ u64(text.len) ^ context_hash) & 2047)
+	return int(((u64(voidptr(text.str)) >> 4) ^ u64(text.len) ^ context_hash) & u64(type_cache_recent_slots - 1))
 }
 
 fn parse_type_cache_get_recent(mut cache TypeCache, file string, module_name string, text string, generic_params []string, resolution bool) ?Type {
@@ -16201,7 +16201,7 @@ pub fn (tc &TypeChecker) c_type(t Type) string {
 	// same-named aliases over different resolved bases) yet fold to different C
 	// representations, so a textual key would hand back the wrong layout.
 	id, canonical := tc.intern_type(t)
-	slot := int(u32(id) & 2047)
+	slot := int(u32(id) & u32(type_cache_recent_slots - 1))
 	if tc.fast_c_type_recent {
 		if cache.c_recent_set[slot] && cache.c_recent_ids[slot] == id {
 			cache.c_hits++

--- a/vlib/v3/types/type_cache_test.v
+++ b/vlib/v3/types/type_cache_test.v
@@ -2,6 +2,28 @@ module types
 
 import v3.flat
 
+fn test_node_cache_reset_clears_string_slots_and_set_bits() {
+	a := flat.FlatAst.new()
+	mut tc := TypeChecker.new(&a)
+	for n in [0, 1, 257, 33] {
+		tc.reset_node_caches(n)
+		assert tc.resolved_call_names.len == n
+		assert tc.resolved_fn_value_names.len == n
+		assert tc.resolved_call_set.len == n
+		assert tc.resolved_fn_value_set.len == n
+		for i in 0 .. n {
+			assert tc.resolved_call_names[i] == ''
+			assert tc.resolved_fn_value_names[i] == ''
+			assert !tc.resolved_call_set[i]
+			assert !tc.resolved_fn_value_set[i]
+			tc.resolved_call_names[i] = 'previous.call'
+			tc.resolved_fn_value_names[i] = 'previous.value'
+			tc.resolved_call_set[i] = true
+			tc.resolved_fn_value_set[i] = true
+		}
+	}
+}
+
 fn test_seeded_field_types_preserve_direct_precedence_and_generic_substitution() {
 	a := flat.FlatAst.new()
 	mut tc := TypeChecker.new(&a)

--- a/vlib/v3/types/type_cache_test.v
+++ b/vlib/v3/types/type_cache_test.v
@@ -12,12 +12,12 @@ fn test_node_cache_reset_clears_string_slots_and_set_bits() {
 		assert tc.resolved_call_set.len == n
 		assert tc.resolved_fn_value_set.len == n
 		for i in 0 .. n {
-			assert tc.resolved_call_names[i] == ''
-			assert tc.resolved_fn_value_names[i] == ''
+			assert isnil(tc.resolved_call_names[i])
+			assert isnil(tc.resolved_fn_value_names[i])
 			assert !tc.resolved_call_set[i]
 			assert !tc.resolved_fn_value_set[i]
-			tc.resolved_call_names[i] = 'previous.call'
-			tc.resolved_fn_value_names[i] = 'previous.value'
+			tc.resolved_call_names[i] = cached_name('previous.call')
+			tc.resolved_fn_value_names[i] = cached_name('previous.value')
 			tc.resolved_call_set[i] = true
 			tc.resolved_fn_value_set[i] = true
 		}


### PR DESCRIPTION
Compiler self-builds retained obsolete buffers, transform merge tables, and recyclable arena
blocks after their useful lifetime. This follow-up releases their physical storage and isolates
constant-dependency memoization from a disposable traversal arena.

Obsolete reallocation buffers and freed container backing now release complete physical pages
while retaining their arena addresses. Array growth uses its existing ownership checks. Transform
helpers allocate merge bookkeeping in disposable arenas and publish escaping AST text into the
parent arena; the completed master transform releases private indexes and rewrite logs. Recycled
arena storage is bounded to 4 MiB per thread. Constant-dependency discovery uses a private checker
and lookup caches, fixing a dangling cache entry exposed when recycling is disabled.

The new unsafe `prealloc_discard_pages` API is documented in its source and the V3 README.
Compiler language behavior, diagnostics, and emitted C remain unchanged in the checks above.

The branch now preserves the pointer-sized map layout from `master`: probe-tail reservation
lives in `new_map_data`, and page reclamation lives in `VMapData.free` behind the public map
free wrapper. The allocator test follows the normal builtin test layout, guards the
preallocation-only API, and verifies that the slice test uses a real borrowed view.

Validation after this integration: 35 targeted configurations, the map-layout test, two scoped
lifetime tests with recycling disabled, allocator checks with both V1 and V3, and 20 generic
cross-module integration cases passed. A V3 -> V4 -> V5 -> Hello World chain passed with
preallocation enabled and recycling disabled. Formatting and `git diff --check` passed.
The generic integration runner used the freshly rebuilt V3 binary in place of its build helper;
its fixtures and assertions were unchanged.

The timing/RAM measurements and original validation details below were recorded before the
pointer-sized map integration. They have not been remeasured on the rebased head.

Measurements compare the previous PR head `b99580d6a3390d7ad324c53471ee1dd270608465`
with `bb14e0763bf597dd535ab376e2668e3ccd64af0f` on an 18-core Apple M5 Max using Apple Clang 21.0.0.
Each executable consumes the same final V sources. Ordinary builds use
`-gc none -prealloc -prod`; PGO builds use `vlib/v3/build_pgo.sh`.

Peak RSS comes from twelve full self-builds per executable, alternating baseline/candidate:

```sh
./compiler -nocache -building-v -o /tmp/v4 v3.v
```

| Metric | Before | After | Before PGO | After PGO |
| --- | ---: | ---: | ---: | ---: |
| Peak RSS (MiB) | 987.00 | 850.00 | 988.50 | 852.50 |

This is a **13.9% ordinary / 13.8% PGO** peak-RSS reduction. The requested 20% reduction
has not been reached.

The lower-load timing protocol uses twelve additional C-output builds per executable,
rotating all four executables, with external CPU limited to four cores before and during each
sample. It accepted 48 of 61 attempts. Other user/system jobs continued running; this was not
an idle-machine measurement. Full-build wall times had uncontrolled concurrent compilation and
are not used for speed claims.

| Metric | Before | After | Before PGO | After PGO |
| --- | ---: | ---: | ---: | ---: |
| Checker (ms) | 106.09 | 105.81 | 93.66 | 92.73 |
| Transform (ms) | 144.99 | 144.31 | 119.50 | 126.38 |
| C generation (ms) | 144.70 | 146.38 | 133.25 | 131.47 |
| Combined stages (ms) | 394.72 | 401.96 | 345.83 | 353.19 |
| Complete frontend (ms) | 517.92 | 524.12 | 458.89 | 465.09 |
| Compiler CPU (s) | 4.03 | 4.12 | 3.56 | 3.65 |

Median complete frontend time rose **1.2% ordinary / 1.4% PGO**; total compiler CPU rose
**2.5%** in both cases. This does not establish the requested no-performance-loss condition.
The earlier protocol allowed up to nine cores of external CPU and accepted 48 of 54 attempts:
frontend medians were 634.03 -> 631.49 ms ordinary and 556.35 -> 557.77 ms PGO, with CPU
4.575 -> 4.655 s and 3.945 -> 4.010 s respectively. Both protocols are retained; the tighter
protocol is the primary timing result. Stage totals are medians of per-run sums.

The complete PR also reduces repeated declaration/type work and temporary strings, balances
parallel work, preserves AST reservations, reduces C-generation scratch batches, and provides
the documented Clang PGO build workflow. Worker concurrency is unchanged.

Validation recorded with those measurements:

- 48 full uncached self-builds passed, twelve per baseline/candidate ordinary/PGO executable.
- Both timing protocols completed 48 accepted C-output builds; busy samples were rejected
  by external CPU load, with no timing-based outlier removal.
- 35 targeted test configurations passed: 26 with preallocation and nine without it.
  Coverage includes builtin array/map operations, arena ownership, page discard, string builders,
  flat AST storage, type-cache identity and lifetime, scoped interning, checker workers,
  all nine parser test files, transform merges, and C-generation workers/constant dependencies.
- Nine parallel C-generation integration cases and three focused transform merge/cache cases passed.
- The new helper-merge lifetime test and constant-dependency test passed with arena recycling
  disabled, so the disposable arenas are actually unmapped.
- Ordinary preallocated V4 -> V5 -> Hello World bootstrap passed.
- PGO preallocated V4 -> V5 -> Hello World bootstrap passed with recycling disabled throughout.
- Baseline, ordinary candidate, and PGO candidate emitted identical production/preallocated
  self-build C: 21,709,207 bytes, SHA-256
  `e7ad9ebe46f0adc1879a5c10a13c65b5a397d58180ad29f1a9dd34d38abc036c`.
- Baseline and candidate also emitted identical self-build C with `-no-parallel`.
- Rebuilt `vnew`, formatted touched code, passed README `check-md` with zero warnings/errors,
  and passed `git diff --check`.

The page-release implementation was exercised on macOS; its Linux `madvise` branch was not
executed here. No test expectations were changed. The full `gen/c/types_test.v` and
`transform/fn_test.v` files have pre-existing compilation problems (a reserved `thread` variable
and private checker-field access respectively); relevant focused cases pass. Earlier validation
of the complete PR also recorded baseline-matching failures in scoped-transform signatures,
storage-source assertions, transform-parallel fixtures, and a parser fallback-position comparison.

Follow-up to #28499.
