### PR TITLE
net.openssl: honor read_timeout by making the client socket non-blocking (fix #28506)

### DIFF
--- a/vlib/net/http/h2_pooled_transport.v
+++ b/vlib/net/http/h2_pooled_transport.v
@@ -15,6 +15,13 @@ import time
 // (see its doc comment for why), so this is the ONLY bound on how long an
 // idle reader can hold io_mu and make a writer wait — kept short for exactly
 // that reason, not because a longer internal retry would be incorrect.
+// This bound only holds if the backend's read really does return on timeout:
+// mbedTLS gets it from mbedtls_ssl_conf_read_timeout on its recv callback, and
+// OpenSSL from its socket being non-blocking (SSLConn.connect switches it), so
+// SSL_read yields WANT_READ instead of blocking in read(). Before that switch a
+// reader parked in a blocking SSL_read held io_mu until the peer sent anything
+// at all, stalling every writer — including the request that had already
+// received its full response — for the server's idle timeout (vlang/v#28506).
 //
 // Both mbedTLS and OpenSSL's write_ptr (vlib/net/mbedtls/ssl_connection.c.v,
 // vlib/net/openssl/ssl_connection.c.v) reuse this SAME configured duration for

--- a/vlib/net/mbedtls/ssl_connection.c.v
+++ b/vlib/net/mbedtls/ssl_connection.c.v
@@ -996,8 +996,6 @@ fn select(handle int, test Select, timeout time.Duration) !bool {
 		eprintln('${@METHOD} handle: ${handle}, timeout: ${timeout}')
 	}
 	set := C.fd_set{}
-	C.FD_ZERO(&set)
-	C.FD_SET(handle, &set)
 
 	is_infinite := timeout <= 0 || timeout == net.infinite_timeout
 	deadline := ssl_timeout_deadline(timeout)
@@ -1012,16 +1010,24 @@ fn select(handle int, test Select, timeout time.Duration) !bool {
 		}
 		timeval_timeout := if is_infinite { &C.timeval(unsafe { nil }) } else { &tt }
 
+		// (Re)arm the set on every iteration: select() leaves its contents
+		// unspecified after a failure, so a retry after EINTR must not reuse it.
+		C.FD_ZERO(&set)
+		C.FD_SET(handle, &set)
+		// Inspect the raw result here instead of wrapping the call in
+		// net.socket_error()!, which would turn EINTR (a spurious wakeup, e.g.
+		// from the GC signalling another thread) into a hard error before the
+		// retry below could ever run.
 		mut res := -1
 		match test {
 			.read {
-				res = net.socket_error(C.select(handle + 1, &set, C.NULL, C.NULL, timeval_timeout))!
+				res = C.select(handle + 1, &set, C.NULL, C.NULL, timeval_timeout)
 			}
 			.write {
-				res = net.socket_error(C.select(handle + 1, C.NULL, &set, C.NULL, timeval_timeout))!
+				res = C.select(handle + 1, C.NULL, &set, C.NULL, timeval_timeout)
 			}
 			.except {
-				res = net.socket_error(C.select(handle + 1, C.NULL, C.NULL, &set, timeval_timeout))!
+				res = C.select(handle + 1, C.NULL, C.NULL, &set, timeval_timeout)
 			}
 		}
 
@@ -1033,8 +1039,8 @@ fn select(handle int, test Select, timeout time.Duration) !bool {
 				}
 				continue
 			}
-			cerr := C.errno
-			return error_with_code('net.mbedtls select, failed, res: ${res}', cerr)
+			net.socket_error(res)!
+			return error_with_code('net.mbedtls select, failed, res: ${res}', C.errno)
 		} else if res == 0 {
 			return net.err_timed_out
 		}

--- a/vlib/net/openssl/ssl_connection.c.v
+++ b/vlib/net/openssl/ssl_connection.c.v
@@ -70,7 +70,13 @@ fn ssl_remaining_timeout(deadline time.Time) time.Duration {
 	if deadline.unix() == 0 {
 		return net.infinite_timeout
 	}
-	return deadline - time.now()
+	remaining := deadline - time.now()
+	if remaining <= 0 {
+		// An elapsed deadline must read as "expired" to select(), which treats
+		// a timeout <= 0 as "wait forever" (mirrors the net.mbedtls helper).
+		return time.nanosecond
+	}
+	return remaining
 }
 
 // close closes the ssl connection and does cleanup
@@ -250,7 +256,13 @@ fn (mut s SSLConn) init() ! {
 	}
 }
 
-// connect to server using OpenSSL
+// connect to server using OpenSSL.
+// The socket of `tcp_conn` is switched to non-blocking mode and stays that way
+// for the life of the SSL connection: every OpenSSL call in this backend is
+// driven by a WANT_READ/WANT_WRITE retry loop that applies the configured
+// timeout via wait_for_read/wait_for_write, and a blocking socket never yields
+// WANT_READ — SSL_read() would sit in read() with no bound at all, ignoring
+// set_read_timeout() (vlang/v#28506).
 pub fn (mut s SSLConn) connect(mut tcp_conn net.TcpConn, hostname string) ! {
 	$if trace_ssl ? {
 		eprintln('${@METHOD} hostname: ${hostname}')
@@ -278,6 +290,8 @@ pub fn (mut s SSLConn) connect(mut tcp_conn net.TcpConn, hostname string) ! {
 	if C.SSL_set_fd(voidptr(s.ssl), tcp_conn.sock.handle) != 1 {
 		return error('net.openssl SSLConn.connect, could not assign ssl to socket.')
 	}
+	net.set_blocking(tcp_conn.sock.handle, false)!
+	tcp_conn.is_blocking = false
 	s.complete_connect()!
 	s.verify_hostname(hostname)!
 	connected = true
@@ -427,7 +441,10 @@ pub fn (mut s SSLConn) socket_read_into_ptr(buf_ptr &u8, len int) !int {
 	}
 
 	deadline := ssl_timeout_deadline(s.duration)
-	// s.wait_for_read(deadline - time.now())!
+	// No readiness poll before SSL_read(): OpenSSL may hold decrypted but not
+	// yet returned application data, which a socket-level select() cannot see.
+	// The socket is non-blocking (see connect()), so a read with nothing
+	// available returns WANT_READ and the wait below applies the deadline.
 	for {
 		// Clear the error queue so SSL_get_error() reflects only this call.
 		C.ERR_clear_error()
@@ -556,8 +573,6 @@ fn select(handle int, test Select, timeout time.Duration) !bool {
 		eprintln('${@METHOD} handle: ${handle}, timeout: ${timeout}')
 	}
 	set := C.fd_set{}
-	C.FD_ZERO(&set)
-	C.FD_SET(handle, &set)
 
 	is_infinite := timeout <= 0 || timeout == net.infinite_timeout
 	deadline := ssl_timeout_deadline(timeout)
@@ -576,16 +591,24 @@ fn select(handle int, test Select, timeout time.Duration) !bool {
 			&tt
 		}
 
+		// (Re)arm the set on every iteration: select() leaves its contents
+		// unspecified after a failure, so a retry after EINTR must not reuse it.
+		C.FD_ZERO(&set)
+		C.FD_SET(handle, &set)
+		// Inspect the raw result here instead of wrapping the call in
+		// net.socket_error()!, which would turn EINTR (a spurious wakeup, e.g.
+		// from the GC signalling another thread) into a hard error before the
+		// retry below could ever run.
 		mut res := -1
 		match test {
 			.read {
-				res = net.socket_error(C.select(handle + 1, &set, C.NULL, C.NULL, timeval_timeout))!
+				res = C.select(handle + 1, &set, C.NULL, C.NULL, timeval_timeout)
 			}
 			.write {
-				res = net.socket_error(C.select(handle + 1, C.NULL, &set, C.NULL, timeval_timeout))!
+				res = C.select(handle + 1, C.NULL, &set, C.NULL, timeval_timeout)
 			}
 			.except {
-				res = net.socket_error(C.select(handle + 1, C.NULL, C.NULL, &set, timeval_timeout))!
+				res = C.select(handle + 1, C.NULL, C.NULL, &set, timeval_timeout)
 			}
 		}
 
@@ -597,8 +620,8 @@ fn select(handle int, test Select, timeout time.Duration) !bool {
 				}
 				continue
 			}
-			cerr := C.errno
-			return error_with_code('net.openssl select, failed: ${res}', cerr)
+			net.socket_error(res)!
+			return error_with_code('net.openssl select, failed: ${res}', C.errno)
 		} else if res == 0 {
 			return net.err_timed_out
 		}

--- a/vlib/net/ssl/ssl_read_timeout_test.v
+++ b/vlib/net/ssl/ssl_read_timeout_test.v
@@ -1,0 +1,81 @@
+// vtest build: !sanitize-memory-clang
+module main
+
+import net
+import net.ssl
+import net.mbedtls
+import time
+
+// Hermetic read-timeout test for the net.ssl facade. A local mbedtls TLS
+// server answers one message and then goes silent while keeping the
+// connection open; the client (built with whichever backend net.ssl uses:
+// mbedtls by default, OpenSSL under -d use_openssl) must get its data back
+// promptly, and a subsequent read on the silent connection must fail with a
+// timeout after set_read_timeout(), instead of blocking until the server
+// closes (vlang/v#28506: OpenSSL's SSL_read on a blocking socket ignored the
+// configured timeout entirely).
+
+const timeout_test_cert = '-----BEGIN CERTIFICATE-----\nMIIEOTCCAyECFG64Q2g46jZb3kRbDOJWX/BwjSp6MA0GCSqGSIb3DQEBCwUAMEUx\nCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRl\ncm5ldCBXaWRnaXRzIFB0eSBMdGQwIBcNMjMwODAyMTcyOTQyWhgPMjA1MDEyMTcx\nNzI5NDJaMGsxCzAJBgNVBAYTAlVTMRMwEQYDVQQIDApDYWxpZm9ybmlhMRQwEgYD\nVQQHDAtMb3MgQW5nZWxlczEdMBsGA1UECgwUQ2F0YWx5c3QgRGV2ZWxvcG1lbnQx\nEjAQBgNVBAMMCWxvY2FsaG9zdDCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoC\nggIBALqAI4fqUi+QBVWcsXglouLdOML5+w0+1hSR1KdO0Q5XPdQAs/yYWJ+KUkDw\nG++rfy9DUPq7FNRBVurXQkcAtn6gXdllGUSjwUiDo/N4mMOyS/2sufBuaeww7jVi\nrppH+zwP1tUnjRd6khl6bi1Ian9VSzr3Iy9CkXIg1GU4CPXkOydLeoQfepXxWoK1\nOUNwT3VKC/stAfY3j/NIIeiJYkyuRGFCkxn/BUjN+AsXiTugRcYKEFHdIPkOuCXp\nYbhf+lLsczpxCs3rdZG9b/N6mEDCzXTmeHkmsjdPTf+1k5DZZvKzVBBrgdxCgBb7\n5RwjF5v9WmnIc33wWgfJC6FaUzj9NYxYUbPHD+jTz0rJB/jj4u/xJlM/e5NRmXdW\n70pOMKXtWjRSolLOFIPKLY1qs3KMTAZxKKWPDDF7WlMJxMRt7nnnks5yw43Nog4C\njDLk1ZgETnPpLgo3jbmJdIv+OHKTJrBlVvDq7VTyixCoS5G8KoOmyQJhaXG6NwE2\niVhH5JIKgzgCfetfDsnjxqJ/qtrFXPa8FF2TsomD0NK/GZmIcs+9OeVB75Jn5uhF\nfLHScpiTbuu5w3P/LI/MqihLRB6RRNnRzPH8fIg5bYC9b770ta/8GcFRuYE8t+UR\nGtqXJoIKixbDlqV54kal8FQzYzhETf9+NM6Kb/lKEfG/pslvAgMBAAEwDQYJKoZI\nhvcNAQELBQADggEBALI3uNiNO0QE1brA3QYFK+d9ZroB72NrJ0UNkzYHDg2Fc6xg\n4aVVfaxY08+TmKc0JlMOW+pUxeCW/+UBSngdQiR9EE9xm0k0XIrAsy9RXxRvEtPu\nM1VI2h7ayp1Y2BrnQinevTSgtqLRyS1VbOFRl1FiyVvinw2I0KsDdAMNevAPXcOa\nQ8pUgUq6f56DkhocQaj+hxD/uV8HryNxuoSXnPhvfTN3z4YRGzsaWevJ9EYJliOM\n+XugcqfFJ+W7/QCEcAHCL+Bw6OydG5NFORr3p57PXjjcL/uKmxPBrWg2Bz6uT4uR\nMhj0zttiFHLAt9jGfyk6W57UNUja1e1ggftJJhs=\n-----END CERTIFICATE-----\n'
+
+const timeout_test_key = '-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEAuoAjh+pSL5AFVZyxeCWi4t04wvn7DT7WFJHUp07RDlc91ACz\n/JhYn4pSQPAb76t/L0NQ+rsU1EFW6tdCRwC2fqBd2WUZRKPBSIOj83iYw7JL/ay5\n8G5p7DDuNWKumkf7PA/W1SeNF3qSGXpuLUhqf1VLOvcjL0KRciDUZTgI9eQ7J0t6\nhB96lfFagrU5Q3BPdUoL+y0B9jeP80gh6IliTK5EYUKTGf8FSM34CxeJO6BFxgoQ\nUd0g+Q64JelhuF/6UuxzOnEKzet1kb1v83qYQMLNdOZ4eSayN09N/7WTkNlm8rNU\nEGuB3EKAFvvlHCMXm/1aachzffBaB8kLoVpTOP01jFhRs8cP6NPPSskH+OPi7/Em\nUz97k1GZd1bvSk4wpe1aNFKiUs4Ug8otjWqzcoxMBnEopY8MMXtaUwnExG3ueeeS\nznLDjc2iDgKMMuTVmAROc+kuCjeNuYl0i/44cpMmsGVW8OrtVPKLEKhLkbwqg6bJ\nAmFpcbo3ATaJWEfkkgqDOAJ9618OyePGon+q2sVc9rwUXZOyiYPQ0r8ZmYhyz705\n5UHvkmfm6EV8sdJymJNu67nDc/8sj8yqKEtEHpFE2dHM8fx8iDltgL1vvvS1r/wZ\nwVG5gTy35REa2pcmggqLFsOWpXniRqXwVDNjOERN/340zopv+UoR8b+myW8CAwEA\nAQKCAgEAkcoffF0JOBMOiHlAJhrNtSiX+ZruzNDlCxlgshUjyWEbfQG7sWbqSHUZ\njZflTrqyZqDpyca7Jp2ZM2Vocxa0klIMayfj08trCaOWY3pPeROE4d3HUJMPjEpH\nvEXTFdnVJIOBPgl3+vWfBfm17QIh9j4X3BVbVNNl3WCaiDGAl699Kl+Pe38cFeCh\nD3JZPEWsZ5SlvwjU8sNGbThjAWN8C1NjMuCXG4hGej5Ae3M/nPPR91jgnw4Me4Ut\nIL3K3RVyGqaqAPJjLsu0kWQUArJAGMfvUkXjwVklkaUV5SHtJBs+pdTXjyprTmJR\nvSXWWON5zkAEEJNY7QcZaeKYi96PFLUFI+ciEdnXn74CfSKhgZCBo+OyFZjDWW5R\nNmgAbZTN2RW0z+V54Lg36JfJrmiGs8TN06KwNjFo+iOJCdQnoUSIhTlmMfVbXPah\ntRfQvwqtfqVS9W/jkiGq9yDDqyXx093R/QTM/XqDlWJ2iOJFppOJefGFCWF6Fwll\nVT9povTAGQmXFiAxwFZxWtbFa0i8fP5QG80X6l/gRklSd6ZXAVvcLkaFGqxunDAe\nrYC2jBwHWRpVmbxw880SWRzlAsJXc7M8PQnBTlyX1mFZNnwAJgqplz0BQHQhQh4V\nqNfisUm9smtda+Hr9GBBUxs09ulery3I0lQjsArVxPqPVgUbFPECggEBANqLA5fH\n2LupOBoFH/fK5jixyGdSB8eJvU+XuS8RBBexnzTQApmDHiU7Axa/cKvxAfUgwBpU\n6OIsL6Lq6wowVInBgo7GraACwspGMIP8Z7+A8qDgSWIcpXP21Ny2RW+nukdH8ZnV\nTFtiFxLYU9GRfzSUcqvE0miKfMGP/S9Cqbew00K6CQ2xurLTR2AchfUQZJJIg7eF\nRBoftthXLQ+s1JoiLJX2gqCliFy32RMAUP+pKvKVJmVQh8bxEkoEzTV2eY7eTxsH\nJDH5hD66EZ5bW/nVAMruJ3iKjy3WvjDbnddNAz9IFKrd1RMP9dgSEKuSv/HhqwPe\n1q9Wm6LWZo8BlYcCggEBANp3M14QMcMxRlZE0TiSopi1CaE8OG0C9apToS1dol2s\n4lCsWHVPIC516LMPGU0bmCdtwJey1mgXQEKVxCWHkVhhoCKT/tN53o5qkptrhrXL\npbqmRfoMXI7LwJU+Vqi5fwSPGrSR/IzHwCUL7pHTbYN7wT5rr2rcC84XYSX31TFm\nNfMnbDuUk33ycAo07Vqts5A5FN+xViEUMFSDmfA2XmOAV77awz0l/3n3qOg9lQYe\nU4Av2nT19lGELirLInkB1ndLirWAcLaCBXKOLW4bzpNm9Bt8aiziVzcUzlJlLa+1\nnb/7//xzKi0eM/BhyJfhsmOz5B8AQ6Ca/keDk8M7JtkCggEARl8DDinE6VCpBv/l\ndlX4YgMlQ9fPN3pr4ig58iTpi3Ofj1L3s1TcLSLecMG+Vy9o8PTVxuTWhJWz1SMO\nAh7j6ePM1Yq2N9MLxDRrxOROyASOnCz8lEIjKL8vdc6fdz+sJO3OpzleuAJS6beM\n7euK6XRvpE3hbtZBK9bgsQonOkYPEOp0pds4AgM0dYdZvzrDF7OP7lVUQ5E4wFr5\n4JVHdEZS0wsoru/+g9STaqHscxaXBLvwPCl9Pxs7R2haZ7+5jr6Y/FwFVK5C3ivu\nJm7GpCDpe27KeO8tAZancXYWUlCzHfpo5Ug/Jz85a5UNlyHO+uUuuzVTLeyWew3M\nwnnBGwKCAQEAqGTBP3wUH3TX1p9s9cJxemvxZEra44woeIXF8wX9pV8hgzWVabb4\nA1f3ai31Pq5KdfnvPf8nrUxex/RRIOyCaDG4EW8qOS/zEKutHgef6nly4ZBQ2BC3\nN4pug5ttiNiSw5za5NyyYoGF5ghweA8UlwjJR6gRqri6kL0MsQt7VXyHkUmN787y\ncV5yZiut2PuTMVQOdu5miVDagAqAmdwOnXvMJtzRKU0kw4rWs0zklbbCfkhkh0sf\n9m2AeJPjmoqEGags3wKF3ugR8t8MvZbJgG0XNCiOXtKIj3iGIJTExm+jjNxd0OWk\nWOqy9lMpH4lky91ZtVuqxR0za0RMnWv24QKCAQBe8l0w9AYVNGDLv1jyPcbsncty\nNYI81yqe2mL+TC00sMCeil7C7WCP7kRklY01rH5q5gJ9Q1UV+bOj2fQdXDmQ5Bgo\n41jseh44gkbuXAeWcSDrDkJCrfvlNqFobTmUb8cdb9aQlHYfOJ31367LJspiw2SY\nmCbnLQ5sMnyBiMkcn0GfBV6IAkZVN73DPa8a1m/0Qrrv1GmBJFVbuZd9d/hAWpHa\nekhXPq0Sta+RNDfBR3aI5lAmVA17qRGiubQYJ+Ldq0aRJ40fGE51ctoSU/5RMcmh\n6+Qro+jSC94L46xMFp+1J5atgB1p/jVzTT/Ws7SLyotYUSL8zU7tcLiycQXs\n-----END RSA PRIVATE KEY-----\n'
+
+// How long the server keeps the connection open while sending nothing. The
+// client's read must give up long before this; a backend that ignores the
+// read timeout only returns once the server finally closes.
+const server_silence = 6 * time.second
+
+const client_read_timeout = 300 * time.millisecond
+
+fn start_silent_server() !(&mbedtls.SSLListener, int) {
+	mut port_listener := net.listen_tcp(.ip, '127.0.0.1:0')!
+	port := port_listener.addr()!.port()!
+	port_listener.close()!
+	mut listener := mbedtls.new_ssl_listener('127.0.0.1:${port}', mbedtls.SSLConnectConfig{
+		cert:                   timeout_test_cert
+		cert_key:               timeout_test_key
+		validate:               false
+		in_memory_verification: true
+	})!
+	return listener, port
+}
+
+// accept_answer_then_stall answers the client's first message and then keeps
+// the connection open, silent, for `server_silence` before closing it.
+fn accept_answer_then_stall(mut listener mbedtls.SSLListener) {
+	mut conn := listener.accept() or { return }
+	mut buf := []u8{len: 64}
+	_ := conn.read(mut buf) or { 0 }
+	conn.write_string('ok') or {}
+	time.sleep(server_silence)
+	conn.shutdown() or {}
+}
+
+fn test_read_honors_set_read_timeout_on_a_silent_peer() {
+	mut listener, port := start_silent_server()!
+	defer {
+		listener.shutdown() or {}
+	}
+	spawn accept_answer_then_stall(mut listener)
+
+	mut client := ssl.new_ssl_conn(validate: false)!
+	client.dial('127.0.0.1', port)!
+	defer {
+		client.shutdown() or {}
+	}
+	client.set_read_timeout(client_read_timeout)
+
+	// Normal traffic still flows: the answer to the first message arrives.
+	client.write_string('hi')!
+	mut buf := []u8{len: 64}
+	n := client.read(mut buf)!
+	assert buf[..n].bytestr() == 'ok'
+
+	// The peer now sends nothing. The read must fail with a timeout after
+	// roughly client_read_timeout, not block until the server closes.
+	start := time.now()
+	mut timed_out := false
+	client.read(mut buf) or { timed_out = true }
+	elapsed := time.since(start)
+	assert timed_out, 'read on a silent peer returned data instead of timing out'
+	assert elapsed < server_silence / 2, 'read took ${elapsed} — the read timeout of ${client_read_timeout} was not applied'
+}


### PR DESCRIPTION
Fixes #28506.

## What was happening

With `-d use_openssl`, the client socket stayed **blocking**, so `SSL_read()` sat in `read()` and never returned `SSL_ERROR_WANT_READ`. The backend's timeout logic only runs in the `WANT_READ` → `wait_for_read(deadline)` retry loop, so `set_read_timeout()` had no effect on reads at all: a read on a silent peer blocked until the server closed the connection.

A plain https `http.fetch()` hits this through the pooled HTTP/2 transport: its reader thread (the "background thread" in the issue's strace) parks in a blocking `SSL_read` while holding `io_mu`, and every writer — including the request whose response had already fully arrived — waits behind it until the server's idle timeout (~90 s). Whether the *first* fetch hangs is a race between the request thread's last write and the reader re-entering `SSL_read`, hence "sometimes". mbedTLS is unaffected because its recv callback (`mbedtls_net_recv_timeout`) enforces `mbedtls_ssl_conf_read_timeout`.

## Changes

- `net.openssl.SSLConn.connect` switches the socket to non-blocking (and keeps `TcpConn.is_blocking` in sync). The existing `WANT_READ`/`WANT_WRITE` loops in `complete_connect`/`socket_read_into_ptr`/`write_ptr`/`shutdown` were already written for this; they just never engaged.
- `net.openssl.ssl_remaining_timeout` clamps an elapsed deadline to 1 ns instead of returning `<= 0`, which `select()` interprets as *infinite* — mirrors the `net.mbedtls` helper (#27429), which never got ported.
- `select()` in **both** TLS backends: the `EINTR` retry branch was dead code (`net.socket_error(...)!` propagated first) and the `fd_set` wasn't re-armed between attempts. This became reachable once the OpenSSL read path waits in `select()` while other threads run (GC signals) — it showed up as `net: socket error: 4` connection failures in `transport_h2_test.v -d use_openssl` before this fix.
- New hermetic regression test `vlib/net/ssl/ssl_read_timeout_test.v`: local mbedTLS server answers once then stays silent; the client (whichever backend `net.ssl` is built with) must get its data and then time out in ≪ 6 s. Fails at exactly 6.0 s (server close) on the old OpenSSL code, passes with the fix on both backends.

## Verification

- Issue repro (`http.fetch` to the reported endpoint, 6×, `-d use_openssl`): before — run 1 hung >10 min; after — 12/12 runs in 113–662 ms with the pooled h2 connection reused.
- `v -d use_openssl test vlib/net/ssl vlib/net/openssl`, `v test vlib/net/ssl vlib/net/mbedtls vlib/net/openssl`, `v test vlib/net/http`: all pass.
- `v -d use_openssl vlib/net/http/transport_h2_test.v`: hung/timed out on master; now completes with one pre-existing, unrelated failure (`test_h2_pool_dial_failure_preserves_error_code` — `net.dial_tcp`'s aggregate error carries code 0 under the OpenSSL backend).

🧙 Built with [WOZCODE](https://wozcode.com)
