### PR TITLE
v3: report an incompatible array element type in a generic specialization

### DIFF
--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -2562,10 +2562,25 @@ fn test_generic_specialization_rejects_incompatible_array_element_return() {
 	run_bad(v3_bin, 'bad_generic_array_elem_return_mismatch',
 		'struct Foo {\n\tv int\n}\n\nstruct Bar {\n\tv int\n}\n\nfn take[T](items []T) []Bar {\n\treturn items\n}\n\nfn main() {\n\t_ := take([Foo{\n\t\tv: 1\n\t}])\n}\n',
 		'cannot return `[]Foo` as `[]Bar`')
+	run_bad(v3_bin, 'bad_generic_array_elem_return_unrelated_scalar',
+		'fn take[T](items []T) []string {\n\treturn items\n}\n\nfn main() {\n\t_ := take([1, 2])\n}\n',
+		'cannot return `[]int` as `[]string`')
 	// Elements that only differ in spelling (a registered alias next to its base
 	// type, one level down) are storage-identical, so the same slot must keep
 	// compiling.
 	rows := run_good(v3_bin, 'good_generic_array_elem_alias_return',
 		'type NodeId = int\n\nfn take[T](rows [][]T) [][]NodeId {\n\treturn rows\n}\n\nfn main() {\n\trows := take([[1, 2], [3]])\n\tprintln(int_str(rows.len + rows[0].len))\n}\n')
 	assert rows == '4'
+	// Elements the copy loop does coerce are legal slots, not mismatches: the
+	// declared element type only has to be assignment-compatible, which covers
+	// integer into float, float into float and integer into enum.
+	widened := run_good(v3_bin, 'good_generic_array_elem_int_to_float',
+		'fn take[T](items []T) []f64 {\n\treturn items\n}\n\nfn main() {\n\tprintln(take([1, 2, 3])[0] + 0.5)\n}\n')
+	assert widened == '1.5'
+	narrowed := run_good(v3_bin, 'good_generic_array_elem_float_to_float',
+		'fn take[T](items []T) []f32 {\n\treturn items\n}\n\nfn main() {\n\tprintln(take([1.5, 2.5])[0])\n}\n')
+	assert narrowed == '1.5'
+	enum_slot := run_good(v3_bin, 'good_generic_array_elem_int_to_enum',
+		'enum Color {\n\tred\n\tgreen\n}\n\nfn take[T](items []T) []Color {\n\treturn items\n}\n\nfn main() {\n\tprintln(int_str(take([0, 1]).len))\n}\n')
+	assert enum_slot == '2'
 }

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -2551,3 +2551,21 @@ fn test_bool_condition_alias_rejects_pointer_pointee_writes() {
 	output := run_good(v3_bin, 'good_bool_condition_alias_immutable_local', good)
 	assert output == '7'
 }
+
+// A generic template body is never return-checked on its own (`[]T` can legally
+// become any `[]U` once `T` is known), so an incompatible element type in a
+// specialization used to reach the transform unreported and be lowered into an
+// element-copy loop between unrelated C types - the build then failed inside the
+// generated C instead of naming the offending return.
+fn test_generic_specialization_rejects_incompatible_array_element_return() {
+	v3_bin := build_v3()
+	run_bad(v3_bin, 'bad_generic_array_elem_return_mismatch',
+		'struct Foo {\n\tv int\n}\n\nstruct Bar {\n\tv int\n}\n\nfn take[T](items []T) []Bar {\n\treturn items\n}\n\nfn main() {\n\t_ := take([Foo{\n\t\tv: 1\n\t}])\n}\n',
+		'cannot return `[]Foo` as `[]Bar`')
+	// Elements that only differ in spelling (a registered alias next to its base
+	// type, one level down) are storage-identical, so the same slot must keep
+	// compiling.
+	rows := run_good(v3_bin, 'good_generic_array_elem_alias_return',
+		'type NodeId = int\n\nfn take[T](rows [][]T) [][]NodeId {\n\treturn rows\n}\n\nfn main() {\n\trows := take([[1, 2], [3]])\n\tprintln(int_str(rows.len + rows[0].len))\n}\n')
+	assert rows == '4'
+}

--- a/vlib/v3/tests/type_checker_errors_test.v
+++ b/vlib/v3/tests/type_checker_errors_test.v
@@ -2583,4 +2583,19 @@ fn test_generic_specialization_rejects_incompatible_array_element_return() {
 	enum_slot := run_good(v3_bin, 'good_generic_array_elem_int_to_enum',
 		'enum Color {\n\tred\n\tgreen\n}\n\nfn take[T](items []T) []Color {\n\treturn items\n}\n\nfn main() {\n\tprintln(int_str(take([0, 1]).len))\n}\n')
 	assert enum_slot == '2'
+	// Having a lowering is not the same as being legal: the element copy boxes
+	// any struct into an interface, so an element that does not implement the
+	// target has to be rejected here rather than at `.id = src.id` in the C.
+	run_bad(v3_bin, 'bad_generic_array_elem_unimplemented_interface',
+		'interface HasId {\n\tid int\n}\n\nstruct NoId {\n\tv int\n}\n\nfn take[T](items []T) []HasId {\n\treturn items\n}\n\nfn main() {\n\t_ := take([NoId{\n\t\tv: 1\n\t}])\n}\n',
+		'cannot return `[]NoId` as `[]HasId`')
+	boxed := run_good(v3_bin, 'good_generic_array_elem_interface_field',
+		'interface HasId {\n\tid int\n}\n\nstruct WithId {\n\tid int\n}\n\nfn take[T](items []T) []HasId {\n\treturn items\n}\n\nfn main() {\n\tprintln(int_str(take([WithId{\n\t\tid: 7\n\t}])[0].id))\n}\n')
+	assert boxed == '7'
+	spoken := run_good(v3_bin, 'good_generic_array_elem_interface_method',
+		"interface Speaker {\n\tspeak() string\n}\n\nstruct Dog {}\n\nfn (d Dog) speak() string {\n\treturn 'woof'\n}\n\nfn take[T](items []T) []Speaker {\n\treturn items\n}\n\nfn main() {\n\tprintln(take([Dog{}])[0].speak())\n}\n")
+	assert spoken == 'woof'
+	variants := run_good(v3_bin, 'good_generic_array_elem_sum_variant',
+		'struct Foo {\n\tv int\n}\n\nstruct Bar {\n\tw int\n}\n\ntype FB = Bar | Foo\n\nfn take[T](items []T) []FB {\n\treturn items\n}\n\nfn main() {\n\tprintln(int_str(take([Foo{\n\t\tv: 3\n\t}]).len))\n}\n')
+	assert variants == '1'
 }

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -13020,13 +13020,18 @@ fn (mut t Transformer) validate_specialized_call_result(id flat.NodeId, actual_t
 	return false
 }
 
-// record_specialized_slot_mismatch reports a value whose concrete type cannot be
-// converted to the slot it is being placed in, and reports whether it did.
-// Open generic templates are never body-checked (`[]T` legitimately matches any
-// `[]U` until `T` is known), so a specialization returning `[]Foo` from a
-// `[]Bar` function reaches the transform unreported; without this the slot was
-// lowered to an element copy between unrelated C types and only failed in the C
-// compiler, pointing at generated code instead of the offending return.
+// record_specialized_slot_mismatch reports a value whose concrete type the
+// checker would not accept in the slot it is being placed in, and reports
+// whether it did. Open generic templates are never body-checked (`[]T`
+// legitimately matches any `[]U` until `T` is known), so a specialization
+// returning `[]Foo` from a `[]Bar` function reaches the transform unreported;
+// without this the slot was lowered anyway and only failed in the C compiler,
+// pointing at generated code instead of the offending return.
+//
+// The question is compatibility, never whether a lowering exists. The element
+// copy will box any struct into an interface, so an element that does not
+// implement the target has to be rejected here rather than at `.id = src.id`
+// in the generated C.
 fn (mut t Transformer) record_specialized_slot_mismatch(actual types.Type, expected types.Type) bool {
 	if !t.validating_generic_spec || isnil(t.tc) {
 		return false
@@ -13036,12 +13041,9 @@ fn (mut t Transformer) record_specialized_slot_mismatch(actual types.Type, expec
 	if t.generic_arg_is_unresolved(actual_name) || t.generic_arg_is_unresolved(expected_name) {
 		return false
 	}
-	// `forwarded_slot_conversion_supported` answers "does this slot need one of
-	// the conversions lowered here", which is narrower than "is this legal". It
-	// says no both for slots needing no conversion at all (a registered alias
-	// next to its base type) and for ones the element copy already coerces
-	// (`[]int` into `[]f64`, an integer into an enum). Only the checker's own
-	// rule separates those from a real mismatch.
+	// The checker's own rule is the authority here: it already covers registered
+	// aliases, integer widths, integer-to-float, float-to-float, integer-to-enum,
+	// interfaces and sum variants, recursing through arrays and maps.
 	if t.tc.slot_value_compatible(actual, expected) {
 		return false
 	}

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -13028,7 +13028,7 @@ fn (mut t Transformer) validate_specialized_call_result(id flat.NodeId, actual_t
 // lowered to an element copy between unrelated C types and only failed in the C
 // compiler, pointing at generated code instead of the offending return.
 fn (mut t Transformer) record_specialized_slot_mismatch(actual types.Type, expected types.Type) bool {
-	if !t.validating_generic_spec {
+	if !t.validating_generic_spec || isnil(t.tc) {
 		return false
 	}
 	actual_name := actual.name()
@@ -13036,10 +13036,13 @@ fn (mut t Transformer) record_specialized_slot_mismatch(actual types.Type, expec
 	if t.generic_arg_is_unresolved(actual_name) || t.generic_arg_is_unresolved(expected_name) {
 		return false
 	}
-	// `forwarded_slot_conversion_supported` also says "no" for slots that need no
-	// conversion at all (a registered alias next to its base type, two spellings
-	// of one integer width). Those are not mismatches.
-	if t.forwarded_slot_types_interchangeable(actual, expected) {
+	// `forwarded_slot_conversion_supported` answers "does this slot need one of
+	// the conversions lowered here", which is narrower than "is this legal". It
+	// says no both for slots needing no conversion at all (a registered alias
+	// next to its base type) and for ones the element copy already coerces
+	// (`[]int` into `[]f64`, an integer into an enum). Only the checker's own
+	// rule separates those from a real mismatch.
+	if t.tc.slot_value_compatible(actual, expected) {
 		return false
 	}
 	if t.in_return_expr {
@@ -13048,40 +13051,6 @@ fn (mut t Transformer) record_specialized_slot_mismatch(actual types.Type, expec
 		t.record_monomorph_error('cannot use `${actual_name}` as `${expected_name}`')
 	}
 	return true
-}
-
-// forwarded_slot_types_interchangeable reports whether two types are the same at
-// the C level even though their spellings differ, so moving a value between them
-// needs no conversion.
-fn (t &Transformer) forwarded_slot_types_interchangeable(actual types.Type, expected types.Type) bool {
-	actual_base := forwarded_return_unalias_type(actual)
-	expected_base := forwarded_return_unalias_type(expected)
-	actual_name := t.semantic_type_name(actual_base)
-	expected_name := t.semantic_type_name(expected_base)
-	if actual_name == expected_name
-		|| t.normalize_type_alias(actual_name) == t.normalize_type_alias(expected_name) {
-		return true
-	}
-	if actual_base.is_integer() && expected_base.is_integer() {
-		return forwarded_integer_storage_matches(actual_base, expected_base)
-	}
-	if actual_base is types.Array && expected_base is types.Array {
-		return t.forwarded_slot_types_interchangeable(actual_base.elem_type, expected_base.elem_type)
-	}
-	if actual_base is types.ArrayFixed && expected_base is types.ArrayFixed {
-		return t.forwarded_slot_types_interchangeable(actual_base.elem_type, expected_base.elem_type)
-	}
-	if actual_base is types.Map && expected_base is types.Map {
-		return t.forwarded_slot_types_interchangeable(actual_base.key_type, expected_base.key_type)
-			&& t.forwarded_slot_types_interchangeable(actual_base.value_type, expected_base.value_type)
-	}
-	if actual_base is types.OptionType && expected_base is types.OptionType {
-		return t.forwarded_slot_types_interchangeable(actual_base.base_type, expected_base.base_type)
-	}
-	if actual_base is types.ResultType && expected_base is types.ResultType {
-		return t.forwarded_slot_types_interchangeable(actual_base.base_type, expected_base.base_type)
-	}
-	return false
 }
 
 fn (mut t Transformer) validate_specialized_comparison_operands(node flat.Node, lhs_id flat.NodeId, rhs_id flat.NodeId, transformed_lhs flat.NodeId, transformed_rhs flat.NodeId) bool {

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -13020,6 +13020,70 @@ fn (mut t Transformer) validate_specialized_call_result(id flat.NodeId, actual_t
 	return false
 }
 
+// record_specialized_slot_mismatch reports a value whose concrete type cannot be
+// converted to the slot it is being placed in, and reports whether it did.
+// Open generic templates are never body-checked (`[]T` legitimately matches any
+// `[]U` until `T` is known), so a specialization returning `[]Foo` from a
+// `[]Bar` function reaches the transform unreported; without this the slot was
+// lowered to an element copy between unrelated C types and only failed in the C
+// compiler, pointing at generated code instead of the offending return.
+fn (mut t Transformer) record_specialized_slot_mismatch(actual types.Type, expected types.Type) bool {
+	if !t.validating_generic_spec {
+		return false
+	}
+	actual_name := actual.name()
+	expected_name := expected.name()
+	if t.generic_arg_is_unresolved(actual_name) || t.generic_arg_is_unresolved(expected_name) {
+		return false
+	}
+	// `forwarded_slot_conversion_supported` also says "no" for slots that need no
+	// conversion at all (a registered alias next to its base type, two spellings
+	// of one integer width). Those are not mismatches.
+	if t.forwarded_slot_types_interchangeable(actual, expected) {
+		return false
+	}
+	if t.in_return_expr {
+		t.record_monomorph_error('cannot return `${actual_name}` as `${expected_name}`')
+	} else {
+		t.record_monomorph_error('cannot use `${actual_name}` as `${expected_name}`')
+	}
+	return true
+}
+
+// forwarded_slot_types_interchangeable reports whether two types are the same at
+// the C level even though their spellings differ, so moving a value between them
+// needs no conversion.
+fn (t &Transformer) forwarded_slot_types_interchangeable(actual types.Type, expected types.Type) bool {
+	actual_base := forwarded_return_unalias_type(actual)
+	expected_base := forwarded_return_unalias_type(expected)
+	actual_name := t.semantic_type_name(actual_base)
+	expected_name := t.semantic_type_name(expected_base)
+	if actual_name == expected_name
+		|| t.normalize_type_alias(actual_name) == t.normalize_type_alias(expected_name) {
+		return true
+	}
+	if actual_base.is_integer() && expected_base.is_integer() {
+		return forwarded_integer_storage_matches(actual_base, expected_base)
+	}
+	if actual_base is types.Array && expected_base is types.Array {
+		return t.forwarded_slot_types_interchangeable(actual_base.elem_type, expected_base.elem_type)
+	}
+	if actual_base is types.ArrayFixed && expected_base is types.ArrayFixed {
+		return t.forwarded_slot_types_interchangeable(actual_base.elem_type, expected_base.elem_type)
+	}
+	if actual_base is types.Map && expected_base is types.Map {
+		return t.forwarded_slot_types_interchangeable(actual_base.key_type, expected_base.key_type)
+			&& t.forwarded_slot_types_interchangeable(actual_base.value_type, expected_base.value_type)
+	}
+	if actual_base is types.OptionType && expected_base is types.OptionType {
+		return t.forwarded_slot_types_interchangeable(actual_base.base_type, expected_base.base_type)
+	}
+	if actual_base is types.ResultType && expected_base is types.ResultType {
+		return t.forwarded_slot_types_interchangeable(actual_base.base_type, expected_base.base_type)
+	}
+	return false
+}
+
 fn (mut t Transformer) validate_specialized_comparison_operands(node flat.Node, lhs_id flat.NodeId, rhs_id flat.NodeId, transformed_lhs flat.NodeId, transformed_rhs flat.NodeId) bool {
 	if !t.validating_generic_spec || node.op !in [.eq, .ne, .lt, .gt, .le, .ge] {
 		return true

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -13291,9 +13291,19 @@ fn (mut t Transformer) transform_array_value_for_type(id flat.NodeId, target_typ
 		if actual_base is types.Array {
 			if actual_base.elem_type.name() != expected_base.elem_type.name()
 				&& !forwarded_array_elems_storage_identical(actual_base.elem_type, expected_base.elem_type) {
+				if !t.forwarded_slot_conversion_supported(actual_base.elem_type, expected_base.elem_type)
+					&& t.record_specialized_slot_mismatch(actual_type, expected_type) {
+					return none
+				}
 				return t.convert_forwarded_array_to_dynamic(id, actual_type, actual_base.elem_type, expected_type, expected_base.elem_type, false)
 			}
 		} else if actual_base is types.ArrayFixed {
+			if actual_base.elem_type.name() != expected_base.elem_type.name()
+				&& !forwarded_array_elems_storage_identical(actual_base.elem_type, expected_base.elem_type)
+				&& !t.forwarded_slot_conversion_supported(actual_base.elem_type, expected_base.elem_type)
+				&& t.record_specialized_slot_mismatch(actual_type, expected_type) {
+				return none
+			}
 			return t.convert_forwarded_array_to_dynamic(id, actual_type, actual_base.elem_type, expected_type, expected_base.elem_type, true)
 		}
 	}

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -13291,8 +13291,7 @@ fn (mut t Transformer) transform_array_value_for_type(id flat.NodeId, target_typ
 		if actual_base is types.Array {
 			if actual_base.elem_type.name() != expected_base.elem_type.name()
 				&& !forwarded_array_elems_storage_identical(actual_base.elem_type, expected_base.elem_type) {
-				if !t.forwarded_slot_conversion_supported(actual_base.elem_type, expected_base.elem_type)
-					&& t.record_specialized_slot_mismatch(actual_type, expected_type) {
+				if t.record_specialized_slot_mismatch(actual_type, expected_type) {
 					return none
 				}
 				return t.convert_forwarded_array_to_dynamic(id, actual_type, actual_base.elem_type, expected_type, expected_base.elem_type, false)
@@ -13300,7 +13299,6 @@ fn (mut t Transformer) transform_array_value_for_type(id flat.NodeId, target_typ
 		} else if actual_base is types.ArrayFixed {
 			if actual_base.elem_type.name() != expected_base.elem_type.name()
 				&& !forwarded_array_elems_storage_identical(actual_base.elem_type, expected_base.elem_type)
-				&& !t.forwarded_slot_conversion_supported(actual_base.elem_type, expected_base.elem_type)
 				&& t.record_specialized_slot_mismatch(actual_type, expected_type) {
 				return none
 			}

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -8305,6 +8305,14 @@ fn (tc &TypeChecker) enum_selector_type(node &flat.Node) ?Type {
 }
 
 // type_compatible returns type compatible data for TypeChecker.
+// slot_value_compatible exposes the checker's assignment-compatibility rule to
+// the transform. The transform lowers value slots long after checking, and a
+// generic specialization is the one case where it sees concrete types the
+// checker never judged, so it has to ask the same question the checker would.
+pub fn (tc &TypeChecker) slot_value_compatible(actual Type, expected Type) bool {
+	return tc.type_compatible(actual, expected)
+}
+
 fn (tc &TypeChecker) type_compatible(actual Type, expected Type) bool {
 	actual_raw := actual
 	expected_raw := expected


### PR DESCRIPTION
## Problem

`v . -ownership` on a project using `toml` + `json2` failed inside generated C:

```
src.c:31668:21: error: initializing 'json2__Any' with an expression of incompatible type 'toml__Any'
 31668 | json2__Any __return_array_value_8 = *(toml__Any*)(array_get(__return_array_5, __return_array_idx_7));
```

Reduced, with no TOML involved:

```v
struct Foo {
	v int
}

struct Bar {
	v int
}

fn take[T](items []T) []Bar {
	return items
}

fn main() {
	_ := take([Foo{
		v: 1
	}])
}
```

V1 rejects this with `cannot use []Foo as type []Bar in return argument`. V3
emitted an element-copy loop between the two unrelated structs and only failed
in the C compiler. Under `-ownership` there is no V1 fallback, so that C error
was the only diagnostic.

## Cause

A generic template body is never return-checked on its own — `[]T` legitimately
matches any `[]U` until `T` is known — and the specializations monomorphization
produces are not re-checked either, so the mismatched `return` reached the
transform unreported. `transform_array_value_for_type` then lowered the slot
into an element copy whether or not the elements could actually be converted
(unlike `transform_array_value_for_dynamic_target`, which does consult
`forwarded_slot_conversion_supported`).

## Fix

While a specialization body is being validated, an array slot whose elements
cannot be converted is now reported through the existing monomorphization error
channel:

```
type checker found 1 error(s):
cannot return `[]Foo` as `[]Bar`
```

`forwarded_slot_conversion_supported` also answers "no" for slots that need no
conversion at all (a registered alias next to its base type, two spellings of
one integer width, at any nesting depth — `[][]flat.NodeId` into `[][]i32` in
v3's own sources). Those are filtered out by the new
`forwarded_slot_types_interchangeable` and keep compiling unchanged, as do all
non-generic slots.

## Tests

`vlib/v3/tests/type_checker_errors_test.v` gains the rejected case plus an
alias-element case that must keep compiling and running.

Locally, on macOS arm64:

- `type_checker_errors_test.v`: same 3 pre-existing failures before and after;
  the new test is the only difference (fails on master, passes with the fix).
- `transform/monomorphize_test.v`, `transform/fn_test.v`,
  `transform/comptime_test.v`, `types/generic_placeholder_test.v`,
  `tests/array_filter_specialized_generic_return_test.v`,
  `tests/generic_return_only_monomorph_codegen_test.v`,
  `tests/generic_ownership_implicit_coercion_codegen_test.v`,
  `tests/generic_cross_module_arg_codegen_test.v`,
  `tests/ownership/ownership_test.v`: all pass.
- `cmd/v` self-builds to generation 2; a TOML + `-ownership` program that
  previously failed now compiles and runs.