### PR TITLE
net.http: pin the h2spec target server's worker_num so the CI gate does not starve at 4 cores (fix #28517)

### DIFF
--- a/vlib/net/http/h2spec/h2spec_server.v
+++ b/vlib/net/http/h2spec/h2spec_server.v
@@ -30,6 +30,15 @@ fn main() {
 		enable_http2:           true
 		handler:                H2SpecHandler{}
 		show_startup_message:   false
+		// The TLS handshake runs on the handler workers, and an idle keep-alive
+		// connection pins its worker until the client closes it. Several h2spec
+		// flow-control cases (6.5.3/1, 6.9.1/1, 6.9.2/1, 6.9.2/2) open a preflight
+		// connection and keep it alive while dialing the case's own one, so with
+		// the default worker_num (= nr_jobs(), 4 on the CI runner) those dials
+		// found no free worker and timed out. Pin a generous, host-independent
+		// worker count so the gate does not depend on the runner's core count
+		// (vlang/v#28517).
+		worker_num: 16
 	}
 	println('h2spec target listening on 127.0.0.1:${port} (h2 over TLS)')
 	srv.listen_and_serve()


### PR DESCRIPTION
Fixes #28517.

## Problem

The `h2spec conformance` gate fails deterministically on the 4-core CI runner (e.g. [this run](https://github.com/vlang/v/actions/runs/34638865230), failed identically on re-run):

```
× 2: Sends a SETTINGS frame for window size to be negative
  Error: tls: DialWithDialer timed out
146 tests, 145 passed, 0 skipped, 1 failed
```

In the TLS server the handshake runs on the handler workers, and an idle keep-alive connection pins its worker until the client closes it. The four h2spec flow-control cases that open a *preflight* connection (`6.5.3/1`, `6.9.1/1`, `6.9.2/1`, `6.9.2/2` — the ones printing `using source address …`) keep it alive while dialing the case's own connection. With `worker_num = nr_jobs() = 4` on the runner, every worker is pinned (I measured a peak of exactly 4 established server-side connections during a run), so the case's dial never reaches the handshake and h2spec's 5 s dial timeout fires. It is a capacity limit, not timing — `H2SPEC_TIMEOUT` would not help.

## Change

One config field: the h2spec target server (`vlib/net/http/h2spec/h2spec_server.v`) gets an explicit, host-independent `worker_num: 16` instead of inheriting the runner's core count, with a comment explaining why.

## Verification

`VJOBS` sets `runtime.nr_jobs()`, which is `http.Server`'s default `worker_num`:

| | `VJOBS=1` | `VJOBS=4` (CI) | `VJOBS=8` |
|---|---|---|---|
| master (`e231bc95a0`) | 4 failed | 1 failed | 0 failed |
| this branch | 0 failed | 0 failed | — |

Run as CI does (`bash vlib/net/http/h2spec/run_h2spec.sh`, server built with `./v`, h2spec 2.6.0): `146 tests, 145 passed, 1 skipped, 0 failed`.

The underlying server limitation — idle keep-alive connections consuming TLS-handshake capacity — is the real fix and stays tracked in #28517; this PR only makes the gate independent of the runner's core count.

🧙 Built with [WOZCODE](https://wozcode.com)
