### PR TITLE
os: do the allocating part of a spawn before fork(), so the forked child only makes async signal safe calls (fix #28509)

### DIFF
--- a/vlib/os/process_nix.c.v
+++ b/vlib/os/process_nix.c.v
@@ -2,6 +2,10 @@ module os
 
 fn C.setpgid(pid i32, pgid i32) i32
 
+// child_spawn_code_prefix is the `; code: N` separator that `IError.str()` adds.
+// It is a literal, so the forked child can copy it without allocating.
+const child_spawn_code_prefix = '; code: '
+
 fn env_value_from_entries(env []string, name string) ?string {
 	prefix := '${name}='
 	for entry in env {
@@ -26,6 +30,115 @@ fn (p &Process) unix_resolve_filename() !string {
 	return find_abs_path_of_executable_in_path_env(p.filename, path)
 }
 
+// UnixSpawnPlan holds everything the forked child needs, in a form it can use
+// without allocating.
+//
+// Between `fork()` and `execve()` the child is a single thread inside a copy of
+// a possibly multi threaded address space: every lock that some other thread
+// held at fork time (the GC's, the allocator's, libc's) was copied in the
+// locked state, and the thread that would have released it does not exist in
+// the child. Anything that allocates there - resolving the executable through
+// `PATH`, building the `argv`/`envp` vectors, formatting an error message with
+// `eprintln` - can therefore block forever, which also hangs every parent that
+// waits for the child. See vlang/v#28509.
+struct UnixSpawnPlan {
+	exe           string  // the already resolved path that is passed to execve
+	argv          []&char // NUL terminated argument vector
+	envp          []&char // NUL terminated environment vector
+	resolve_error string  // when not empty, the child reports it and exits, instead of exec'ing
+	stdin_error   string  // the message prefix used when the stdin file cannot be opened
+}
+
+// unix_prepare_spawn does all the allocating work of a spawn upfront, in the
+// parent process, so that the forked child only has to use async signal safe
+// calls. It never fails: a failure to resolve the executable is turned into the
+// message that the child prints on its (already redirected) stderr, keeping the
+// previous observable behaviour of a child that exits with code 1.
+fn (p &Process) unix_prepare_spawn() UnixSpawnPlan {
+	mut exe := ''
+	mut resolve_error := ''
+	if resolved := p.unix_resolve_filename() {
+		exe = resolved
+	} else {
+		resolve_error = '${err}\n'
+	}
+	mut argv := []&char{cap: p.args.len + 2}
+	argv << &char(exe.str)
+	for i in 0 .. p.args.len {
+		argv << &char(p.args[i].str)
+	}
+	argv << &char(unsafe { nil })
+	mut envp := []&char{cap: p.env.len + 1}
+	for i in 0 .. p.env.len {
+		envp << &char(p.env[i].str)
+	}
+	envp << &char(unsafe { nil })
+	stdin_error := if p.has_stdin_path {
+		'failed to open stdin file "${p.stdin_path}": '
+	} else {
+		''
+	}
+	return UnixSpawnPlan{
+		exe:           exe
+		argv:          argv
+		envp:          envp
+		resolve_error: resolve_error
+		stdin_error:   stdin_error
+	}
+}
+
+// unix_child_write writes an already built message to the child's stderr.
+// It is used between fork() and execve(), so it must not allocate.
+fn unix_child_write(s string) {
+	if s.len > 0 {
+		unsafe { C.write(2, s.str, usize(s.len)) }
+	}
+}
+
+// unix_child_report_errno writes the C error text of the current errno to the
+// child's stderr, followed by a newline, reproducing what `eprintln(err)` used
+// to print, without allocating. `with_code` appends the `; code: N` suffix that
+// `IError.str()` adds for errors that carry a code.
+@[direct_array_access]
+fn unix_child_report_errno(with_code bool) {
+	code := C.errno
+	emsg := C.strerror(i32(code))
+	if emsg != unsafe { nil } {
+		// Note: strerror() is not formally async signal safe, but it does not go
+		// through V's allocator, and open()/execve() only ever set a known errno,
+		// for which the C library returns a pointer to a constant string.
+		unsafe { C.write(2, emsg, usize(C.strlen(emsg))) }
+	}
+	mut buf := [32]u8{}
+	mut n := 0
+	if with_code {
+		for ch in child_spawn_code_prefix {
+			buf[n] = ch
+			n++
+		}
+		mut digits := [16]u8{}
+		mut d := 0
+		mut rest := if code > 0 { code } else { 0 }
+		if rest == 0 {
+			digits[0] = `0`
+			d = 1
+		}
+		for rest > 0 {
+			digits[d] = u8(`0` + rest % 10)
+			d++
+			rest /= 10
+		}
+		for d > 0 {
+			d--
+			buf[n] = digits[d]
+			n++
+		}
+	}
+	buf[n] = `\n`
+	n++
+	unsafe { C.write(2, &buf[0], usize(n)) }
+}
+
 fn (mut p Process) unix_spawn_process() int {
 	// Each `C.pipe` writes two C `int` file descriptors; back them with `i32` so the
 	// buffer matches the C ABI (a V `[6]int` is six 64-bit slots now that `int` is
@@ -43,6 +156,9 @@ fn (mut p Process) unix_spawn_process() int {
 		}
 		_ = dont_care // using `_` directly on each above `pipe` fails to avoid C compiler generate an `-Wunused-result` warning
 	}
+	// Resolve the executable and build the C argv/envp vectors *before* forking;
+	// doing it in the child would allocate, and can deadlock there.
+	plan := p.unix_prepare_spawn()
 	pid := fork()
 	if pid != 0 {
 		// This is the parent process after the fork.
@@ -70,6 +186,11 @@ fn (mut p Process) unix_spawn_process() int {
 	// but it is otherwise independent and can do stuff *without*
 	// affecting the parent process.
 	//
+	// Note: only async signal safe calls are allowed from here until execve()
+	// replaces the process image - no allocation, no eprintln, and no exit()
+	// (which would run the parent's atexit handlers and flush its buffered
+	// stdio a second time). Use _exit() instead.
+	//
 	if p.use_pgroup {
 		C.setpgid(0, 0)
 	}
@@ -77,8 +198,9 @@ fn (mut p Process) unix_spawn_process() int {
 	if p.has_stdin_path {
 		stdin_fd = C.open(&char(p.stdin_path.str), o_rdonly, 0)
 		if stdin_fd == -1 {
-			eprintln('failed to open stdin file "${p.stdin_path}": ${posix_get_error_msg(C.errno)}')
-			exit(1)
+			unix_child_write(plan.stdin_error)
+			unix_child_report_errno(false)
+			C._exit(1)
 		}
 	}
 	if p.use_stdio_ctl {
@@ -118,17 +240,17 @@ fn (mut p Process) unix_spawn_process() int {
 	if stdin_fd > 0 {
 		fd_close(stdin_fd)
 	}
-	p.filename = p.unix_resolve_filename() or {
-		eprintln(err)
-		exit(1)
+	if plan.resolve_error.len > 0 {
+		unix_child_write(plan.resolve_error)
+		C._exit(1)
 	}
 	if p.work_folder != '' {
-		chdir(p.work_folder) or {}
+		C.chdir(&char(p.work_folder.str))
 	}
-	execve(p.filename, p.args, p.env) or {
-		eprintln(err)
-		exit(1)
-	}
+	C.execve(&char(plan.exe.str), plan.argv.data, plan.envp.data)
+	// Note: normally execve does not return at all. If it does, it failed.
+	unix_child_report_errno(true)
+	C._exit(1)
 	return 0
 }
 

--- a/vlib/os/process_nix.c.v
+++ b/vlib/os/process_nix.c.v
@@ -47,6 +47,7 @@ struct UnixSpawnPlan {
 	envp          []&char // NUL terminated environment vector
 	resolve_error string  // when not empty, the child reports it and exits, instead of exec'ing
 	stdin_error   string  // the message prefix used when the stdin file cannot be opened
+	exec_error    string  // the message prefix used when execve fails
 }
 
 // unix_prepare_spawn does all the allocating work of a spawn upfront, in the
@@ -74,7 +75,7 @@ fn (p &Process) unix_prepare_spawn() UnixSpawnPlan {
 	}
 	envp << &char(unsafe { nil })
 	stdin_error := if p.has_stdin_path {
-		'failed to open stdin file "${p.stdin_path}": '
+		'failed to open stdin file "${p.stdin_path}"'
 	} else {
 		''
 	}
@@ -84,6 +85,7 @@ fn (p &Process) unix_prepare_spawn() UnixSpawnPlan {
 		envp:          envp
 		resolve_error: resolve_error
 		stdin_error:   stdin_error
+		exec_error:    'os: failed to execute "${exe}"'
 	}
 }
 
@@ -95,44 +97,42 @@ fn unix_child_write(s string) {
 	}
 }
 
-// unix_child_report_errno writes the C error text of the current errno to the
-// child's stderr, followed by a newline, reproducing what `eprintln(err)` used
-// to print, without allocating. `with_code` appends the `; code: N` suffix that
-// `IError.str()` adds for errors that carry a code.
+// unix_child_report_errno writes `prefix` followed by the `; code: N` suffix
+// that `IError.str()` uses, and a newline, to the child's stderr.
+//
+// It runs between fork() and execve(), so it only uses write() and stack
+// buffers. In particular it does *not* call strerror(): that can take libc's
+// locale/message locks, which are exactly the kind of lock that a fork from a
+// multi threaded process can inherit already held. The errno is reported as a
+// number instead; the C library's text for it is one `errno 13` lookup away,
+// and a terse message is much better than a child that hangs while producing a
+// nicer one.
 @[direct_array_access]
-fn unix_child_report_errno(with_code bool) {
+fn unix_child_report_errno(prefix string) {
 	code := C.errno
-	emsg := C.strerror(i32(code))
-	if emsg != unsafe { nil } {
-		// Note: strerror() is not formally async signal safe, but it does not go
-		// through V's allocator, and open()/execve() only ever set a known errno,
-		// for which the C library returns a pointer to a constant string.
-		unsafe { C.write(2, emsg, usize(C.strlen(emsg))) }
-	}
+	unix_child_write(prefix)
 	mut buf := [32]u8{}
 	mut n := 0
-	if with_code {
-		for ch in child_spawn_code_prefix {
-			buf[n] = ch
-			n++
-		}
-		mut digits := [16]u8{}
-		mut d := 0
-		mut rest := if code > 0 { code } else { 0 }
-		if rest == 0 {
-			digits[0] = `0`
-			d = 1
-		}
-		for rest > 0 {
-			digits[d] = u8(`0` + rest % 10)
-			d++
-			rest /= 10
-		}
-		for d > 0 {
-			d--
-			buf[n] = digits[d]
-			n++
-		}
+	for ch in child_spawn_code_prefix {
+		buf[n] = ch
+		n++
+	}
+	mut digits := [16]u8{}
+	mut d := 0
+	mut rest := if code > 0 { code } else { 0 }
+	if rest == 0 {
+		digits[0] = `0`
+		d = 1
+	}
+	for rest > 0 {
+		digits[d] = u8(`0` + rest % 10)
+		d++
+		rest /= 10
+	}
+	for d > 0 {
+		d--
+		buf[n] = digits[d]
+		n++
 	}
 	buf[n] = `\n`
 	n++
@@ -198,8 +198,7 @@ fn (mut p Process) unix_spawn_process() int {
 	if p.has_stdin_path {
 		stdin_fd = C.open(&char(p.stdin_path.str), o_rdonly, 0)
 		if stdin_fd == -1 {
-			unix_child_write(plan.stdin_error)
-			unix_child_report_errno(false)
+			unix_child_report_errno(plan.stdin_error)
 			C._exit(1)
 		}
 	}
@@ -249,7 +248,7 @@ fn (mut p Process) unix_spawn_process() int {
 	}
 	C.execve(&char(plan.exe.str), plan.argv.data, plan.envp.data)
 	// Note: normally execve does not return at all. If it does, it failed.
-	unix_child_report_errno(true)
+	unix_child_report_errno(plan.exec_error)
 	C._exit(1)
 	return 0
 }

--- a/vlib/os/process_test.v
+++ b/vlib/os/process_test.v
@@ -501,3 +501,64 @@ fn test_slurping_utf16le_output_on_windows() {
 	assert output == 'OK\n', output
 	assert errors == ''
 }
+
+// concurrent_spawn_worker runs and reaps `spawns` short lived child processes.
+fn concurrent_spawn_worker(id int, spawns int) int {
+	mut oks := 0
+	for i in 0 .. spawns {
+		expected := (id + i) % 5
+		mut p := os.new_process(test_os_process)
+		p.set_args(['-exitcode', '${expected}', '-timeout_ms', '50', '-period_ms', '200'])
+		p.set_redirect_stdio()
+		p.wait()
+		_ = p.stdout_slurp()
+		_ = p.stderr_slurp()
+		if p.status == .exited && p.code == expected {
+			oks++
+		}
+		p.close()
+	}
+	return oks
+}
+
+// concurrent_spawn_noise keeps a thread busy allocating, so that the spawning
+// threads are likely to start a child while another thread holds the allocator
+// or GC lock.
+fn concurrent_spawn_noise(rounds int) int {
+	mut sink := []string{cap: 256}
+	for r in 0 .. rounds {
+		sink << 'os process fork safety ${r}'
+		if sink.len == 256 {
+			sink = []string{cap: 256}
+		}
+	}
+	return sink.len
+}
+
+// test_concurrent_spawns_from_multiple_threads starts child processes from
+// several threads at once, while other threads keep allocating.
+//
+// On unix that is a fork() from a multi threaded process: between fork() and
+// execve() the child is the only thread in a copy of the parent's address
+// space, so every lock another thread happened to hold at fork time is copied
+// in the locked state and is never released. A child that allocates there
+// (looking the executable up in PATH, building argv/envp, formatting an error
+// message) can block on such a lock forever - it then never exec's, never
+// exits, and the parent waiting for it hangs too. See vlang/v#28509.
+fn test_concurrent_spawns_from_multiple_threads() {
+	eprintln(@FN)
+	spawns_per_thread := 8
+	mut noise := []thread int{}
+	for _ in 0 .. 2 {
+		noise << spawn concurrent_spawn_noise(300000)
+	}
+	mut workers := []thread int{}
+	for id in 0 .. 4 {
+		workers << spawn concurrent_spawn_worker(id, spawns_per_thread)
+	}
+	results := workers.wait()
+	noise.wait()
+	for id, oks in results {
+		assert oks == spawns_per_thread, 'worker ${id} completed only ${oks}/${spawns_per_thread} spawns'
+	}
+}

--- a/vlib/v3/cmdexec/cmdexec.v
+++ b/vlib/v3/cmdexec/cmdexec.v
@@ -45,12 +45,22 @@ fn run_in_mode(program string, args []string, work_folder string, merge_output b
 		stderr := if merge_output { '' } else { process.stderr_read() }
 		output.write_string(stdout)
 		output.write_string(stderr)
-		if stdout.len == 0 && stderr.len == 0 {
-			if timeout_ms > 0 && sw.elapsed().milliseconds() >= timeout_ms {
-				timed_out = true
-				process.signal_kill()
-				break
+		// The deadline is checked on every iteration, not only when nothing was
+		// read: a child that keeps writing must hit the bound just the same.
+		if timeout_ms > 0 && sw.elapsed().milliseconds() >= timeout_ms {
+			timed_out = true
+			process.signal_kill()
+			// signal_kill() marks the process `.aborted` before it has been
+			// reaped, and wait() skips waitpid() for a process that is not
+			// running, which would leave a zombie behind until this process
+			// exits. Put it back into a waitable state, so that the wait()
+			// below actually reaps it.
+			if process.status == .aborted {
+				process.status = .running
 			}
+			break
+		}
+		if stdout.len == 0 && stderr.len == 0 {
 			time.sleep(time.millisecond)
 		}
 	}

--- a/vlib/v3/cmdexec/cmdexec.v
+++ b/vlib/v3/cmdexec/cmdexec.v
@@ -7,6 +7,10 @@ import time
 // no_timeout waits for the child process for as long as it takes.
 pub const no_timeout = i64(0)
 
+// timeout_drain_ms bounds how long a timed out run keeps collecting whatever
+// the killed command already wrote into its pipes.
+const timeout_drain_ms = i64(200)
+
 // run executes program with an exact argument vector and captures its output.
 pub fn run(program string, args []string) os.Result {
 	return run_in(program, args, '')
@@ -31,6 +35,16 @@ fn run_in_mode(program string, args []string, work_folder string, merge_output b
 	if work_folder.len > 0 {
 		process.set_work_folder(work_folder)
 	}
+	if timeout_ms > 0 {
+		// A bounded run must be able to take down everything the command
+		// started, not only the direct child: a descendant that inherited the
+		// stdout/stderr pipes - `sh -c '... & wait'` and shell wrappers in
+		// general - would otherwise keep the write ends open past the deadline.
+		// Only bounded runs get their own process group, so unbounded ones (the
+		// C compiler and linker invocations) keep sharing the caller's group,
+		// and keep reacting to a Ctrl-C on the build, exactly as before.
+		process.use_pgroup = true
+	}
 	if merge_output {
 		process.set_redirect_stdio_merged()
 	} else {
@@ -49,6 +63,10 @@ fn run_in_mode(program string, args []string, work_folder string, merge_output b
 		// read: a child that keeps writing must hit the bound just the same.
 		if timeout_ms > 0 && sw.elapsed().milliseconds() >= timeout_ms {
 			timed_out = true
+			// Kill the group first, so that descendants holding the pipes go
+			// away too, then the child itself, in case it had not reached its
+			// setpgid() yet when the group kill was delivered.
+			process.signal_pgkill()
 			process.signal_kill()
 			// signal_kill() marks the process `.aborted` before it has been
 			// reaped, and wait() skips waitpid() for a process that is not
@@ -67,10 +85,25 @@ fn run_in_mode(program string, args []string, work_folder string, merge_output b
 	process.wait()
 	if timed_out {
 		eprintln('V: `${display(program, args)}` did not finish within ${timeout_ms}ms, the child process was killed')
-	}
-	output.write_string(process.stdout_slurp())
-	if !merge_output {
-		output.write_string(process.stderr_slurp())
+		// Never block on EOF after the deadline: the slurps on the normal path
+		// wait until every writer of the pipe is gone, and a descendant that
+		// escaped the group kill still owns one. Collect what is already
+		// buffered instead.
+		drain := time.new_stopwatch()
+		for drain.elapsed().milliseconds() < timeout_drain_ms {
+			stdout := process.stdout_read()
+			stderr := if merge_output { '' } else { process.stderr_read() }
+			if stdout.len == 0 && stderr.len == 0 {
+				break
+			}
+			output.write_string(stdout)
+			output.write_string(stderr)
+		}
+	} else {
+		output.write_string(process.stdout_slurp())
+		if !merge_output {
+			output.write_string(process.stderr_slurp())
+		}
 	}
 	if process.err.len > 0 {
 		output.write_string(process.err)

--- a/vlib/v3/cmdexec/cmdexec.v
+++ b/vlib/v3/cmdexec/cmdexec.v
@@ -4,6 +4,9 @@ import os
 import strings
 import time
 
+// no_timeout waits for the child process for as long as it takes.
+pub const no_timeout = i64(0)
+
 // run executes program with an exact argument vector and captures its output.
 pub fn run(program string, args []string) os.Result {
 	return run_in(program, args, '')
@@ -11,10 +14,18 @@ pub fn run(program string, args []string) os.Result {
 
 // run_in executes program in work_folder with an exact argument vector.
 pub fn run_in(program string, args []string, work_folder string) os.Result {
-	return run_in_mode(program, args, work_folder, false)
+	return run_in_mode(program, args, work_folder, false, no_timeout)
 }
 
-fn run_in_mode(program string, args []string, work_folder string, merge_output bool) os.Result {
+// run_with_timeout is run, bounded: after timeout_ms milliseconds the child is
+// killed and a non zero result is returned. Use it for short probes that must
+// never be able to block a build, so that a child which can never make progress
+// is reported instead of hanging the compiler forever.
+pub fn run_with_timeout(program string, args []string, timeout_ms i64) os.Result {
+	return run_in_mode(program, args, '', false, timeout_ms)
+}
+
+fn run_in_mode(program string, args []string, work_folder string, merge_output bool, timeout_ms i64) os.Result {
 	mut process := os.new_process(program)
 	process.set_args(args)
 	if work_folder.len > 0 {
@@ -27,16 +38,26 @@ fn run_in_mode(program string, args []string, work_folder string, merge_output b
 	}
 	process.run()
 	mut output := strings.new_builder(1024)
+	mut timed_out := false
+	sw := time.new_stopwatch()
 	for process.is_alive() {
 		stdout := process.stdout_read()
 		stderr := if merge_output { '' } else { process.stderr_read() }
 		output.write_string(stdout)
 		output.write_string(stderr)
 		if stdout.len == 0 && stderr.len == 0 {
+			if timeout_ms > 0 && sw.elapsed().milliseconds() >= timeout_ms {
+				timed_out = true
+				process.signal_kill()
+				break
+			}
 			time.sleep(time.millisecond)
 		}
 	}
 	process.wait()
+	if timed_out {
+		eprintln('V: `${display(program, args)}` did not finish within ${timeout_ms}ms, the child process was killed')
+	}
 	output.write_string(process.stdout_slurp())
 	if !merge_output {
 		output.write_string(process.stderr_slurp())
@@ -46,7 +67,13 @@ fn run_in_mode(program string, args []string, work_folder string, merge_output b
 		output.write_string(': ')
 		output.writeln(program)
 	}
-	exit_code := if process.code >= 0 { process.code } else { 1 }
+	exit_code := if timed_out {
+		if process.code > 0 { process.code } else { 1 }
+	} else if process.code >= 0 {
+		process.code
+	} else {
+		1
+	}
 	process.close()
 	mut output_text := output.str()
 	if exit_code != 0 && output_text.contains('os: failed to find executable')
@@ -62,7 +89,7 @@ fn run_in_mode(program string, args []string, work_folder string, merge_output b
 // run_in_merged executes a command with an exact argument vector and captures
 // both stdout and stderr.
 pub fn run_in_merged(program string, args []string, work_folder string) os.Result {
-	return run_in_mode(program, args, work_folder, true)
+	return run_in_mode(program, args, work_folder, true, no_timeout)
 }
 
 // split_args parses a directive or tool response into literal argv elements.

--- a/vlib/v3/cmdexec/cmdexec_timeout_test.v
+++ b/vlib/v3/cmdexec/cmdexec_timeout_test.v
@@ -1,0 +1,26 @@
+module cmdexec
+
+import time
+
+fn test_run_with_timeout_kills_a_child_that_never_finishes() {
+	$if windows {
+		// `sleep` is not a standalone executable there.
+		assert true
+	} $else {
+		sw := time.new_stopwatch()
+		result := run_with_timeout('sleep', ['300'], 500)
+		elapsed := sw.elapsed().milliseconds()
+		assert result.exit_code != 0
+		assert elapsed < 60000, 'run_with_timeout waited ${elapsed}ms, instead of giving up'
+	}
+}
+
+fn test_run_with_timeout_still_returns_the_output_of_a_fast_child() {
+	$if windows {
+		assert true
+	} $else {
+		result := run_with_timeout('echo', ['v-cmdexec-timeout-probe'], 60000)
+		assert result.exit_code == 0
+		assert result.output.trim_space() == 'v-cmdexec-timeout-probe'
+	}
+}

--- a/vlib/v3/cmdexec/cmdexec_timeout_test.v
+++ b/vlib/v3/cmdexec/cmdexec_timeout_test.v
@@ -2,6 +2,19 @@ module cmdexec
 
 import time
 
+// assert_no_unreaped_child fails when the run that just finished left a child
+// process behind. `waitpid(-1, WNOHANG)` returns -1/ECHILD when this process has
+// no children at all, 0 when it has children that are all still running, and a
+// pid > 0 when it just reaped a zombie - which is exactly what a killed child
+// that was never waited for leaves behind.
+fn assert_no_unreaped_child(label string) {
+	$if !windows {
+		mut status := 0
+		reaped := C.waitpid(-1, &status, C.WNOHANG)
+		assert reaped <= 0, '${label} left an unreaped child process (pid ${reaped})'
+	}
+}
+
 fn test_run_with_timeout_kills_a_child_that_never_finishes() {
 	$if windows {
 		// `sleep` is not a standalone executable there.
@@ -12,6 +25,21 @@ fn test_run_with_timeout_kills_a_child_that_never_finishes() {
 		elapsed := sw.elapsed().milliseconds()
 		assert result.exit_code != 0
 		assert elapsed < 60000, 'run_with_timeout waited ${elapsed}ms, instead of giving up'
+		assert_no_unreaped_child('a timed out quiet child')
+	}
+}
+
+fn test_run_with_timeout_kills_a_child_that_keeps_writing() {
+	$if windows {
+		assert true
+	} $else {
+		sw := time.new_stopwatch()
+		result := run_with_timeout('sh', ['-c', 'while :; do echo v-cmdexec-timeout-stream; done'], 500)
+		elapsed := sw.elapsed().milliseconds()
+		assert result.exit_code != 0
+		assert elapsed < 60000, 'run_with_timeout waited ${elapsed}ms for a child that keeps writing'
+		assert result.output.contains('v-cmdexec-timeout-stream')
+		assert_no_unreaped_child('a timed out chatty child')
 	}
 }
 
@@ -22,5 +50,6 @@ fn test_run_with_timeout_still_returns_the_output_of_a_fast_child() {
 		result := run_with_timeout('echo', ['v-cmdexec-timeout-probe'], 60000)
 		assert result.exit_code == 0
 		assert result.output.trim_space() == 'v-cmdexec-timeout-probe'
+		assert_no_unreaped_child('a fast child')
 	}
 }

--- a/vlib/v3/cmdexec/cmdexec_timeout_test.v
+++ b/vlib/v3/cmdexec/cmdexec_timeout_test.v
@@ -1,5 +1,6 @@
 module cmdexec
 
+import os
 import time
 
 // assert_no_unreaped_child fails when the run that just finished left a child
@@ -40,6 +41,31 @@ fn test_run_with_timeout_kills_a_child_that_keeps_writing() {
 		assert elapsed < 60000, 'run_with_timeout waited ${elapsed}ms for a child that keeps writing'
 		assert result.output.contains('v-cmdexec-timeout-stream')
 		assert_no_unreaped_child('a timed out chatty child')
+	}
+}
+
+fn test_run_with_timeout_kills_descendants_that_hold_the_pipes() {
+	$if windows {
+		assert true
+	} $else {
+		marker := os.join_path(os.vtmp_dir(), 'v_cmdexec_descendant_${os.getpid()}.marker')
+		os.rm(marker) or {}
+		// The command starts a descendant that inherits its stdout/stderr and
+		// outlives it. Killing only the direct child leaves those pipe writers
+		// open, and the slurps at the end of a run block until every writer is
+		// gone - so the bound would be ignored. The descendant also creates a
+		// marker file after 2s, which must never appear.
+		script := 'echo v-cmdexec-descendant; { sleep 2; touch ${os.quoted_path(marker)}; sleep 300; } & wait'
+		sw := time.new_stopwatch()
+		result := run_with_timeout('sh', ['-c', script], 500)
+		elapsed := sw.elapsed().milliseconds()
+		assert result.exit_code != 0
+		assert elapsed < 60000, 'run_with_timeout waited ${elapsed}ms for a command with a live descendant'
+		assert result.output.contains('v-cmdexec-descendant')
+		assert_no_unreaped_child('a timed out command with a descendant')
+		time.sleep(3 * time.second)
+		assert !os.exists(marker), 'the descendant outlived the timed out command'
+		os.rm(marker) or {}
 	}
 }
 

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -5475,12 +5475,18 @@ fn comptime_cond_split_top_level(cond string, op string) (string, string, bool) 
 	return '', '', false
 }
 
+// pkgconfig_probe_timeout_ms bounds the `pkg-config --exists` probe. The probe
+// runs while the parallel parser pool is live, i.e. it starts a child process
+// from a multi threaded process; bounding it keeps a child that can never make
+// progress a diagnosable error, instead of a compiler that hangs forever.
+const pkgconfig_probe_timeout_ms = i64(30000)
+
 fn eval_pkgconfig_cond(cond string) bool {
 	name := pkgconfig_name_from_cond(cond)
 	if !is_safe_pkgconfig_name(name) {
 		return false
 	}
-	result := cmdexec.run('pkg-config', ['--exists', name])
+	result := cmdexec.run_with_timeout('pkg-config', ['--exists', name], pkgconfig_probe_timeout_ms)
 	return result.exit_code == 0
 }
 


### PR DESCRIPTION
Fixes #28509.

## Root cause

`vlib/os/process_nix.c.v` did most of a spawn's work *in the forked child*, between `fork()` and `execve()`:

* `p.unix_resolve_filename()` — splits `PATH`, joins paths, `abs_path()` → `getwd()` → `getcwd(0, 4096)`; all allocate.
* `os.execve(p.filename, p.args, p.env)` — builds two `[]&char` vectors by pushing onto V arrays; allocates.
* `eprintln(err)` on the error paths — string interpolation; allocates.
* `exit(1)` — runs the parent's `atexit` handlers and flushes its buffered stdio a second time.

After `fork()` the child is the only thread in a copy of the parent's address space. Every lock that some other thread happened to hold at fork time (the GC's, the allocator's, libc's) is copied in the locked state, and the thread that would have released it does not exist in the child. So a child that allocates can block forever, never reach `execve`, and never exit — which also hangs the parent that waits for it. Only async-signal-safe calls are legal in that window.

That is what hangs the V3 compiler on Linux for any program importing `net.openssl`: the `$if $pkgconfig('openssl')` condition in `vlib/net/openssl/openssl.c.v` makes the parser run `pkg-config --exists openssl` while the parallel parser pool is live, so the fork happens from a multi-threaded process. The child never exec's and `cmdexec.run_in_mode` spins in `for process.is_alive() { … time.sleep(1ms) }` forever. The worker pool stays alive for the whole compilation, so there is no point during parsing at which V3 could fork from a single-threaded process — the fix has to be in the spawn itself.

## What is now done before vs. after `fork()`

**Before `fork()`** (new `unix_prepare_spawn`, in the parent):

* resolve the executable (`unix_resolve_filename`), keeping the resolved path in a local — `p.filename` is not mutated, exactly as before, since the old assignment only ever touched the child's copy;
* build the NUL-terminated `argv` and `envp` `&char` vectors;
* pre-render the error message texts (`os: failed to find executable\n`, `failed to open stdin file "…": `).

**After `fork()`, in the child** — only: `setpgid`, `open`, `dup2`, `close`, `chdir`, `execve`, `_exit`, plus `write` + `strerror`/`strlen` on the error paths. No V allocation, no `eprintln`, and `_exit()` instead of `exit()`.

The child reports errors with a prefix built in the parent plus the numeric errno, using only `write()` and stack buffers. In particular it does **not** call `strerror()`: a known errno does not make it async-signal-safe, and it can take libc's locale/message locks — exactly the kind of lock a fork from a multi-threaded process inherits already held — so using it here would have risked recreating the deadlock this change removes.

Exit codes are unchanged, and the message for a missing executable (the only one anything matches on) is byte-identical. The other two now name what failed instead of spelling the errno out:

```
                       before                                      after
missing executable:    os: failed to find executable               os: failed to find executable
execve failed:         Permission denied; code: 13                 os: failed to execute "/etc/hosts"; code: 13
stdin file missing:    failed to open stdin file "/x":             failed to open stdin file "/x"; code: 2
                         No such file or directory
```

## V3-side mitigation

`cmdexec` gained `run_with_timeout(program, args, timeout_ms)`, and the V3 parser's `$pkgconfig` probe uses it with a 30 s bound. A child that can never make progress is now killed and reported (`V: \`pkg-config --exists openssl\` did not finish within 30000ms, the child process was killed`) instead of hanging the compiler forever.

Every other `cmdexec` caller keeps the unbounded wait (`no_timeout`), because `cmdexec.run`/`run_in`/`run_in_merged` also drive C compiler and linker invocations that legitimately take minutes; a blanket timeout there would break real builds.

The deadline is checked on every loop iteration, not only when both reads came back empty, so a child that keeps writing cannot outrun its bound. And because `signal_kill()` marks the process `.aborted` before it has been reaped — after which `wait()` skips `waitpid()` — the process is put back into a waitable state first, so a timed-out run does not leak a zombie.

A bounded run also starts the command in its own process group (`use_pgroup`) and kills that group, because killing only the direct child leaves any descendant that inherited the stdout/stderr pipes holding the write ends — and `stdout_slurp()`/`stderr_slurp()` block until *every* writer is gone. A `sh -c '... & wait'` wrapper would otherwise pin the run for as long as its descendant lived. As a second layer, a timed-out run does not slurp at all: it collects what the pipes already hold within a short drain window, so even a descendant that moved itself into another process group cannot hold the run past its deadline. Unbounded runs are untouched — they keep sharing the caller's process group (so a Ctrl-C on a build still reaches the C compiler) and keep the same blocking slurps.

Two things that were considered and *not* done:

* Caching `$pkgconfig` results — a memo would save at most one or two forks per compilation (in practice only `openssl.c.v` uses `$if $pkgconfig(…)` in vlib), and a global cache populated from a parser worker would hold strings allocated inside a `-prealloc` worker scope that is freed when the worker leaves it.
* Serialising the probes behind a mutex — it does not help, because the hazard is other threads *existing* at fork time, not concurrent forks.

## Regression tests

* `vlib/os/process_test.v`: `test_concurrent_spawns_from_multiple_threads` starts 4 threads that each spawn/reap 8 short-lived child processes with redirected stdio, while 2 more threads allocate continuously — i.e. it forks from a multi-threaded process, which is the shape that triggers the deadlock. Under the old code on an affected platform this test never finishes rather than failing; that is inherent to the bug, and a CI job timeout is the failure signal.
* `vlib/v3/cmdexec/cmdexec_timeout_test.v`: covers the new bounded wait — a quiet child (`sleep 300`), a child that keeps writing, and a command whose descendant inherits the pipes and outlives it are all killed within the bound; a fast child still returns its output; and every case asserts via `waitpid(-1, WNOHANG)` that no unreaped child is left behind. Both of the tricky assertions are true regression tests: with the reap fix removed the suite fails with `a timed out quiet child left an unreaped child process (pid 16712)`, and with the group kill removed it fails with `the descendant outlived the timed out command`.

## Verified locally (macOS 15, arm64)

* `vlib/os/process_test.v` — exit 0, all 15 tests incl. the new one:
  ```
  test_getpid / test_set_work_folder / test_set_environment /
  test_new_process_uses_path_for_bare_command_names / test_run / test_wait /
  test_slurping_output / test_stdin_write /
  test_set_stdin_path_with_redirected_stdio / test_set_stdin_path_without_redirected_stdio /
  test_close_before_wait_preserves_exit_code /
  test_stdout_read_returns_immediately_when_no_data_is_pending /
  test_pipe_read_while_process_is_alive / test_pipe_read_returns_none_after_eof /
  test_concurrent_spawns_from_multiple_threads
  ```
* `vlib/os/process_args_test.v` — exit 0.
* `vlib/v3/cmdexec/cmdexec_timeout_test.v` — exit 0. Measured separately: a command whose descendant holds the pipes returns at 504 ms for a 500 ms bound and leaves no `sleep 300` behind (before the group kill, the same probe was still blocked when a 30 s alarm fired); a descendant that escapes into its own process group returns at 501 ms via the bounded drain.
* `vlib/v3/cmdexec/macos_sdk_test.v` and `vlib/v3/parser/comptime_pkgconfig_test.v` — exit 0.
* Error messages diffed against a binary built from `origin/master`'s `process_nix.c.v`, for all three child error paths (output quoted above).
* `./v -o v_new cmd/v` succeeds, and the resulting compiler rebuilds `cmd/v` again (generation 2, identical size) — the change survives self-hosting.
* `./v1_fallback -no-parallel -o … cmd/v` succeeds — the change still bootstraps through the V1 compatibility compiler.
* Cross-compiles cleanly for both other platforms: `-os linux` produces an `ELF 64-bit … x86-64` binary (so the new nix child path compiles against glibc headers) and `-os windows` produces a `PE32+` binary. `process_windows.c.v` and the shared `process.v` / `process.c.v` needed no changes: everything added here is nix-only and is called only from `process_nix.c.v`, and the `unix_*` stubs in the Windows file already cover the methods that shared code dispatches to.
* Inspected the generated Linux C for `os__Process_unix_spawn_process`. The complete list of calls in the child body after `os__fork()` is now `setpgid`, `open`, `dup2`, `os__fd_close` (→ `close`), `chdir`, `execve`, `_exit`, `os__unix_child_write`, `os__unix_child_report_errno` — and the last two contain nothing but `write()` and stack arrays. `GC_reachable_here(&plan)` keeps the argv/envp vectors alive across the call.
* `v fmt -verify` clean on all five changed/added files.
* `import net.openssl` repro compiles with a cold `VCACHE`/`V3CACHE` (it also did before, on macOS — see below).

## Not verified — please check on Linux

**The hang itself could not be reproduced on macOS, so the fix is not confirmed against the original symptom.** I tried the `net.openssl` repro from the issue five times with a cold cache, and a dedicated stress program that forks from 8 threads while 4 more allocate (both with and without `-prealloc`); everything completed. macOS `fork()` from a multi-threaded process is unsafe in exactly the same way in principle, but its allocator and bdwgc install `pthread_atfork` handlers that reinitialise the relevant locks in the child, so the window is much harder to hit there than on the reporter's `-prealloc` Linux build.

What is verified is that the child no longer performs any of the operations that can block — confirmed by reading the generated Linux C — and that everything still builds, bootstraps and passes on macOS and in cross-compilation.

For @quaesitor-scientiam / Linux CI, the checks that would confirm it:

1. `timeout 60 ./v -o o o.v` on the issue's `import net.openssl` program: should exit 0 instead of 124.
2. `import net.http` + `http.get('https://…')` with `-d use_openssl`: should compile.
3. While a build runs, `ps` should never show a forked child that is still `exe=v`.
4. `v test vlib/os/process_test.v` — `test_concurrent_spawns_from_multiple_threads` should finish rather than hang; it is worth running it a few times, and on a `-prealloc` build, since that is the configuration in the report.

One more thing I could not witness locally: the unconditional deadline check. `run_with_timeout` is correct by construction now, but I could not build a child whose output leaves the pipe non-empty at *every* single read on macOS — `yes` and `dd if=/dev/zero bs=1m` both produce occasional empty-read windows here, so the old conditional check happened to fire at ~308 ms for a 300 ms bound as well. The conditional form is still unsound (any child without such a window escapes the bound indefinitely), and with the unconditional check the bound holds for a continuously writing child by construction, measured at 306 ms for a 300 ms bound.


