### PR TITLE
orm: decode enum fields returned as text labels (fix #28513)

### DIFF
--- a/vlib/db/mysql/orm.c.v
+++ b/vlib/db/mysql/orm.c.v
@@ -458,7 +458,19 @@ fn data_pointers_to_primitives(is_null []C.v_mysql_bool, data_pointers []&u8, ty
 					}
 				}
 				orm.enum_ {
-					primitive = *(unsafe { &i64(data) })
+					// V's ORM stores enums in a `BIGINT` column, but a native MySQL
+					// `ENUM(...)` column returns the label of the value instead. Pass
+					// such a label on unchanged, so that the ORM can match it against
+					// the names of the enum values.
+					primitive = match field_types[i] {
+						.type_string, .type_var_string, .type_blob, .type_tiny_blob,
+						.type_medium_blob, .type_long_blob {
+							orm.Primitive(unsafe { cstring_to_vstring(&char(data)) })
+						}
+						else {
+							orm.Primitive(*(unsafe { &i64(data) }))
+						}
+					}
 				}
 				else {
 					return error('Unknown type ${types[i]}')

--- a/vlib/db/pg/orm.v
+++ b/vlib/db/pg/orm.v
@@ -736,7 +736,14 @@ fn val_to_primitive(val ?string, typ int) !orm.Primitive {
 				return orm.Primitive(pg_parse_timestamp(str)!)
 			}
 			orm.enum_ {
-				return orm.Primitive(str.i64())
+				// V's ORM stores enums in a `BIGINT` column, but a native PostgreSQL
+				// enum type (`CREATE TYPE ... AS ENUM`) returns the label of the value
+				// instead. Pass such a label on unchanged, so that the ORM can match it
+				// against the names of the enum values.
+				if number := strconv.atoi64(str.trim_space()) {
+					return orm.Primitive(number)
+				}
+				return orm.Primitive(str)
 			}
 			else {}
 		}

--- a/vlib/db/sqlite/orm.v
+++ b/vlib/db/sqlite/orm.v
@@ -278,6 +278,15 @@ fn (stmt Stmt) sqlite_select_column(idx int, typ int) !orm.Primitive {
 			return orm.Null{}
 		}
 	} else if typ == orm.enum_ {
+		// V's ORM stores enums as integers, but a table that was created outside of V
+		// can keep them as their textual label. Pass such a label on unchanged, so that
+		// the ORM can match it against the names of the enum values.
+		if stmt.get_column_type(idx) == sqlite_text {
+			if v := stmt.get_text(idx) {
+				return v.clone()
+			}
+			return orm.Null{}
+		}
 		return stmt.get_i64(idx) or { return orm.Null{} }
 	} else if typ == orm.time_ {
 		if v := stmt.get_int(idx) {

--- a/vlib/db/sqlite/sqlite_orm_enum_test.v
+++ b/vlib/db/sqlite/sqlite_orm_enum_test.v
@@ -1,0 +1,171 @@
+// vtest build: present_sqlite3?
+import db.sqlite
+
+enum Element {
+	unset
+	fire
+	water
+	air
+	earth
+}
+
+enum Rank {
+	novice = 10
+	adept  = 20
+	master = 30
+}
+
+struct Traits {
+	element Element
+	rank    Rank
+}
+
+@[table: 'mobs']
+struct Mob {
+	id      int @[primary; sql: serial]
+	name    string
+	element Element
+	rank    Rank
+}
+
+@[table: 'embed_mobs']
+struct EmbedMob {
+	Traits
+	id   int @[primary; sql: serial]
+	name string
+}
+
+// TextMob is mapped onto a table that was *not* created by V, and whose enum columns
+// keep the textual label of the value, the way a native PostgreSQL `ENUM` type does.
+@[table: 'text_mobs']
+struct TextMob {
+	id      int @[primary; sql: serial]
+	name    string
+	element Element
+	rank    Rank
+}
+
+// TextEmbedMob checks the same, for the fields of an embedded struct.
+@[table: 'text_embed_mobs']
+struct TextEmbedMob {
+	Traits
+	id   int @[primary; sql: serial]
+	name string
+}
+
+fn test_enum_fields_round_trip() {
+	mut db := sqlite.connect(':memory:')!
+	defer {
+		db.close() or {}
+	}
+	sql db {
+		create table Mob
+	}!
+	gnome := Mob{
+		name:    'gnome'
+		element: .air
+		rank:    .adept
+	}
+	imp := Mob{
+		name:    'imp'
+		element: .fire
+		rank:    .master
+	}
+	sql db {
+		insert gnome into Mob
+	}!
+	sql db {
+		insert imp into Mob
+	}!
+
+	rows := sql db {
+		select from Mob order by id
+	}!
+	assert rows.len == 2
+	assert rows[0].element == .air
+	assert rows[0].rank == .adept
+	assert rows[1].element == .fire
+	assert rows[1].rank == .master
+
+	// enums are stored as their integer value
+	raw := db.exec('select element, rank from mobs order by id')!
+	assert raw[0].vals == ['3', '20']
+	assert raw[1].vals == ['1', '30']
+
+	filtered := sql db {
+		select from Mob where element == Element.fire
+	}!
+	assert filtered.len == 1
+	assert filtered[0].name == 'imp'
+	assert filtered[0].element == .fire
+	assert filtered[0].rank == .master
+}
+
+fn test_embedded_enum_fields_round_trip() {
+	mut db := sqlite.connect(':memory:')!
+	defer {
+		db.close() or {}
+	}
+	sql db {
+		create table EmbedMob
+	}!
+	orc := EmbedMob{
+		Traits: Traits{
+			element: .earth
+			rank:    .master
+		}
+		name:   'orc'
+	}
+	sql db {
+		insert orc into EmbedMob
+	}!
+
+	rows := sql db {
+		select from EmbedMob
+	}!
+	assert rows.len == 1
+	assert rows[0].element == .earth
+	assert rows[0].rank == .master
+}
+
+fn test_embedded_enum_fields_read_from_text_columns() {
+	mut db := sqlite.connect(':memory:')!
+	defer {
+		db.close() or {}
+	}
+	db.exec('create table text_embed_mobs (`Traits.element` text not null, `Traits.rank` text not null, id integer primary key, name text not null)')!
+	db.exec("insert into text_embed_mobs values ('water', 'novice', 1, 'nixie')")!
+
+	rows := sql db {
+		select from TextEmbedMob
+	}!
+	assert rows.len == 1
+	assert rows[0].name == 'nixie'
+	assert rows[0].element == .water
+	assert rows[0].rank == .novice
+}
+
+fn test_enum_fields_read_from_text_columns() {
+	mut db := sqlite.connect(':memory:')!
+	defer {
+		db.close() or {}
+	}
+	db.exec('create table text_mobs (id integer primary key, name text not null, element text not null, rank text not null)')!
+	// the label of the enum value, like a native `ENUM` column returns it
+	db.exec("insert into text_mobs values (1, 'orc', 'air', 'master')")!
+	// the integer value of the enum, stored in a text column
+	db.exec("insert into text_mobs values (2, 'troll', '2', '10')")!
+	// a label that matches no enum value keeps the field at its default
+	db.exec("insert into text_mobs values (3, 'ghost', 'plasma', 'novice')")!
+
+	rows := sql db {
+		select from TextMob order by id
+	}!
+	assert rows.len == 3
+	assert rows[0].element == .air
+	assert rows[0].rank == .master
+	assert rows[1].element == .water
+	assert rows[1].rank == .novice
+	assert rows[2].element == .unset
+	assert rows[2].rank == .novice
+}

--- a/vlib/db/sqlite/stmt.c.v
+++ b/vlib/db/sqlite/stmt.c.v
@@ -1,5 +1,6 @@
 module sqlite
 
+const sqlite_text = 3
 const sqlite_null = 5
 
 fn C.sqlite3_bind_null(&C.sqlite3_stmt, i32) i32
@@ -87,6 +88,10 @@ fn (stmt &Stmt) get_text(idx int) ?string {
 		l := C.sqlite3_column_bytes(stmt.stmt, idx)
 		return unsafe { b.vstring_with_len(l) }
 	}
+}
+
+fn (stmt &Stmt) get_column_type(idx int) int {
+	return C.sqlite3_column_type(stmt.stmt, idx)
 }
 
 fn (stmt &Stmt) get_count() int {

--- a/vlib/orm/orm_func.v
+++ b/vlib/orm/orm_func.v
@@ -1,6 +1,7 @@
 module orm
 
 import time
+import strconv
 import strings.textscanner
 
 const operators = ['=', '!=', '<>', '>=', '<=', '>', '<', 'LIKE', 'ILIKE', 'IS NULL', 'IS NOT NULL',
@@ -993,6 +994,7 @@ fn (qb &QueryBuilder[T]) map_row(row []Primitive) !T {
 
 	$for field in T.fields {
 		$if field.is_embed {
+			mut embedded := instance.$(field.name)
 			$for sub in field.typ.fields {
 				mut m := TableField{}
 				mm := qb.meta.filter(it.name == '${field.name}.${sub.name}')
@@ -1004,7 +1006,7 @@ fn (qb &QueryBuilder[T]) map_row(row []Primitive) !T {
 
 						if value != Primitive(Null{}) {
 							$if sub.unaliased_typ is i8 || sub.unaliased_typ is ?i8 {
-								instance.$(field.name).$(sub.name) = match value {
+								embedded.$(sub.name) = match value {
 									i8 { i8(value) }
 									i16 { i8(value) }
 									int { i8(value) }
@@ -1019,7 +1021,7 @@ fn (qb &QueryBuilder[T]) map_row(row []Primitive) !T {
 									else { 0 }
 								}
 							} $else $if sub.unaliased_typ is i16 || sub.unaliased_typ is ?i16 {
-								instance.$(field.name).$(sub.name) = match value {
+								embedded.$(sub.name) = match value {
 									i8 { i16(value) }
 									i16 { i16(value) }
 									int { i16(value) }
@@ -1034,7 +1036,7 @@ fn (qb &QueryBuilder[T]) map_row(row []Primitive) !T {
 									else { 0 }
 								}
 							} $else $if sub.unaliased_typ is int || sub.unaliased_typ is ?int {
-								instance.$(field.name).$(sub.name) = match value {
+								embedded.$(sub.name) = match value {
 									i8 { int(value) }
 									i16 { int(value) }
 									int { int(value) }
@@ -1048,9 +1050,11 @@ fn (qb &QueryBuilder[T]) map_row(row []Primitive) !T {
 									f64 { int(value) }
 									else { 0 }
 								}
-							} $else $if sub.unaliased_typ is i64 || sub.unaliased_typ is ?i64
-								|| sub.unaliased_typ is $enum {
-								instance.$(field.name).$(sub.name) = match value {
+							} $else $if sub.unaliased_typ is $enum {
+								embedded = orm_embedded_enum_from_primitive(embedded, sub.name,
+									value)
+							} $else $if sub.unaliased_typ is i64 || sub.unaliased_typ is ?i64 {
+								embedded.$(sub.name) = match value {
 									i8 { i64(value) }
 									i16 { i64(value) }
 									int { i64(value) }
@@ -1065,7 +1069,7 @@ fn (qb &QueryBuilder[T]) map_row(row []Primitive) !T {
 									else { 0 }
 								}
 							} $else $if sub.unaliased_typ is u8 || sub.unaliased_typ is ?u8 {
-								instance.$(field.name).$(sub.name) = match value {
+								embedded.$(sub.name) = match value {
 									i8 { u8(value) }
 									i16 { u8(value) }
 									int { u8(value) }
@@ -1080,7 +1084,7 @@ fn (qb &QueryBuilder[T]) map_row(row []Primitive) !T {
 									else { 0 }
 								}
 							} $else $if sub.unaliased_typ is u16 || sub.unaliased_typ is ?u16 {
-								instance.$(field.name).$(sub.name) = match value {
+								embedded.$(sub.name) = match value {
 									i8 { u16(value) }
 									i16 { u16(value) }
 									int { u16(value) }
@@ -1095,7 +1099,7 @@ fn (qb &QueryBuilder[T]) map_row(row []Primitive) !T {
 									else { 0 }
 								}
 							} $else $if sub.unaliased_typ is u32 || sub.unaliased_typ is ?u32 {
-								instance.$(field.name).$(sub.name) = match value {
+								embedded.$(sub.name) = match value {
 									i8 { u32(value) }
 									i16 { u32(value) }
 									int { u32(value) }
@@ -1110,7 +1114,7 @@ fn (qb &QueryBuilder[T]) map_row(row []Primitive) !T {
 									else { 0 }
 								}
 							} $else $if sub.unaliased_typ is u64 || sub.unaliased_typ is ?u64 {
-								instance.$(field.name).$(sub.name) = match value {
+								embedded.$(sub.name) = match value {
 									i8 { u64(value) }
 									i16 { u64(value) }
 									int { u64(value) }
@@ -1125,7 +1129,7 @@ fn (qb &QueryBuilder[T]) map_row(row []Primitive) !T {
 									else { 0 }
 								}
 							} $else $if sub.unaliased_typ is f32 || sub.unaliased_typ is ?f32 {
-								instance.$(field.name).$(sub.name) = match value {
+								embedded.$(sub.name) = match value {
 									i8 { f32(value) }
 									i16 { f32(value) }
 									int { f32(value) }
@@ -1140,7 +1144,7 @@ fn (qb &QueryBuilder[T]) map_row(row []Primitive) !T {
 									else { 0 }
 								}
 							} $else $if sub.unaliased_typ is f64 || sub.unaliased_typ is ?f64 {
-								instance.$(field.name).$(sub.name) = match value {
+								embedded.$(sub.name) = match value {
 									i8 { f64(value) }
 									i16 { f64(value) }
 									int { f64(value) }
@@ -1155,7 +1159,7 @@ fn (qb &QueryBuilder[T]) map_row(row []Primitive) !T {
 									else { 0 }
 								}
 							} $else $if sub.unaliased_typ is bool || sub.unaliased_typ is ?bool {
-								instance.$(field.name).$(sub.name) = match value {
+								embedded.$(sub.name) = match value {
 									i8 { value != 0 }
 									i16 { value != 0 }
 									int { value != 0 }
@@ -1170,20 +1174,20 @@ fn (qb &QueryBuilder[T]) map_row(row []Primitive) !T {
 									else { false }
 								}
 							} $else $if sub.unaliased_typ is string || sub.unaliased_typ is ?string {
-								instance.$(field.name).$(sub.name) = value as string
+								embedded.$(sub.name) = value as string
 							} $else $if sub.unaliased_typ is time.Time
 								|| sub.unaliased_typ is ?time.Time {
 								if m.typ == time_ {
-									instance.$(field.name).$(sub.name) = value as time.Time
+									embedded.$(sub.name) = value as time.Time
 								} else if m.typ == type_string {
-									instance.$(field.name).$(sub.name) =
-										time.parse(value as string)!
+									embedded.$(sub.name) = time.parse(value as string)!
 								}
 							}
 						}
 					}
 				}
 			}
+			instance.$(field.name) = embedded
 		} $else {
 			mut m := TableField{}
 			mm := qb.meta.filter(it.name == field.name)
@@ -1244,8 +1248,10 @@ fn (qb &QueryBuilder[T]) map_row(row []Primitive) !T {
 								f64 { int(value) }
 								else { 0 }
 							}
-						} $else $if field.unaliased_typ is i64 || field.unaliased_typ is ?i64
-							|| field.unaliased_typ is $enum {
+						} $else $if field.unaliased_typ is $enum {
+							instance.$(field.name) = orm_enum_i64_from_primitive(value,
+								instance.$(field.name))
+						} $else $if field.unaliased_typ is i64 || field.unaliased_typ is ?i64 {
 							instance.$(field.name) = match value {
 								i8 { i64(value) }
 								i16 { i64(value) }
@@ -2146,8 +2152,9 @@ fn set_field_from_primitive[T](mut value T, field_name string, primitive Primiti
 				value.$(field.name) = i16(primitive_to_int(primitive))
 			} $else $if field.unaliased_typ is int || field.unaliased_typ is ?int {
 				value.$(field.name) = primitive_to_int(primitive)
-			} $else $if field.unaliased_typ is i64 || field.unaliased_typ is ?i64
-				|| field.unaliased_typ is $enum {
+			} $else $if field.unaliased_typ is $enum {
+				value.$(field.name) = orm_enum_i64_from_primitive(primitive, value.$(field.name))
+			} $else $if field.unaliased_typ is i64 || field.unaliased_typ is ?i64 {
 				value.$(field.name) = i64(primitive_to_int(primitive))
 			} $else $if field.unaliased_typ is u8 || field.unaliased_typ is ?u8 {
 				value.$(field.name) = u8(primitive_to_int(primitive))
@@ -2210,6 +2217,57 @@ fn primitive_to_string(value Primitive) string {
 		string { value }
 		else { '' }
 	}
+}
+
+fn primitive_to_i64(value Primitive) i64 {
+	return match value {
+		i8 { i64(value) }
+		i16 { i64(value) }
+		int { i64(value) }
+		i64 { value }
+		u8 { i64(value) }
+		u16 { i64(value) }
+		u32 { i64(value) }
+		u64 { i64(value) }
+		bool { i64(value) }
+		f32 { i64(value) }
+		f64 { i64(value) }
+		else { 0 }
+	}
+}
+
+// orm_enum_i64_from_primitive maps a value read back from a database onto the numeric
+// value of the enum field it is assigned to. V's ORM stores enums as integers, but a
+// database can also return the *label* of a native enum column (`CREATE TYPE ... AS ENUM`
+// in PostgreSQL, `ENUM(...)` in MySQL, or a plain `TEXT` column in SQLite), so labels are
+// matched against the names of the enum values too. Labels that match no enum value and
+// are not numeric leave the field untouched.
+fn orm_enum_i64_from_primitive[E](value Primitive, current E) i64 {
+	if value is string {
+		$for item in E.values {
+			if value == item.name {
+				return i64(item.value)
+			}
+		}
+		return strconv.atoi64(value.trim_space()) or { i64(current) }
+	}
+	return primitive_to_i64(value)
+}
+
+// orm_embedded_enum_from_primitive returns a copy of the embedded struct `current`, with
+// its enum field `field_name` set from a value read back from a database. It exists
+// because the enum type of a field of an *embedded* struct can only be reached through a
+// value of that struct.
+fn orm_embedded_enum_from_primitive[S](current S, field_name string, value Primitive) S {
+	mut res := current
+	$for f in S.fields {
+		$if f.unaliased_typ is $enum {
+			if f.name == field_name {
+				res.$(f.name) = orm_enum_i64_from_primitive(value, current.$(f.name))
+			}
+		}
+	}
+	return res
 }
 
 fn orm_relation_lookup_key_has_value(value Primitive) bool {


### PR DESCRIPTION
## What was broken

`select` discarded enum fields of the result struct, leaving them at their zero value, as reported in #28513:

```v
enum Element { unset fire water air earth }
struct Mob { id string  element Element }

rows := sql db { select from Mob where id == id }!
// got: Mob{ id: '8bc78...', element: unset }   want: element: air
```

The reporter's `mob` table was created with a native PostgreSQL enum type (`CREATE TYPE element AS ENUM (...)`), so PostgreSQL returns the *label* of the value (`air`), not an integer.

## Root cause

Two layers had to be fixed, because neither one could have handled a label on its own:

* The backends decoded an enum column as an integer, unconditionally:
  * `vlib/db/pg/orm.v` used `str.i64()`, which is `0` for any label, so every row decoded to the enum's zero value;
  * `vlib/db/sqlite/orm.v` used `sqlite3_column_int64()`, which is likewise `0` for a `TEXT` column;
  * `vlib/db/mysql/orm.c.v` reinterpreted the bytes of the returned string as an `i64`, for a native `ENUM(...)` column.
* The shared row decoder in `vlib/orm/orm_func.v` (`map_row()`, and `set_field_from_primitive()`) folded enum fields into the `i64` branch, so it only ever assigned integer primitives to them; a string primitive would have been dropped on the floor.

Enum columns *written* by V's ORM are stored as integers (`BIGINT`/`INTEGER`), and reading those back always worked; only values produced outside of V's own schema were affected.

## What changed

* `vlib/db/pg/orm.v`, `vlib/db/sqlite/orm.v` (+ a small `get_column_type()` helper in `vlib/db/sqlite/stmt.c.v`) and `vlib/db/mysql/orm.c.v` now hand an enum column back as a string when the database did not return a number (a PostgreSQL/MySQL native enum label, or a SQLite `TEXT` column), and as an integer otherwise.
* `vlib/orm/orm_func.v` gained `orm_enum_i64_from_primitive()`, which maps a `Primitive` onto the numeric value of the enum field it is assigned to: an exact match against the names of the enum values first, then a numeric label, and finally the value the field already holds, so an unknown label cannot produce a bogus enum value. Enum fields now use it in `map_row()` and in `set_field_from_primitive()` instead of sharing the `i64` branch.
* Enum fields of *embedded* structs are handled through `orm_embedded_enum_from_primitive()`. The enum type of such a field can only be reached through a value of the embedded struct, so `map_row()` now decodes each embedded struct into a local and writes it back once.

The write path is unchanged: enums are still stored as integers, so existing V-created schemas keep working exactly as before.

## How it was tested

New `vlib/db/sqlite/sqlite_orm_enum_test.v` (SQLite is bundled, so it runs everywhere), covering both directions and both storage forms:

```
running tests in: vlib/db/sqlite/sqlite_orm_enum_test.v
     OK    [1/4]     1.988 ms     11 asserts | main.test_enum_fields_round_trip()
     OK    [2/4]     0.178 ms     3 asserts | main.test_embedded_enum_fields_round_trip()
     OK    [3/4]     0.109 ms     4 asserts | main.test_embedded_enum_fields_read_from_text_columns()
     OK    [4/4]     0.457 ms     7 asserts | main.test_enum_fields_read_from_text_columns()
     Summary for running V tests in "sqlite_orm_enum_test.v": 4 passed, 4 total. Elapsed time: 2.851 ms.
```

It asserts that an `insert` + `select` round trip preserves enum values (including an enum with explicit, non sequential values), that the values are stored as integers, that `where element == Element.fire` still matches, and that a table created by raw SQL with `TEXT` enum columns decodes `'air'`/`'master'` labels, numeric labels such as `'2'`, and leaves the field alone for a label that matches no enum value.

The full existing ORM suite was run as a regression check: all 50 test files under `vlib/orm/` and `vlib/db/sqlite/` pass, in particular `orm_embed_test.v` (11/11), `orm_scope_test.v` (54/54), `orm_test.v` (8/8), `orm_func_test.v` (7/7) and `sqlite_orm_test.v` (4/4).

## Not verified locally

* **PostgreSQL**: no server available here, so the exact scenario from the issue (a `CREATE TYPE ... AS ENUM` column) could not be exercised end to end; it is covered indirectly by the SQLite `TEXT` column test, which reaches the same decoder with the same string primitive. The `db.pg` module was compiled to check the change builds.
* **MySQL**: same, no server; `db.mysql` was compiled only. Its fix keys off the field type reported for the column, so a native `ENUM(...)` column is read as a string instead of reinterpreted bytes.
* Option enum fields (`?Element`) are still not decoded; they are not matched by `$if ... is $enum`, and a separate codegen problem currently prevents them from compiling in an ORM struct at all. That is left as is, out of scope here.