### PR TITLE
net: preserve the connect error code in the aggregate dial error (fix #28510)

### DIFF
--- a/vlib/net/openssl/ssl_connection.c.v
+++ b/vlib/net/openssl/ssl_connection.c.v
@@ -311,6 +311,9 @@ pub fn (mut s SSLConn) dial(hostname string, port int) ! {
 	$if trace_ssl ? {
 		eprintln('${@METHOD} hostname: ${hostname} | port: ${port}')
 	}
+	// Note: net.dial_tcp's error is returned as is, on purpose - it carries
+	// the code of the failing connect (ECONNREFUSED etc), which callers use to
+	// classify the failure, just like for a plain net.dial_tcp call.
 	mut tcp_conn := net.dial_tcp('${hostname}:${port}') or { return err }
 	mut connected := false
 	defer {

--- a/vlib/net/ssl/ssl_dial_error_code_test.v
+++ b/vlib/net/ssl/ssl_dial_error_code_test.v
@@ -1,0 +1,25 @@
+// vtest build: !sanitize-memory-clang
+module ssl
+
+import net
+
+// SSLConn.dial has to report a non 0 error code, when the TCP connect under
+// the TLS handshake fails, with both backends (mbedTLS by default, OpenSSL
+// under -d use_openssl). The OpenSSL backend returns net.dial_tcp's error as
+// is, so it used to lose the code, while the mbedTLS one returned
+// MBEDTLS_ERR_NET_CONNECT_FAILED (-68).
+// See https://github.com/vlang/v/issues/28510 .
+fn test_dial_failure_has_a_non_zero_error_code() {
+	mut port_listener := net.listen_tcp(.ip, '127.0.0.1:0')!
+	port := port_listener.addr()!.port()!
+	// nothing is listening on `port` any more:
+	port_listener.close()!
+
+	mut conn := new_ssl_conn(validate: false)!
+	conn.dial('127.0.0.1', port) or {
+		assert err.code() != 0, 'SSLConn.dial should report a coded failure, got: ${err}'
+		return
+	}
+	conn.shutdown() or {}
+	assert false, 'dialing a port, that nothing listens on, should have failed'
+}

--- a/vlib/net/tcp.c.v
+++ b/vlib/net/tcp.c.v
@@ -85,17 +85,7 @@ pub fn dial_tcp(oaddress string) !&TcpConn {
 
 	// Once we've failed now try and explain why we failed to connect
 	// to any of these addresses
-	mut err_builder := strings.new_builder(1024)
-	err_builder.write_string('dial_tcp failed for address ${address}\n')
-	err_builder.write_string('tried addrs:\n')
-	for i := 0; i < errs.len; i++ {
-		addr := addrs[i]
-		why := errs[i]
-		err_builder.write_string('\t${addr}: ${why}\n')
-	}
-
-	// failed
-	return error(err_builder.str())
+	return dial_error(addrs, errs, 'dial_tcp failed for address ${address}')
 }
 
 // dial_tcp_with_bind will bind the given local address `laddr` and dial.
@@ -104,16 +94,21 @@ pub fn dial_tcp_with_bind(saddr string, laddr string) !&TcpConn {
 		return error('${err.msg()}; could not resolve address ${saddr} in dial_tcp_with_bind')
 	}
 
+	// Keep track of dialing errors that take place
+	mut errs := []IError{}
+
 	// Very simple dialer
 	for addr in addrs {
 		mut s := new_tcp_socket(addr.family()) or {
 			return error('${err.msg()}; could not create new tcp socket in dial_tcp_with_bind')
 		}
 		s.bind(laddr) or {
+			errs << err
 			s.close() or { continue }
 			continue
 		}
 		s.connect(addr) or {
+			errs << err
 			// Connection failed
 			s.close() or { continue }
 			continue
@@ -131,7 +126,42 @@ pub fn dial_tcp_with_bind(saddr string, laddr string) !&TcpConn {
 		return conn
 	}
 	// failed
-	return error('dial_tcp_with_bind failed for address ${saddr}')
+	return dial_error(addrs, errs, 'dial_tcp_with_bind failed for address ${saddr}')
+}
+
+// dial_error produces the error that a dial returns, when every candidate
+// address of a host failed. The message lists each tried address with its own
+// error, while the code of the returned error is the *last* non 0 per address
+// code (it is 0, only if no attempt reported a code at all).
+//
+// Rationale for using the last code: a host can resolve to several addresses,
+// that fail differently (on a dual stack machine, the IPv6 candidate often
+// fails with ENETUNREACH, while the IPv4 one fails with ECONNREFUSED), so a
+// single code can not describe all of them. The last attempt is the one, that
+// the dialer finally gave up on, so its code is the most useful one for a
+// caller, that wants to classify the failure; the other codes are still
+// visible in the message. When all attempts failed with the same code (the
+// common case, for example a single resolved address), that code is propagated
+// unchanged.
+//
+// Without a code here, callers like net.http's retry loop, and
+// net.openssl.SSLConn.dial (which returns dial_tcp's error verbatim), would see
+// err.code() == 0, and could not distinguish a hopeless failure from a
+// retryable one. See https://github.com/vlang/v/issues/28510 .
+fn dial_error(addrs []Addr, errs []IError, header string) IError {
+	mut err_builder := strings.new_builder(1024)
+	err_builder.write_string('${header}\n')
+	err_builder.write_string('tried addrs:\n')
+	mut last_code := 0
+	for i := 0; i < errs.len && i < addrs.len; i++ {
+		addr := addrs[i]
+		why := errs[i]
+		err_builder.write_string('\t${addr}: ${why}\n')
+		if why.code() != 0 {
+			last_code = why.code()
+		}
+	}
+	return error_with_code(err_builder.str(), last_code)
 }
 
 // close closes the tcp connection

--- a/vlib/net/tcp_dial_error_code_test.v
+++ b/vlib/net/tcp_dial_error_code_test.v
@@ -1,0 +1,42 @@
+import net
+
+// A failed dial has to preserve the error code of the underlying connect, so
+// that callers (net.http's retry loop, the TLS backends, ...) can classify the
+// failure, instead of having to parse the error message for it. dial_tcp used
+// to aggregate the per address errors into a plain error(), dropping their
+// codes, which made net.openssl.SSLConn.dial (that returns dial_tcp's error
+// verbatim) report err.code() == 0 for a refused connection.
+// See https://github.com/vlang/v/issues/28510 .
+
+// free_port returns a port on 127.0.0.1, that nothing is listening on, so that
+// dialing it fails fast and deterministically (ECONNREFUSED: 111 on Linux, 61
+// on macOS, WSAECONNREFUSED 10061 on Windows - hence the tests below only
+// assert, that the code is not 0).
+fn free_port() !int {
+	mut l := net.listen_tcp(.ip, '127.0.0.1:0')!
+	port := l.addr()!.port()!
+	l.close()!
+	return port
+}
+
+fn test_dial_tcp_failure_preserves_the_error_code() {
+	port := free_port()!
+	mut conn := net.dial_tcp('127.0.0.1:${port}') or {
+		assert err.code() != 0, 'dial_tcp should preserve the connect error code, got: ${err}'
+		assert err.msg().contains('dial_tcp failed for address'), 'unexpected message: ${err}'
+		return
+	}
+	conn.close() or {}
+	assert false, 'dialing a port, that nothing listens on, should have failed'
+}
+
+fn test_dial_tcp_with_bind_failure_preserves_the_error_code() {
+	port := free_port()!
+	mut conn := net.dial_tcp_with_bind('127.0.0.1:${port}', '0.0.0.0:0') or {
+		assert err.code() != 0, 'dial_tcp_with_bind should preserve the connect error code, got: ${err}'
+		assert err.msg().contains('dial_tcp_with_bind failed for address'), 'unexpected message: ${err}'
+		return
+	}
+	conn.close() or {}
+	assert false, 'dialing a port, that nothing listens on, should have failed'
+}


### PR DESCRIPTION
## Root cause

`net.dial_tcp` tries every address that a host resolves to, collects the per address `connect()` errors, formats them into a single message, and then returns that message with a plain `error()`. The formatting keeps each failure's code as *text* (`net: socket error: 111; code: 111`), but the returned error itself has `code() == 0`.

`net.openssl.SSLConn.dial` is `net.dial_tcp('${hostname}:${port}') or { return err }`, so it inherits that uncoded error, while `net.mbedtls.SSLConn.dial` returns `MBEDTLS_ERR_NET_CONNECT_FAILED` (-68) for the same failure. `net.http` classifies failures by `err.code()` (`is_no_need_retry_error`), so with `-d use_openssl` a hopeless connect was retried up to `max_retries` times, and `vlib/net/http/transport_h2_test.v`'s `test_h2_pool_dial_failure_preserves_error_code` failed with `Left value: 0`.

Fixes #28510.

## What changed

- `vlib/net/tcp.c.v`: a new private `dial_error(addrs, errs, header)` helper builds the aggregate failure and returns it with `error_with_code()` instead of `error()`.
  - `dial_tcp` uses it; its message is byte for byte the same as before.
  - `dial_tcp_with_bind` uses it too, and now also collects its per address bind/connect errors instead of discarding them, so its message explains why each candidate failed, instead of only naming the address it could not reach.
- `vlib/net/openssl/ssl_connection.c.v`: comment only, documenting that `SSLConn.dial` returns `net.dial_tcp`'s error as is, on purpose.
- New regression tests (see below).

## The code selection rule for several addresses

**The last non 0 per address code wins** (the aggregate code is 0 only when no attempt reported a code at all). This is documented in the doc comment of `dial_error`.

A host can resolve to several addresses that fail *differently* - on a dual stack machine the IPv6 candidate often fails with `ENETUNREACH` while the IPv4 one fails with `ECONNREFUSED` - so no single code can describe all of them. The last attempt is the one that the dialer finally gave up on, so its code is the most useful one for a caller that wants to classify the failure, and all the individual errors remain listed in the message, which is where the full picture stays available. When every attempt failed with the same code (the common case, e.g. a single resolved address, which is what #28510 reports), that code is propagated unchanged.

## Why the OpenSSL backend inherits the errno instead of wrapping it

The issue accepts either the OS `errno` or a backend portable "connect failed" code. Inheriting is the better fit here:

- it makes `ssl.SSLConn.dial` report exactly what a plain `net.dial_tcp` to the same address reports, so TLS and non TLS dials are classified with the same code space on the same platform;
- wrapping would *lose* information (`ECONNREFUSED` vs `ENETUNREACH` vs `ETIMEDOUT` all collapsing into one code) while the callers that motivated the issue only need "is this code non zero / is it one of the hopeless ones";
- the mbedTLS backend keeps returning `-68`, because that code comes from mbedTLS' own `mbedtls_net_connect`, not from V - it is untouched by this PR.

Both backends now satisfy the issue's requirement: a non zero, classifiable code.

## Blast radius

`error_with_code` changes `err.code()` for every `dial_tcp` / `dial_tcp_with_bind` caller, so:

- **Error type is unchanged**: `error_with_code` returns the same `&MessageError` that `error()` returns, only with `code` set, so `match`/`is` checks on the error type are unaffected.
- **No caller branches on the aggregate being uncoded**: the only `err.code() == 0` assertions in `vlib/net` are `vlib/net/http/response_test.v` (vschannel connect failure message normalization) and `vlib/net/http/h3_mux_conn_test.v` (narrowing a peer supplied u64 error code) - neither goes through `dial_tcp`.
- **No test asserts on the aggregate message**: the only other `'dial_tcp failed'` occurrence in the tree is `vlib/v/tests/options/or_expr_with_nested_match_expr_test.v`, which builds that string itself and never calls `net`.
- **Retry classification**: `is_no_need_retry_error` matches `errors_base + {5, 6, 8, 9}` and `transport_err_unsafe_retry`. The `errno` values that a `connect()` can produce (`ECONNREFUSED` 111/61, `ETIMEDOUT` 110/60, `ENETUNREACH` 101/51, `EHOSTUNREACH` 113/65, `EACCES` 13, and the `WSAE*` 10xxx codes on Windows) do not collide with that small range, so no dial failure starts being misclassified. The one code from that range that a dial can now legitimately propagate is `net.err_timed_out` (9), which `TcpSocket.connect` returns for a timed out connect with `-d net_nonblocking_sockets`; that is exactly the case `is_no_need_retry_error` is meant to stop retrying, so retry behaviour only becomes more correct.

## Tests

New `vlib/net/tcp_dial_error_code_test.v` (binds a port, closes it, dials it, asserts a non zero code - the concrete value is platform specific: 111 on Linux, 61 on macOS, 10061 on Windows):

```
running tests in: vlib/net/tcp_dial_error_code_test.v
     OK    [1/2]     0.724 ms     2 asserts | main.test_dial_tcp_failure_preserves_the_error_code()
     OK    [2/2]     0.094 ms     2 asserts | main.test_dial_tcp_with_bind_failure_preserves_the_error_code()
     Summary for running V tests in "tcp_dial_error_code_test.v": 2 passed, 2 total. Elapsed time: 0.857 ms.
```

New `vlib/net/ssl/ssl_dial_error_code_test.v` (the reproduction from the issue, backend agnostic), with the default mbedTLS backend and with `-d use_openssl`:

```
running tests in: vlib/net/ssl/ssl_dial_error_code_test.v
     OK    [1/1]     0.845 ms     1 assert | main.test_dial_failure_has_a_non_zero_error_code()
     Summary for running V tests in "ssl_dial_error_code_test.v": 1 passed, 1 total. Elapsed time: 0.894 ms.

running tests in: vlib/net/ssl/ssl_dial_error_code_test.v      # -d use_openssl
     OK    [1/1]     2.135 ms     1 assert | main.test_dial_failure_has_a_non_zero_error_code()
     Summary for running V tests in "ssl_dial_error_code_test.v": 1 passed, 1 total. Elapsed time: 2.191 ms.
```

Both new tests fail without the fix (`right value: 0`), and the issue's reproduction now prints:

```
v run code.v                 # code=-68 msg=net.mbedtls SSLConn.dial, failed to connect to host
v -d use_openssl run code.v  # code=61  msg=dial_tcp failed for address 127.0.0.1:57130 ... (macOS ECONNREFUSED)
```

The test from the issue report passes now with `-d use_openssl`:

```
running tests in: vlib/net/http/transport_h2_test.v
     OK    [1/1]     2.362 ms     2 asserts | main.test_h2_pool_dial_failure_preserves_error_code()
     Summary for running V tests in "transport_h2_test.v": 1 passed, 1 total. Elapsed time: 2.412 ms.
```

Also run, all passing: `vlib/net/tcp_test.v`, `vlib/net/udp_test.v`, `vlib/net/tcp_simple_client_server_test.v`, `vlib/net/tcp_last_write_sent_test.v`, `vlib/net/tcp_non_blocking_test.v`, `vlib/net/dial_tcp_with_bind_test.v`. `v fmt -verify` is clean on all four files.

## What was not verified locally

- Only macOS (arm64) was available, so the Windows `WSAE*` path was not exercised; `-os windows` C generation additionally needs the V1 fallback compiler, which is not built in this worktree.
- `vlib/net/http/transport_h2_test.v` has an unrelated, pre-existing failure under `-d use_openssl` on this machine: `test_h2_dial_and_do_reuses_pooled_conn_instead_of_redialing` fails with "got 2 accepts", and it does so on an unmodified checkout of the same base commit too (rebuilt from pristine sources to confirm). That file is also very slow with this backend (`test_h2_pool_respects_max_idle_conns_cap` alone takes ~123 s, and it passes in isolation both with and without this change - 123054 ms vs 123098 ms), so the dial error code test from the issue was run on its own, via `VTEST_ONLY_FN`, as shown above.
