### PR TITLE
vfmt: normalize string literal quotes again, keeping escape spelling (fix #28511)

### DIFF
--- a/cmd/tools/vfmt_test.v
+++ b/cmd/tools/vfmt_test.v
@@ -84,7 +84,7 @@ fn test_fmt_uses_v3_formatter() {
 
 	assert res.exit_code == 0, res.output
 	assert res.output.contains('vfmt running v3.gen.v over file:'), res.output
-	assert res.output.contains('fn main() {\n\tprintln("v3")\n}'), res.output
+	assert res.output.contains("fn main() {\n\tprintln('v3')\n}"), res.output
 }
 
 fn test_fmt_checks_accept_legacy_formatted_source() {
@@ -164,7 +164,7 @@ fn test_fmt_preserves_comments_with_v3() {
 	assert formatted.contains('// vfmt off')
 	assert formatted.contains('// vfmt on')
 	assert formatted.contains('println("keep this")')
-	assert formatted.contains('fn format_me() {\n\tprintln("yes")\n}'), formatted
+	assert formatted.contains("fn format_me() {\n\tprintln('yes')\n}"), formatted
 }
 
 fn test_fmt_keeps_regular_comments_attached_with_v3() {

--- a/cmd/tools/vgit-fmt-hook_test.v
+++ b/cmd/tools/vgit-fmt-hook_test.v
@@ -3,7 +3,7 @@ import os
 const vexe = @VEXE
 const tfolder = os.to_slash(os.join_path(os.vtmp_dir(), 'fmt_hook_test'))
 const unformatted_content = '   fn main() {\nprintln(   "hi" )\n println ( 123 )\n   }'
-const formatted_content = 'fn main() {\n\tprintln("hi")\n\tprintln(123)\n}\n'
+const formatted_content = "fn main() {\n\tprintln('hi')\n\tprintln(123)\n}\n"
 const hook_file = '.git/hooks/pre-commit'
 
 // 'env -S' not supported on OpenBSD
@@ -142,7 +142,7 @@ fn test_run_git_fmt_hook_install() {
 	// dump(dres)
 	assert dres.exit_code == 0
 	assert dres.output.contains('+fn main() {')
-	assert dres.output.contains('+\tprintln("hi")')
+	assert dres.output.contains("+\tprintln('hi')")
 	second := os.execute_or_exit('${os.quoted_path(vexe)} git-fmt-hook install')
 	assert second.exit_code == 0
 }

--- a/vlib/v/tests/or_block_in_if_expr_branch_with_g_test.v
+++ b/vlib/v/tests/or_block_in_if_expr_branch_with_g_test.v
@@ -17,7 +17,7 @@ fn test_or_block_in_if_expr_branch_compiles_with_g() {
 	}
 	source := os.join_path(test_dir, 'test.v')
 	out_c := os.join_path(test_dir, 'test.c')
-	os.write_file(source, "struct Params {
+	os.write_file(source, 'struct Params {
 	initial_max_stream_data_bidi_remote ?u64
 	initial_max_stream_data_bidi_local  ?u64
 }
@@ -51,7 +51,7 @@ fn main() {
 	println(c.process(true) or { -1 })
 	println(c.process(false) or { -1 })
 }
-")!
+')!
 	res :=
 		os.execute('${os.quoted_path(vexe)} -g -o ${os.quoted_path(out_c)} -b c ${os.quoted_path(source)}')
 	assert res.exit_code == 0, res.output

--- a/vlib/v/tests/string_escape_opaque_backslash_test.v
+++ b/vlib/v/tests/string_escape_opaque_backslash_test.v
@@ -228,7 +228,7 @@ fn test_orm_table_name_with_decoded_backslash() {
 	sql db {
 		create table OrmTableHazardItem
 	} or { panic(err) }
-	rows := db.exec('select name from sqlite_master where type = \'table\'') or { panic(err) }
+	rows := db.exec("select name from sqlite_master where type = 'table'") or { panic(err) }
 	mut found := false
 	for row in rows {
 		if row.vals.len > 0 {

--- a/vlib/v3/gen/fastc/fastc_test.v
+++ b/vlib/v3/gen/fastc/fastc_test.v
@@ -7292,7 +7292,7 @@ fn test_selfhost_fixed_array_elements_skip_dynamic_inner_array_initialization() 
 fn test_selfhost_append_array_result_to_struct_field() {
 	mut prefs := pref.new_preferences()
 	prefs.building_v = true
-	c_source := generate('module main
+	c_source := generate("module main
 
 struct State {
 mut:
@@ -7300,7 +7300,7 @@ mut:
 }
 
 fn load_values() ![]string {
-	return [\'one\', \'two\']
+	return ['one', 'two']
 }
 
 fn add_values(mut state State) ! {
@@ -7311,7 +7311,7 @@ fn main() {
 	mut state := State{}
 	add_values(mut state) or { panic(err) }
 }
-', 'selfhost_append_array_result_to_struct_field.v', prefs) or { panic(err) }
+", 'selfhost_append_array_result_to_struct_field.v', prefs) or { panic(err) }
 	assert c_source.contains('builtin__array_push_many'), c_source
 	assert !c_source.contains('state->values<<'), c_source
 }
@@ -9571,12 +9571,12 @@ fn main() {
 fn test_selfhost_or_block_with_multiline_struct_fallback_is_a_value() {
 	mut prefs := pref.new_preferences()
 	prefs.building_v = true
-	c_source := generate('module main
+	c_source := generate("module main
 
 struct Item {}
 
 fn get(items map[string]Item) Item {
-	return items[\'missing\'] or {
+	return items['missing'] or {
 		Item{}
 	}
 }
@@ -9584,7 +9584,7 @@ fn get(items map[string]Item) Item {
 fn main() {
 	_ := get(map[string]Item{})
 }
-', 'selfhost_multiline_struct_fallback.v', prefs) or { panic(err) }
+", 'selfhost_multiline_struct_fallback.v', prefs) or { panic(err) }
 	assert c_source.contains('? ((Item){}) : *((Item *)'), c_source
 	assert !c_source.contains('if (__v'), c_source
 }
@@ -12488,7 +12488,7 @@ fn main() {
 fn test_selfhost_map_assignment_with_propagated_result() {
 	mut prefs := pref.new_preferences()
 	prefs.building_v = true
-	c_source := generate('module main
+	c_source := generate("module main
 
 struct Item {
 	value int
@@ -12499,14 +12499,14 @@ fn load_item() !Item {
 }
 
 fn insert(mut items map[string]Item) ! {
-	items[\'answer\'] = load_item()!
+	items['answer'] = load_item()!
 }
 
 fn main() {
 	mut items := map[string]Item{}
 	insert(mut items) or { panic(err) }
 }
-', 'selfhost_map_assignment_propagated_result.v', prefs) or { panic(err) }
+", 'selfhost_map_assignment_propagated_result.v', prefs) or { panic(err) }
 	assert c_source.contains('builtin__map_set'), c_source
 	assert c_source.contains('__vf_op'), c_source
 	assert !c_source.contains('items[_S("answer")]'), c_source

--- a/vlib/v3/gen/v/README.md
+++ b/vlib/v3/gen/v/README.md
@@ -4,14 +4,22 @@ The V3 formatter formats source syntax without type checking.
 
 ## String literal spelling
 
-Non-interpolated string literals retain their original source spelling, including
-quote delimiters, escape sequences, and the `r`, `c`, or `js` prefix. For example,
-`'x=\0'` stays `'x=\0'`, `'x=\x00'` stays `'x=\x00'`, and `"text"` keeps its double
-quotes. Surrounding code is still formatted normally.
+Non-interpolated string literals retain their original source spelling for
+everything except the quote delimiter: escape sequences and the `r`, `c`, or `js`
+prefix are copied byte for byte. For example, `'x=\0'` stays `'x=\0'` and
+`'x=\x00'` stays `'x=\x00'`. Surrounding code is still formatted normally.
 
 The formatter uses the original literal's source span rather than decoding and
-re-encoding it. This also avoids collapsing hex or Unicode escapes into characters
-and keeps a NUL followed by digits distinct from an octal escape.
+re-encoding it. This avoids collapsing hex or Unicode escapes into characters and
+keeps a NUL followed by digits distinct from an octal escape.
+
+The delimiter is normalized: single quotes are preferred, unless the literal
+contains a `'` but no `"`. So `"text"` becomes `'text'`, while `"it's"` keeps its
+double quotes. Only the quote escaping is rewritten along with the delimiter, so
+`"say \"hi\""` becomes `'say "hi"'` and `'it\'s'` becomes `"it's"`. This is the
+rule that interpolated literals and the legacy formatter already follow, so plain
+and interpolated literals are spelled the same way. A raw literal cannot escape a
+quote, so its delimiter decides what it can hold and is kept as written.
 
 Literals without a usable source spelling, such as synthesized AST nodes, still
 use the existing escaping fallback. That fallback emits NUL as `\x00` so that
@@ -20,6 +28,6 @@ following octal digits cannot change the value.
 The C-backend rewrite from a string literal's `.str` selector to a `c` literal
 retains the literal spelling and is stable on subsequent formatting passes.
 
-This policy does not change interpolation formatting, attribute formatting, or
-compiler/scanner escape semantics. Interpolated strings continue to use their
-existing formatting path so embedded expressions can be formatted.
+This policy does not change attribute formatting or compiler/scanner escape
+semantics. Interpolated strings continue to use their existing formatting path so
+embedded expressions can be formatted.

--- a/vlib/v3/gen/v/gen.v
+++ b/vlib/v3/gen/v/gen.v
@@ -4298,12 +4298,18 @@ fn (g &Gen) string_literal_text(n &flat.Node) string {
 		start--
 	}
 	if source := g.source_span(start, n.pos.end) {
-		// Keep the original quotes and escapes, as gofmt does for string literals.
+		// Keep the original escapes, but normalize the delimiter, so that `'\0'` and
+		// `'\x00'` both survive while `"text"` still becomes `'text'`.
 		// Empty or non-literal spans can belong to synthesized nodes; use the fallback below.
 		if source.len >= prefix.len + 2 && source.starts_with(prefix)
 			&& source[prefix.len] in [`'`, `"`]
 			&& source[source.len - 1] == source[prefix.len] {
-			return source
+			// A raw literal cannot escape its delimiter, so its quotes are part of
+			// what it can hold and are kept as written, as they were before.
+			if n.typ.starts_with('raw:') {
+				return source
+			}
+			return requote_literal_text(source, prefix.len)
 		}
 	}
 	if is_c_string {
@@ -4317,6 +4323,51 @@ fn (g &Gen) string_literal_text(n &flat.Node) string {
 		return 'js${quote_string(n.value)}'
 	}
 	return quote_string(n.value)
+}
+
+// preferred_quote picks the delimiter for a literal body: single quotes, unless
+// the body holds a `'` but no `"`. `quote_string` and `string_interp` follow the
+// same rule, so plain and interpolated literals are spelled consistently.
+fn preferred_quote(body string) u8 {
+	return if body.contains("'") && !body.contains('"') { `"` } else { `'` }
+}
+
+// requote_literal_text re-emits an escaped literal's own source spelling under
+// the preferred delimiter. Only the quote escaping is rewritten: every other
+// escape, including `\0` vs `\x00` and hex or Unicode forms, is copied byte for
+// byte. `prefix_len` is the length of a `c` or `js` prefix.
+fn requote_literal_text(source string, prefix_len int) string {
+	old_quote := source[prefix_len]
+	body := source[prefix_len + 1..source.len - 1]
+	new_quote := preferred_quote(body)
+	if new_quote == old_quote {
+		return source
+	}
+	mut b := strings.new_builder(source.len + 8)
+	b.write_string(source[..prefix_len])
+	b.write_u8(new_quote)
+	mut i := 0
+	for i < body.len {
+		c := body[i]
+		if c == `\\` && i + 1 < body.len {
+			next := body[i + 1]
+			// The former delimiter no longer needs escaping; `\\` and every other
+			// escape sequence keep their original spelling.
+			if next != old_quote {
+				b.write_u8(c)
+			}
+			b.write_u8(next)
+			i += 2
+			continue
+		}
+		if c == new_quote {
+			b.write_u8(`\\`)
+		}
+		b.write_u8(c)
+		i++
+	}
+	b.write_u8(new_quote)
+	return b.str()
 }
 
 // quote_string wraps a decoded string-literal value in quotes, preferring

--- a/vlib/v3/gen/v/gen_test.v
+++ b/vlib/v3/gen/v/gen_test.v
@@ -533,7 +533,7 @@ fn test_formatter_keeps_comment_between_brace_and_else_if_clean() {
 	source := 'fn f(name string, x int) {\n\tif x == 1 {\n\t\tprintln(1)\n\t}\n\t// pick the other branch\n\telse if !name.contains(".") {\n\t\tprintln(2)\n\t}\n\tif x == 2 {\n\t\tprintln(3)\n\t}\n\t// plain else\n\telse {\n\t\tprintln(4)\n\t}\n\tif x == 3 {\n\t\tprintln(5)\n\t} // trailing on brace\n\telse {\n\t\tprintln(6)\n\t}\n}\n'
 	out := vfmt('comment_between_brace_and_else_if', source)
 	assert !out.split_into_lines().any(it.ends_with(' ') || it.ends_with('\t')), out
-	assert out.contains('\t}\n\t// pick the other branch\n\telse if !name.contains(".") {\n'), out
+	assert out.contains("\t}\n\t// pick the other branch\n\telse if !name.contains('.') {\n"), out
 	assert out.contains('\t}\n\t// plain else\n\telse {\n'), out
 	assert out.contains('\t} // trailing on brace\n\telse {\n'), out
 	assert vfmt('comment_between_brace_and_else_if_twice', out) == out

--- a/vlib/v3/gen/v/string_literal_spelling_test.v
+++ b/vlib/v3/gen/v/string_literal_spelling_test.v
@@ -26,11 +26,16 @@ fn format_literal_spelling_source(name string, source string) string {
 	return format(parse_literal_spelling_source(name, source))
 }
 
-fn assert_literal_spelling(name string, literal string) {
+fn assert_literal_formats_to(name string, literal string, expected_literal string) {
 	source := 'fn main() {\n\ts := ${literal}\n\t_ = s\n}\n'
+	expected := 'fn main() {\n\ts := ${expected_literal}\n\t_ = s\n}\n'
 	out := format_literal_spelling_source(name, source)
-	assert out == source, '${name}: ${out}'
+	assert out == expected, '${name}: ${out}'
 	assert format_literal_spelling_source('${name}_twice', out) == out
+}
+
+fn assert_literal_spelling(name string, literal string) {
+	assert_literal_formats_to(name, literal, literal)
 }
 
 fn test_formatter_preserves_each_nul_escape_spelling() {
@@ -63,43 +68,56 @@ fn test_formatter_preserves_hex_unicode_and_backslash_spelling() {
 	}
 }
 
-fn test_formatter_preserves_string_quote_delimiters() {
-	literals := [
-		r"''",
-		r'""',
-		r"'single quoted'",
-		r'"double quoted"',
-		r"'it\'s still single quoted'",
-		r'"\"double\""',
-	]
-	for i, literal in literals {
-		assert_literal_spelling('quotes_${i}', literal)
-	}
+fn test_formatter_normalizes_string_quote_delimiters() {
+	// Single quotes are preferred, unless the literal holds a `'` but no `"`.
+	// Interpolated literals already follow that rule, so plain ones must too.
+	assert_literal_spelling('quotes_empty_single', r"''")
+	assert_literal_formats_to('quotes_empty_double', r'""', r"''")
+	assert_literal_spelling('quotes_single', r"'single quoted'")
+	assert_literal_formats_to('quotes_double', r'"double quoted"', r"'double quoted'")
+	// `'it\'s'` -> `"it's"`: double quotes win and the escape is dropped.
+	assert_literal_formats_to('quotes_escaped_single', r"'it\'s single'", '"it\'s single"')
+	assert_literal_spelling('quotes_kept_double', '"it\'s single"')
+	// `"\"double\""` -> `'"double"'`: single quotes win and the escape is dropped.
+	assert_literal_formats_to('quotes_escaped_double', r'"\"double\""', '\'"double"\'')
+	// With both quotes present, single quotes win and `'` stays escaped.
+	assert_literal_spelling('quotes_both_single', '\'has \\\' and \\" both\'')
+	// A double quoted literal with both becomes single quoted, escaping only `'`.
+	assert_literal_formats_to('quotes_both_double', '"has \' and \\" both"', '\'has \\\' and " both\'')
 }
 
-fn test_formatter_preserves_prefixed_string_spelling() {
-	literals := [
-		r"r'\0\x00 $name'",
-		r'r"\0\x00 $name"',
-		r"js'\x41'",
-		r'js"\x41"',
-		r"c''",
-		r'c""',
-		r"c'\0'",
-		r'c"\0"',
-		r"c'\x41'",
-		r'c"\x41"',
-		r'c"\"quoted\""',
-		r"c'A\x5cnB'",
-	]
-	for i, literal in literals {
-		assert_literal_spelling('prefixes_${i}', literal)
-	}
+fn test_formatter_normalizes_prefixed_string_spelling() {
+	assert_literal_spelling('prefixes_js_single', r"js'\x41'")
+	assert_literal_formats_to('prefixes_js_double', r'js"\x41"', r"js'\x41'")
+	assert_literal_spelling('prefixes_c_empty_single', r"c''")
+	assert_literal_formats_to('prefixes_c_empty_double', r'c""', r"c''")
+	assert_literal_spelling('prefixes_c_nul_single', r"c'\0'")
+	assert_literal_formats_to('prefixes_c_nul_double', r'c"\0"', r"c'\0'")
+	assert_literal_spelling('prefixes_c_hex_single', r"c'\x41'")
+	assert_literal_formats_to('prefixes_c_hex_double', r'c"\x41"', r"c'\x41'")
+	assert_literal_spelling('prefixes_c_backslash', r"c'A\x5cnB'")
+	// `c"\"quoted\""` -> `c'"quoted"'`
+	assert_literal_formats_to('prefixes_c_quoted', r'c"\"quoted\""', 'c\'"quoted"\'')
+}
+
+fn test_formatter_keeps_raw_literal_delimiters() {
+	// A raw literal cannot escape a quote, so its delimiter decides what it can
+	// hold and is never rewritten.
+	assert_literal_spelling('raw_single', r"r'\0\x00 $name'")
+	assert_literal_spelling('raw_double', r'r"\0\x00 $name"')
+	assert_literal_spelling('raw_single_inside_double', 'r"raw \' quote"')
+	assert_literal_spelling('raw_double_inside_single', "r'raw \" quote'")
 }
 
 fn test_formatter_recovers_c_string_prefix_from_quote_only_spans() {
 	mut g := Gen.new()
-	for literal in [r"c''", r'c""', r"c'\x41'", r'c"\x41"'] {
+	cases := {
+		r"c''":     r"c''"
+		r'c""':     r"c''"
+		r"c'\x41'": r"c'\x41'"
+		r'c"\x41"': r"c'\x41'"
+	}
+	for literal, expected in cases {
 		g.source = literal
 		// The scanner excludes `c` from a parsed C string's span.
 		quote_only := flat.Node{
@@ -107,14 +125,14 @@ fn test_formatter_recovers_c_string_prefix_from_quote_only_spans() {
 			value: 'c:A'
 			pos: token.new_span(1, 1, literal.len)
 		}
-		assert g.string_literal_text(&quote_only) == literal
+		assert g.string_literal_text(&quote_only) == expected
 		// Also accept nodes whose span already includes the prefix.
 		with_prefix := flat.Node{
 			kind: .char_literal
 			value: 'c:A'
 			pos: token.new_span(1, 0, literal.len)
 		}
-		assert g.string_literal_text(&with_prefix) == literal
+		assert g.string_literal_text(&with_prefix) == expected
 	}
 	// Do not borrow a different preceding byte for a synthesized node.
 	g.source = r'x"\x41"'
@@ -152,14 +170,14 @@ fn test_formatter_aligns_map_keys_using_preserved_literal_spelling() {
 
 fn test_formatter_keeps_c_string_selector_rewrite_idempotent() {
 	source := 'fn main() {\n\ts := "\\x41".str\n}\n'
-	expected := 'fn main() {\n\ts := c"\\x41"\n}\n'
+	expected := "fn main() {\n\ts := c'\\x41'\n}\n"
 	out := format_literal_spelling_source('c_string_selector_spelling', source)
 	assert out == expected, out
 	assert format_literal_spelling_source('c_string_selector_spelling_twice', out) == out
 	js_out := format_with_options(parse_literal_spelling_source('js_string_selector', source), FormatOptions{
 		backend: 'js'
 	})
-	assert js_out == source, js_out
+	assert js_out == "fn main() {\n\ts := '\\x41'.str\n}\n", js_out
 }
 
 fn test_formatter_preserves_multiline_string_contents() {


### PR DESCRIPTION
Fixes #28511.

## Root cause

82e3ade3b5 (#28491) changed `string_literal_text` in `vlib/v3/gen/v/gen.v` to
return a non-interpolated literal's source span verbatim:

```v
if source.len >= prefix.len + 2 && source.starts_with(prefix)
    && source[prefix.len] in [`'`, `"`]
    && source[source.len - 1] == source[prefix.len] {
    return source
}
```

That fixed real escape churn (`'x=\0'` was being rewritten to `'x=\x00'`, hex and
Unicode escapes were collapsed), but it also dropped the `"x"` -> `'x'` rewrite
that `vfmt` has always performed, and it only did so for *plain* literals:
`string_interp` still chooses the delimiter itself. The formatter therefore
disagreed with itself inside one expression list:

```
$ v fmt q.v
fn main() {
	x := 1
	println('v3 ${x}')   // normalised
	println("plain")     // not normalised
}
```

## Policy decision

The two concerns are separable, so I restored normalisation and kept #28491's win.

The escape churn came from a *different* code path: the fallback decodes
`n.value` and re-encodes it through `escape_string`, which is what turns `\0`
into `\x00` and `\x41` into `A`. The delimiter is an independent choice that can
be made on the original source text. This is exactly how the legacy formatter
works — `vlib/v/fmt/fmt.v:4060` picks a quote and then does a
`replace_each`/unescape dance over `node.val`, which in the V1 AST is the raw
source spelling.

`requote_literal_text` now walks the original span, copies every escape byte for
byte, and rewrites *only* the quote escaping:

| input | output |
| --- | --- |
| `"plain"` | `'plain'` |
| `"x=\0"` | `'x=\0'` |
| `"x=\x00"` | `'x=\x00'` |
| `"say \"hi\""` | `'say "hi"'` |
| `'it\'s'` | `"it's"` |
| `"it's"` | `"it's"` |
| `'has \' and \" both'` | unchanged |
| `c"\x41"` | `c'\x41'` |
| `js"\x41"` | `js'\x41'` |

The delimiter rule is the one `string_interp` and the legacy formatter already
use: prefer single quotes, unless the literal holds a `'` but no `"`. Plain and
interpolated literals are now spelled the same way.

A **raw** literal keeps its delimiter, because it cannot escape a quote, so the
delimiter decides what the literal can hold. That is also what v3 did before
#28491 (the old fallback was `'r${quote}${n.value}${quote}'` with the quote taken
from `n.typ`), and it is what `test_fmt_preserves_raw_string_prefix_with_v3`
already asserts.

I also round-tripped a program containing every one of the cases above through
`v fmt` and compared `.bytes().hex()` of each literal before and after: the byte
values are identical, and a second `v fmt` pass is a no-op.

## Files changed and why

**The fix**

* `vlib/v3/gen/v/gen.v` — new `preferred_quote` / `requote_literal_text`;
  `string_literal_text` calls the latter instead of returning the span verbatim,
  with an early return for raw literals.
* `vlib/v3/gen/v/README.md` — the "String literal spelling" section documented
  the #28491 policy; updated to describe escape preservation + delimiter
  normalisation.

**Tests for the fix**

* `vlib/v3/gen/v/string_literal_spelling_test.v` — the file #28491 added.
  `assert_literal_spelling` gained an `assert_literal_formats_to` variant so a
  literal can assert a *mapping*, not just identity. The escape-preservation
  tests are untouched and still pass; the two quote-preservation tests became
  `test_formatter_normalizes_string_quote_delimiters` /
  `test_formatter_normalizes_prefixed_string_spelling`, plus a new
  `test_formatter_keeps_raw_literal_delimiters`.
* `vlib/v3/gen/v/gen_test.v` — one assertion in
  `test_formatter_keeps_comment_between_brace_and_else_if_clean` expected the
  output to contain `name.contains(".")`. The test is about comment placement;
  its input still uses `"."`, and the expected output is now `'.'`.

**The four assertions from the issue** — note these are *restored*, not updated.
e231bc95a0 (`ci: restore bootstrap and fix master failures`, already on master)
had flipped them to the preserve-quotes behaviour, so on current master they pass
and it is the formatter that is inconsistent. Restoring normalisation means
flipping them back to their original, pre-#28491 single-quote form:

* `cmd/tools/vfmt_test.v` — `test_fmt_uses_v3_formatter` and
  `test_fmt_preserves_comments_with_v3`.
* `cmd/tools/vgit-fmt-hook_test.v` — `formatted_content` (used by
  `test_run_vfmt_manually`) and the diff assertion in
  `test_run_git_fmt_hook_install`.

**Fallout in committed sources** — these three are genuine fallout, not unrelated
churn. They are *exactly* the files the whole-tree sweep below flagged as newly
differing, and every hunk is a quote-delimiter change with no reflow:

* `vlib/v/tests/or_block_in_if_expr_branch_with_g_test.v` — a multiline
  `"..."` payload with no quote characters in it becomes `'...'`.
* `vlib/v/tests/string_escape_opaque_backslash_test.v` —
  `'select ... type = \'table\''` becomes `"select ... type = 'table'"`.
* `vlib/v3/gen/fastc/fastc_test.v` — three multiline `'...\'x\'...'` payloads
  become `"...'x'..."`.

Without these, the three files newly fail `v fmt -verify` (I confirmed each:
master binary `OK`, patched binary `FAIL`). After reformatting they match what
*both* the legacy formatter and the v3 formatter produce. The three affected
`fastc_test.v` test functions still pass.

## Tests

`vlib/v3/gen/v/string_literal_spelling_test.v`:

```
     OK    [ 1/11]     5.753 ms    28 asserts | v3.gen.v.test_formatter_preserves_each_nul_escape_spelling()
     OK    [ 2/11]     4.445 ms    28 asserts | v3.gen.v.test_formatter_preserves_hex_unicode_and_backslash_spelling()
     OK    [ 3/11]     5.738 ms    36 asserts | v3.gen.v.test_formatter_normalizes_string_quote_delimiters()
     OK    [ 4/11]     5.499 ms    40 asserts | v3.gen.v.test_formatter_normalizes_prefixed_string_spelling()
     OK    [ 5/11]     2.100 ms    16 asserts | v3.gen.v.test_formatter_keeps_raw_literal_delimiters()
     OK    [ 6/11]     0.007 ms    12 asserts | v3.gen.v.test_formatter_recovers_c_string_prefix_from_quote_only_spans()
     OK    [ 7/11]     0.417 ms     4 asserts | v3.gen.v.test_formatter_preserves_literals_while_formatting_surrounding_code()
     OK    [ 8/11]     0.826 ms     4 asserts | v3.gen.v.test_formatter_aligns_map_keys_using_preserved_literal_spelling()
     OK    [ 9/11]     0.704 ms     6 asserts | v3.gen.v.test_formatter_keeps_c_string_selector_rewrite_idempotent()
     OK    [10/11]     0.441 ms     4 asserts | v3.gen.v.test_formatter_preserves_multiline_string_contents()
     OK    [11/11]     0.003 ms     3 asserts | v3.gen.v.test_formatter_keeps_safe_escaping_without_literal_source()
     Summary for running V tests in "string_literal_spelling_test.v": 181 passed, 181 total. Elapsed time: 26 ms.
```

`vlib/v3/gen/v/gen_test.v`:

```
     Summary for running V tests in "gen_test.v": 459 passed, 459 total. Elapsed time: 91 ms.
```

`cmd/tools/vfmt_test.v` — the two functions from the issue, and the total:

```
     OK    [ 4/96]    20.894 ms     3 asserts | main.test_fmt_uses_v3_formatter()
     OK    [ 9/96]    21.079 ms     6 asserts | main.test_fmt_preserves_comments_with_v3()
     Summary for running V tests in "vfmt_test.v": 485 passed, 485 total. Elapsed time: 4275 ms.
```

`cmd/tools/vgit-fmt-hook_test.v`:

```
     OK    [1/9]   145.504 ms     3 asserts | main.testsuite_begin()
     OK    [2/9]    95.432 ms     6 asserts | main.test_commit_no_vfmt()
     OK    [3/9]   119.467 ms     7 asserts | main.test_run_vfmt_manually()
     OK    [4/9]    39.285 ms     7 asserts | main.test_run_git_fmt_hook()
     OK    [5/9]    34.952 ms     7 asserts | main.test_run_git_fmt_hook_status_explicit()
     OK    [6/9]  1268.166 ms    18 asserts | main.test_run_git_fmt_hook_install()
     OK    [7/9]   130.547 ms     7 asserts | main.test_run_git_fmt_hook_remove()
     OK    [8/9]  1044.785 ms    16 asserts | main.test_run_git_fmt_hook_install_and_remove_on_foreign_hook_should_be_a_nop()
     OK    [9/9]    56.646 ms     2 asserts | main.testsuite_end()
     Summary for running V tests in "vgit-fmt-hook_test.v": 73 passed, 73 total. Elapsed time: 2934 ms.
```

Every changed `.v` file passes `v fmt -verify` with an unmodified master binary.

## Whole-tree sweep

Both sides format the *same* pristine snapshot of `vlib cmd examples`
(6425 `.v`/`.vsh` files, taken at the base commit so the inputs are byte-identical),
run a second pass over their own output, and use the same compiler binary — the
only variable is this patch.

| | baseline | patched |
| --- | --- | --- |
| files | 6425 | 6425 |
| differ from committed source | 2335 | 2338 |
| unstable (pass 2 != pass 1) | 37 | 37 |

* **newly differing: 3** — the three files reformatted in this PR
* **newly unstable: 0**
* **no longer differing: 0**, **no longer unstable: 0**
* files whose formatter output changed at all (baseline output vs patched output): **3**, the same three

I diffed baseline output against patched output for every file. All hunks in
those three files are quote-delimiter changes only; nothing else in the tree
moves. The absolute "differing" totals are large on both sides because the v3
formatter already disagrees with roughly a third of the committed tree
independently of this change.
