### PR TITLE
cmd/v: drive the V3 dispatcher in the macos_v3 process tests (fix #28512)

### DIFF
--- a/cmd/v/macos_v3_dispatch.c.v
+++ b/cmd/v/macos_v3_dispatch.c.v
@@ -209,10 +209,11 @@ fn is_macos_v3_relevant_command(command string, prefs &pref.Preferences) bool {
 		|| macos_v3_non_compilation_command(command) {
 		return false
 	}
-	// The legacy preference parser deliberately rejects `v build <source>`, so it
-	// does not populate prefs.path for the explicit build command. Let V3 parse the
-	// original arguments and report missing or invalid inputs instead of reaching
-	// the V3-only command shell's unreachable V1 builder guard.
+	// The legacy preference parser deliberately rejects `v build <source>`, so an
+	// explicit build command reaching this point has no path, or a path that does
+	// not exist. Let V3 parse the original arguments and report missing or invalid
+	// inputs instead of reaching the V3-only command shell's unreachable V1 builder
+	// guard.
 	if command == 'build' {
 		return true
 	}
@@ -239,11 +240,11 @@ fn launch_macos_v3_compiler(prefs &pref.Preferences, raw_args []string) {
 	mut environment := macos_v3_child_environment(vexe, caller_environment, dispatch_environment)
 	no_fallback := environment[macos_v3_no_fallback_env] or { '' }
 	// cmd/v self-builds deliberately remain V3-only. The compatibility compiler
-	// exists for user programs and tools, not as an alternate self-host path. An
-	// empty path belongs to explicit `build` argument validation, which V1 cannot
-	// recover and would only report again with a less useful empty-path error.
-	fallback_enabled := prefs.path != '' && !prefs.new_compiler && no_fallback != '1'
-		&& !macos_v3_is_self_build_target(prefs)
+	// exists for user programs and tools, not as an alternate self-host path. A
+	// missing or empty input path belongs to explicit argument validation, which V1
+	// cannot recover and would only report a second time.
+	fallback_enabled := prefs.path != '' && os.exists(prefs.path) && !prefs.new_compiler
+		&& no_fallback != '1' && !macos_v3_is_self_build_target(prefs)
 	fallback_file := macos_v3_fallback_file_for_pid()
 	c_error_dir := macos_v3_c_error_report_dir(fallback_file)
 	os.rm(fallback_file) or {}

--- a/cmd/v/macos_v3_external_fallback_test.v
+++ b/cmd/v/macos_v3_external_fallback_test.v
@@ -2,21 +2,33 @@ module main
 
 import os
 
+// The tools workflow compiles and runs this suite with the V1 compatibility
+// compiler, so `@VEXE` is `v1_fallback` there. This dispatcher test must still drive
+// the sibling V3 enabled `v`. Returns none when that binary is absent, e.g. in a plain
+// developer build without one, so the test can skip instead of fail.
+fn external_fallback_test_dispatcher() ?string {
+	if os.base(@VEXE) !in ['v1_fallback', 'v1_fallback.exe'] {
+		return @VEXE
+	}
+	dispatcher := os.join_path(os.dir(@VEXE), 'v' + $if windows { '.exe' } $else { '' })
+	if !os.is_executable(dispatcher) {
+		return none
+	}
+	return dispatcher
+}
+
 fn run_external_fallback_test_process(executable string, args []string, work_dir string, overrides map[string]string) os.Result {
 	mut environment := os.environ()
 	environment['VFLAGS'] = ''
 	environment['VOSARGS'] = ''
+	// The compiler started here has to identify itself by its own path: the stub C
+	// compiler below recognizes the V1 compatibility stage by VEXE, and an inherited
+	// VEXE from the tools lanes would already name `v1_fallback` in the V3 stage.
+	environment.delete('VEXE')
 	for name, value in overrides {
 		environment[name] = value
 	}
-	// The tools workflow runs this suite through the V1 compatibility compiler.
-	// Process-level dispatcher tests must still invoke the sibling V3-enabled `v`.
-	actual_executable := if os.base(executable) in ['v1_fallback', 'v1_fallback.exe'] {
-		os.join_path(os.dir(executable), 'v' + $if windows { '.exe' } $else { '' })
-	} else {
-		executable
-	}
-	mut process := os.new_process(actual_executable)
+	mut process := os.new_process(executable)
 	process.set_args(args)
 	process.set_work_folder(work_dir)
 	process.set_environment(environment)
@@ -46,6 +58,10 @@ fn test_macos_v3_uses_external_v1_fallback_after_c_compilation_error() {
 		if !os.is_executable(fallback) {
 			return
 		}
+		vexe := external_fallback_test_dispatcher() or {
+			eprintln('> skipping ${@FN}: the V3 dispatcher `v` is missing next to `${@VEXE}`')
+			return
+		}
 		root := os.join_path(os.vtmp_dir(), 'v3_external_v1_fallback_${os.getpid()}')
 		os.rmdir_all(root) or {}
 		os.mkdir_all(root)!
@@ -57,7 +73,7 @@ fn test_macos_v3_uses_external_v1_fallback_after_c_compilation_error() {
 		compiler := os.join_path(root, 'reject-v3-cc')
 		write_v3_rejecting_c_compiler(compiler)!
 		output := os.join_path(root, 'main')
-		result := run_external_fallback_test_process(@VEXE, ['-silent', '-nocache', '-no-parallel',
+		result := run_external_fallback_test_process(vexe, ['-silent', '-nocache', '-no-parallel',
 			'-cc', compiler, '-o', output, source], vroot, {
 			'V_MACOS_V3_NO_FALLBACK': ''
 		})
@@ -70,7 +86,7 @@ fn test_macos_v3_uses_external_v1_fallback_after_c_compilation_error() {
 		strict_compiler := os.join_path(root, 'strict-reject-v3-cc')
 		write_v3_rejecting_c_compiler(strict_compiler)!
 		strict_output := os.join_path(root, 'strict')
-		strict := run_external_fallback_test_process(@VEXE, ['-silent', '-nocache', '-no-parallel',
+		strict := run_external_fallback_test_process(vexe, ['-silent', '-nocache', '-no-parallel',
 			'-cc', strict_compiler, '-o', strict_output, source], vroot, {
 			'V_MACOS_V3_NO_FALLBACK': '1'
 		})

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -5,21 +5,40 @@ import v.pref
 
 const macos_v3_test_vroot = os.dir(@VEXE)
 
+// The tools workflow compiles and runs this suite with the V1 compatibility
+// compiler, so `@VEXE` is `v1_fallback` there. Process level dispatcher tests must
+// still drive the sibling V3 enabled `v`. Returns none when that binary is absent,
+// e.g. in a plain developer build without one, so the test can skip instead of fail.
+fn macos_v3_test_dispatcher() ?string {
+	if os.base(@VEXE) !in ['v1_fallback', 'v1_fallback.exe'] {
+		return @VEXE
+	}
+	dispatcher := os.join_path(os.dir(@VEXE), 'v' + $if windows { '.exe' } $else { '' })
+	if !os.is_executable(dispatcher) {
+		return none
+	}
+	return dispatcher
+}
+
+fn macos_v3_test_dispatcher_or_skip(test_name string) ?string {
+	return macos_v3_test_dispatcher() or {
+		eprintln('> skipping ${test_name}: the V3 dispatcher `v` is missing next to `${@VEXE}`')
+		return none
+	}
+}
+
 fn run_macos_v3_test_process(executable string, args []string, work_dir string, overrides map[string]string) os.Result {
 	mut environment := os.environ()
 	environment['VFLAGS'] = ''
 	environment['VOSARGS'] = ''
+	// Every compiler started here has to identify itself by its own path. The tools
+	// lanes run this suite with VEXE set to the compatibility compiler, and a child
+	// `v` would otherwise inherit that identity from its caller.
+	environment.delete('VEXE')
 	for name, value in overrides {
 		environment[name] = value
 	}
-	// The tools workflow runs this suite through the V1 compatibility compiler.
-	// Process-level dispatcher tests must still invoke the sibling V3-enabled `v`.
-	actual_executable := if os.base(executable) in ['v1_fallback', 'v1_fallback.exe'] {
-		os.join_path(os.dir(executable), 'v' + $if windows { '.exe' } $else { '' })
-	} else {
-		executable
-	}
-	mut process := os.new_process(actual_executable)
+	mut process := os.new_process(executable)
 	process.set_args(args)
 	process.set_work_folder(work_dir)
 	process.set_environment(environment)
@@ -86,13 +105,14 @@ fn test_macos_v3_relevant_command_owns_every_direct_c_build() {
 }
 
 fn test_macos_v3_explicit_build_reports_a_regular_input_error() {
+	vexe := macos_v3_test_dispatcher_or_skip(@FN) or { return }
 	for args in [['build', 'help'], ['-new-compiler', 'build', 'help']] {
-		result := run_macos_v3_test_process(@VEXE, args, macos_v3_test_vroot, {})
+		result := run_macos_v3_test_process(vexe, args, macos_v3_test_vroot, {})
 		assert result.exit_code == 1, result.output
 		assert result.output.trim_space() == "builder error: help doesn't exist", result.output
 	}
 	for args in [['build'], ['-new-compiler', 'build']] {
-		result := run_macos_v3_test_process(@VEXE, args, macos_v3_test_vroot, {})
+		result := run_macos_v3_test_process(vexe, args, macos_v3_test_vroot, {})
 		assert result.exit_code == 1, result.output
 		assert result.output.trim_space() == 'no input file', result.output
 	}
@@ -180,6 +200,7 @@ fn test_v1_fallback_can_bootstrap_cmd_v_without_target_define() {
 }
 
 fn test_macos_v3_old_compiler_uses_external_v1_command() {
+	vexe := macos_v3_test_dispatcher_or_skip(@FN) or { return }
 	fallback := macos_v3_v1_fallback_executable()
 	if !os.is_executable(fallback) {
 		return
@@ -193,7 +214,7 @@ fn test_macos_v3_old_compiler_uses_external_v1_command() {
 	source := os.join_path(root, 'main.v')
 	os.write_file(source, 'fn main() { println("v1") }\n')!
 	output := os.join_path(root, 'main')
-	result := run_macos_v3_test_process(@VEXE, ['-old-compiler', '-o', output, source], macos_v3_test_vroot, {})
+	result := run_macos_v3_test_process(vexe, ['-old-compiler', '-o', output, source], macos_v3_test_vroot, {})
 	assert result.exit_code == 0, result.output
 	assert os.is_executable(output)
 	run := os.execute(os.quoted_path(output))
@@ -202,6 +223,7 @@ fn test_macos_v3_old_compiler_uses_external_v1_command() {
 }
 
 fn test_macos_v3_invalid_program_still_reports_an_error_after_v1_retry() {
+	vexe := macos_v3_test_dispatcher_or_skip(@FN) or { return }
 	root := os.join_path(os.vtmp_dir(), 'v3_invalid_program_${os.getpid()}')
 	os.rmdir_all(root) or {}
 	os.mkdir_all(root)!
@@ -210,7 +232,7 @@ fn test_macos_v3_invalid_program_still_reports_an_error_after_v1_retry() {
 	}
 	source := os.join_path(root, 'main.v')
 	os.write_file(source, 'fn main() { missing_name() }\n')!
-	result := run_macos_v3_test_process(@VEXE, ['-o', os.join_path(root, 'main'), source], macos_v3_test_vroot, {
+	result := run_macos_v3_test_process(vexe, ['-o', os.join_path(root, 'main'), source], macos_v3_test_vroot, {
 		'V_MACOS_V3_FALLBACK_FILE': os.join_path(root, 'stale_fallback')
 		'V_MACOS_V3_C_ERROR_DIR':   os.join_path(root, 'stale_report')
 		'V_MACOS_V3_RETRY':         '1'
@@ -221,6 +243,7 @@ fn test_macos_v3_invalid_program_still_reports_an_error_after_v1_retry() {
 }
 
 fn test_macos_v3_fatal_errors_reports_only_the_first_error() {
+	vexe := macos_v3_test_dispatcher_or_skip(@FN) or { return }
 	root := os.join_path(os.vtmp_dir(), 'v3_fatal_errors_${os.getpid()}')
 	os.rmdir_all(root) or {}
 	os.mkdir_all(root)!
@@ -229,7 +252,7 @@ fn test_macos_v3_fatal_errors_reports_only_the_first_error() {
 	}
 	source := os.join_path(root, 'main.v')
 	os.write_file(source, 'fn main() {\n\tmissing_first()\n\tmissing_second()\n}\n')!
-	result := run_macos_v3_test_process(@VEXE, ['-Wfatal-errors', '-o', os.join_path(root, 'main'),
+	result := run_macos_v3_test_process(vexe, ['-Wfatal-errors', '-o', os.join_path(root, 'main'),
 		source], macos_v3_test_vroot, {})
 	assert result.exit_code == 1, result.output
 	assert result.output.contains('missing_first'), result.output
@@ -376,6 +399,7 @@ fn test_macos_v3_ownership_delegation_never_selects_v1() {
 
 fn test_macos_v3_autofree_direct_and_run_use_ownership_compiler() {
 	$if bsd || linux {
+		vexe := macos_v3_test_dispatcher_or_skip(@FN) or { return }
 		root := os.join_path(os.vtmp_dir(), 'v3_autofree_run_${os.getpid()}')
 		os.rmdir_all(root) or {}
 		os.mkdir_all(root)!
@@ -385,12 +409,12 @@ fn test_macos_v3_autofree_direct_and_run_use_ownership_compiler() {
 		source := os.join_path(root, 'main.v')
 		os.write_file(source, "fn main() { println('autofree run') }\n")!
 		output := os.join_path(root, 'direct')
-		direct := run_macos_v3_test_process(@VEXE, ['-autofree', '-o', output, source], macos_v3_test_vroot, {})
+		direct := run_macos_v3_test_process(vexe, ['-autofree', '-o', output, source], macos_v3_test_vroot, {})
 		assert direct.exit_code == 0, direct.output
 		direct_run := run_macos_v3_test_process(output, [], macos_v3_test_vroot, {})
 		assert direct_run.exit_code == 0, direct_run.output
 		assert direct_run.output.trim_space() == 'autofree run', direct_run.output
-		result := run_macos_v3_test_process(@VEXE, ['-autofree', 'run', source], macos_v3_test_vroot, {})
+		result := run_macos_v3_test_process(vexe, ['-autofree', 'run', source], macos_v3_test_vroot, {})
 		assert result.exit_code == 0, result.output
 		assert result.output.trim_space() == 'autofree run', result.output
 	}
@@ -398,6 +422,7 @@ fn test_macos_v3_autofree_direct_and_run_use_ownership_compiler() {
 
 fn test_macos_v3_parallel_cc_ignores_inactive_header_definitions() {
 	$if bsd || linux {
+		vexe := macos_v3_test_dispatcher_or_skip(@FN) or { return }
 		root := os.join_path(os.vtmp_dir(), 'v3_parallel_cc_inactive_${os.getpid()}')
 		os.rmdir_all(root) or {}
 		os.mkdir_all(root)!
@@ -408,7 +433,7 @@ fn test_macos_v3_parallel_cc_ignores_inactive_header_definitions() {
 		source := os.join_path(root, 'main.v')
 		os.write_file(source, '\$if windows {\n#include "@DIR/inactive_impl.h"\n}\n\nfn main() { println("ok") }\n')!
 		output := os.join_path(root, 'main')
-		result := run_macos_v3_test_process(@VEXE, ['-gc', 'none', '-parallel-cc', '-nocache', '-o',
+		result := run_macos_v3_test_process(vexe, ['-gc', 'none', '-parallel-cc', '-nocache', '-o',
 			output, source], macos_v3_test_vroot, {})
 		assert result.exit_code == 0, result.output
 		assert !result.output.contains('failed to link after parallel C compilation'), result.output
@@ -419,11 +444,12 @@ fn test_macos_v3_parallel_cc_ignores_inactive_header_definitions() {
 }
 
 fn test_macos_v3_compiles_cmd_v_without_v1_modules() {
+	vexe := macos_v3_test_dispatcher_or_skip(@FN) or { return }
 	compiler := os.join_path(macos_v3_test_vroot, '.v3_only_cmd_test_${os.getpid()}')
 	defer {
 		os.rm(compiler) or {}
 	}
-	result := run_macos_v3_test_process(@VEXE, ['-no-memory-limit', '-no-parallel', '-o', compiler,
+	result := run_macos_v3_test_process(vexe, ['-no-memory-limit', '-no-parallel', '-o', compiler,
 		'cmd/v'], macos_v3_test_vroot, {})
 	assert result.exit_code == 0, result.output
 	assert os.is_executable(compiler)

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -1358,6 +1358,11 @@ fn parse_args_impl(known_external_commands []string, args []string, show_output 
 		}
 	} else if is_source_file(command) {
 		res.path = command
+	} else if command == 'build' {
+		// `v build <target>` compiles <target>, just like `v <target>` does. Without
+		// the target in res.path, the builder could only report an empty path in its
+		// `<target> doesn't exist` error.
+		res.path = command_args[0] or { eprintln_exit('no input file') }
 	}
 	if !res.is_bare && res.bare_builtin_dir != '' {
 		eprintln_cond(show_output && !res.is_quiet, '`-bare-builtin-dir` must be used with `-freestanding`')

--- a/vlib/v/pref/pref.v
+++ b/vlib/v/pref/pref.v
@@ -482,6 +482,7 @@ fn parse_args_impl(known_external_commands []string, args []string, show_output 
 	mut no_skip_unused := false
 	mut command, mut command_idx := '', 0
 	mut build_vsh_source := false
+	mut build_target := ''
 	mut new_compiler_set_by_flag := false
 	for i := 0; i < args.len; i++ {
 		arg := args[i]
@@ -1251,6 +1252,11 @@ fn parse_args_impl(known_external_commands []string, args []string, show_output 
 						if res.is_eval_argument || command in ['run', 'crun', 'watch'] {
 							break
 						}
+					} else if command == 'build' && build_target == '' {
+						// The first argument after the `build` command that is neither an
+						// option nor an option value is its target. Options may precede it,
+						// as in `v build -o out target`.
+						build_target = arg
 					} else if is_source_file(command) && is_source_file(arg) && !res.is_vsh
 						&& command !in known_external_commands && res.raw_vsh_tmp_prefix == '' {
 						eprintln_exit('Too many targets. Specify just one target: <target.v|target_directory>.')
@@ -1362,7 +1368,10 @@ fn parse_args_impl(known_external_commands []string, args []string, show_output 
 		// `v build <target>` compiles <target>, just like `v <target>` does. Without
 		// the target in res.path, the builder could only report an empty path in its
 		// `<target> doesn't exist` error.
-		res.path = command_args[0] or { eprintln_exit('no input file') }
+		if build_target == '' {
+			eprintln_exit('no input file')
+		}
+		res.path = build_target
 	}
 	if !res.is_bare && res.bare_builtin_dir != '' {
 		eprintln_cond(show_output && !res.is_quiet, '`-bare-builtin-dir` must be used with `-freestanding`')


### PR DESCRIPTION
## Root cause

The `tools-*` lanes in `.github/workflows/tools_ci.yml` set `VFLAGS=-old-compiler`, so `./v -silent test-self cmd` is exec'd into `v1_fallback` by the dispatcher. Everything below it inherits that: the cmd/v test binaries are compiled by `v1_fallback`, their `@VEXE` is `<vroot>/v1_fallback`, and `VEXE=<vroot>/v1_fallback` is exported for the whole run. Both process level dispatcher tests drove `@VEXE` while assuming it is the V3 dispatcher `v`:

* `test_macos_v3_explicit_build_reports_a_regular_input_error` ran `v1_fallback build help` and got `builder error:  doesn't exist` instead of the expected `builder error: help doesn't exist`.
* `test_macos_v3_uses_external_v1_fallback_after_c_compilation_error` has a stub C compiler that only accepts the V1 stage (`${VEXE##*/} = v1_fallback`). Run by `v1_fallback` there is no V3 stage to reject, so the strict `V_MACOS_V3_NO_FALLBACK=1` build succeeded and `assert strict.exit_code != 0` failed.

## What changed, and why

**`cmd/v/macos_v3_test.v`, `cmd/v/macos_v3_external_fallback_test.v`** - resolve the dispatcher instead of skipping. Every `@VEXE` driven process in both suites now goes through a small `..._dispatcher()` helper that returns `@VEXE` normally, and `os.join_path(os.dir(@VEXE), 'v' + exe_ext)` when `@VEXE` is `v1_fallback`. Resolving keeps the V3 dispatch covered on the old compiler lanes, where `make` always puts `v` next to `v1_fallback`; a skip would silently drop that coverage on three lanes. The helper verifies that the binary exists and returns none otherwise, so a build that never went through `make` skips with an explanatory `eprintln` rather than starting a missing executable.

This replaces the blanket redirect that was added to the two `run_*_process` helpers in e231bc95a0. That redirect also rewrote the explicitly passed fallback path in `test_v1_fallback_can_bootstrap_cmd_v_without_target_define`, i.e. that test silently stopped exercising `v1_fallback`. Deciding at the call site keeps both intents: the dispatcher tests drive `v`, the fallback tests drive `v1_fallback`.

A resolved dispatcher alone is not enough for the external fallback test. Its stub C compiler recognizes the V1 stage by `VEXE`, and on the tools lanes `VEXE` already names `v1_fallback`, so the stub accepted the V3 stage and the strict build succeeded anyway. Both suites now drop the inherited `VEXE` from the child environment, next to the existing `VFLAGS`/`VOSARGS` reset, so every compiler they start identifies itself by its own path.

**`vlib/v/pref/pref.v`** - the issue asks for the legacy builder's empty path message to be fixed. The path was empty because the parser never carried the explicit `build` target into `pref.path`, so `Builder.add_file_or_dir('')` reported `` doesn't exist``. `v build <target>` now stores the target, the same way `run` does, and a bare `v build` reports `no input file` like V3. An existing target is still rejected earlier with ``Use `v <target>` instead.``, so this only affects missing targets.

**`cmd/v/macos_v3_dispatch.c.v`** - required follow up of the parser fix. `fallback_enabled` used `prefs.path != ''` to keep the `build <missing>` validation away from the V3 to V1 retry. With the path now populated, `v build help` fell into the retry and printed the error twice. The condition is now `prefs.path != '' && os.exists(prefs.path)`: V1 cannot recover an input that does not exist, and would only report the same error again. This also removes the pre-existing double report for `v -o out missing.v`.

## Verification (macOS, arm64)

Reproduced both failures first, with the test binaries compiled by a `v1_fallback` built from master and run with the lane environment (`VEXE=$PWD/v1_fallback VCHILD=true VFLAGS=-old-compiler -cc clang`):

```
######## BEFORE: macos_v3_test.v (state the issue was filed against)
cmd/v/macos_v3_test.v:85: fn test_macos_v3_explicit_build_reports_a_regular_input_error
  > assert result.output.trim_space() == 'builder error: help doesn't exist', result.output
    Left value (len: 29):
      `builder error:  doesn't exist`
    Right value (len: 33):
      `builder error: help doesn't exist`
exit=1

######## BEFORE: macos_v3_external_fallback_test.v (master HEAD, with the redirect)
cmd/v/macos_v3_external_fallback_test.v:77: fn test_macos_v3_uses_external_v1_fallback_after_c_compilation_error
   > assert strict.exit_code != 0, strict.output
     Left value (len: 1): `0`
exit=1
```

After, both suites pass whether they are compiled and run by `v1_fallback` or by the V3 dispatcher:

```
######## FINAL, -old-compiler lane (compiled + run by v1_fallback)
macos_v3_external_fallback_test.v exit=0
macos_v3_test.v exit=0

######## FINAL, normal lane (compiled + run by the V3 dispatcher v)
macos_v3_external_fallback_test.v exit=0
macos_v3_test.v exit=0
```

The skip path was checked by hiding `v` next to `v1_fallback`:

```
> skipping test_macos_v3_uses_external_v1_fallback_after_c_compilation_error: the V3 dispatcher `v` is missing next to `/.../v1_fallback`
> skipping test_macos_v3_explicit_build_reports_a_regular_input_error: the V3 dispatcher `v` is missing next to `/.../v1_fallback`
...
exit=0
```

Both compilers now agree on the explicit build command:

```
### ./v
  build help -> [builder error: help doesn't exist] exit=1
  -new-compiler build help -> [builder error: help doesn't exist] exit=1
  build -> [no input file] exit=1
  -new-compiler build -> [no input file] exit=1
### ./v1_fallback
  build help -> [builder error: help doesn't exist] exit=1
  -new-compiler build help -> [builder error: help doesn't exist] exit=1
  build -> [no input file] exit=1
  -new-compiler build -> [no input file] exit=1
```

Also checked: `./v -no-memory-limit -o v_new cmd/v` builds cleanly, `v build <script>.vsh` and `v build-module` are unaffected, `cmd/v/macos_v3_compat_routing_test.v` and `vlib/v/pref/pref_test.v` pass, and `v fmt -verify` is clean on all four files.