### PR TITLE
v3: call veb route handlers that omit their context parameter

### DIFF
--- a/vlib/v3/tests/veb_implicit_ctx_test.v
+++ b/vlib/v3/tests/veb_implicit_ctx_test.v
@@ -244,3 +244,53 @@ fn main() {
 	assert run.exit_code == 0, run.output
 	assert run.output.trim_space() == 'first:second', run.output
 }
+
+// A reflected `app.$method(mut ctx)` call passes the hidden veb context as its
+// only argument. Handlers that declare no parameters of their own still accept
+// it, so the specialization must be kept: dropping it as an arity mismatch made
+// veb answer `HTTP/ 0` for every route whose handler omitted `ctx`.
+fn test_veb_reflected_implicit_ctx_call_without_spread_args() {
+	v3_bin := build_v3()
+	src := '
+import veb
+
+pub struct Context {
+	veb.Context
+}
+
+pub struct App {}
+
+pub fn (mut app App) index() veb.Result {
+	println("index called")
+	return veb.Result{}
+}
+
+pub fn (mut app App) explicit(mut ctx Context) veb.Result {
+	println("explicit called")
+	return veb.Result{}
+}
+
+fn dispatch[A, X](mut app A, mut ctx X) {
+	$for method in A.methods {
+		$if method.return_type is veb.Result {
+			app.$method(mut ctx)
+		}
+	}
+}
+
+fn main() {
+	mut app := App{}
+	mut ctx := Context{}
+	dispatch(mut app, mut ctx)
+}
+'
+	src_file := os.join_path(os.temp_dir(), 'v3_veb_implicit_ctx_no_spread.v')
+	os.write_file(src_file, src) or { panic(err) }
+	bin_out := os.join_path(os.temp_dir(), 'v3_veb_implicit_ctx_no_spread')
+	os.rm(bin_out) or {}
+	compile := os.execute('${v3_bin} -no-memory-limit -b c ${src_file} -o ${bin_out}')
+	assert compile.exit_code == 0, compile.output
+	run := os.execute(bin_out)
+	assert run.exit_code == 0, run.output
+	assert run.output.trim_space().split_into_lines() == ['index called', 'explicit called'], run.output
+}

--- a/vlib/v3/transform/comptime.v
+++ b/vlib/v3/transform/comptime.v
@@ -1259,7 +1259,33 @@ fn (t &Transformer) comptime_method_call_arity_matches(node flat.Node, method Me
 	if method.params.len > 0 && method.params[method.params.len - 1].typ.starts_with('...') {
 		return actual_count >= method.params.len - 1
 	}
-	return actual_count == method.params.len
+	if actual_count == method.params.len {
+		return true
+	}
+	// A veb route handler may omit its `ctx` parameter, in which case it is not in
+	// the reflected parameter list but still exists in the signature. Reflected
+	// `app.$method(mut ctx)` calls pass that context explicitly, so one extra
+	// argument is the correct arity for such a method.
+	return actual_count == method.params.len + 1 && t.method_has_implicit_veb_ctx(method)
+}
+
+// method_has_implicit_veb_ctx reports whether `method` is a veb route handler that
+// declares no `ctx` parameter and therefore had one inserted into its signature.
+fn (t &Transformer) method_has_implicit_veb_ctx(method MethodMeta) bool {
+	if isnil(t.tc) || t.tc.fn_implicit_veb_ctx.len == 0 || method.name.len == 0 {
+		return false
+	}
+	receiver_name := comptime_method_receiver_name(method.receiver, method.module_name)
+	if receiver_name.len == 0 {
+		return false
+	}
+	key := '${receiver_name}.${method.name}'
+	for name in [key, c_name(key)] {
+		if t.tc.fn_implicit_veb_ctx[name] {
+			return true
+		}
+	}
+	return false
 }
 
 fn (mut t Transformer) clone_method_subst_scoped(id flat.NodeId, var_name string, method MethodMeta, inner_vars []string) ?flat.NodeId {


### PR DESCRIPTION
## Problem

A veb app whose routes are written in the vweb style — handler methods that do **not** declare a `ctx` parameter — silently serves a malformed response for those routes:

```
$ printf 'GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n' | nc -w2 127.0.0.1 8082 | xxd
00000000: 4854 5450 2f20 3020 0d0a 0d0a            HTTP/ 0 ....
```

`curl` reports `Unsupported HTTP version in response`; a browser just shows a connection failure, and the server prints no error at all. `examples/veb/veb_example.v` is affected, because its index route is declared as:

```v
pub fn (mut app App) index() veb.Result {
```

Routes declared with an explicit `mut ctx Context` work, so the server is listening and reachable the whole time — only some routes are dead, which makes it look like a networking problem.

## Cause

Such a handler gets the context injected into its signature (`App__index(main__App* app, main__Context* ctx)`), but the reflected `method.params` list that `$for method in A.methods` exposes does not include it.

`comptime_method_call_arity_matches` compared veb's dispatch call `app.$method(mut user_context)` — one argument — against that list, found `1 != 0`, and treated it as a specialization that cannot call the current method, so `clone_method_subst_scoped` returned `none` and the call was dropped.

`vlib/veb/veb.v` dispatches from four places. Two use the non-spread form above — the immediate path match and the `index` special case — and both were emitted as an empty block followed by `return`:

```c
if ((url_words.len == 0) && (route_words.len == 1) && string__eq(..., _str_968) && ...) {
	{
	}
	{
		bool was_done = true;
		...
	}
	return;
}
```

The handler never ran, so veb serialized an untouched zeroed `ctx.res` — hence `HTTP/ 0`. The other two sites spread their arguments (`...method_args`), which the arity check short-circuits to `true`, which is why only some routes broke. V1 emits the call at all four sites.

## Fix

Accept `params.len + 1` arguments when the callee is registered in the checker's `fn_implicit_veb_ctx` map. Programs that never inject a veb context leave that map empty and take an early `false`, so nothing outside veb changes.

## Verification

- `examples/veb/veb_example.v`: `/` now returns `200` with the 354-byte rendered template instead of `HTTP/ 0`; `/show_text`, `/cookie` and `/users/:user` also `200`.
- New regression test `test_veb_reflected_implicit_ctx_call_without_spread_args` in `vlib/v3/tests/veb_implicit_ctx_test.v`. A/B against an unpatched compiler: without the fix the program prints only `explicit called`, with it both handlers run. All 5 tests in that file pass.
- The `vlib/veb/**` suite was A/B'd against a `v` built from unpatched source: identical pass/fail sets (the 8 failures are pre-existing — `memory_leak_test`, `veb_app_test`, and the known flaky `Middleware[Context]` group).
- `vlib/v3/transform/{comptime,fn,monomorphize}_test.v` pass; `comptime_review_round4_test.v` fails identically before and after (output diff is timing numbers only).
- `cmd/v` self-hosts with the patched compiler; `v fmt -verify` clean on both changed files.
