### PR TITLE
v3: reduce self-host peak memory by another 11%

### DIFF
--- a/vlib/builtin/prealloc.c.v
+++ b/vlib/builtin/prealloc.c.v
@@ -70,8 +70,8 @@ const prealloc_block_size = 16 * 1024 * 1024
 // size of the first chunk for a scoped prealloc arena. Request-scoped arenas
 // should not force a 16MB libc allocation for every request.
 const prealloc_scope_block_size = 256 * 1024
-// Bound retained scope blocks to 4 MiB per thread, including compiler workers.
-const prealloc_recycle_cache_slots = 16
+// Bound retained scope blocks to 2 MiB per thread, including compiler workers.
+const prealloc_recycle_cache_slots = 8
 
 // `malloc` has to return memory suitably aligned for any V value. Keep the
 // default at the common max alignment used by libc malloc on current targets.
@@ -925,8 +925,9 @@ pub fn prealloc_scope_owns(scope_ptr voidptr, ptr voidptr) bool {
 		if lo == 0 {
 			return false
 		}
-		range := scope.ranges[lo - 1]
-		return address < range.stop
+		// Read the field in place: copying the @[heap] range struct into a local
+		// would heap-allocate on every probe, and callers probe once per AST node.
+		return address < scope.ranges[lo - 1].stop
 	}
 }
 

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -6270,6 +6270,26 @@ fn promote_scoped_ast_nodes_flagged(mut ast flat.FlatAst, base_nodes int, new_en
 	}
 }
 
+// release_transform_prepare_scope canonicalizes every node text still owned by
+// the self-host transform preparation arena and then frees that arena.
+fn release_transform_prepare_scope(mut a flat.FlatAst, scope voidptr) {
+	mut flags := []u8{len: a.nodes.len}
+	if transform.scan_scoped_text_flags_parallel(a, scope, mut flags) {
+		mut canon_cache := flat.TextProbeCache{}
+		for idx, flag in flags {
+			if flag != 0 {
+				canonicalize_scoped_node_cached(mut a, idx, scope, mut canon_cache.ptrs, mut canon_cache.values)
+			}
+		}
+	} else {
+		for idx in 0 .. a.nodes.len {
+			canonicalize_scoped_node(mut a, idx, scope)
+		}
+	}
+	unsafe { flags.free() }
+	prealloc_scope_free_for_v3(scope)
+}
+
 // canonicalize_scoped_node_cached is canonicalize_scoped_node with a pointer
 // probe over the caller's cache arrays: owned texts repeat the same shared
 // string instances heavily, so most content-hash intern lookups are skipped.
@@ -10764,6 +10784,13 @@ pub fn run(args []string) {
 			parse_cache_enabled := pre_tc.type_cache_parse_enabled()
 			mut post_sw := time.new_stopwatch()
 			prealloc_scope_leave_for_v3(transform_scope)
+			if retained_transform_prepare_scope != unsafe { nil } {
+				// The preparation arena backs only a few thousand lowered node texts.
+				// Publish those into the compilation arena and release the arena now
+				// instead of keeping its index scratch alive through codegen.
+				release_transform_prepare_scope(mut a, retained_transform_prepare_scope)
+				retained_transform_prepare_scope = unsafe { nil }
+			}
 			retain_transform_scope := building_v && current_parallel_transform && backend == 'c'
 				&& !cache_state.manager.enabled && retained_transform_regions.len == 0
 				&& (cmd_v_build || input_is_v3_compiler_entry(input_file)

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -17,7 +17,7 @@ const min_flat_cgen_parallel_items = 128
 // expression. Keep self-host body batches narrow so those values are released
 // throughout cgen instead of accumulating across hundreds of functions.
 const scoped_cgen_worker_batches = 256
-const flat_cgen_chunks_per_job = 16
+const flat_cgen_chunks_per_job = 32
 
 // FlatCgenChunkArgs represents flat cgen chunk args data used by c.
 struct FlatCgenChunkArgs {
@@ -303,11 +303,13 @@ $if !windows {
 		// tables; running these emitters on the master would mutate shared name and
 		// type caches. The private worker keeps those writes isolated while its
 		// already-complete const/global metadata is read-only.
+		// The tail worker is private, so its scratch can live in a disposable
+		// arena; only its two output texts are published into this thread's arena.
+		tail_scope := cgen_worker_scope_begin(w.scope_parallel_workers)
 		mut tail := w.new_parallel_tail_worker(max_flat_cgen_jobs + 1)
 		if !w.cache_split {
 			tail.interface_method_stubs()
-			w.parallel_interface_stubs = tail.sb.str()
-			unsafe { tail.sb.free() }
+			w.parallel_interface_stubs = cgen_publish_builder_text(mut tail.sb, tail_scope)
 			tail.sb = strings.new_builder(4096)
 		}
 		w.timing_profile('  [ttime]       td iface defs ${f64(tdpsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
@@ -315,10 +317,11 @@ $if !windows {
 		if w.print_fn_names.len == 0 {
 			tail.gen_vinit()
 			tail.gen_vcleanup()
-			w.parallel_init_defs = tail.sb.str()
-			unsafe { tail.sb.free() }
+			w.parallel_init_defs = cgen_publish_builder_text(mut tail.sb, tail_scope)
 			tail.sb = strings.new_builder(0)
 		}
+		cgen_worker_scope_leave(tail_scope)
+		cgen_worker_scope_free(tail_scope)
 		w.timing_profile('  [ttime]       td init defs  ${f64(tdpsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		w.restore_scratch_lookup_caches(saved_lookup_caches)
 		w.parallel_support_ready = true
@@ -1176,6 +1179,32 @@ fn (mut g FlatGen) write_scoped_cgen_batch_output(batch &FlatGen) bool {
 	return true
 }
 
+// cgen_publish_builder_text copies a helper builder's text into the arena that
+// encloses `scope` and releases the builder's scoped storage.
+fn cgen_publish_builder_text(mut sb strings.Builder, scope voidptr) string {
+	$if prealloc {
+		if scope != unsafe { nil } {
+			state := unsafe { prealloc_scope_suspend(scope) }
+			text := sb.str()
+			unsafe { prealloc_scope_resume(scope, state) }
+			unsafe { sb.free() }
+			return text
+		}
+	}
+	text := sb.str()
+	unsafe { sb.free() }
+	return text
+}
+
+// moved_segment returns its argument unchanged. Appending an addressable
+// string (a local or field) to an array clones its bytes; passing the value
+// through a call appends the existing storage instead. Output segments are
+// already private copies, so the clone would only double their footprint.
+@[inline]
+fn moved_segment(s string) string {
+	return s
+}
+
 // absorb_scoped_cgen_batch copies a finished batch's observable side tables
 // and, when needed, output into the helper's result arena.
 fn (mut g FlatGen) absorb_scoped_cgen_batch(batch &FlatGen, output_streamed bool) {
@@ -1184,13 +1213,10 @@ fn (mut g FlatGen) absorb_scoped_cgen_batch(batch &FlatGen, output_streamed bool
 		g.windows_entry_point_generated = true
 		g.windows_gui_entry_point = batch.windows_gui_entry_point
 	}
-	if !output_streamed {
-		output := b.sb.str()
-		if output.len > 0 {
-			g.fn_segs << output
-		} else {
-			unsafe { output.free() }
-		}
+	if !output_streamed && b.sb.len > 0 {
+		// Append the builder's copy directly: appending an addressable local
+		// would clone the whole chunk output a second time into this arena.
+		g.fn_segs << b.sb.str()
 	}
 	unsafe { b.sb.free() }
 	// Preserve worker-only literals at the IDs already written into batch output.
@@ -1398,25 +1424,57 @@ fn (mut g FlatGen) publish_fixed_storage_scan(mut fs_worker FlatGen) {
 	for opt_name, val_type in fs_worker.needed_optional_types {
 		g.needed_optional_types[opt_name.clone()] = val_type.clone()
 	}
+	if fs_worker.worker_scope != unsafe { nil } {
+		// The whole-AST scan leaves far more scratch behind than its three result
+		// tables hold. Publish owned copies into the enclosing cgen arena and
+		// release the helper arena before the function workers start, instead of
+		// keeping it resident through emission.
+		g.fixed_storage_consts = clone_cgen_string_bool_map(fs_worker.fixed_storage_consts)
+		g.param_types_by_short = clone_cgen_param_types_map(fs_worker.param_types_by_short)
+		g.concrete_optional_abi_fns = clone_cgen_string_bool_map(fs_worker.concrete_optional_abi_fns)
+		cgen_worker_scope_free(fs_worker.worker_scope)
+		fs_worker.worker_scope = unsafe { nil }
+		return
+	}
 	g.fixed_storage_consts = fs_worker.fixed_storage_consts.move()
 	g.param_types_by_short = fs_worker.param_types_by_short.move()
 	g.concrete_optional_abi_fns = fs_worker.concrete_optional_abi_fns.move()
-	if fs_worker.worker_scope != unsafe { nil } {
-		// These tables stay live through function emission. Retaining the small
-		// helper arena is cheaper than deep-cloning their type/string payloads and
-		// matches the optional/fixed-array support publishers below.
-		g.parallel_worker_scopes << fs_worker.worker_scope
-		fs_worker.worker_scope = unsafe { nil }
+}
+
+fn clone_cgen_param_types_map(values map[string][]types.Type) map[string][]types.Type {
+	mut cloned := map[string][]types.Type{}
+	for key, params in values {
+		cloned[key.clone()] = types.clone_owned_types(params)
 	}
+	return cloned
+}
+
+fn clone_cgen_fixed_array_typedef_map(values map[string]FixedArrayTypedefInfo) map[string]FixedArrayTypedefInfo {
+	mut cloned := map[string]FixedArrayTypedefInfo{}
+	for key, info in values {
+		cloned[key.clone()] = FixedArrayTypedefInfo{
+			arr: types.ArrayFixed{
+				elem_type: types.clone_owned_type(info.arr.elem_type)
+				len: info.arr.len
+				len_expr: info.arr.len_expr.clone()
+			}
+			module: info.module.clone()
+		}
+	}
+	return cloned
 }
 
 fn (mut g FlatGen) publish_fixed_array_support(mut worker FlatGen) {
-	g.fixed_array_typedefs_needed = worker.fixed_array_typedefs_needed.move()
 	g.fixed_array_typedefs_ready = worker.fixed_array_typedefs_ready
 	if worker.worker_scope != unsafe { nil } {
-		g.parallel_worker_scopes << worker.worker_scope
+		// Same trade as publish_fixed_storage_scan: the typedef table is small,
+		// the discovery scan's scratch is not.
+		g.fixed_array_typedefs_needed = clone_cgen_fixed_array_typedef_map(worker.fixed_array_typedefs_needed)
+		cgen_worker_scope_free(worker.worker_scope)
 		worker.worker_scope = unsafe { nil }
+		return
 	}
+	g.fixed_array_typedefs_needed = worker.fixed_array_typedefs_needed.move()
 }
 
 fn (mut g FlatGen) publish_optional_support(mut worker FlatGen) {
@@ -1636,7 +1694,7 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 			g.timing_profile('  [ttime]   cg merge         ${f64(msw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 			for output in ordered_chunk_outputs {
 				if output.len > 0 {
-					g.fn_segs << output
+					g.fn_segs << moved_segment(output)
 				}
 			}
 			cgen_worker_scope_free(worker_setup_scope)
@@ -1644,14 +1702,11 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 			// overlay so worker-arena memo values cannot escape into the base.
 			g.tc.discard_type_cache_overlay_after_forks()
 			g.gen_synthetic_main_after_fns()
-			synthetic_output := g.sb.str()
+			if g.sb.len > 0 {
+				g.fn_segs << g.sb.str()
+			}
 			unsafe { g.sb.free() }
 			g.sb = strings.new_builder(0)
-			if synthetic_output.len > 0 {
-				g.fn_segs << synthetic_output
-			} else {
-				unsafe { synthetic_output.free() }
-			}
 			return
 		}
 		// chunk[0] is emitted by the master directly into its own builder; the
@@ -1694,14 +1749,11 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 			}
 		}
 		g.parallel_used = g.a.worker_pool.run(tasks)
-		master_output := g.sb.str()
+		if g.sb.len > 0 {
+			g.fn_segs << g.sb.str()
+		}
 		unsafe { g.sb.free() }
 		g.sb = strings.new_builder(4096)
-		if master_output.len > 0 {
-			g.fn_segs << master_output
-		} else {
-			unsafe { master_output.free() }
-		}
 		for ci := 0; ci < thread_count; ci++ {
 			mut w := unsafe { &FlatGen(cgen_workers[ci]) }
 			g.merge_parallel_worker(w)
@@ -1713,14 +1765,11 @@ fn (mut g FlatGen) gen_fns_dispatch(no_parallel bool) {
 		g.tc.discard_type_cache_overlay_after_forks()
 		// Synthetic main temps continue after the master's chunk[0] range.
 		g.gen_synthetic_main_after_fns()
-		synthetic_output := g.sb.str()
+		if g.sb.len > 0 {
+			g.fn_segs << g.sb.str()
+		}
 		unsafe { g.sb.free() }
 		g.sb = strings.new_builder(0)
-		if synthetic_output.len > 0 {
-			g.fn_segs << synthetic_output
-		} else {
-			unsafe { synthetic_output.free() }
-		}
 	}
 }
 
@@ -2959,20 +3008,19 @@ fn (mut g FlatGen) merge_parallel_worker_into(w &FlatGen, mut ordered []string, 
 	} else {
 		map[string]bool{}
 	}
-	worker_output := ww.sb.str()
-	if worker_output.len > 0 {
+	if ww.sb.len > 0 {
 		if g.cache_stable_symbols {
+			worker_output := ww.sb.str()
 			stable_output := ww.rewrite_cache_string_symbols(worker_output)
-			g.fn_segs << stable_output
+			g.fn_segs << moved_segment(stable_output)
 			unsafe { worker_output.free() }
 		} else if string_id_remap.len > 0 {
+			worker_output := ww.sb.str()
 			g.fn_segs << remap_scoped_worker_string_symbols(worker_output, string_id_remap, user_c_symbols)
 			unsafe { worker_output.free() }
 		} else {
-			g.fn_segs << worker_output
+			g.fn_segs << ww.sb.str()
 		}
-	} else {
-		unsafe { worker_output.free() }
 	}
 	// The ordered segment owns the copied output; release the worker builder.
 	unsafe { ww.sb.free() }
@@ -2996,7 +3044,7 @@ fn (mut g FlatGen) merge_parallel_worker_into(w &FlatGen, mut ordered []string, 
 				continue
 			}
 		}
-		g.fn_segs << normalized
+		g.fn_segs << moved_segment(normalized)
 	}
 	if g.cache_split {
 		for literal in w.str_lits {

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -2513,6 +2513,9 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 			return false
 		}
 		t.tc.freeze_type_cache_for_forks()
+		// The chunk partition, its cost tables and the helper forks below are
+		// only read until the join; keep them out of the retained stage arena.
+		setup_scope := transform_worker_scope_begin(t.scope_parallel_workers)
 		mut chunk_target := n_jobs * shared_transform_chunks_per_job
 		if chunk_target > bounded_items.len {
 			chunk_target = bounded_items.len
@@ -2563,7 +2566,6 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 		shared_used_fns := t.used_fns.clone()
 		t.used_fns_root = unsafe { &shared_used_fns }
 		t.timing_profile('  [ttime]     ss split+part  ${f64(ttsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
-		setup_scope := transform_worker_scope_begin(t.scope_parallel_workers)
 		mut args := []SharedChunkArgs{len: chunk_count}
 		args[0] = SharedChunkArgs{
 			worker: voidptr(t)

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -993,6 +993,9 @@ fn (mut tc TypeChecker) check_semantics_parallel() bool {
 		final_file := tc.cur_file
 		final_module := tc.cur_module
 		was_parallel := tc.run_parallel_check(items)
+		// Per-function check costs only schedule the parallel batches above.
+		unsafe { tc.fn_check_costs.free() }
+		tc.fn_check_costs = []i32{}
 		tc.cur_file = final_file
 		tc.cur_module = final_module
 		if tc.defer_ierror_gating {
@@ -2851,6 +2854,31 @@ mut:
 	set    [512]bool
 }
 
+// CheckNamePromotionCache maps a still-alive worker-arena name instance to
+// the single persistent CachedName already published for it. Resolved call
+// names repeat across thousands of nodes, so this avoids one string clone and
+// one box per node. Never retain it across arena frees.
+struct CheckNamePromotionCache {
+mut:
+	ptrs   [1024]voidptr
+	lens   [1024]int
+	values [1024]&CachedName
+}
+
+@[inline]
+fn promote_cached_name_value(name &CachedName, mut cache CheckNamePromotionCache) &CachedName {
+	value := name.value
+	slot := int((u64(voidptr(value.str)) >> 4) & 1023)
+	if cache.ptrs[slot] == voidptr(value.str) && cache.lens[slot] == value.len {
+		return cache.values[slot]
+	}
+	promoted := cached_name(value.clone())
+	cache.ptrs[slot] = voidptr(value.str)
+	cache.lens[slot] = value.len
+	cache.values[slot] = promoted
+	return promoted
+}
+
 // Source payloads stay alive and immutable for the entire promotion pass. Raw
 // identities are safe within that pass; never retain this cache across arena frees.
 fn (tc &TypeChecker) cached_check_type_promotion(typ Type, mut cache CheckTypePromotionCache, promote_missing bool) ?Type {
@@ -2882,13 +2910,14 @@ fn check_clone_chunk_thread(arg voidptr) voidptr {
 	mut tc := unsafe { &TypeChecker(a.tc) }
 	items := unsafe { &[]CheckWorkItem(a.items_ptr) }
 	mut cache := CheckTypePromotionCache{}
+	mut names := CheckNamePromotionCache{}
 	for item in *items {
 		for idx in item.range_lo .. item.fn_idx + 1 {
 			if idx < tc.resolved_call_set.len && tc.resolved_call_set[idx] {
-				tc.resolved_call_names[idx] = cached_name(tc.resolved_call_names[idx].value.clone())
+				tc.resolved_call_names[idx] = promote_cached_name_value(tc.resolved_call_names[idx], mut names)
 			}
 			if idx < tc.resolved_fn_value_set.len && tc.resolved_fn_value_set[idx] {
-				tc.resolved_fn_value_names[idx] = cached_name(tc.resolved_fn_value_names[idx].value.clone())
+				tc.resolved_fn_value_names[idx] = promote_cached_name_value(tc.resolved_fn_value_names[idx], mut names)
 			}
 			if idx < tc.expr_type_set.len && tc.expr_type_set[idx] {
 				if canonical := tc.cached_check_type_promotion(tc.expr_type_values[idx], mut cache, false) {
@@ -2928,13 +2957,14 @@ fn par_check_clone_enabled() bool {
 
 fn (mut tc TypeChecker) clone_parallel_worker_node_caches(items []CheckWorkItem) {
 	mut cache := CheckTypePromotionCache{}
+	mut names := CheckNamePromotionCache{}
 	for item in items {
 		for idx in item.range_lo .. item.fn_idx + 1 {
 			if idx < tc.resolved_call_set.len && tc.resolved_call_set[idx] {
-				tc.resolved_call_names[idx] = cached_name(tc.resolved_call_names[idx].value.clone())
+				tc.resolved_call_names[idx] = promote_cached_name_value(tc.resolved_call_names[idx], mut names)
 			}
 			if idx < tc.resolved_fn_value_set.len && tc.resolved_fn_value_set[idx] {
-				tc.resolved_fn_value_names[idx] = cached_name(tc.resolved_fn_value_names[idx].value.clone())
+				tc.resolved_fn_value_names[idx] = promote_cached_name_value(tc.resolved_fn_value_names[idx], mut names)
 			}
 			if idx < tc.expr_type_set.len && tc.expr_type_set[idx] {
 				tc.expr_type_values[idx] = tc.cached_check_type_promotion(tc.expr_type_values[idx], mut cache, true) or {


### PR DESCRIPTION
Follow-up to #28504. Same benchmark (`cd vlib/v3 && ../../v -gc none -prealloc -prod -o v3 v3.v && ./v3 -nocache -building-v -o v4 v3.v`), measured in interleaved baseline/new pairs at equal machine load:

| | master (48a395b) | this PR |
|---|---|---|
| peak memory footprint | 864–879 MB | 769–781 MB |
| max RSS | 882–888 MB | 791–795 MB |

The peak is cgen's function-worker phase, not write-out. A temporary block registry with `mincore` accounting plus a sampling allocation tracer (both removed) attributed it; the fixes:

- **`prealloc_scope_owns` allocated on every call.** It copied a `@[heap]` range struct into a local, which v3 lowers to `memdup`. Callers probe once per AST node per promotion pass, on every worker thread's never-freed base arena. Read the field in place.
- **cgen cloned the C output three to four times.** `arr << local` deep-clones an addressable string, so absorb, merge and the ordered replay each copied the segments again. Builder results are pushed directly and moves go through `moved_segment()`.
- **Transform prepare arena** stayed alive through cgen but only backs ~7k lowered node texts. Re-intern those and free it right after transform.
- **Fixed-storage / fixed-array scan arenas** were retained through emission for three small tables. Clone the tables out and free the arenas before dispatch; the declaration task's private tail worker runs in a disposable arena.
- **Parallel transform setup scope** now begins before the work split, so chunk tables and helper forks are freed with it instead of living in the retained stage arena.
- **Checker**: `fn_check_costs` freed after scheduling; resolved-name boxes de-duplicated while publishing worker results.
- prealloc recycle cache 16 → 8 slots; cgen chunks per job 16 → 32.

Validation: generated C is byte-identical to master's (same sources compiled by both binaries), identical under `-d prealloc_no_recycle` (freed arenas are unmapped, so stale reads crash), and v3 and the v4 it builds emit identical C. `prealloc_discard_test` and `parallel_worker_test` pass; `vlib/v3` + `vlib/builtin` tests passed 45/99 with no failures before the run was cut short on a saturated machine.

CPU cost: +1.5–2% instructions retired (mostly the recycle-cache and chunk knobs, i.e. extra minor faults and per-chunk setup), a few milliseconds of wall time on a 9 s run. Reverting those two knobs recovers that at the price of ~18 MB.

Not addressed here: every self-host run executes the whole frontend twice, because the parallel C compile reports "monolithic regeneration" (the declaration header is judged unsafe to share) and the driver re-execs itself with `-d v3_parallel_cc_monolithic`. That is ~1 s per run.
