### PR TITLE
v3: keep explicit generic type arguments on calls inside generic functions

### DIFF
--- a/vlib/v/tests/generics/explicit_generic_call_args_inside_generic_fn_test.v
+++ b/vlib/v/tests/generics/explicit_generic_call_args_inside_generic_fn_test.v
@@ -1,0 +1,90 @@
+// Regression coverage for explicit type arguments on a generic call that is made from inside
+// another generic function.
+//
+// The enclosing function's return type (and its own generic arguments) must never replace an
+// explicit `fn_name[Type]` list when the nested call has nothing to infer from.
+
+type Sum = int | string
+
+struct Box {
+	v int
+}
+
+fn make_it[X]() X {
+	return X{}
+}
+
+fn make_from_string[X](_s string) X {
+	return X{}
+}
+
+fn make_result[X](_s string) !X {
+	return X{}
+}
+
+fn make_option[X](_s string) ?X {
+	return X{}
+}
+
+// The enclosing generic parameter is deliberately named `T` here and `X` in the callees, and
+// `same_name_param` reuses `T` for both, so a name collision cannot leak the caller's argument.
+fn same_name_param[T]() T {
+	return T{}
+}
+
+fn outer_returns_string[T](_unused T) string {
+	v := make_it[Sum]()
+	return typeof(v).name
+}
+
+fn outer_returns_box[T](_unused T) string {
+	v := make_it[Box]()
+	return typeof(v).name
+}
+
+fn outer_with_arg[T](_unused T) string {
+	v := make_from_string[Sum]('x')
+	return typeof(v).name
+}
+
+fn outer_with_result[T](_unused T) string {
+	v := make_result[Sum]('x') or { return 'failed' }
+	return typeof(v).name
+}
+
+fn outer_with_option[T](_unused T) string {
+	v := make_option[Sum]('x') or { return 'failed' }
+	return typeof(v).name
+}
+
+fn outer_same_generic_name[T](_unused T) string {
+	v := same_name_param[Sum]()
+	return typeof(v).name
+}
+
+fn test_explicit_type_args_survive_inside_generic_fn() {
+	assert outer_returns_string(1) == 'Sum'
+	assert outer_returns_string('s') == 'Sum'
+	assert outer_returns_string(Box{}) == 'Sum'
+	assert outer_returns_box(1) == 'Box'
+	assert outer_with_arg(1) == 'Sum'
+	assert outer_with_result(1) == 'Sum'
+	assert outer_with_option(1) == 'Sum'
+}
+
+fn test_explicit_type_args_ignore_matching_generic_param_names() {
+	assert outer_same_generic_name(1) == 'Sum'
+	assert outer_same_generic_name('s') == 'Sum'
+}
+
+// A nested call without explicit type arguments still has to be re-inferred for every
+// specialization of its caller.
+fn passthrough[T]() T {
+	return make_it()
+}
+
+fn test_implicit_nested_generic_calls_are_still_retargeted() {
+	assert passthrough[int]() == 0
+	assert passthrough[string]() == ''
+	assert typeof(passthrough[Box]()).name == 'Box'
+}

--- a/vlib/v/tests/generics/explicit_generic_call_args_partial_inside_generic_fn_test.v
+++ b/vlib/v/tests/generics/explicit_generic_call_args_partial_inside_generic_fn_test.v
@@ -1,0 +1,42 @@
+// Regression coverage for explicit type arguments that only pin some of a callee's generic
+// parameters, on a call made from inside another generic function.
+//
+// Positions fixed by the explicit list must survive in every specialization of the caller, even
+// when the remaining positions are inferable from a value argument and the caller reuses one of the
+// callee's generic parameter names.
+
+fn pick[A, B](_b B) string {
+	return '${typeof[A]().name}/${typeof[B]().name}'
+}
+
+// `A` deliberately shadows the callee's first generic parameter name.
+fn pick_caller[A](value A) string {
+	return pick[string, int](value)
+}
+
+fn test_explicit_args_survive_when_another_param_is_inferable() {
+	assert pick[string, int](1) == 'string/int'
+	assert pick_caller(1) == 'string/int'
+}
+
+struct Holder[T] {
+	value T
+}
+
+fn (_h Holder[T]) tagged[U](_u U) string {
+	return '${typeof[T]().name}/${typeof[U]().name}'
+}
+
+// Method-level generics are the one place V accepts a partial explicit list: the receiver's `T` is
+// inferred from the receiver and only the trailing arguments are spelled out.
+fn method_caller[T](value T) string {
+	h := Holder[string]{}
+	return h.tagged[int](1) + ' ' + h.tagged(value)
+}
+
+fn test_partial_explicit_method_generics_survive_inside_generic_fn() {
+	h := Holder[string]{}
+	assert h.tagged[int](1) == 'string/int'
+	assert method_caller(1.5) == 'string/int string/f64'
+	assert method_caller(7) == 'string/int string/int'
+}

--- a/vlib/v/tests/generics/explicit_generic_call_args_partial_inside_generic_fn_test.v
+++ b/vlib/v/tests/generics/explicit_generic_call_args_partial_inside_generic_fn_test.v
@@ -19,6 +19,16 @@ fn test_explicit_args_survive_when_another_param_is_inferable() {
 	assert pick_caller(1) == 'string/int'
 }
 
+type AliasedInt = int
+
+// Instantiating the caller with an alias makes this clone infer `AliasedInt` for `B`, which differs
+// from the `int` the explicit list fixed. That inference is not evidence against the list: the call
+// stays bound to `pick[string, int]`.
+fn test_explicit_args_survive_when_inference_disagrees() {
+	assert pick_caller(AliasedInt(3)) == 'string/int'
+	assert pick_caller(1) == 'string/int'
+}
+
 struct Holder[T] {
 	value T
 }

--- a/vlib/v/tests/generics/implicit_generic_call_retargeting_inside_generic_fn_test.v
+++ b/vlib/v/tests/generics/implicit_generic_call_retargeting_inside_generic_fn_test.v
@@ -1,0 +1,54 @@
+// Regression coverage for implicit nested generic calls in a generic body that is instantiated with
+// several outer types.
+//
+// The template node is shared between instances, so a nested callee may already name the
+// specialization chosen while transforming an earlier instance. Every later instance must still be
+// retargeted, and that must stay true alongside the pinning of explicit `fn_name[Type]` callees.
+
+fn tag[X](_x X) string {
+	return typeof[X]().name
+}
+
+fn produce[X]() X {
+	return X{}
+}
+
+// Both spellings target the same callee from one shared template: the explicit call is pinned to
+// `string` for every instance, while the implicit one has to follow `T`.
+fn mixed[T](v T) string {
+	explicit := tag[string]('literal')
+	implicit := tag(v)
+	return '${explicit}/${implicit}'
+}
+
+fn test_implicit_call_retargets_while_explicit_call_stays_pinned() {
+	assert mixed(1) == 'string/int'
+	assert mixed(2.5) == 'string/f64'
+	assert mixed('s') == 'string/string'
+}
+
+// The nested call takes no arguments, so its type argument comes from the enclosing return type and
+// changes with every instance.
+fn relay[T]() T {
+	return produce()
+}
+
+fn test_argumentless_implicit_call_follows_each_instance() {
+	assert relay[int]() == 0
+	assert relay[string]() == ''
+	assert relay[f64]() == 0.0
+}
+
+// Same shape behind a closure, which is the case the retarget path calls out explicitly.
+fn closured[T](v T) string {
+	f := fn [v] [T]() string {
+		return tag(v)
+	}
+	return f()
+}
+
+fn test_implicit_call_inside_cloned_closure_retargets() {
+	assert closured(1) == 'int'
+	assert closured('s') == 'string'
+	assert closured(2.5) == 'f64'
+}

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -10584,30 +10584,34 @@ fn (mut t Transformer) retarget_cloned_generic_call(node flat.Node, mut children
 			}
 			param_idx++
 		}
-		if t.call_keeps_explicit_specialization(callee, decl, inferred) {
+		if preserved := t.generic_call_args_preserving_explicit(callee, decl, inferred) {
 			// The callee already names the specialization picked by an explicit
-			// `fn_name[Type]` list, and this call carries nothing to infer from. Neither the
-			// enclosing return type nor the enclosing generic arguments may retarget it.
-			return ''
-		}
-		if inferred.len < param_names.len && t.cur_fn_ret_type.len > 0 {
-			mut return_inferred := map[string]string{}
-			infer_generic_type_args(decl.node.typ, t.generic_inference_expected_type(t.cur_fn_ret_type), mut return_inferred)
-			for name, inferred_type in return_inferred {
-				if name !in inferred {
-					inferred[name] = inferred_type
+			// `fn_name[Type]` list. Every position that list fixed must survive; neither the
+			// enclosing return type nor the enclosing generic arguments may replace it.
+			if t.callee_matches_generic_args(callee, decl, preserved) {
+				return ''
+			}
+			call_args = preserved.clone()
+		} else {
+			if inferred.len < param_names.len && t.cur_fn_ret_type.len > 0 {
+				mut return_inferred := map[string]string{}
+				infer_generic_type_args(decl.node.typ, t.generic_inference_expected_type(t.cur_fn_ret_type), mut return_inferred)
+				for name, inferred_type in return_inferred {
+					if name !in inferred {
+						inferred[name] = inferred_type
+					}
 				}
 			}
-		}
-		for name in param_names {
-			arg := inferred[name] or {
-				idx := t.active_generic_param_index(name)
-				if idx < 0 || idx >= args.len {
-					return ''
+			for name in param_names {
+				arg := inferred[name] or {
+					idx := t.active_generic_param_index(name)
+					if idx < 0 || idx >= args.len {
+						return ''
+					}
+					args[idx]
 				}
-				args[idx]
+				call_args << t.inherited_generic_arg_for_decl_module(arg, decl.module, args)
 			}
-			call_args << t.inherited_generic_arg_for_decl_module(arg, decl.module, args)
 		}
 	}
 	if call_args.len == 0 || t.generic_args_have_placeholders(call_args) {
@@ -10868,19 +10872,27 @@ fn (mut t Transformer) retarget_cloned_implicit_generic_call(clone_id flat.NodeI
 			}
 			param_idx++
 		}
-		if inferred.len < param_names.len && t.cur_fn_ret_type.len > 0
-			&& !t.call_keeps_explicit_specialization(callee, decl, inferred) {
-			mut return_inferred := map[string]string{}
-			t.infer_generic_return_type_args(decl, t.generic_inference_expected_type(t.cur_fn_ret_type), mut return_inferred, receiver_params)
-			for name, inferred_type in return_inferred {
-				if name !in inferred {
-					inferred[name] = inferred_type
+		if preserved := t.generic_call_args_preserving_explicit(callee, decl, inferred) {
+			// See `retarget_cloned_generic_call`: an explicit `fn_name[Type]` list pins these
+			// positions for every clone of this body.
+			if t.callee_matches_generic_args(callee, decl, preserved) {
+				return
+			}
+			call_args = preserved.clone()
+		} else {
+			if inferred.len < param_names.len && t.cur_fn_ret_type.len > 0 {
+				mut return_inferred := map[string]string{}
+				t.infer_generic_return_type_args(decl, t.generic_inference_expected_type(t.cur_fn_ret_type), mut return_inferred, receiver_params)
+				for name, inferred_type in return_inferred {
+					if name !in inferred {
+						inferred[name] = inferred_type
+					}
 				}
 			}
-		}
-		for name in param_names {
-			arg := inferred[name] or { return }
-			call_args << t.inherited_generic_arg_for_decl_module(arg, decl.module, active_args)
+			for name in param_names {
+				arg := inferred[name] or { return }
+				call_args << t.inherited_generic_arg_for_decl_module(arg, decl.module, active_args)
+			}
 		}
 	}
 	if call_args.len == 0 || t.generic_args_have_placeholders(call_args) {
@@ -10906,25 +10918,48 @@ fn (mut t Transformer) retarget_cloned_implicit_generic_call(clone_id flat.NodeI
 	}
 }
 
-// call_keeps_explicit_specialization reports whether a cloned call is already bound to the concrete
-// specialization selected by an explicit `fn_name[Type]` type-argument list.
-//
-// Such callees are rewritten to a plain specialization ident before the enclosing generic body is
-// cloned, so the explicit arguments are no longer visible on the call node. The call resolves to the
-// same specialization in every clone of that body, and nothing could be inferred from its
-// arguments, so the enclosing function's return type must not retarget it to another
-// specialization.
-fn (t &Transformer) call_keeps_explicit_specialization(callee flat.Node, decl GenericFnDecl, inferred map[string]string) bool {
-	if inferred.len > 0 || callee.kind != .ident || callee.value.len == 0 {
+// callee_matches_generic_args reports whether `callee` already names the specialization of `decl`
+// for exactly `args`.
+fn (t &Transformer) callee_matches_generic_args(callee flat.Node, decl GenericFnDecl, args []string) bool {
+	if callee.kind != .ident || callee.value.len == 0 || args.len == 0 {
 		return false
 	}
-	recorded := t.recorded_generic_specialization_args(callee.value) or { return false }
-	if recorded.len == 0 || t.generic_args_have_placeholders(recorded) {
-		return false
-	}
-	spec_value := specialized_generic_fn_value(decl.node.value, recorded)
+	spec_value := specialized_generic_fn_value(decl.node.value, args)
 	qualified_spec := transform_qualified_fn_name(decl.module, spec_value)
 	return callee.value in [spec_value, qualified_spec, c_name(spec_value), c_name(qualified_spec)]
+}
+
+// generic_call_args_preserving_explicit returns the type arguments a cloned call must keep because
+// an explicit `fn_name[Type]` list already chose them, or none when the callee is not bound to a
+// specialization of `decl`.
+//
+// Such callees are rewritten to a plain specialization ident before the enclosing generic body is
+// cloned, so the explicit list is no longer visible on the call node and the retarget paths would
+// otherwise treat the call as implicit. Every position the list fixed resolves identically in each
+// clone of that body; only positions it left open may be filled from this clone's inference. Today
+// `explicit_generic_fn_value_specialization` collapses a list only when it covers every generic
+// parameter, so the recorded arguments are normally complete, but the tail is filled positionally so
+// a partial list can never be silently replaced.
+fn (mut t Transformer) generic_call_args_preserving_explicit(callee flat.Node, decl GenericFnDecl, inferred map[string]string) ?[]string {
+	if callee.kind != .ident || callee.value.len == 0 {
+		return none
+	}
+	recorded := t.recorded_generic_specialization_args(callee.value) or { return none }
+	if recorded.len == 0 || t.generic_args_have_placeholders(recorded) {
+		return none
+	}
+	if !t.callee_matches_generic_args(callee, decl, recorded) {
+		return none
+	}
+	param_names := t.generic_fn_param_names(decl.node, decl.module)
+	if param_names.len < recorded.len {
+		return none
+	}
+	mut preserved := recorded.clone()
+	for name in param_names[recorded.len..] {
+		preserved << inferred[name] or { return none }
+	}
+	return preserved
 }
 
 fn (t &Transformer) generic_specialization_registered(decl GenericFnDecl, args []string) bool {

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -10956,10 +10956,16 @@ fn (mut t Transformer) callee_is_erased_explicit_generic(callee flat.Node, decl 
 //
 // A genuinely implicit callee must not be preserved: the template node is shared between instances,
 // so it can still name the specialization chosen for an earlier one and has to be retargeted. The
-// signature check separates the two, and a position whose inferred type contradicts the recorded one
-// declines preservation as well. `explicit_generic_fn_value_specialization` collapses a list only
-// when it covers every generic parameter, so the recorded arguments are normally complete, but the
-// tail is filled positionally so a partial list can never be silently replaced.
+// signature check separates the two, and it is the only thing that may: once a slot is known to come
+// from source, inference about it is not evidence against it. A caller instantiated with a type the
+// list does not accept still infers something for that slot, and declining on the mismatch would
+// hand the call back to implicit inference and lose the explicit arguments entirely -- the very
+// thing this function exists to prevent. Mismatches between an explicit argument and a value passed
+// for it are the checker's to report.
+//
+// `explicit_generic_fn_value_specialization` collapses a list only when it covers every generic
+// parameter, so the recorded arguments are normally complete, but the tail is filled positionally so
+// a partial list can never be silently replaced.
 fn (mut t Transformer) generic_call_args_preserving_explicit(callee flat.Node, decl GenericFnDecl, inferred map[string]string) ?[]string {
 	if callee.kind != .ident || callee.value.len == 0 {
 		return none
@@ -10979,17 +10985,7 @@ fn (mut t Transformer) generic_call_args_preserving_explicit(callee flat.Node, d
 		return none
 	}
 	mut preserved := recorded.clone()
-	for i, name in param_names {
-		if i < recorded.len {
-			// If this clone infers a different type for a position the explicit list fixed,
-			// the callee is not the binding it appears to be; retarget normally instead.
-			if got := inferred[name] {
-				if got != recorded[i] {
-					return none
-				}
-			}
-			continue
-		}
+	for name in param_names[recorded.len..] {
 		preserved << inferred[name] or { return none }
 	}
 	return preserved

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -10584,6 +10584,12 @@ fn (mut t Transformer) retarget_cloned_generic_call(node flat.Node, mut children
 			}
 			param_idx++
 		}
+		if t.call_keeps_explicit_specialization(callee, decl, inferred) {
+			// The callee already names the specialization picked by an explicit
+			// `fn_name[Type]` list, and this call carries nothing to infer from. Neither the
+			// enclosing return type nor the enclosing generic arguments may retarget it.
+			return ''
+		}
 		if inferred.len < param_names.len && t.cur_fn_ret_type.len > 0 {
 			mut return_inferred := map[string]string{}
 			infer_generic_type_args(decl.node.typ, t.generic_inference_expected_type(t.cur_fn_ret_type), mut return_inferred)
@@ -10862,7 +10868,8 @@ fn (mut t Transformer) retarget_cloned_implicit_generic_call(clone_id flat.NodeI
 			}
 			param_idx++
 		}
-		if inferred.len < param_names.len && t.cur_fn_ret_type.len > 0 {
+		if inferred.len < param_names.len && t.cur_fn_ret_type.len > 0
+			&& !t.call_keeps_explicit_specialization(callee, decl, inferred) {
 			mut return_inferred := map[string]string{}
 			t.infer_generic_return_type_args(decl, t.generic_inference_expected_type(t.cur_fn_ret_type), mut return_inferred, receiver_params)
 			for name, inferred_type in return_inferred {
@@ -10897,6 +10904,27 @@ fn (mut t Transformer) retarget_cloned_implicit_generic_call(clone_id flat.NodeI
 	} else {
 		t.rewrite_generic_plain_call(clone_id, clone, decl, concrete_call_args)
 	}
+}
+
+// call_keeps_explicit_specialization reports whether a cloned call is already bound to the concrete
+// specialization selected by an explicit `fn_name[Type]` type-argument list.
+//
+// Such callees are rewritten to a plain specialization ident before the enclosing generic body is
+// cloned, so the explicit arguments are no longer visible on the call node. The call resolves to the
+// same specialization in every clone of that body, and nothing could be inferred from its
+// arguments, so the enclosing function's return type must not retarget it to another
+// specialization.
+fn (t &Transformer) call_keeps_explicit_specialization(callee flat.Node, decl GenericFnDecl, inferred map[string]string) bool {
+	if inferred.len > 0 || callee.kind != .ident || callee.value.len == 0 {
+		return false
+	}
+	recorded := t.recorded_generic_specialization_args(callee.value) or { return false }
+	if recorded.len == 0 || t.generic_args_have_placeholders(recorded) {
+		return false
+	}
+	spec_value := specialized_generic_fn_value(decl.node.value, recorded)
+	qualified_spec := transform_qualified_fn_name(decl.module, spec_value)
+	return callee.value in [spec_value, qualified_spec, c_name(spec_value), c_name(qualified_spec)]
 }
 
 fn (t &Transformer) generic_specialization_registered(decl GenericFnDecl, args []string) bool {

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -235,13 +235,7 @@ fn (mut t Transformer) monomorphize_pass() []string {
 			spec_value := specialized_generic_fn_value(decl.node.value, concrete_args)
 			spec_name := transform_qualified_fn_name(decl.module, spec_value)
 			t.record_generic_specialization_args_for_names([spec_name, c_name(spec_name)], concrete_args)
-			params := t.specialized_generic_call_param_type_texts(decl, concrete_args)
-			ret_type := t.specialized_fn_return_type_text(decl, concrete_args)
-			fn_type := 'fn (${params.join(', ')})${if ret_type.len > 0 && ret_type != 'void' {
-				' ${ret_type}'
-			} else {
-				''
-			}}'
+			fn_type := t.specialized_generic_fn_type_text(decl, concrete_args)
 			t.set_node(i, flat.Node{
 				kind: .ident
 				value: spec_name
@@ -327,13 +321,7 @@ fn (mut t Transformer) monomorphize_pass() []string {
 					spec_value := specialized_generic_fn_value(decl.node.value, concrete_args)
 					spec_name := transform_qualified_fn_name(decl.module, spec_value)
 					t.record_generic_specialization_args_for_names([spec_name, c_name(spec_name)], concrete_args)
-					params := t.specialized_generic_call_param_type_texts(decl, concrete_args)
-					ret_type := t.specialized_fn_return_type_text(decl, concrete_args)
-					fn_type := 'fn (${params.join(', ')})${if ret_type.len > 0 && ret_type != 'void' {
-						' ${ret_type}'
-					} else {
-						''
-					}}'
+					fn_type := t.specialized_generic_fn_type_text(decl, concrete_args)
 					t.set_node(i, flat.Node{
 						kind: .ident
 						value: spec_name
@@ -10929,17 +10917,49 @@ fn (t &Transformer) callee_matches_generic_args(callee flat.Node, decl GenericFn
 	return callee.value in [spec_value, qualified_spec, c_name(spec_value), c_name(qualified_spec)]
 }
 
+// specialized_generic_fn_type_text renders the `fn (params) ret` type that
+// `explicit_generic_fn_value_specialization` writes onto a callee ident when it erases an explicit
+// `fn_name[Type]` list into a specialization ident.
+fn (mut t Transformer) specialized_generic_fn_type_text(decl GenericFnDecl, args []string) string {
+	params := t.specialized_generic_call_param_type_texts(decl, args)
+	ret_type := t.specialized_fn_return_type_text(decl, args)
+	return 'fn (${params.join(', ')})${if ret_type.len > 0 && ret_type != 'void' {
+		' ${ret_type}'
+	} else {
+		''
+	}}'
+}
+
+// callee_is_erased_explicit_generic reports whether `callee` is an ident that
+// `explicit_generic_fn_value_specialization` produced from a source-level `fn_name[Type]` list.
+//
+// That erasure is the only thing that writes the specialized signature into a callee ident's type:
+// `make_ident`, which retargets an implicit call, types a name only when it resolves to a variable
+// and so leaves a specialization ident untyped. Checking the signature therefore separates an erased
+// explicit callee from a stale implicit one without per-worker bookkeeping, which matters because
+// the erasure and the retarget can happen in different monomorphization workers.
+fn (mut t Transformer) callee_is_erased_explicit_generic(callee flat.Node, decl GenericFnDecl, args []string) bool {
+	if !callee.typ.starts_with('fn (') {
+		return false
+	}
+	return callee.typ == t.specialized_generic_fn_type_text(decl, args)
+}
+
 // generic_call_args_preserving_explicit returns the type arguments a cloned call must keep because
-// an explicit `fn_name[Type]` list already chose them, or none when the callee is not bound to a
-// specialization of `decl`.
+// an explicit `fn_name[Type]` list already chose them, or none when the callee is not an erased
+// explicit callee bound to a specialization of `decl`.
 //
 // Such callees are rewritten to a plain specialization ident before the enclosing generic body is
 // cloned, so the explicit list is no longer visible on the call node and the retarget paths would
 // otherwise treat the call as implicit. Every position the list fixed resolves identically in each
-// clone of that body; only positions it left open may be filled from this clone's inference. Today
-// `explicit_generic_fn_value_specialization` collapses a list only when it covers every generic
-// parameter, so the recorded arguments are normally complete, but the tail is filled positionally so
-// a partial list can never be silently replaced.
+// clone of that body; only positions it left open may be filled from this clone's inference.
+//
+// A genuinely implicit callee must not be preserved: the template node is shared between instances,
+// so it can still name the specialization chosen for an earlier one and has to be retargeted. The
+// signature check separates the two, and a position whose inferred type contradicts the recorded one
+// declines preservation as well. `explicit_generic_fn_value_specialization` collapses a list only
+// when it covers every generic parameter, so the recorded arguments are normally complete, but the
+// tail is filled positionally so a partial list can never be silently replaced.
 fn (mut t Transformer) generic_call_args_preserving_explicit(callee flat.Node, decl GenericFnDecl, inferred map[string]string) ?[]string {
 	if callee.kind != .ident || callee.value.len == 0 {
 		return none
@@ -10951,12 +10971,25 @@ fn (mut t Transformer) generic_call_args_preserving_explicit(callee flat.Node, d
 	if !t.callee_matches_generic_args(callee, decl, recorded) {
 		return none
 	}
+	if !t.callee_is_erased_explicit_generic(callee, decl, recorded) {
+		return none
+	}
 	param_names := t.generic_fn_param_names(decl.node, decl.module)
 	if param_names.len < recorded.len {
 		return none
 	}
 	mut preserved := recorded.clone()
-	for name in param_names[recorded.len..] {
+	for i, name in param_names {
+		if i < recorded.len {
+			// If this clone infers a different type for a position the explicit list fixed,
+			// the callee is not the binding it appears to be; retarget normally instead.
+			if got := inferred[name] {
+				if got != recorded[i] {
+					return none
+				}
+			}
+			continue
+		}
 		preserved << inferred[name] or { return none }
 	}
 	return preserved


### PR DESCRIPTION
## Problem

An explicit type-argument list on a generic call is discarded when the call is made from
inside another generic function. The compiler re-infers the callee's generic arguments
and silently retargets the call to a different specialization.

```v
type Sum = int | string

fn make_it[X]() X {
	return X{}
}

fn outer[T](_unused T) string {
	v := make_it[Sum]()
	return typeof(v).name
}

fn main() {
	println(outer(1)) // prints `string`, should print `Sum`
}
```

`outer` returns `string`, and that return type is what ends up bound to `X`. When the
callee's generic parameter happens to share a name with the caller's, the caller's own
generic argument is used instead.

This is not a corner case in practice: it breaks every `json2.decode[json2.Any](...)`
performed inside a generic function, which decodes as `string` and fails at run time
with `Invalid json: Data: Expected string, but got object`.

```v
import x.json2

fn contains[T](ctx &T, needle string) bool {
	encoded := json2.encode(*ctx)
	value := json2.decode[json2.Any](encoded) or { return false } // always fails
	return walk(value, needle)
}
```

## Cause

`explicit_generic_fn_value_specialization` rewrites a `fn_name[Type]` callee to a plain
specialization ident. That happens before the enclosing generic body is cloned, so when
`retarget_cloned_generic_call` / `retarget_cloned_implicit_generic_call` inspect the
cloned call, `call_has_source_generic_args` no longer sees an index node and
`explicit_generic_call_args` finds nothing. Both paths then fall through to the implicit
branch and re-infer, first from `cur_fn_ret_type` and then from the enclosing
specialization's arguments by generic-parameter name.

Implicitly specialized calls are unaffected: `rewrite_generic_plain_call` stores their
resolved arguments in the call node's value, so they still take the explicit branch and
are substituted correctly for each specialization. Only source-explicit calls lose that
information, which is what makes the existing `source_has_explicit_args` guard miss them.

## Fix

Add `call_keeps_explicit_specialization`, which reports whether a cloned call is already
bound to the specialization chosen by an explicit list: the callee is an ident naming a
recorded specialization of that decl, and nothing could be inferred from the call
arguments. Such a call resolves identically in every clone of the body, so neither the
enclosing return type nor the enclosing generic arguments may retarget it.

## Tests

`vlib/v/tests/generics/explicit_generic_call_args_inside_generic_fn_test.v` covers
explicit type args inside a generic caller for plain, result and option returns, for a
callee whose generic parameter shares the caller's name, and — as a guard against
over-correcting — for implicit nested calls, which must still be retargeted per
specialization. The new test fails on master and passes with this change.

- `vlib/v/tests/generics/`: 304 passed, 4 failed; the same 4 fail on master and all 4
  pass when run individually, so they are pre-existing flakiness in the parallel runner.
- `vlib/v3/tests/`: 228 passed, 55 failed — byte-identical to master on this machine
  (macOS/arm64), with no failure present here that is absent there.
- `vlib/v/compiler_errors_test.v`: 1707 passed, 1 skipped.
- Self-hosts cleanly through three generations, and the resulting compiler still passes
  the new test.