### PR TITLE
json2: fix decoding structs with skipped shared fields

### DIFF
--- a/vlib/json2/decode.v
+++ b/vlib/json2/decode.v
@@ -584,7 +584,9 @@ fn decode_struct_key[T](mut decoder Decoder, val T, key_info ValueInfo, prefix s
 							decoder.decode_error('`raw` attribute can only be used with string fields')!
 						}
 					} else {
-						$if field.typ is $option {
+						$if field.is_shared {
+							decoder.decode_error('shared fields cannot be decoded')!
+						} $else $if field.typ is $option {
 							if decoder.current_node.value.value_kind == .null {
 								new_val.$(field.name) = none
 
@@ -973,7 +975,9 @@ fn (mut decoder Decoder) decode_value[T](mut val T) ! {
 										decoder.decode_error('`raw` attribute can only be used with string fields')!
 									}
 								} else {
-									$if field.typ is $option {
+									$if field.is_shared {
+										decoder.decode_error('shared fields cannot be decoded')!
+									} $else $if field.typ is $option {
 										if decoder.current_node.value.value_kind == .null {
 											val.$(field.name) = none
 

--- a/vlib/json2/tests/attributes_test.v
+++ b/vlib/json2/tests/attributes_test.v
@@ -18,6 +18,12 @@ struct StruWithJsonSkipAttribute {
 	b    int
 }
 
+struct StruWithSkippedSharedFields {
+	name      string
+	data      shared string @[skip]
+	json_data shared string @[json: '-']
+}
+
 struct StruWithOmitemptyAttribute {
 	a    int
 	name ?string @[omitempty]
@@ -107,6 +113,17 @@ fn test_skip_and_rename_attributes() {
 		name: 'hola'
 		b:    3
 	}, '`omitempty` attribute not working'
+}
+
+fn test_decode_skipped_shared_fields() {
+	value := StruWithSkippedSharedFields{
+		name:      'foo'
+		data:      'bar'
+		json_data: 'baz'
+	}
+	assert json.encode(value) == '{"name":"foo"}'
+	decoded := json.decode[StruWithSkippedSharedFields]('{"name":"foo","data":"ignored","json_data":"ignored"}')!
+	assert decoded.name == value.name
 }
 
 fn test_raw_attribute() {


### PR DESCRIPTION
`json2.decode` type-checked its pointer decoding path for `shared` struct fields even when the field was marked `@[skip]` or `@[json: '-']`. As a result, an ignored shared field prevented the containing struct from compiling.

Handle shared fields before the pointer path so the existing skip handling can consume ignored values without generating an unlocked field access. Non-skipped shared fields now produce a JSON decode error instead of a compile error.

Fixes #28522

Tests:
- `./vnew -silent test vlib/json2/tests/attributes_test.v`
- Original issue reproducer with the default compiler and `-old-compiler`
- `./vnew -silent test vlib/json2/` (72 passed, 1 skipped; the existing `decode_custom_test.v` object-order assertion also fails with the baseline decoder)
