### PR TITLE
v3: key the cached tcc atomic.S object by compiler and target

### DIFF
--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -521,3 +521,50 @@ fn test_add_c_language_runtime_link_flags() {
 	add_c_language_runtime_link_flags(mut existing, existing.clone(), 'objective-c++', target)
 	assert existing == ['-lstdc++', '-lobjc']
 }
+
+fn test_tcc_atomic_object_key_separates_compilers_targets_and_args() {
+	root := os.join_path(os.vtmp_dir(), 'v3_atomic_object_key_${os.getpid()}')
+	os.mkdir_all(root)!
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	target := pref.Target{
+		os: 'macos'
+		arch: 'arm64'
+		object_format: 'macho'
+	}
+	first_tcc := os.join_path(root, 'first_tcc')
+	second_tcc := os.join_path(root, 'second_tcc')
+	os.write_file(first_tcc, 'first')!
+	os.write_file(second_tcc, 'second compiler build')!
+	args := ['-std=gnu11', '-fwrapv']
+	key := tcc_atomic_object_key('source-signature', first_tcc, args, target)
+
+	assert key == tcc_atomic_object_key('source-signature', first_tcc, args, target)
+	// A different compiler build must not reuse the object: tcc emits ELF
+	// objects even on macOS, and rejects a Mach-O object with
+	// "unrecognized file type" instead of falling back to reassembling atomic.S.
+	assert key != tcc_atomic_object_key('source-signature', second_tcc, args, target)
+	assert key != tcc_atomic_object_key('other-signature', first_tcc, args, target)
+	assert key != tcc_atomic_object_key('source-signature', first_tcc, ['-std=gnu11'], target)
+	assert key != tcc_atomic_object_key('source-signature', first_tcc, args, pref.Target{
+		...target
+		arch: 'amd64'
+	})
+}
+
+fn test_tcc_compiler_identity_tracks_rebuilds() {
+	root := os.join_path(os.vtmp_dir(), 'v3_atomic_compiler_identity_${os.getpid()}')
+	os.mkdir_all(root)!
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	compiler := os.join_path(root, 'tcc.exe')
+	os.write_file(compiler, 'first')!
+	first := tcc_compiler_identity(compiler)
+	assert first == tcc_compiler_identity(compiler)
+	// `make` re-pulls and rebuilds thirdparty/tcc in place, so the identity has
+	// to change when the executable at the same path does.
+	os.write_file(compiler, 'a rebuilt compiler with a different size')!
+	assert first != tcc_compiler_identity(compiler)
+}

--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -568,3 +568,21 @@ fn test_tcc_compiler_identity_tracks_rebuilds() {
 	os.write_file(compiler, 'a rebuilt compiler with a different size')!
 	assert first != tcc_compiler_identity(compiler)
 }
+
+fn test_tcc_compiler_identity_tracks_same_size_rebuilds() {
+	root := os.join_path(os.vtmp_dir(), 'v3_atomic_identity_same_size_${os.getpid()}')
+	os.mkdir_all(root)!
+	defer {
+		os.rmdir_all(root) or {}
+	}
+	compiler := os.join_path(root, 'tcc.exe')
+	os.write_file(compiler, 'first build')!
+	first := tcc_compiler_identity(compiler)
+	// Rewritten in place to the same byte count, within one filesystem timestamp
+	// second. Size plus a second-resolution mtime cannot separate these two
+	// compilers, and reusing an object across them is what produces an
+	// "unrecognized file type" link failure that no later build clears.
+	os.write_file(compiler, 'other build')!
+	assert os.file_size(compiler) == 11
+	assert first != tcc_compiler_identity(compiler)
+}

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -234,12 +234,22 @@ fn tcc_atomic_s_arg(prefs &pref.Preferences) string {
 }
 
 // tcc_compiler_identity describes which compiler build a cached object came
-// from. Reading the whole executable to hash it would cost more than the object
-// cache saves, so size and modification time stand in for its contents; both
-// change when thirdparty/tcc is rebuilt or pulled.
+// from. Hashing the whole executable on every link would cost more than the
+// object cache saves, so stat metadata stands in for its contents: inode, size
+// and nanosecond mtime/ctime all move when thirdparty/tcc is rebuilt, pulled or
+// reinstalled. Size with a second-resolution mtime does not - it cannot tell an
+// in-place rebuild to the same size within one second from no change at all, nor
+// an install that preserves mtime - and reusing the object across that would
+// recreate the incompatible-object failure this key exists to prevent.
+// Platforms without that metadata fall back to hashing the executable, which is
+// exact; only they pay for the read.
 fn tcc_compiler_identity(tcc_path string) string {
 	resolved := os.real_path(os.find_abs_path_of_executable(tcc_path) or { tcc_path })
-	return '${resolved}\x00${os.file_size(resolved)}\x00${os.file_last_mod_unix(resolved)}'
+	metadata := modulecache.file_metadata_signature(resolved)
+	if metadata.len > 0 {
+		return '${resolved}\x00${metadata}'
+	}
+	return '${resolved}\x00${modulecache.file_signature(resolved)}'
 }
 
 // tcc_atomic_object_key names the cached atomic.S object. Only the compiler that

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -233,6 +233,31 @@ fn tcc_atomic_s_arg(prefs &pref.Preferences) string {
 	return atomic_s
 }
 
+// tcc_compiler_identity describes which compiler build a cached object came
+// from. Reading the whole executable to hash it would cost more than the object
+// cache saves, so size and modification time stand in for its contents; both
+// change when thirdparty/tcc is rebuilt or pulled.
+fn tcc_compiler_identity(tcc_path string) string {
+	resolved := os.real_path(os.find_abs_path_of_executable(tcc_path) or { tcc_path })
+	return '${resolved}\x00${os.file_size(resolved)}\x00${os.file_last_mod_unix(resolved)}'
+}
+
+// tcc_atomic_object_key names the cached atomic.S object. Only the compiler that
+// produced the object can consume it again - tcc emits ELF objects even on
+// macOS, where clang emits Mach-O and neither reads the other's format - so the
+// key covers the compiler build, the target and the assembler arguments as well
+// as atomic.S itself. Keying on atomic.S alone let one producer publish an
+// object that every later link rejected with "unrecognized file type", silently
+// degrading every tcc build on the machine to the `cc` fallback.
+fn tcc_atomic_object_key(source_signature string, tcc_path string, args []string, target pref.Target) string {
+	mut hash := u64(1469598103934665603)
+	for identity in [source_signature, tcc_compiler_identity(tcc_path), target.os, target.arch,
+		target.object_format, args.join('\x00')] {
+		hash = c_hash_bytes(hash, identity.bytes())
+	}
+	return hash.hex()
+}
+
 // tcc_atomic_arg returns the atomic-support argument for a tcc link,
 // preferring a cached precompiled object: assembling atomic.S inside every
 // link costs ~28ms, while the object only changes when the source does.
@@ -247,13 +272,6 @@ fn tcc_atomic_arg(prefs &pref.Preferences, tcc_path string, tcc_includes string)
 	if signature.len == 0 {
 		return atomic_s
 	}
-	wrapv_suffix := if wrapv_flag.len > 0 { '_wrapv' } else { '' }
-	object_path := os.join_path(cache_dir, 'atomic_${naming.sanitize(signature)}${wrapv_suffix}.o')
-	if os.is_file(object_path) {
-		return object_path
-	}
-	os.mkdir_all(cache_dir) or { return atomic_s }
-	build_path := '${object_path}.tmp.${os.getpid()}'
 	mut args := ['-std=gnu11']
 	if tcc_includes != '' {
 		args << tcc_includes
@@ -261,6 +279,13 @@ fn tcc_atomic_arg(prefs &pref.Preferences, tcc_path string, tcc_includes string)
 	if wrapv_flag.len > 0 {
 		args << wrapv_flag
 	}
+	key := tcc_atomic_object_key(signature, tcc_path, args, prefs.target)
+	object_path := os.join_path(cache_dir, 'atomic_${naming.sanitize(signature)}_${key}.o')
+	if os.is_file(object_path) {
+		return object_path
+	}
+	os.mkdir_all(cache_dir) or { return atomic_s }
+	build_path := '${object_path}.tmp.${os.getpid()}'
 	args << ['-c', atomic_s, '-o', build_path]
 	result := cmdexec.run(tcc_path, args)
 	if result.exit_code != 0 || !os.is_file(build_path) {


### PR DESCRIPTION
## Problem

`v self` on macOS arm64 builds with `-cc tcc`, but the tcc link failed on every attempt and silently fell back to `cc`:

```
$ time v self
V self compiling (-cc tcc -gc none -prealloc -o v2)...
warning: tcc compilation failed, falling back to cc
V built successfully as executable "vnew".
v self  66.90s user 2.01s system 270% cpu 25.452 total
```

With `-show-c-output` the real error appears:

```
tcc: error: /tmp/v_501/v3_thirdparty_objs/atomic_<sig>_wrapv.o: unrecognized file type
```

## Cause

`tcc_atomic_arg` precompiles `thirdparty/stdatomic/nix/atomic.S` once and caches the object, because assembling it inside every link costs ~28ms. The object was cached under a name derived from **atomic.S alone**, so one shared entry served every producer.

Only the compiler that assembled the object can read it back: tcc emits ELF objects even on macOS, where clang emits Mach-O, and neither accepts the other's format. Once any other producer published that path — a clang-built object, or one from an older `thirdparty/tcc` — every later tcc link on the machine rejected it. `atomic.S` almost never changes, so the entry never expired, and the only symptom was the fallback warning.

This affects every `-cc tcc` build on the affected machine, not just `v self`.

## Fix

Fold the compiler build (resolved path, size, mtime), the target, and the assembler arguments into the cache key, so objects from different producers no longer collide and a stale entry is ignored rather than reused. The `_wrapv` filename suffix is dropped — that flag is part of the hashed arguments now.

## Verification

- Reproduced the failure, then confirmed the patched compiler ignores a deliberately re-created poisoned entry and links with tcc cleanly.
- `v self` warm: **3.9s** wall / 17.9s user via tcc, vs **13.0s** / 35.2s via `cc`. The resulting compiler builds and runs programs, including `sync.stdatomic` and threaded ones.
- New unit tests in `vlib/v3/driver/c_compiler_flags_test.v`; all 9 `vlib/v3/driver/*_test.v` files pass.
- A/B'd `vlib/v3/tests/driver_cli_test.v` against a baseline build of the same tree: identical failure sets (6 failures, all pre-existing on master).