### PR TITLE
v: pass the Windows stack size to the linker as `-Wl,--stack=`

### DIFF
--- a/vlib/v/builder/cc.v
+++ b/vlib/v/builder/cc.v
@@ -1361,14 +1361,14 @@ fn (v &Builder) only_compile_args(ccoptions CcompilerOptions) []string {
 	$if windows {
 		// Adding default options for tcc, gcc and clang as done in msvc.v.
 		// This is done before pre_args is added so that it can be overwritten if needed.
-		// -Wl,-stack=33554432 == /F33554432
+		// -Wl,--stack=33554432 == /F33554432
 		// -Werror=implicit-function-declaration == /we4013
 		// /volatile:ms - there seems to be no equivalent,
 		// normally msvc should use /volatile:iso
 		// but it could have an impact on vinix if it is created with msvc.
 		if ccoptions.cc != .msvc {
 			if v.pref.os != .wasm32_emscripten {
-				all << '-Wl,-stack=33554432'
+				all << '-Wl,--stack=33554432'
 			}
 			if !v.pref.is_cstrict {
 				all << '-Werror=implicit-function-declaration'

--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -451,23 +451,23 @@ fn test_v3_fastc_default_linker_flags() {
 }
 
 fn test_v3_windows_executable_linker_flags() {
-	expected := ['-municode', '-Wl,-stack=33554432']
+	expected := ['-municode', '-Wl,--stack=33554432']
 	assert v3_windows_executable_linker_flags('windows', 'tinyc', false, false, .auto, false) == expected
 	assert v3_windows_executable_linker_flags('windows', 'gcc', false, false, .auto, false) == expected
 	assert v3_windows_executable_linker_flags('windows', 'tinyc', false, false, .auto, true) == [
 		'-municode',
 		'-mwindows',
-		'-Wl,-stack=33554432',
+		'-Wl,--stack=33554432',
 	]
 	assert v3_windows_executable_linker_flags('windows', 'tinyc', false, false, .console, true) == [
 		'-municode',
 		'-mconsole',
-		'-Wl,-stack=33554432',
+		'-Wl,--stack=33554432',
 	]
 	assert v3_windows_executable_linker_flags('windows', 'tinyc', false, false, .windows, false) == [
 		'-municode',
 		'-mwindows',
-		'-Wl,-stack=33554432',
+		'-Wl,--stack=33554432',
 	]
 	assert v3_windows_executable_linker_flags('windows', 'msvc', false, false, .auto, true) == []
 	assert v3_windows_executable_linker_flags('windows', 'tinyc', true, false, .auto, true) == []
@@ -480,7 +480,7 @@ fn test_v3_windows_executable_linker_flags() {
 	})
 	assert '-municode' in plan.before_inputs
 	assert '-mwindows' in plan.before_inputs
-	assert '-Wl,-stack=33554432' in plan.before_inputs
+	assert '-Wl,--stack=33554432' in plan.before_inputs
 }
 
 fn test_v3_cgen_metadata_preserves_windows_gui_entry_point() {

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -2343,7 +2343,7 @@ fn v3_windows_executable_linker_flags(target_os string, c_compiler string, is_sh
 				}
 			}
 		}
-		flags << '-Wl,-stack=33554432'
+		flags << '-Wl,--stack=33554432'
 		return flags
 	}
 	return []


### PR DESCRIPTION
Cross-compiling to Windows produced a linker flag with one dash too few:

```
$ v -os windows -arch amd64 -o /tmp/hi.exe -cc x86_64-w64-mingw32-gcc .
> x86_64-w64-mingw32-gcc -std=gnu11 -municode -mwindows -Wl,-stack=33554432 ...
```

`--stack=<reserve>` is the spelling binutils documents for PE targets. The
single dash form only works because GNU ld parses long options with
`getopt_long_only`; linkers without that quirk reject it.

Both the V3 driver (`v3_windows_executable_linker_flags`) and the V1
compatibility builder now emit `-Wl,--stack=33554432`.

## Compatibility

- mingw's `ld` links both spellings and produces the same PE header —
  `SizeOfStackReserve 0000000002000000` either way, so the resulting binaries
  are byte-identical in that respect.
- TinyCC accepts either spelling: its `link_option` helper skips one *or two*
  leading dashes. Verified against the bundled tcc, which treats
  `-Wl,-rpath=`/`-Wl,--rpath=`, `-Wl,-whole-archive`/`-Wl,--whole-archive` and
  `-Wl,-Bsymbolic`/`-Wl,--Bsymbolic` identically.
- MSVC is unaffected (it uses `/F33554432`), as is the Darwin
  `-Wl,-stack_size,...` flag, which is correct ld64 syntax.

The bootstrap scripts that pass the flag directly to a C compiler (`makev.bat`,
`thirdparty/tccbin_automation/bootstrap/bootstrap.sh`, the Windows/cross CI
workflows) are left alone — they work as-is and are not part of the compiler's
own output.

`vlib/v3/driver/c_compiler_flags_test.v` covers the emitted flag and is updated
to the new spelling.