### PR TITLE
v3: discard cache entries the C toolchain rejects, and retry

### DIFF
--- a/vlib/v3/driver/c_compiler_flags_test.v
+++ b/vlib/v3/driver/c_compiler_flags_test.v
@@ -521,3 +521,65 @@ fn test_add_c_language_runtime_link_flags() {
 	add_c_language_runtime_link_flags(mut existing, existing.clone(), 'objective-c++', target)
 	assert existing == ['-lstdc++', '-lobjc']
 }
+
+fn test_v3_cache_failure_artifacts_needs_a_cached_path_and_a_whole_file_failure() {
+	cache_dir := os.join_path(os.vtmp_dir(), 'v3_thirdparty_objs')
+	object := os.join_path(cache_dir, 'atomic_deadbeef_cafe.o')
+	rejected := 'tcc: error: ${object}: unrecognized file type'
+	assert v3_cache_failure_artifacts(rejected) == [object]
+
+	// A line-scoped diagnostic in a cached unit is a real compile error, not a
+	// poisoned entry; spending a rebuild on it would only reproduce it.
+	module_source := os.join_path(os.vtmp_dir(), 'v3_module_cache_1234', 'abcd', 'main_9.c')
+	compile_error := '${module_source}:41:7: error: use of undeclared identifier'
+	assert v3_cache_failure_artifacts(compile_error) == []
+
+	// The build directory sits next to the caches but holds generated source.
+	build_source := os.join_path(os.vtmp_dir(), 'prog.01M2AH.tmp.c')
+	assert v3_cache_failure_artifacts('cc: ${build_source}: no such file or directory') == []
+
+	// A whole-file failure about a file V does not own is the user's to fix.
+	assert v3_cache_failure_artifacts('ld: file not found: /usr/local/lib/libfoo.a') == []
+
+	// Every marker has to be paired with a cached path.
+	assert v3_cache_failure_artifacts('ld: duplicate symbol _main') == []
+}
+
+fn test_v3_cache_error_artifacts_reads_paths_out_of_toolchain_diagnostics() {
+	cache_dir := os.join_path(os.vtmp_dir(), 'v3_fastc_unit_cache')
+	first := os.join_path(cache_dir, 'unit_1.o')
+	second := os.join_path(cache_dir, 'unit_2.o')
+	output := "ld: warning: ignoring file '${first}', building for macOS-arm64\n" + 'ld: ${second}: file format not recognized\n' + 'ld: ${first}: not an object file\n'
+	// Quoting and punctuation differ per toolchain, and one path can be blamed
+	// more than once.
+	assert v3_cache_error_artifacts(output) == [first, second]
+	assert v3_cache_error_artifacts('') == []
+}
+
+fn test_v3_discard_cache_artifacts_drops_sidecars_and_link_plans() {
+	cache_dir := os.join_path(os.vtmp_dir(), 'v3_thirdparty_objs')
+	os.mkdir_all(cache_dir)!
+	token := 'v3_discard_test_${os.getpid()}'
+	object := os.join_path(cache_dir, '${token}.o')
+	stamp := '${object}.stamp'
+	deps := '${object}.deps'
+	plan := os.join_path(cache_dir, 'link_${token}.manifest')
+	unrelated := os.join_path(cache_dir, '${token}_keep.o')
+	for path in [object, stamp, deps, plan, unrelated] {
+		os.write_file(path, 'x')!
+	}
+	defer {
+		for path in [object, stamp, deps, plan, unrelated] {
+			os.rm(path) or {}
+		}
+	}
+	discarded := v3_discard_cache_artifacts([object])
+	assert discarded >= 4, '${discarded}'
+	assert !os.exists(object)
+	// A stamp still certifies a deleted object, and a link plan replays its path
+	// into the next link, so both have to go with it.
+	assert !os.exists(stamp)
+	assert !os.exists(deps)
+	assert !os.exists(plan)
+	assert os.exists(unrelated)
+}

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -9549,10 +9549,16 @@ pub fn run(args []string) {
 				os.rm(fastc_bin_file) or {}
 			}
 			if !fastc_result.success {
+				if v3_recover_from_cache_failure(args, fastc_result.output, '') {
+					return
+				}
 				if fastc_result.command.len == 0 {
 					eprintln('fastc requires the bundled TinyCC executable')
 				} else if !show_c_output && fastc_result.output.len > 0 {
 					eprintln(fastc_result.output.trim_space())
+				}
+				if v3_cache_failure_artifacts(fastc_result.output).len > 0 {
+					eprintln("Suggestion: the C toolchain keeps rejecting files from V's cache. Run `v wipe-cache`, then repeat your compilation.")
 				}
 				exit(1)
 			}
@@ -12292,9 +12298,24 @@ pub fn run(args []string) {
 			}
 			show_v3_c_compiler_output(show_c_output, c_compiler, result)
 			if result.exit_code != 0 {
+				// Before degrading to the fallback compiler: a stale cache entry
+				// is repairable, and falling back would hide it indefinitely.
+				if v3_recover_from_cache_failure(args, result.output, cc_dir) {
+					return
+				}
 				if retry_compilation && v3_is_tcc_compilation_failure(c_compiler, result.output) {
 					fallback := v3_platform_c_compiler(host_os)
 					eprintln('warning: tcc compilation failed, falling back to ${fallback}')
+					// Recovery above already declined, so discarding the entries
+					// did not help. Name them: the fallback still produces a
+					// working binary, which is what makes this easy to miss.
+					if artifacts := v3_unrepaired_cache_failure_artifacts(result.output) {
+						eprintln('warning: tcc rejected cached V build artifacts that a rebuild did not repair:')
+						for artifact in artifacts {
+							eprintln('  ${artifact}')
+						}
+						eprintln('Suggestion: run `v wipe-cache`, then repeat your compilation.')
+					}
 					retry_args := v3_retry_compilation_args(args, c_compiler_arg_index, fallback)
 					cleanup_c_build_dir(cc_dir)
 					retry_result := cmdexec.run(os.executable(), retry_args)
@@ -12329,6 +12350,11 @@ Please install the corresponding development package/libraries and make sure the
 				} else {
 					eprintln('C compilation failed:')
 					eprintln(result.output)
+				}
+				if v3_cache_failure_artifacts(result.output).len > 0 {
+					// Reached only after the automatic retry above already
+					// discarded these entries and the rebuild republished them.
+					eprintln("Suggestion: the C toolchain keeps rejecting files from V's cache. Run `v wipe-cache`, then repeat your compilation.")
 				}
 				cleanup_c_build_dir(cc_dir)
 				exit(1)
@@ -12503,6 +12529,162 @@ fn v3_is_tcc_compilation_failure(c_compiler string, output string) bool {
 		}
 	}
 	return false
+}
+
+// v3_cache_artifact_dir_names are the persistent caches a build links artifacts
+// out of. The live build directory is deliberately absent: a diagnostic naming
+// a file there describes generated or user source, not a stale cache entry.
+const v3_cache_artifact_dir_names = ['v3_module_cache_', 'v3_thirdparty_objs', 'v3_fastc_unit_cache',
+	'v3_fastc_link_cache', 'v3_crun_cache']
+
+// v3_cache_failure_markers are whole-file rejections: the toolchain could not
+// read or find an input, or saw the same symbol twice. Line-scoped diagnostics
+// are excluded on purpose, so a compile error inside a cached unit is reported
+// to the user instead of costing a rebuild that reproduces it.
+const v3_cache_failure_markers = ['unrecognized file type', 'file format not recognized',
+	'not an object file', 'no such file or directory', 'file not found', 'malformed object',
+	'truncated or malformed', 'archive has no index', 'duplicate symbol', 'multiple definition',
+	'defined twice', 'incompatible file format']
+
+const v3_cache_recovery_env = 'V3_INTERNAL_CACHE_RECOVERY'
+
+fn v3_cache_artifact_prefixes() []string {
+	mut roots := [os.vtmp_dir()]
+	if configured := os.getenv_opt('V3CACHE') {
+		root := os.abs_path(configured)
+		if root !in roots {
+			roots << root
+		}
+	}
+	mut prefixes := []string{cap: roots.len * v3_cache_artifact_dir_names.len}
+	for root in roots {
+		for name in v3_cache_artifact_dir_names {
+			prefixes << os.join_path_single(root, name)
+		}
+	}
+	return prefixes
+}
+
+// v3_cache_error_artifacts returns the cached artifacts named by a C toolchain
+// error. The wording differs per toolchain, but every such diagnostic quotes
+// the offending path, so the path is the portable signal.
+fn v3_cache_error_artifacts(output string) []string {
+	if output.len == 0 {
+		return []
+	}
+	prefixes := v3_cache_artifact_prefixes()
+	mut artifacts := []string{}
+	for raw in output.fields() {
+		token := raw.trim('\'"`()[],;:')
+		if token.len == 0 || token in artifacts {
+			continue
+		}
+		for prefix in prefixes {
+			if token.starts_with(prefix) {
+				artifacts << token
+				break
+			}
+		}
+	}
+	return artifacts
+}
+
+// v3_cache_failure_artifacts returns the cache entries to discard after a C
+// toolchain failure. Both signals are required: the output has to name a cached
+// artifact *and* report a whole-file failure, so an ordinary compile error is
+// never mistaken for a poisoned cache.
+fn v3_cache_failure_artifacts(output string) []string {
+	lowered := output.to_lower_ascii()
+	mut has_marker := false
+	for marker in v3_cache_failure_markers {
+		if lowered.contains(marker) {
+			has_marker = true
+			break
+		}
+	}
+	if !has_marker {
+		return []
+	}
+	return v3_cache_error_artifacts(output)
+}
+
+// v3_discard_cache_artifacts removes the rejected entries together with the
+// sidecars that would otherwise keep certifying them: a stamp still validates a
+// deleted object, and a link plan replays the object path into the next link
+// even once the object is gone.
+fn v3_discard_cache_artifacts(artifacts []string) int {
+	mut discarded := 0
+	mut object_dirs := []string{}
+	for artifact in artifacts {
+		for path in [artifact, '${artifact}.stamp', '${artifact}.deps', '${artifact}.deps.stamp'] {
+			if !os.exists(path) {
+				continue
+			}
+			os.rm(path) or { continue }
+			discarded++
+		}
+		dir := os.dir(artifact)
+		if os.base(dir).starts_with('v3_thirdparty_objs') && dir !in object_dirs {
+			object_dirs << dir
+		}
+	}
+	for dir in object_dirs {
+		for name in os.ls(dir) or { []string{} } {
+			if !name.ends_with('.manifest') {
+				continue
+			}
+			os.rm(os.join_path_single(dir, name)) or { continue }
+			discarded++
+		}
+	}
+	return discarded
+}
+
+// v3_unrepaired_cache_failure_artifacts returns the cached artifacts a failure
+// blames once automatic recovery has already had its turn, so the caller can
+// report what discarding them did not fix. It yields nothing on a build that
+// never attempted recovery, where the retry is still pending.
+fn v3_unrepaired_cache_failure_artifacts(output string) ?[]string {
+	if os.getenv(v3_cache_recovery_env) != '1' {
+		return none
+	}
+	artifacts := v3_cache_failure_artifacts(output)
+	if artifacts.len == 0 {
+		return none
+	}
+	return artifacts
+}
+
+// v3_recover_from_cache_failure discards the cache entries a C toolchain
+// failure blamed and restarts the build once. Such an entry is otherwise
+// permanent - it outlives the build that published it, and the only symptom is
+// a toolchain error about a file the user never named - so recovering here is
+// preferred over degrading the build to a fallback compiler.
+fn v3_recover_from_cache_failure(args []string, output string, cc_dir string) bool {
+	if os.getenv(v3_cache_recovery_env) == '1' {
+		return false
+	}
+	artifacts := v3_cache_failure_artifacts(output)
+	if artifacts.len == 0 {
+		return false
+	}
+	if v3_discard_cache_artifacts(artifacts) == 0 {
+		return false
+	}
+	// Reported even under `-silent`, like the tcc fallback warning: a repair the
+	// user cannot see is indistinguishable from the silent degradation that
+	// makes a poisoned cache entry so hard to notice in the first place.
+	eprintln('warning: the C toolchain rejected cached V build artifacts; discarding them and retrying:')
+	for artifact in artifacts {
+		eprintln('  ${artifact}')
+	}
+	cleanup_c_build_dir(cc_dir)
+	os.setenv(v3_cache_recovery_env, '1', true)
+	os.execvp(os.executable(), args) or {
+		eprintln('failed to restart the build after discarding stale cache entries: ${err.msg()}')
+		exit(1)
+	}
+	return true
 }
 
 fn v3_retry_compilation_args(args []string, c_compiler_arg_index int, fallback string) []string {


### PR DESCRIPTION
Follow-up to #28529, which fixed one way a cache entry gets poisoned. This makes v3 recover from the *class* of problem instead of only that instance.

## Problem

A poisoned cache entry is permanent. It outlives the build that published it, nothing revalidates it, and the only symptom is a C toolchain error naming a file the user never mentioned:

```
tcc: error: /tmp/v_501/v3_thirdparty_objs/atomic_<sig>.o: unrecognized file type
```

For a tcc build that error then triggers the `cc` fallback, so the build still *succeeds* — it just got several times slower, permanently, behind a one-line `warning: tcc compilation failed, falling back to cc`. That is how #28529 went unnoticed.

## What this does

Detect the case and repair it.

**Detection requires two independent signals.** The output has to name a path under one of V's persistent caches (`v3_module_cache_*`, `v3_thirdparty_objs`, `v3_fastc_unit_cache`, `v3_fastc_link_cache`, `v3_crun_cache`) **and** report a whole-file rejection — unreadable, missing, or duplicated symbols. Requiring both keeps ordinary errors out:

- a line-scoped diagnostic inside a cached unit is a real compile error, and is reported as one;
- `ld: file not found: /usr/local/lib/libfoo.a` is the user's to fix;
- the build directory is not a cache, so generated source never qualifies.

**Repair discards the sidecars too.** A stamp still certifies a deleted object, and a link plan replays the object path into the next link even after the object is gone, so both go with it.

**Then the build restarts once**, guarded by an environment variable so it cannot loop. Recovery runs *before* the tcc fallback, so a repairable cache gets repaired rather than hidden behind a slower compiler.

**If the retry hits the same rejection**, the entries are named and `v wipe-cache` is suggested — including on the fallback path, where the build still succeeds and the problem is otherwise invisible.

## Behaviour

Poisoned entry, before:

```
$ v -cc tcc -o hello hello.v
warning: tcc compilation failed, falling back to cc
```

After:

```
$ v -cc tcc -o hello hello.v
warning: the C toolchain rejected cached V build artifacts; discarding them and retrying:
  /tmp/v_501/v3_thirdparty_objs/atomic_9c646e209acb927_wrapv.o
```

…and the build completes with tcc. `v self` with a poisoned cache self-repairs the same way.

If a rebuild republishes the same bad entry:

```
warning: tcc compilation failed, falling back to cc
warning: tcc rejected cached V build artifacts that a rebuild did not repair:
  /tmp/v_501/v3_thirdparty_objs/atomic_9c646e209acb927_wrapv.o
Suggestion: run `v wipe-cache`, then repeat your compilation.
```

## Verification

- On this branch alone (without #28529) a deliberately poisoned atomic object is detected, discarded and rebuilt, and the build finishes on tcc — so this would have fixed the original `v self` report by itself.
- Negative cases confirmed not to trigger it: a checker error, a C link error for an undeclared function (cache file count unchanged, no suggestion printed), and paths in the build directory.
- Loop guard confirmed: with the guard set, recovery declines, nothing is deleted twice, and the escalation message names the entries.
- New unit tests in `vlib/v3/driver/c_compiler_flags_test.v` cover detection, path extraction across toolchain quoting styles, and sidecar/link-plan removal. All 9 `vlib/v3/driver/*_test.v` files pass.
- `v self` (cold and warm), `-prod`, threaded/`sync.stdatomic` programs, and `v wipe-cache` all verified working.