### PR TITLE
v3: expand environment macros in C directives

### DIFF
--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -11,6 +11,7 @@ import v3.modulecache
 import v3.pref
 import v3.types
 import v3.util
+import v.util as vutil
 
 const spread_index_expected_type_marker = '__v3_spread_index_expected_type'
 const source_mut_pointer_deref_marker = '__v3_source_mut_pointer_deref'
@@ -9645,6 +9646,9 @@ fn c_include_arg(raw string, vroot string, source_file string) string {
 
 fn c_include_arg_for_target(raw string, vroot string, source_file string, target pref.Target) string {
 	mut clean := c_directive_arg_for_target(raw.trim_space(), target) or { return '' }
+	if clean.contains('\$env(') {
+		clean = vutil.resolve_env_value(clean, true) or { return '' }
+	}
 	clean = c_resolve_pseudo_paths(clean.trim_space(), vroot, source_file)
 	if clean.len == 0 {
 		return ''
@@ -9683,7 +9687,12 @@ fn c_flag_args_with_values(raw string, vroot string, source_file string, target 
 	defaults_expanded := c_expand_default_define_macros(without_comment, compile_values) or {
 		return []string{}
 	}
-	clean := c_expand_existing_path_macros(defaults_expanded, vroot, source_file) or {
+	environment_expanded := if defaults_expanded.contains('\$env(') {
+		vutil.resolve_env_value(defaults_expanded, true) or { return []string{} }
+	} else {
+		defaults_expanded
+	}
+	clean := c_expand_existing_path_macros(environment_expanded, vroot, source_file) or {
 		return []string{}
 	}
 	args := cmdexec.split_args(clean) or { return []string{} }

--- a/vlib/v3/gen/c/target_test.v
+++ b/vlib/v3/gen/c/target_test.v
@@ -42,6 +42,26 @@ fn test_c_directive_targets_use_requested_platform() {
 	assert c_include_arg_for_target('windows <windows.h>', '', '', target) == ''
 }
 
+fn test_c_directive_environment_macros_are_expanded() {
+	name := 'V3_C_DIRECTIVE_ENV_TEST'
+	old_value := os.getenv(name)
+	was_set := name in os.environ()
+	defer {
+		if was_set {
+			os.setenv(name, old_value, true)
+		} else {
+			os.unsetenv(name)
+		}
+	}
+	os.setenv(name, 'v3-sdk', true)
+
+	assert c_flag_args("-I\$env('${name}')/include -L\$env('${name}')/lib", '', '', pref.host_target()) == [
+		'-Iv3-sdk/include',
+		'-Lv3-sdk/lib',
+	]
+	assert c_include_arg('"\$env(\'${name}\')/include/header.h"', '', '') == '"v3-sdk/include/header.h"'
+}
+
 fn test_c_flag_default_define_macros_stay_single_arguments() {
 	target := pref.host_target()
 	assert c_flag_args("-DNUMBER=\$d('N', 1234 ) ##", '', '', target) == [


### PR DESCRIPTION
## What does this PR do?

Expand `$env(...)` macros in V3 C flags and include directives before argument splitting and pseudo-path resolution. This restores the behavior already supported by the default compiler and lets modules locate SDK headers and libraries through environment variables.

The regression test covers both `#flag -I$env(...)` and `#include "$env(...)/..."` processing.

## Verification

- Built the current V3 compiler directly without preallocation.
- `./v3np vlib/v3/gen/c/target_test.v`
- Compiled and ran a small C-interoperability program whose header is reachable only through `#flag -I$env('V3_ENV_HEADER_DIR')`.
- Ran all 20 `vlib/v3/gen/c` tests on the original reproducing V3 revision before rebasing the patch onto current `master`.
