### PR TITLE
v3: create TinyCC thread-local slot keys lazily (fix the Linux startup crash)

### DIFF
--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -20409,8 +20409,10 @@ fn (mut g FlatGen) emit_tinyc_windows_thread_local_slot(cname string, ct string,
 	g.writeln('static ${cname}_fls_get_fn ${cname}_fls_get;')
 	g.writeln('static ${cname}_fls_set_fn ${cname}_fls_set;')
 	g.writeln('static void WINAPI ${cname}_slot_free(void* p) { free(p); }')
-	g.writeln('static void ${cname}_key_init(void) __attribute__((constructor));')
+	// TinyCC parses `__attribute__((constructor))` but never runs the function,
+	// so the key has to be allocated on first use instead.
 	g.writeln('static void ${cname}_key_init(void) {')
+	g.writeln('\tif (${cname}_key != 0xFFFFFFFF) { return; }')
 	g.writeln('\tvoid* kernel32 = GetModuleHandleA("kernel32.dll");')
 	g.writeln('\t${cname}_fls_alloc_fn fls_alloc = (${cname}_fls_alloc_fn)GetProcAddress(kernel32, "FlsAlloc");')
 	g.writeln('\t${cname}_fls_get = (${cname}_fls_get_fn)GetProcAddress(kernel32, "FlsGetValue");')
@@ -20418,12 +20420,40 @@ fn (mut g FlatGen) emit_tinyc_windows_thread_local_slot(cname string, ct string,
 	g.writeln('\t${cname}_key = fls_alloc && ${cname}_fls_get && ${cname}_fls_set ? fls_alloc(${cname}_slot_free) : TlsAlloc();')
 	g.writeln('}')
 	if dims.len > 0 {
-		g.writeln('static ${ct} (*${cname}_slot(void))${dims} { void* p = ${cname}_fls_get ? ${cname}_fls_get(${cname}_key) : TlsGetValue(${cname}_key); if (!p) { p = calloc(1, sizeof(*${cname}_slot())); if (${cname}_fls_set) ${cname}_fls_set(${cname}_key, p); else TlsSetValue(${cname}_key, p); } return p; }')
+		g.writeln('static ${ct} (*${cname}_slot(void))${dims} { ${cname}_key_init(); void* p = ${cname}_fls_get ? ${cname}_fls_get(${cname}_key) : TlsGetValue(${cname}_key); if (!p) { p = calloc(1, sizeof(*${cname}_slot())); if (${cname}_fls_set) ${cname}_fls_set(${cname}_key, p); else TlsSetValue(${cname}_key, p); } return p; }')
 	} else {
-		g.writeln('static ${ct}* ${cname}_slot(void) { void* p = ${cname}_fls_get ? ${cname}_fls_get(${cname}_key) : TlsGetValue(${cname}_key); if (!p) { p = calloc(1, sizeof(${ct})); if (${cname}_fls_set) ${cname}_fls_set(${cname}_key, p); else TlsSetValue(${cname}_key, p); } return (${ct}*)p; }')
+		g.writeln('static ${ct}* ${cname}_slot(void) { ${cname}_key_init(); void* p = ${cname}_fls_get ? ${cname}_fls_get(${cname}_key) : TlsGetValue(${cname}_key); if (!p) { p = calloc(1, sizeof(${ct})); if (${cname}_fls_set) ${cname}_fls_set(${cname}_key, p); else TlsSetValue(${cname}_key, p); } return (${ct}*)p; }')
 	}
 	g.writeln('#define ${cname} (*${cname}_slot())')
 	g.writeln('#elif defined(__TINYC__)')
+}
+
+// emit_tinyc_pthread_slot_key emits the pthread key that backs a TinyCC
+// thread-local slot. The key is created on first use through `pthread_once`,
+// never from `__attribute__((constructor))`: TinyCC accepts that attribute but
+// never runs the function, leaving the key at its zero initializer - which is
+// also the key `pthread_key_create` hands out for the first key the process
+// really creates. Two slots would then share one key, and the wider one would
+// write through the narrower one's storage (see the `-prealloc` arena slot in
+// emit_tinyc_pthread_pointer_slot, which is created that way).
+fn (mut g FlatGen) emit_tinyc_pthread_slot_key(cname string) {
+	g.writeln('static pthread_key_t ${cname}_key;')
+	g.writeln('static pthread_once_t ${cname}_key_once = PTHREAD_ONCE_INIT;')
+	g.writeln('static void ${cname}_key_create(void) { pthread_key_create(&${cname}_key, free); }')
+	g.writeln('static void ${cname}_key_init(void) { pthread_once(&${cname}_key_once, ${cname}_key_create); }')
+}
+
+// emit_tinyc_pthread_value_slot emits the TinyCC replacement for a thread-local
+// value of type `ct` (with `dims` set for a fixed array), stored in its own
+// pthread key and allocated per thread on first access.
+fn (mut g FlatGen) emit_tinyc_pthread_value_slot(cname string, ct string, dims string) {
+	g.emit_tinyc_pthread_slot_key(cname)
+	if dims.len > 0 {
+		g.writeln('static ${ct} (*${cname}_slot(void))${dims} { ${cname}_key_init(); void* p = pthread_getspecific(${cname}_key); if (!p) { p = calloc(1, sizeof(*${cname}_slot())); pthread_setspecific(${cname}_key, p); } return p; }')
+	} else {
+		g.writeln('static ${ct}* ${cname}_slot(void) { ${cname}_key_init(); void* p = pthread_getspecific(${cname}_key); if (!p) { p = calloc(1, sizeof(${ct})); pthread_setspecific(${cname}_key, p); } return (${ct}*)p; }')
+	}
+	g.writeln('#define ${cname} (*${cname}_slot())')
 }
 
 fn (mut g FlatGen) emit_tinyc_pthread_pointer_slot(cname string, ct string) {
@@ -20467,11 +20497,7 @@ fn (mut g FlatGen) global_decls() {
 			init := if g.has_zero_sized_leading_init_slot(decl_typ) { '' } else { ' = {0}' }
 			if is_thread_local {
 				g.emit_tinyc_windows_thread_local_slot(g.cname(name), c_elem, dims)
-				g.writeln('static pthread_key_t ${g.cname(name)}_key;')
-				g.writeln('static void ${g.cname(name)}_key_init(void) __attribute__((constructor));')
-				g.writeln('static void ${g.cname(name)}_key_init(void) { pthread_key_create(&${g.cname(name)}_key, free); }')
-				g.writeln('static ${c_elem} (*${g.cname(name)}_slot(void))${dims} { void* p = pthread_getspecific(${g.cname(name)}_key); if (!p) { p = calloc(1, sizeof(*${g.cname(name)}_slot())); pthread_setspecific(${g.cname(name)}_key, p); } return p; }')
-				g.writeln('#define ${g.cname(name)} (*${g.cname(name)}_slot())')
+				g.emit_tinyc_pthread_value_slot(g.cname(name), c_elem, dims)
 				g.emit_thread_local_decl_after_tinyc('${c_elem} ${g.cname(name)}${dims}${init};')
 			} else {
 				g.writeln('${c_elem} ${g.cname(name)}${dims}${init};')
@@ -20509,20 +20535,12 @@ fn (mut g FlatGen) global_decls() {
 			cname := g.cname(name)
 			if shared_ct := g.fn_capture_shared_global_c_type(name) {
 				g.emit_tinyc_windows_thread_local_slot(cname, shared_ct, '')
-				g.writeln('static pthread_key_t ${cname}_key;')
-				g.writeln('static void ${cname}_key_init(void) __attribute__((constructor));')
-				g.writeln('static void ${cname}_key_init(void) { pthread_key_create(&${cname}_key, free); }')
-				g.writeln('static ${shared_ct}* ${cname}_slot(void) { void* p = pthread_getspecific(${cname}_key); if (!p) { p = calloc(1, sizeof(${shared_ct})); pthread_setspecific(${cname}_key, p); } return (${shared_ct}*)p; }')
-				g.writeln('#define ${cname} (*${cname}_slot())')
+				g.emit_tinyc_pthread_value_slot(cname, shared_ct, '')
 				g.emit_thread_local_decl_after_tinyc('${shared_ct} ${cname};')
 				continue
 			}
 			g.emit_tinyc_windows_thread_local_slot(cname, ct, '')
-			g.writeln('static pthread_key_t ${cname}_key;')
-			g.writeln('static void ${cname}_key_init(void) __attribute__((constructor));')
-			g.writeln('static void ${cname}_key_init(void) { pthread_key_create(&${cname}_key, free); }')
-			g.writeln('static ${ct}* ${cname}_slot(void) { void* p = pthread_getspecific(${cname}_key); if (!p) { p = calloc(1, sizeof(${ct})); pthread_setspecific(${cname}_key, p); } return (${ct}*)p; }')
-			g.writeln('#define ${cname} (*${cname}_slot())')
+			g.emit_tinyc_pthread_value_slot(cname, ct, '')
 			g.emit_thread_local_decl_after_tinyc('${ct} ${cname}${init};')
 			continue
 		}

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -20409,15 +20409,27 @@ fn (mut g FlatGen) emit_tinyc_windows_thread_local_slot(cname string, ct string,
 	g.writeln('static ${cname}_fls_get_fn ${cname}_fls_get;')
 	g.writeln('static ${cname}_fls_set_fn ${cname}_fls_set;')
 	g.writeln('static void WINAPI ${cname}_slot_free(void* p) { free(p); }')
+	g.writeln('static unsigned int ${cname}_key_claim;')
+	g.writeln('static unsigned int ${cname}_key_ready;')
 	// TinyCC parses `__attribute__((constructor))` but never runs the function,
-	// so the key has to be allocated on first use instead.
+	// so the TLS index has to be allocated on first use. Exactly one thread may
+	// do that: a second `FlsAlloc`/`TlsAlloc` would replace a key whose storage
+	// other threads are already using, stranding both the storage and the key.
+	// `__atomic_add_fetch` is the primitive TinyCC itself uses for Windows
+	// Interlocked operations; the seq_cst publish also orders the key and
+	// function pointer stores before any waiter observes them.
 	g.writeln('static void ${cname}_key_init(void) {')
-	g.writeln('\tif (${cname}_key != 0xFFFFFFFF) { return; }')
-	g.writeln('\tvoid* kernel32 = GetModuleHandleA("kernel32.dll");')
-	g.writeln('\t${cname}_fls_alloc_fn fls_alloc = (${cname}_fls_alloc_fn)GetProcAddress(kernel32, "FlsAlloc");')
-	g.writeln('\t${cname}_fls_get = (${cname}_fls_get_fn)GetProcAddress(kernel32, "FlsGetValue");')
-	g.writeln('\t${cname}_fls_set = (${cname}_fls_set_fn)GetProcAddress(kernel32, "FlsSetValue");')
-	g.writeln('\t${cname}_key = fls_alloc && ${cname}_fls_get && ${cname}_fls_set ? fls_alloc(${cname}_slot_free) : TlsAlloc();')
+	g.writeln('\tif (__atomic_add_fetch(&${cname}_key_ready, 0, 5)) { return; }')
+	g.writeln('\tif (__atomic_add_fetch(&${cname}_key_claim, 1, 5) == 1) {')
+	g.writeln('\t\tvoid* kernel32 = GetModuleHandleA("kernel32.dll");')
+	g.writeln('\t\t${cname}_fls_alloc_fn fls_alloc = (${cname}_fls_alloc_fn)GetProcAddress(kernel32, "FlsAlloc");')
+	g.writeln('\t\t${cname}_fls_get = (${cname}_fls_get_fn)GetProcAddress(kernel32, "FlsGetValue");')
+	g.writeln('\t\t${cname}_fls_set = (${cname}_fls_set_fn)GetProcAddress(kernel32, "FlsSetValue");')
+	g.writeln('\t\t${cname}_key = fls_alloc && ${cname}_fls_get && ${cname}_fls_set ? fls_alloc(${cname}_slot_free) : TlsAlloc();')
+	g.writeln('\t\t__atomic_add_fetch(&${cname}_key_ready, 1, 5);')
+	g.writeln('\t} else {')
+	g.writeln('\t\twhile (!__atomic_add_fetch(&${cname}_key_ready, 0, 5)) { Sleep(0); }')
+	g.writeln('\t}')
 	g.writeln('}')
 	if dims.len > 0 {
 		g.writeln('static ${ct} (*${cname}_slot(void))${dims} { ${cname}_key_init(); void* p = ${cname}_fls_get ? ${cname}_fls_get(${cname}_key) : TlsGetValue(${cname}_key); if (!p) { p = calloc(1, sizeof(*${cname}_slot())); if (${cname}_fls_set) ${cname}_fls_set(${cname}_key, p); else TlsSetValue(${cname}_key, p); } return p; }')

--- a/vlib/v3/gen/c/preamble_test.v
+++ b/vlib/v3/gen/c/preamble_test.v
@@ -93,10 +93,20 @@ fn test_tinyc_windows_thread_local_slot_uses_win32_tls() {
 	assert windows_code.contains('state_slot_free(void* p) { free(p); }')
 	assert !windows_code.contains('pthread_')
 	// TinyCC never runs `__attribute__((constructor))`, so the slot has to
-	// allocate the key itself on first use.
+	// allocate the TLS index itself on first use - and exactly once, or a
+	// second index would strand the storage threads already hold in the first.
 	assert !windows_code.contains('__attribute__((constructor))')
-	assert windows_code.contains('if (state_key != 0xFFFFFFFF) { return; }')
 	assert windows_code.contains('state_slot(void) { state_key_init();')
+	assert windows_code.contains('if (__atomic_add_fetch(&state_key_ready, 0, 5)) { return; }')
+	assert windows_code.contains('if (__atomic_add_fetch(&state_key_claim, 1, 5) == 1) {')
+	assert windows_code.contains('__atomic_add_fetch(&state_key_ready, 1, 5);')
+	assert windows_code.contains('while (!__atomic_add_fetch(&state_key_ready, 0, 5)) { Sleep(0); }')
+	// The key and the resolved Fls* pointers are only read after the publish.
+	claim_index := windows_code.index('__atomic_add_fetch(&state_key_claim, 1, 5)')?
+	publish_index := windows_code.index('__atomic_add_fetch(&state_key_ready, 1, 5)')?
+	alloc_index := windows_code.index('fls_alloc(state_slot_free)')?
+	assert claim_index < alloc_index
+	assert alloc_index < publish_index
 }
 
 fn test_tinyc_pthread_value_slot_creates_its_own_key_lazily() {

--- a/vlib/v3/gen/c/preamble_test.v
+++ b/vlib/v3/gen/c/preamble_test.v
@@ -92,6 +92,36 @@ fn test_tinyc_windows_thread_local_slot_uses_win32_tls() {
 	assert !windows_code.contains('FlsSetValue(state_key, p)')
 	assert windows_code.contains('state_slot_free(void* p) { free(p); }')
 	assert !windows_code.contains('pthread_')
+	// TinyCC never runs `__attribute__((constructor))`, so the slot has to
+	// allocate the key itself on first use.
+	assert !windows_code.contains('__attribute__((constructor))')
+	assert windows_code.contains('if (state_key != 0xFFFFFFFF) { return; }')
+	assert windows_code.contains('state_slot(void) { state_key_init();')
+}
+
+fn test_tinyc_pthread_value_slot_creates_its_own_key_lazily() {
+	mut g := FlatGen.new()
+	g.emit_tinyc_pthread_value_slot('state', 'State', '')
+	c_code := g.sb.str()
+	assert c_code.contains('static pthread_key_t state_key;')
+	assert c_code.contains('static pthread_once_t state_key_once = PTHREAD_ONCE_INIT;')
+	assert c_code.contains('static void state_key_create(void) { pthread_key_create(&state_key, free); }')
+	assert c_code.contains('static void state_key_init(void) { pthread_once(&state_key_once, state_key_create); }')
+	assert c_code.contains('static State* state_slot(void) { state_key_init(); void* p = pthread_getspecific(state_key);')
+	assert c_code.contains('#define state (*state_slot())')
+	// A constructor-initialized key stays 0 under TinyCC and aliases the first
+	// key the process really creates, so one slot writes through another's
+	// storage.
+	assert !c_code.contains('__attribute__((constructor))')
+}
+
+fn test_tinyc_pthread_value_slot_supports_fixed_arrays() {
+	mut g := FlatGen.new()
+	g.emit_tinyc_pthread_value_slot('stack', 'i64', '[64]')
+	c_code := g.sb.str()
+	assert c_code.contains('static i64 (*stack_slot(void))[64] { stack_key_init(); void* p = pthread_getspecific(stack_key);')
+	assert c_code.contains('calloc(1, sizeof(*stack_slot()))')
+	assert !c_code.contains('__attribute__((constructor))')
 }
 
 fn test_tinyc_pthread_pointer_slot_does_not_rely_on_constructor() {


### PR DESCRIPTION
`make` on Linux currently produces a `v` that aborts before it can print anything:

```
./v2 -nocache -o ./v -gc none     cmd/v
rm -rf v1 v2
Fatal glibc error: malloc.c:2599 (sysmalloc): assertion failed: (old_top == initial_top (av) && old_size == 0) || ...
src.c: by vmemory_block_new_sized
src.c: by vmemory_block_new
src.c: by prealloc_vinit
src.c: by builtin_init
src.c: by _vinit
make: *** [GNUmakefile:235: all] Error 255
```

## Cause

TinyCC is the default C compiler for the Linux self-build, and it parses
`__attribute__((constructor))` but never runs the function:

```c
static void init(void) __attribute__((constructor));
static void init(void) { ran = 1; pthread_key_create(&k, 0); }
// tcc: ran=0, k=0        gcc: ran=1
```

The TinyCC replacement that V3 emits for a thread-local global created its
`pthread_key_t` from exactly such a constructor, so the key kept its zero
initializer — which is also the key `pthread_key_create` returns for the first
key a process really creates.

Under `-prealloc` (on by default for compiler builds) that first key belongs to
`g_memory_block`, whose slot *is* created correctly, through `pthread_once`.
`g_autostr_addr_state` then read key `0` as well, got `g_memory_block`'s 8-byte
slot back from `pthread_getspecific`, and assigned 1040 bytes of
`AutostrAddrStackState` over it while `_vinit` was still running. That smashes
the top chunk of the heap, so the next allocation — the arena block
`prealloc_vinit` asks for — trips glibc's `sysmalloc` assertion.

`pthread_setspecific` on the uncreated key also fails with `EINVAL`, so every
access allocated a fresh slot and the stored pointer was thrown away.

## Fix

Create these keys the way the arena slot already does: lazily, from the
accessor, through `pthread_once`, so every slot gets its own key. The
Windows/TinyCC slot had the same constructor dependency and now allocates its
TLS index on first use as well.

Only the `#if defined(__TINYC__)` branches change; native compilers keep using
`_Thread_local` / `__declspec(thread)` / `thread_local` as before.

## Checks

On x86_64 Linux (Ubuntu 24.04, bundled tcc 0.9.28rc), same host compiler and
flags both times:

| build | before | after |
| --- | --- | --- |
| `./v2 -nocache -o ./v -gc none cmd/v`, then `./v version` | `Fatal glibc error` in `_vinit`, SIGSEGV | `V 0.5.2`, exit 0 |
| `./v run examples/hello_world.v` with that binary | never reached | `Hello, World!` |

`-cc gcc` builds were unaffected before and after, which is what kept this off
macOS and the arm64 Linux lanes, where the self-build does not use TinyCC.

New unit tests cover the emitted slot: `pthread_once`-created key, the
accessor's `_key_init()` call, and the absence of `__attribute__((constructor))`.