### PR TITLE
v3: reduce self-host peak memory another ~8%, performance-neutral

### DIFF
--- a/vlib/builtin/prealloc.c.v
+++ b/vlib/builtin/prealloc.c.v
@@ -915,6 +915,20 @@ pub fn prealloc_scope_owns(scope_ptr voidptr, ptr voidptr) bool {
 	}
 }
 
+// prealloc_scope_address_range returns the lowest and one-past-highest
+// addresses of the blocks owned by scope_ptr, so callers probing many pointers
+// can reject most of them before the per-block search in prealloc_scope_owns.
+@[inline; unsafe]
+pub fn prealloc_scope_address_range(scope_ptr voidptr) (usize, usize) {
+	if scope_ptr == unsafe { nil } {
+		return 0, 0
+	}
+	unsafe {
+		scope := &VPreallocScope(scope_ptr)
+		return scope.min_address, scope.max_address
+	}
+}
+
 // prealloc_scope_abandon restores the current thread arena and intentionally
 // leaks the scoped blocks. It is only for APIs that transfer request state to
 // user code without providing a close hook yet.

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -6305,24 +6305,31 @@ fn promote_scoped_ast_nodes_flagged(mut ast flat.FlatAst, base_nodes int, new_en
 	}
 }
 
-// release_transform_prepare_scope canonicalizes every node text still owned by
-// the self-host transform preparation arena and then frees that arena.
-fn release_transform_prepare_scope(mut a flat.FlatAst, scope voidptr) {
+// release_transform_helper_scopes canonicalizes every node text still owned by
+// one of the self-host transform helper arenas (preparation and pre-scan
+// indexes) and then frees those arenas.
+fn release_transform_helper_scopes(mut a flat.FlatAst, scopes []voidptr) {
 	mut flags := []u8{len: a.nodes.len}
-	if transform.scan_scoped_text_flags_parallel(a, scope, mut flags) {
+	if transform.scan_scoped_text_flags_parallel_multi(a, scopes, mut flags) {
 		mut canon_cache := flat.TextProbeCache{}
 		for idx, flag in flags {
 			if flag != 0 {
-				canonicalize_scoped_node_cached(mut a, idx, scope, mut canon_cache.ptrs, mut canon_cache.values)
+				for scope in scopes {
+					canonicalize_scoped_node_cached(mut a, idx, scope, mut canon_cache.ptrs, mut canon_cache.values)
+				}
 			}
 		}
 	} else {
 		for idx in 0 .. a.nodes.len {
-			canonicalize_scoped_node(mut a, idx, scope)
+			for scope in scopes {
+				canonicalize_scoped_node(mut a, idx, scope)
+			}
 		}
 	}
 	unsafe { flags.free() }
-	prealloc_scope_free_for_v3(scope)
+	for scope in scopes {
+		prealloc_scope_free_for_v3(scope)
+	}
 }
 
 // canonicalize_scoped_node_cached is canonicalize_scoped_node with a pointer
@@ -10330,6 +10337,7 @@ pub fn run(args []string) {
 	mut texts_canonical_after_annotation := cgen_cache_hit
 	mut retained_transform_scope := unsafe { nil }
 	mut retained_transform_prepare_scope := unsafe { nil }
+	mut retained_transform_prescan_scopes := []voidptr{}
 	mut trivial_literal_output := false
 	if !cgen_cache_hit {
 		pre_tc.verbose = prefs.verbose
@@ -10808,6 +10816,7 @@ pub fn run(args []string) {
 			if prepare_transform_overlap {
 				transform_used_fns, transform_was_parallel, transform_errors, scoped_owned_base_nodes, retained_transform_regions = transform.transform_prepared_selfhost_owned(mut prepared_transform, mut a, &pre_tc, used_fns, transform_scope)
 				retained_transform_prepare_scope = prepared_transform.take_scope()
+				retained_transform_prescan_scopes = prepared_transform.take_prescan_scopes()
 			} else {
 				// Large user programs keep more memory live when function-body workers
 				// overlap the transformed AST. Scoped serial batches trade a little CPU
@@ -10819,12 +10828,19 @@ pub fn run(args []string) {
 			parse_cache_enabled := pre_tc.type_cache_parse_enabled()
 			mut post_sw := time.new_stopwatch()
 			prealloc_scope_leave_for_v3(transform_scope)
-			if retained_transform_prepare_scope != unsafe { nil } {
-				// The preparation arena backs only a few thousand lowered node texts.
-				// Publish those into the compilation arena and release the arena now
-				// instead of keeping its index scratch alive through codegen.
-				release_transform_prepare_scope(mut a, retained_transform_prepare_scope)
+			if retained_transform_prepare_scope != unsafe { nil }
+				|| retained_transform_prescan_scopes.len > 0 {
+				// The preparation and pre-scan arenas back only a few thousand lowered
+				// node texts. Publish those into the compilation arena and release the
+				// arenas now instead of keeping their index scratch alive through codegen.
+				mut helper_scopes := []voidptr{cap: retained_transform_prescan_scopes.len + 1}
+				if retained_transform_prepare_scope != unsafe { nil } {
+					helper_scopes << retained_transform_prepare_scope
+				}
+				helper_scopes << retained_transform_prescan_scopes
+				release_transform_helper_scopes(mut a, helper_scopes)
 				retained_transform_prepare_scope = unsafe { nil }
+				retained_transform_prescan_scopes = []voidptr{}
 			}
 			retain_transform_scope := building_v && current_parallel_transform && backend == 'c'
 				&& !cache_state.manager.enabled && retained_transform_regions.len == 0

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -789,6 +789,20 @@ fn (mut g FlatGen) declare_ierror_pointer_alias(name string, needs_copy bool) {
 	if name.len == 0 {
 		return
 	}
+	if !needs_copy {
+		// An absent entry already reads as "no copy needed". Only record the
+		// negative when an enclosing scope tracks an alias it must shadow.
+		mut any_tracked := false
+		for aliases in g.ierror_stack_pointer_aliases {
+			if aliases.len > 0 {
+				any_tracked = true
+				break
+			}
+		}
+		if !any_tracked {
+			return
+		}
+	}
 	if g.ierror_stack_pointer_aliases.len == 0 {
 		g.ierror_stack_pointer_aliases << map[string]bool{}
 	}
@@ -4443,19 +4457,25 @@ fn (mut g FlatGen) reserve_collect_gen_info_maps(no_parallel bool, deferred_sign
 	if incremental && fn_count < g.incremental_fn_names.len {
 		fn_count = g.incremental_fn_names.len
 	}
-	fn_alias_count := u32(fn_count * 7 + 1024)
+	// Self-host declarations register about two spellings per function; the
+	// exact per-registration reservation below covers the rest.
+	fn_alias_count := u32(fn_count * 3 + 1024)
 	fn_name_count := u32(fn_count * 2 + 1024)
+	// Node indexes hold about one entry per emitted function and variadic
+	// registrations are rare; their metadata tables are zeroed, so oversized
+	// reservations cost resident memory.
+	fn_node_count := u32(fn_count / 2 + 1024)
 	if !deferred_signatures {
 		g.fn_decl_param_types.reserve(fn_alias_count)
-		g.fn_decl_variadic.reserve(fn_name_count)
-		g.fn_decl_shared_params.reserve(fn_alias_count)
+		g.fn_decl_variadic.reserve(u32(fn_count / 4 + 256))
+		g.fn_decl_shared_params.reserve(fn_name_count)
 		g.fn_decl_mut_receivers.reserve(fn_name_count)
 		g.fn_decl_ret_types.reserve(fn_alias_count)
 	}
 	g.fn_decl_variadic_short_counts.reserve(u32(fn_count + 256))
-	g.fn_decl_nodes_by_name.reserve(fn_name_count)
+	g.fn_decl_nodes_by_name.reserve(fn_node_count)
 	g.fn_decl_nodes_by_short.reserve(u32(fn_count + 256))
-	g.fn_decl_nodes_by_module_short.reserve(fn_name_count)
+	g.fn_decl_nodes_by_module_short.reserve(fn_node_count)
 	g.module_init_fn_modules.reserve(u32(fn_count / 8 + 64))
 	g.module_cleanup_fn_modules.reserve(u32(fn_count / 8 + 64))
 	g.struct_decl_infos.reserve(u32(struct_count * 2 + 256))
@@ -13136,8 +13156,12 @@ fn (mut g FlatGen) const_address_can_force_fixed_storage(const_name string) bool
 
 fn fixed_storage_node_scan_thread(arg voidptr) voidptr {
 	mut scan := unsafe { &FixedStorageNodeScanArgs(arg) }
+	// The scan's item lists and scratch live in a disposable arena that the
+	// caller releases once it has copied the items out.
+	scope := cgen_worker_scope_begin(true)
 	scan.g.scan_fixed_storage_node_range(mut scan)
-	return unsafe { nil }
+	cgen_worker_scope_leave(scope)
+	return scope
 }
 
 fn (g &FlatGen) scan_fixed_storage_node_range(mut scan FixedStorageNodeScanArgs) {
@@ -13322,7 +13346,7 @@ fn (mut g FlatGen) collect_fixed_storage_consts(allow_parallel bool) {
 		scan_threads << spawn fixed_storage_node_scan_thread(unsafe { voidptr(&scans[scan_idx]) })
 	}
 	g.scan_fixed_storage_node_range(mut scans[0])
-	scan_threads.wait()
+	scan_scopes := scan_threads.wait()
 	for scan in scans {
 		address_items << scan.address_items
 		ref_items << scan.ref_items
@@ -13333,6 +13357,9 @@ fn (mut g FlatGen) collect_fixed_storage_consts(allow_parallel bool) {
 				fixed_safe_refs[id] = true
 			}
 		}
+	}
+	for scope in scan_scopes {
+		cgen_worker_scope_free(scope)
 	}
 	g.timing_profile('  [ttime]         fs node scan ${f64(fssw.elapsed().microseconds()) / 1000.0:7.2f} ms (refs: ${ref_items.len}, calls: ${call_base_items.len}, indexes: ${index_base_items.len})')
 	fssw.restart()

--- a/vlib/v3/gen/c/fn.v
+++ b/vlib/v3/gen/c/fn.v
@@ -18720,6 +18720,11 @@ fn (mut g FlatGen) fn_returns_veb_result(node flat.Node) bool {
 	if node.typ == 'veb.Result' {
 		return true
 	}
+	// Only a spelling ending in `Result` can resolve to `veb.Result`; skip the
+	// type parse for every other method return type.
+	if !node.typ.ends_with('Result') {
+		return false
+	}
 	ret := g.parse_node_type(&node)
 	return ret.name() == 'veb.Result'
 }

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -35,6 +35,7 @@ struct FlatCgenCostArgs {
 mut:
 	refs  map[string]bool
 	cands []FlatCgenPrepCandidate
+	scope voidptr // disposable arena holding refs/cands until the master replays them
 }
 
 struct FlatCgenDynamicArgs {
@@ -211,6 +212,15 @@ $if !windows {
 
 	fn flat_cgen_cost_thread(arg voidptr) voidptr {
 		mut a := unsafe { &FlatCgenCostArgs(arg) }
+		// Costs are written into the shared item array; the collected refs and
+		// candidates are replayed by the master, which then frees this arena.
+		a.scope = cgen_worker_scope_begin(true)
+		flat_cgen_cost_range(mut a)
+		cgen_worker_scope_leave(a.scope)
+		return unsafe { nil }
+	}
+
+	fn flat_cgen_cost_range(mut a FlatCgenCostArgs) {
 		mut items := unsafe { &[]FlatFnGenItem(a.items_ptr) }
 		mut stack := []flat.NodeId{cap: 256}
 		if !isnil(a.g) {
@@ -236,7 +246,7 @@ $if !windows {
 					items[idx].skip_prelude_scan = !needs_prelude_scan
 				}
 			}
-			return unsafe { nil }
+			return
 		}
 		for idx in a.start .. a.end {
 			unsafe {
@@ -245,7 +255,7 @@ $if !windows {
 				items[idx].skip_prelude_scan = !needs_prelude_scan
 			}
 		}
-		return unsafe { nil }
+		return
 	}
 
 	fn parallel_type_decls_thread(arg voidptr) voidptr {
@@ -932,6 +942,9 @@ fn (mut g FlatGen) refine_fn_item_costs(no_parallel bool, reserve_worker bool) {
 			g.prep_costs_pending = false
 		}
 		g.prep_externs_pending = false
+		for arg in args {
+			cgen_worker_scope_free(arg.scope)
+		}
 	}
 }
 
@@ -1478,18 +1491,24 @@ fn (mut g FlatGen) publish_fixed_array_support(mut worker FlatGen) {
 }
 
 fn (mut g FlatGen) publish_optional_support(mut worker FlatGen) {
-	g.needed_optional_types = worker.needed_optional_types.move()
 	g.optional_types_ready = worker.optional_types_ready
-	g.multi_return_types = worker.multi_return_types
-	g.multi_return_type_names = worker.multi_return_type_names.move()
 	g.multi_return_types_ready = worker.multi_return_types_ready
 	g.decl_types_ready = worker.decl_types_ready
 	g.parallel_worker_scopes << worker.parallel_worker_scopes
 	worker.parallel_worker_scopes = []voidptr{}
 	if worker.worker_scope != unsafe { nil } {
-		g.parallel_worker_scopes << worker.worker_scope
+		// Publish owned copies of the three result tables and release the
+		// signature scan's arena instead of keeping it resident through emission.
+		g.needed_optional_types = clone_cgen_string_map(worker.needed_optional_types)
+		g.multi_return_types = types.clone_owned_types(worker.multi_return_types)
+		g.multi_return_type_names = clone_cgen_string_bool_map(worker.multi_return_type_names)
+		cgen_worker_scope_free(worker.worker_scope)
 		worker.worker_scope = unsafe { nil }
+		return
 	}
+	g.needed_optional_types = worker.needed_optional_types.move()
+	g.multi_return_types = worker.multi_return_types
+	g.multi_return_type_names = worker.multi_return_type_names.move()
 }
 
 fn (mut g FlatGen) publish_unresolved_call_optional_types(mut worker FlatGen) {
@@ -1509,15 +1528,30 @@ fn (mut g FlatGen) publish_interface_impl_scan(mut worker FlatGen) {
 			g.interfaces[name.clone()] = methods.clone()
 		}
 	}
-	g.interface_boxed_types = worker.interface_boxed_types.move()
 	g.interface_boxed_types_done = worker.interface_boxed_types_done
+	if worker.worker_scope != unsafe { nil } {
+		// Same trade as the other scan publishers: copy the small result tables
+		// and free the scan arena now.
+		g.interface_boxed_types = clone_cgen_string_bool_map(worker.interface_boxed_types)
+		g.iface_impls = clone_cgen_string_list_map(worker.iface_impls)
+		g.iface_type_ids = clone_cgen_string_int_map(worker.iface_type_ids)
+		g.ierror_method_emit_names = clone_cgen_string_bool_map(worker.ierror_method_emit_names)
+		cgen_worker_scope_free(worker.worker_scope)
+		worker.worker_scope = unsafe { nil }
+		return
+	}
+	g.interface_boxed_types = worker.interface_boxed_types.move()
 	g.iface_impls = worker.iface_impls.move()
 	g.iface_type_ids = worker.iface_type_ids.move()
 	g.ierror_method_emit_names = worker.ierror_method_emit_names.move()
-	if worker.worker_scope != unsafe { nil } {
-		g.parallel_worker_scopes << worker.worker_scope
-		worker.worker_scope = unsafe { nil }
+}
+
+fn clone_cgen_string_list_map(values map[string][]string) map[string][]string {
+	mut cloned := map[string][]string{}
+	for key, list in values {
+		cloned[key.clone()] = clone_cgen_string_list(list)
 	}
+	return cloned
 }
 
 // gen_fns_dispatch emits fns dispatch output for c.
@@ -1844,7 +1878,7 @@ fn split_flat_cgen_items(items []FlatFnGenItem, n_jobs int) [][]FlatFnGenItem {
 		next_target := total_cost * (chunk_idx + 1) / n_jobs
 		if current.len > 0 && consumed_cost >= next_target && chunks_left > 1
 			&& remaining_items >= chunks_left {
-			chunks << current
+			chunks << moved_items(current)
 			current = []FlatFnGenItem{}
 			chunk_idx++
 			chunks_left--
@@ -1853,9 +1887,16 @@ fn split_flat_cgen_items(items []FlatFnGenItem, n_jobs int) [][]FlatFnGenItem {
 		consumed_cost += item.cost
 	}
 	if current.len > 0 {
-		chunks << current
+		chunks << moved_items(current)
 	}
 	return chunks
+}
+
+// moved_items returns its argument unchanged so the caller can append a
+// finished chunk without the implicit deep clone of an addressable array.
+@[inline]
+fn moved_items(items []FlatFnGenItem) []FlatFnGenItem {
+	return items
 }
 
 // stripe_flat_cgen_items mixes several narrow, cost-balanced source ranges

--- a/vlib/v3/gen/c/names.v
+++ b/vlib/v3/gen/c/names.v
@@ -546,6 +546,13 @@ fn trimmed_space(s string) string {
 // c_escape supports c escape handling for c.
 fn c_escape(s string) string {
 	mut out := strings.new_builder(s.len * 4)
+	c_escape_into(mut out, s)
+	return out.str()
+}
+
+// c_escape_into appends the C-escaped form of s to out, without the temporary
+// builder and copy that c_escape needs for its return value.
+fn c_escape_into(mut out strings.Builder, s string) {
 	for b in s.bytes() {
 		match b {
 			`\\` {
@@ -576,7 +583,6 @@ fn c_escape(s string) string {
 			}
 		}
 	}
-	return out.str()
 }
 
 fn c_byte_string_escape(s string) string {

--- a/vlib/v3/gen/c/str_intp.v
+++ b/vlib/v3/gen/c/str_intp.v
@@ -391,20 +391,29 @@ fn (mut g FlatGen) string_literals_from(start int) {
 		mut literals := g.str_lits[start..].clone()
 		literals.sort()
 		for s in literals {
-			i := g.str_lit_ids[s]
-			escaped := c_escape(s)
-			g.writeln('static const string _str_${i} = {"${escaped}", ${s.len}, 1};')
+			g.write_string_literal_def(g.str_lit_ids[s], s)
 		}
 	} else {
 		for i := start; i < g.str_lits.len; i++ {
-			s := g.str_lits[i]
-			escaped := c_escape(s)
-			g.writeln('static const string _str_${i} = {"${escaped}", ${s.len}, 1};')
+			g.write_string_literal_def(i, g.str_lits[i])
 		}
 	}
 	if g.str_lits.len > start {
 		g.writeln('')
 	}
+}
+
+// write_string_literal_def emits one literal table entry straight into the
+// output builder: escaping into a temporary and interpolating the line would
+// leave two copies of every literal behind in the cgen arena.
+fn (mut g FlatGen) write_string_literal_def(id int, s string) {
+	g.write('static const string _str_')
+	g.sb.write_decimal(i64(id))
+	g.sb.write_string(' = {"')
+	c_escape_into(mut g.sb, s)
+	g.sb.write_string('", ')
+	g.sb.write_decimal(i64(s.len))
+	g.writeln(', 1};')
 }
 
 // intern_string supports intern string handling for FlatGen.

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -199,8 +199,10 @@ pub fn Parser.new(prefs &pref.Preferences) &Parser {
 		unsupported_inline_asm_guards: map[int]bool{}
 		sql_query_data_aliases: map[string]bool{}
 		a: &flat.FlatAst{
-			nodes: []flat.Node{cap: 256}
-			children: []flat.NodeId{cap: 512}
+			// Parallel-parse workers reserve for their chunk before parsing and
+			// the self-host reserves the whole AST, so start without capacity.
+			nodes: []flat.Node{}
+			children: []flat.NodeId{}
 			disabled_fns: map[string]bool{}
 			export_fn_names: map[string]string{}
 			source_files: map[int]&token.File{}

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -504,7 +504,13 @@ mut:
 	inplace_child_log           []InplaceChildRewrite
 	worker_scope                voidptr
 	// Helper merge tables are disposable; published AST text uses their parent arena.
-	merge_scratch_scope     voidptr
+	merge_scratch_scope voidptr
+	// Arenas of the prepare-time index helpers; the driver frees them with the
+	// preparation arena after canonicalizing the node texts they back. Only the
+	// self-host prepared path collects them, so the helper threads scope their
+	// indexes only when this is set.
+	retain_prescan_scopes   bool
+	prescan_scopes          []voidptr
 	scoped_base_nodes       int = -1
 	scoped_owned_base_nodes map[int]bool
 	scoped_owned_base_log   []flat.NodeId
@@ -889,6 +895,22 @@ mut:
 	ready       bool
 }
 
+// add_prescan_scope records a helper-index arena returned by a pre-scan thread.
+fn (mut t Transformer) add_prescan_scope(scope voidptr) {
+	if scope != unsafe { nil } {
+		t.prescan_scopes << scope
+	}
+}
+
+// take_prescan_scopes transfers the pre-scan helper arenas to the driver. They
+// back index tables and possibly lowered node text, so they are released only
+// together with the preparation arena.
+pub fn (mut prepared PreparedSelfhostTransform) take_prescan_scopes() []voidptr {
+	scopes := prepared.transformer.prescan_scopes
+	prepared.transformer.prescan_scopes = []voidptr{}
+	return scopes
+}
+
 // take_scope transfers ownership of the preparation arena to the driver. The
 // arena can back lowered AST text, so it must remain alive through codegen.
 pub fn (mut prepared PreparedSelfhostTransform) take_scope() voidptr {
@@ -909,6 +931,7 @@ pub fn prepare_selfhost_transform(a &flat.FlatAst, tc &types.TypeChecker, enable
 	prep_tc := tc.fork_for_parallel_transform(a)
 	mut t := new_transformer_view(a, prep_tc, map[string]bool{})
 	configure_transformer(mut t, true, true, true, true, false, unsafe { nil })
+	t.retain_prescan_scopes = true
 	t.prepare_with_pre_scans()
 	// This whole-AST scan is independent of reachability and otherwise leaves
 	// the persistent worker pool idle at the start of transform.
@@ -2341,11 +2364,10 @@ fn (mut t Transformer) set_node_generic_params(idx int, gparams []string) {
 @[inline]
 fn (mut t Transformer) mark_scoped_owned_base_node(idx int) {
 	if t.scope_parallel_workers && idx >= 0 && idx < t.scoped_base_nodes {
-		if t.scoped_base_log_active {
-			t.scoped_owned_base_log << flat.NodeId(idx)
-		} else {
-			t.scoped_owned_base_nodes[idx] = true
-		}
+		// Every consumer tolerates repeated ids (promotion and cloning are
+		// ownership-guarded no-ops the second time), so a compact append-only
+		// log replaces the per-node map entries in the retained stage arena.
+		t.scoped_owned_base_log << flat.NodeId(idx)
 	}
 }
 

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -198,12 +198,22 @@ $if !windows {
 	// collect_types walk, and the permanent thread arena keeps them alive. Alias
 	// method collection stays on the master because its normalization reads the
 	// type maps collect_types is still populating.
+	// The pre-scan helpers build their indexes in disposable arenas returned
+	// to the joiner. The indexes stay live through transform; lowered node
+	// texts that borrow from them are canonicalized before the driver frees
+	// the arenas together with the preparation arena.
 	fn transform_pre_scan_index_thread(arg voidptr) voidptr {
 		mut t := unsafe { &Transformer(arg) }
+		scope := if t.retain_prescan_scopes {
+			transform_worker_scope_begin(true)
+		} else {
+			unsafe { nil }
+		}
 		t.build_source_parent_index()
 		t.collect_multi_return_fn_ret_types()
 		t.rebuild_variadic_suffix_index()
-		return unsafe { nil }
+		transform_worker_scope_leave(scope)
+		return scope
 	}
 
 	// transform_const_fixed_scan_thread classifies array-literal constants on a
@@ -226,8 +236,14 @@ $if !windows {
 	// caches and publishes only its completed declaration maps after joining.
 	fn transform_param_prep_thread(arg voidptr) voidptr {
 		mut w := unsafe { &Transformer(arg) }
+		scope := if w.retain_prescan_scopes {
+			transform_worker_scope_begin(true)
+		} else {
+			unsafe { nil }
+		}
 		w.prepare_parallel_call_param_types()
-		return unsafe { nil }
+		transform_worker_scope_leave(scope)
+		return scope
 	}
 
 	// TransformChunkArgs is the payload handed to each persistent worker.
@@ -286,11 +302,11 @@ mut:
 
 // ScopedTextScanArgs is the payload for one scoped-text flag-scan worker.
 struct ScopedTextScanArgs {
-	a     &flat.FlatAst = unsafe { nil }
-	scope voidptr
-	start int
-	end   int
-	flags voidptr // &u8 base of the per-node flag array
+	a      &flat.FlatAst = unsafe { nil }
+	scopes voidptr
+	start  int
+	end    int
+	flags  voidptr // &u8 base of the per-node flag array
 }
 
 struct WorkerScopeFreeArgs {
@@ -301,7 +317,47 @@ struct WorkerScopeFreeArgs {
 
 // node_has_scoped_text reports whether any text payload of `node` lives in
 // `scope`'s arena, i.e. whether canonicalization/promotion would rewrite it.
+
+// node_has_any_scoped_text reports whether any node text is owned by one of
+// `scopes`. `lo`/`hi` bound the union of the arenas' address ranges: nearly
+// every text lives outside them, so the per-arena search is rarely needed.
 @[inline]
+fn node_has_any_scoped_text(node &flat.Node, scopes []voidptr, lo usize, hi usize) bool {
+	value_addr := usize(voidptr(node.value.str))
+	typ_addr := usize(voidptr(node.typ.str))
+	if (node.value.len == 0 || value_addr < lo || value_addr >= hi)
+		&& (node.typ.len == 0 || typ_addr < lo || typ_addr >= hi) && isnil(node.payload) {
+		return false
+	}
+	for scope in scopes {
+		if node_has_scoped_text(node, scope) {
+			return true
+		}
+	}
+	return false
+}
+
+// scopes_address_range returns the union address range of `scopes`.
+fn scopes_address_range(scopes []voidptr) (usize, usize) {
+	mut lo := usize(0)
+	mut hi := usize(0)
+	$if prealloc {
+		for scope in scopes {
+			scope_lo, scope_hi := unsafe { prealloc_scope_address_range(scope) }
+			if scope_hi <= scope_lo {
+				continue
+			}
+			if hi == 0 || scope_lo < lo {
+				lo = scope_lo
+			}
+			if scope_hi > hi {
+				hi = scope_hi
+			}
+		}
+	}
+	return lo, hi
+}
+
 fn node_has_scoped_text(node &flat.Node, scope voidptr) bool {
 	if node.value.len > 0 && transform_scope_owns(scope, node.value.str) {
 		return true
@@ -337,9 +393,11 @@ $if !windows {
 	fn scoped_text_scan_thread(arg voidptr) voidptr {
 		a := unsafe { &ScopedTextScanArgs(arg) }
 		flags := unsafe { &u8(a.flags) }
+		scopes := unsafe { &[]voidptr(a.scopes) }
+		lo, hi := scopes_address_range(*scopes)
 		for idx in a.start .. a.end {
 			node := unsafe { &a.a.nodes[idx] }
-			if node_has_scoped_text(node, a.scope) {
+			if node_has_any_scoped_text(node, *scopes, lo, hi) {
 				unsafe {
 					flags[idx] = 1
 				}
@@ -844,6 +902,12 @@ pub fn promote_scoped_checker_node_caches_parallel(mut tc types.TypeChecker, a &
 // worker pool. Returns false when no pool is available so the caller can walk
 // every node serially instead.
 pub fn scan_scoped_text_flags_parallel(a &flat.FlatAst, scope voidptr, mut flags []u8) bool {
+	return scan_scoped_text_flags_parallel_multi(a, [scope], mut flags)
+}
+
+// scan_scoped_text_flags_parallel_multi flags every node whose text is owned by
+// any of `scopes`.
+pub fn scan_scoped_text_flags_parallel_multi(a &flat.FlatAst, scopes []voidptr, mut flags []u8) bool {
 	$if windows {
 		return false
 	} $else {
@@ -865,7 +929,7 @@ pub fn scan_scoped_text_flags_parallel(a &flat.FlatAst, scope voidptr, mut flags
 			}
 			args << ScopedTextScanArgs{
 				a: a
-				scope: scope
+				scopes: unsafe { voidptr(&scopes) }
 				start: start
 				end: end
 				flags: flags.data
@@ -2507,15 +2571,18 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 		mut ttsw := time.new_stopwatch()
 		node_pool := t.a.nodes.cap - base_nodes
 		child_pool := t.a.children.cap - base_children
+		// The bounded item list, the chunk partition, its cost tables and the
+		// helper forks below are only read until the join; keep them out of the
+		// retained stage arena.
+		setup_scope := transform_worker_scope_begin(t.scope_parallel_workers)
 		bounded_items := t.bound_shared_expansion(items, node_pool, child_pool)
 		if bounded_items.len < min_parallel_transform_items {
+			transform_worker_scope_leave(setup_scope)
 			t.transform_pure_items_serial(bounded_items)
+			transform_worker_scope_free(setup_scope)
 			return false
 		}
 		t.tc.freeze_type_cache_for_forks()
-		// The chunk partition, its cost tables and the helper forks below are
-		// only read until the join; keep them out of the retained stage arena.
-		setup_scope := transform_worker_scope_begin(t.scope_parallel_workers)
 		mut chunk_target := n_jobs * shared_transform_chunks_per_job
 		if chunk_target > bounded_items.len {
 			chunk_target = bounded_items.len
@@ -2963,6 +3030,7 @@ fn (mut t Transformer) prepare_with_pre_scans() {
 				a: t.a
 				tc: param_tc
 				prefix_param_scan: t.prefix_param_scan
+				retain_prescan_scopes: t.retain_prescan_scopes
 				call_param_types_decl_cache: map[int][]types.Type{}
 				call_param_types_decl_misses: map[string]bool{}
 				call_param_types_decl_index: map[string]FnParamDeclRef{}
@@ -2971,8 +3039,8 @@ fn (mut t Transformer) prepare_with_pre_scans() {
 			t.defer_pre_scan_indexes = true
 			index_thread := spawn transform_pre_scan_index_thread(voidptr(t))
 			t.prepare()
-			_ = param_thread.wait()
-			_ = index_thread.wait()
+			t.add_prescan_scope(param_thread.wait())
+			t.add_prescan_scope(index_thread.wait())
 			t.call_param_types_decl_cache = param_w.call_param_types_decl_cache.move()
 			t.call_param_types_decl_misses = param_w.call_param_types_decl_misses.move()
 			t.call_param_types_decl_shared = true
@@ -2983,7 +3051,7 @@ fn (mut t Transformer) prepare_with_pre_scans() {
 			t.defer_pre_scan_indexes = true
 			index_thread := spawn transform_pre_scan_index_thread(voidptr(t))
 			t.prepare()
-			_ = index_thread.wait()
+			t.add_prescan_scope(index_thread.wait())
 		}
 		_ = scan_thread.wait()
 		t.defer_pre_scan_indexes = false

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -2571,18 +2571,17 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 		mut ttsw := time.new_stopwatch()
 		node_pool := t.a.nodes.cap - base_nodes
 		child_pool := t.a.children.cap - base_children
-		// The bounded item list, the chunk partition, its cost tables and the
-		// helper forks below are only read until the join; keep them out of the
-		// retained stage arena.
-		setup_scope := transform_worker_scope_begin(t.scope_parallel_workers)
+		// Bounding may append to t.deferred_expansion_items, which outlives this
+		// call, so it must run before the disposable setup arena becomes current.
 		bounded_items := t.bound_shared_expansion(items, node_pool, child_pool)
 		if bounded_items.len < min_parallel_transform_items {
-			transform_worker_scope_leave(setup_scope)
 			t.transform_pure_items_serial(bounded_items)
-			transform_worker_scope_free(setup_scope)
 			return false
 		}
 		t.tc.freeze_type_cache_for_forks()
+		// The chunk partition, its cost tables and the helper forks below are
+		// only read until the join; keep them out of the retained stage arena.
+		setup_scope := transform_worker_scope_begin(t.scope_parallel_workers)
 		mut chunk_target := n_jobs * shared_transform_chunks_per_job
 		if chunk_target > bounded_items.len {
 			chunk_target = bounded_items.len

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -465,6 +465,9 @@ fn (mut cache TypeCache) clear_c_type_entries() {
 struct ResolutionTypeViewCache {
 mut:
 	by_file map[string]&TypeChecker
+	// Import-aware views keyed by source file, reused across every declaration
+	// type resolved in that file instead of forking a full checker per call.
+	scoped_by_file map[string]&TypeChecker
 }
 
 // TypeCacheStats reports semantic cache effectiveness for compiler telemetry.
@@ -3091,7 +3094,7 @@ fn (mut tc TypeChecker) reserve_collect_maps() {
 			tc.receiver_method_suffix_index.reserve(u32(tc.receiver_method_suffix_index.len) + decl_estimate * 3)
 			if !isnil(tc.visible_mutation_cache) {
 				mut mutation_cache := tc.visible_mutation_cache
-				mutation_cache.decls.reserve(u32(mutation_cache.decls.len) + decl_estimate * 8)
+				mutation_cache.decls.reserve(u32(mutation_cache.decls.len) + decl_estimate * 3)
 			}
 			if os.getenv('V3_NO_EXTENDED_COLLECT_RESERVES') == '' {
 				tc.fn_type_files.reserve(u32(tc.fn_type_files.len) + decl_estimate * 3)
@@ -5185,6 +5188,15 @@ pub fn (tc &TypeChecker) parse_resolution_type_in_file(typ string, file string) 
 		return tc.parse_type(typ)
 	}
 	module_name := tc.file_modules[file] or { '' }
+	if !isnil(tc.resolution_type_views) {
+		mut views := unsafe { tc.resolution_type_views }
+		if cached := views.scoped_by_file[file] {
+			return cached.parse_resolution_type(typ)
+		}
+		mut scoped := tc.fork_type_parse_view(file, module_name)
+		views.scoped_by_file[file] = scoped
+		return scoped.parse_resolution_type(typ)
+	}
 	mut scoped := tc.fork_type_parse_view(file, module_name)
 	return scoped.parse_resolution_type(typ)
 }
@@ -12194,8 +12206,45 @@ fn (tc &TypeChecker) infer_decl_generic_params(node flat.Node) map[string]bool {
 }
 
 fn (tc &TypeChecker) infer_decl_generic_param_names(node flat.Node) []string {
+	if node.generic_params().len == 0 && !tc.decl_receiver_may_carry_generic_params(node) {
+		// The common non-generic declaration: skip the temporary map and sort.
+		return []string{}
+	}
 	params := tc.infer_decl_generic_params(node)
 	return generic_param_names_from_map(params)
+}
+
+// decl_receiver_may_carry_generic_params reports whether a method receiver
+// type spelling can contribute generic parameters (`Foo[T]`), mirroring the
+// early exits of collect_generic_receiver_params without allocating.
+fn (tc &TypeChecker) decl_receiver_may_carry_generic_params(node flat.Node) bool {
+	if node.kind != .fn_decl && node.kind != .c_fn_decl {
+		return false
+	}
+	if !node.value.contains('.') || node.children_count == 0 {
+		return false
+	}
+	receiver_id := tc.a.child(&node, 0)
+	if int(receiver_id) < 0 {
+		return false
+	}
+	receiver := tc.a.nodes[int(receiver_id)]
+	if receiver.kind != .param {
+		return false
+	}
+	if receiver.typ.contains('[') {
+		return true
+	}
+	// A bare generic-parameter spelling is the only bracket-free candidate the
+	// full scan can report.
+	mut clean := receiver.typ.trim_space()
+	for clean.starts_with('shared ') || clean.starts_with('atomic ') {
+		clean = clean[7..].trim_space()
+	}
+	for clean.len > 0 && clean[0] in [`&`, `?`, `!`] {
+		clean = clean[1..].trim_space()
+	}
+	return is_bare_generic_param(clean)
 }
 
 fn generic_param_names_from_map(params map[string]bool) []string {

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -47,6 +47,9 @@ struct InterfaceImplChunkArgs {
 	results     voidptr
 	start       int
 	end         int
+	scoped      bool
+mut:
+	scope voidptr
 }
 
 struct InterfaceImplResults {
@@ -55,7 +58,13 @@ mut:
 }
 
 fn interface_impl_index_chunk_thread(arg voidptr) voidptr {
-	a := unsafe { &InterfaceImplChunkArgs(arg) }
+	mut a := unsafe { &InterfaceImplChunkArgs(arg) }
+	if a.scoped {
+		// A forked checker only writes its private caches, so the whole index
+		// scratch can live in a disposable arena; the master publishes copies of
+		// the names before releasing it.
+		a.scope = check_worker_scope_begin(true)
+	}
 	tc := unsafe { &TypeChecker(a.checker) }
 	iface_names := unsafe { &[]string(a.iface_names) }
 	mut results := unsafe { &InterfaceImplResults(a.results) }
@@ -70,6 +79,9 @@ fn interface_impl_index_chunk_thread(arg voidptr) voidptr {
 			names: impls
 			ids: stable_interface_type_ids(impls)
 		}
+	}
+	if a.scoped {
+		check_worker_scope_leave(a.scope)
 	}
 	return unsafe { nil }
 }
@@ -106,6 +118,9 @@ fn (mut tc TypeChecker) prepare_interface_impl_indexes_parallel(iface_names []st
 				results: voidptr(results)
 				start: iface_names.len * job / n_jobs
 				end: iface_names.len * (job + 1) / n_jobs
+				// Job 0 runs on the master checker, whose overlay is folded back
+				// into the shared cache below; only forks may use scratch arenas.
+				scoped: job > 0
 			}
 			tasks << workers.Task{
 				run: interface_impl_index_chunk_thread
@@ -128,6 +143,11 @@ fn (mut tc TypeChecker) prepare_interface_impl_indexes_parallel(iface_names []st
 					names: names
 					ids: stable_interface_type_ids(names)
 				}
+			}
+		}
+		for arg in args {
+			if arg.scope != unsafe { nil } {
+				check_worker_scope_free(arg.scope)
 			}
 		}
 		return true
@@ -988,11 +1008,16 @@ fn (mut tc TypeChecker) check_semantics_parallel() bool {
 		tc.check_export_attrs()
 		tc.timing_profile('  [ttime]   ck export attrs  ${f64(cksw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		cksw.restart()
+		// The work list only drives the dispatch below; keep it and its
+		// collection scratch out of the persistent arena.
+		items_scope := check_worker_scope_begin(tc.scope_parallel_check_workers)
 		items := tc.collect_parallel_check_items()
+		check_worker_scope_leave(items_scope)
 		tc.timing_profile('  [ttime]   ck collect items ${f64(cksw.elapsed().microseconds()) / 1000.0:7.2f} ms (items: ${items.len})')
 		final_file := tc.cur_file
 		final_module := tc.cur_module
 		was_parallel := tc.run_parallel_check(items)
+		check_worker_scope_free(items_scope)
 		// Per-function check costs only schedule the parallel batches above.
 		unsafe { tc.fn_check_costs.free() }
 		tc.fn_check_costs = []i32{}
@@ -1239,6 +1264,9 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 		dynamic_dispatch := tc.scope_parallel_check_workers && tc.building_v_fast && fail.len == 0
 		// Dynamic workers record their actual assignments after dispatch; the
 		// static partition would only allocate and sort buckets that get replaced.
+		// The chunk partition only serves the dispatch below; keep it out of the
+		// persistent arena together with the worker forks.
+		setup_scope := check_worker_scope_begin(tc.scope_parallel_check_workers)
 		mut chunks := if dynamic_dispatch {
 			[][]CheckWorkItem{len: chunk_target}
 		} else {
@@ -1257,7 +1285,6 @@ fn (mut tc TypeChecker) run_parallel_check(items []CheckWorkItem) bool {
 			chunk_queue.close()
 		}
 		thread_count := chunk_count - 1
-		setup_scope := check_worker_scope_begin(tc.scope_parallel_check_workers)
 		worker_count := if tc.scope_parallel_check_workers { chunk_count } else { thread_count }
 		rpsw := time.new_stopwatch()
 		mut checker_workers := []voidptr{cap: worker_count}

--- a/vlib/v3/types/checker_tail.v
+++ b/vlib/v3/types/checker_tail.v
@@ -11862,7 +11862,7 @@ fn (tc &TypeChecker) selector_has_shared_elements(node flat.Node) bool {
 
 // struct_field_is_shared reports whether a resolved struct field uses shared storage.
 pub fn (tc &TypeChecker) struct_field_is_shared(struct_name string, field_name string) bool {
-	if struct_name.len == 0 || field_name.len == 0 {
+	if struct_name.len == 0 || field_name.len == 0 || tc.struct_shared_fields.len == 0 {
 		return false
 	}
 	mut candidates := []string{cap: 4}

--- a/vlib/v3/types/checker_tail_stmt.v
+++ b/vlib/v3/types/checker_tail_stmt.v
@@ -16744,12 +16744,23 @@ pub fn (tc &TypeChecker) resolve_generic_struct_method(type_name string, method 
 
 fn (tc &TypeChecker) generic_struct_method_alias_target(type_name string) string {
 	mut current := type_name
-	mut seen := map[string]bool{}
+	// The chain is at most 16 deep; a fixed scratch list replaces the per-call
+	// map this hot path used to allocate.
+	mut seen := [16]string{}
+	mut seen_len := 0
 	for _ in 0 .. 16 {
-		if seen[current] {
+		mut cycle := false
+		for i in 0 .. seen_len {
+			if seen[i] == current {
+				cycle = true
+				break
+			}
+		}
+		if cycle {
 			break
 		}
-		seen[current] = true
+		seen[seen_len] = current
+		seen_len++
 		qualified := tc.qualify_name(current)
 		target := tc.type_aliases[current] or { tc.type_aliases[qualified] or { break } }
 		if target == current {


### PR DESCRIPTION
Follow-up to #28526. Same benchmark (`cd vlib/v3 && ../../v -gc none -prealloc -prod -o v3 v3.v && ./v3 -nocache -building-v -o v4 v3.v`), interleaved with master at equal machine load:

| | master (416ad27) | this PR |
|---|---|---|
| peak memory footprint | 755 MB | 699 MB (-7.5%) |
| max RSS | 764 MB | 707 MB (-7.5%) |
| frontend instructions | 46.0 G | 45.7 G (-0.6%) |

Note #28529 changed the benchmark: the self-host now links with tcc in ~1.2 s instead of silently falling back to clang, so the whole run is ~1.3-1.8 s and compiler CPU is a large share. Every change here is CPU-neutral or better; instruction count actually drops slightly because the reservation trims cut both allocation and zeroing.

The peak is cgen's function-worker phase. A temporary block registry (mincore-resident bytes per arena) plus a sampling allocation tracer attributed it. The reductions:

- **Interface-implementation index forks** (check) run in disposable arenas freed after the master copies out the names. Largest single win, ~27 MB of never-freed worker arena.
- **Transform pre-scan helper threads** build their indexes into arenas retained through transform; the driver canonicalizes the node texts they back in one multi-arena scan (with a union address-range precheck so the scan stays cheap) and frees them all after transform. Gated to the self-host prepared path so other compilations keep the old behavior.
- **cgen cost threads and fixed-storage node-scan** run in scratch arenas freed after replay; the optional-type and interface-impl scan publishers clone their small result tables out and free the scan arenas.
- **check work list and dispatch chunks** move into scopes.
- Cheaper hot paths: `parse_resolution_type_in_file` caches its per-file import view instead of forking a full checker per call; `fn_returns_veb_result` / `struct_field_is_shared` prefilters; `declare_ierror_pointer_alias` skips no-op negatives; generic-param inference skips the map+sort for non-generic decls; `generic_struct_method_alias_target` uses a fixed scratch list; string literal table entries escape straight into the builder; cgen chunk arrays and output segments are moved, not cloned; the scoped-owned-base-node map becomes an append-only log.
- Right-size the cgen fn-registration and visible-mutation reservations (over-allocated and zeroed); drop the parser's fixed initial AST capacity.

Validation: generated C is byte-identical to master's (same sources compiled by both binaries), identical under `-d prealloc_no_recycle` (freed arenas are unmapped, so stale reads crash), generation-stable (v3 and the v4 it builds emit identical C), deterministic across runs, and the targeted `vlib/v3` check/transform/cgen tests pass.

I also tried dropping the prealloc recycle cache from 8 to 6 slots, which reaches ~10-11% but costs a real ~1.7% frontend instructions (extra page faults), so I kept it at master's value to stay performance-neutral.
