### PR TITLE
v3: give array-literal compound literals their length, so TinyCC accepts them

### DIFF
--- a/vlib/v3/gen/c/array.v
+++ b/vlib/v3/gen/c/array.v
@@ -112,7 +112,10 @@ fn (mut g FlatGen) gen_array_literal_value(node flat.Node, elem_type types.Type)
 	} else {
 		'new_array_from_c_array'
 	}
-	g.write('${new_fn}(${count}, ${count}, sizeof(${sizeof_elem}), (${c_elem}[]){')
+	// Size the compound literal explicitly. TinyCC mis-accounts an unsized
+	// `(T[]){a, b}` whose elements are struct values rather than brace
+	// initializers, and aborts with an internal `initializer overflow`.
+	g.write('${new_fn}(${count}, ${count}, sizeof(${sizeof_elem}), (${c_elem}[${count}]){')
 	for i in 0 .. count {
 		if i > 0 {
 			g.write(', ')

--- a/vlib/v3/gen/c/array_literal_length_test.v
+++ b/vlib/v3/gen/c/array_literal_length_test.v
@@ -1,0 +1,42 @@
+module c
+
+import v3.flat
+import v3.types
+
+fn array_literal_length_test_gen() &FlatGen {
+	mut ast := &flat.FlatAst{}
+	mut tc := types.TypeChecker.new(ast)
+	mut g := FlatGen.new()
+	g.a = ast
+	g.tc = &tc
+	return &g
+}
+
+// TinyCC mis-accounts an unsized `(T[]){a, b}` whose elements are struct values
+// instead of brace initializers, and aborts with an internal `initializer
+// overflow`, so the literal has to carry its own length.
+fn test_array_literal_compound_literal_carries_its_length() {
+	mut g := array_literal_length_test_gen()
+	first := g.a.add_node(flat.Node{
+		kind:  .ident
+		value: 'first'
+		typ:   'string'
+	})
+	second := g.a.add_node(flat.Node{
+		kind:  .ident
+		value: 'second'
+		typ:   'string'
+	})
+	start := g.a.children.len
+	g.a.children << first
+	g.a.children << second
+	node := flat.Node{
+		kind:           .array_init
+		children_start: i32(start)
+		children_count: 2
+	}
+	g.gen_array_literal_value(node, types.Type(types.string_))
+	out := g.sb.str()
+	assert out.contains('(string[2]){'), out
+	assert !out.contains('(string[]){'), out
+}


### PR DESCRIPTION
V3 emits an array literal as an *unsized* compound literal:

```c
new_array_from_c_array(18, 18, sizeof(string), (string[]){_str_1, ...})
```

TinyCC mis-accounts that form when the elements are struct values rather than brace initializers, and on aarch64 it aborts outright:

```
tccgen.c:7728: in init_assert(): initializer overflow
```

The first one in a self-build is `time__tokens_2` in `_vinit`, so every tcc-targeted unit fails and V3 silently regenerates it with `cc` — the "self-build is several times slower than it should be" symptom, with only the fallback warning to go on. x86_64 TinyCC accepts the literal, so the two hosts disagree for no good reason.

Reduced:

```c
typedef struct string { char* str; long len; int is_lit; } string;
static const string _s1 = {"a", 1, 1};
static const string _s2 = {"b", 1, 1};
void f(void) { sink((string[]){_s1, _s2}); }   // aarch64 tcc: internal compiler error
```

A single element, scalar elements, brace initializers, and an explicit length are all handled correctly everywhere.

## Change

Emit the length, which every C compiler accepts and which the generator already knows. The generated C is otherwise byte-identical: 833 literals gain `[N]` and nothing else changes.

## Not the startup crash

This is **not** the Linux `make` crash — that one is the TinyCC thread-local key aliasing being fixed separately. A compiler built with only this change still aborted in `prealloc_vinit`. The two are independent TinyCC issues that happen to sit in the same `_vinit`.

## Testing

- New unit test in `vlib/v3/gen/c/array_literal_length_test.v`; it fails on master and passes with the change.
- Ubuntu 24.04 aarch64: the bundled tcc no longer aborts on the generated `src.c` (it now gets past `_vinit` to the pre-existing `ARM asm not implemented` limitation, rather than dying in `init_assert`).
- Ubuntu 24.04 x86_64: full `make` bootstrap still builds and the resulting compiler runs.
- `v test-cleancode`: 6435/6435.