### PR TITLE
cgen: look up map-of-map values through a helper, not a statement expression

### DIFF
--- a/vlib/v/gen/c/cgen.v
+++ b/vlib/v/gen/c/cgen.v
@@ -249,6 +249,7 @@ mut:
 	array_get_types                      []ast.Type
 	auto_fn_definitions                  []string // auto generated functions definition list
 	sumtype_casting_fns                  []SumtypeCastingFn
+	map_value_lookup_fns                 []MapValueLookupFn // lazily-defaulted map-of-map lookups
 	anon_fn_definitions                  []string // anon generated functions definition list
 	anon_fns                             shared []string // remove duplicate anon generated functions
 	sumtype_definitions                  map[string]bool // `_TypeA_to_sumtype_TypeB()` fns that have been generated
@@ -582,6 +583,18 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) GenO
 					global_g.sumtype_casting_fns << scf
 				}
 			}
+			for mvl in g.map_value_lookup_fns {
+				mut already_exists := false
+				for existing in global_g.map_value_lookup_fns {
+					if existing.fn_name == mvl.fn_name {
+						already_exists = true
+						break
+					}
+				}
+				if !already_exists {
+					global_g.map_value_lookup_fns << mvl
+				}
+			}
 
 			for at in g.array_typedefs {
 				if at !in global_g.array_typedefs {
@@ -647,6 +660,9 @@ pub fn gen(files []&ast.File, mut table ast.Table, pref_ &pref.Preferences) GenO
 	}
 	for sumtype_casting_fn in global_g.sumtype_casting_fns {
 		global_g.write_sumtype_casting_fn(sumtype_casting_fn)
+	}
+	for map_value_lookup_fn in global_g.map_value_lookup_fns {
+		global_g.write_map_value_lookup_fn(map_value_lookup_fn)
 	}
 	global_g.write_shareds()
 	global_g.emit_late_chan_type_definitions()

--- a/vlib/v/gen/c/coutput_test.v
+++ b/vlib/v/gen/c/coutput_test.v
@@ -287,10 +287,13 @@ fn test_addressable_map_fallback_does_not_allocate_carrier() {
 	compilation := os.execute(cmd)
 	ensure_compilation_succeeded(compilation, cmd)
 	assert !generated_c_uses_v3_codegen(compilation.output)
-	assert compilation.output.contains('Map_string_main__Entry _t')
-	assert compilation.output.contains('*ADDR(Map_string_main__Entry, ({')
-	assert compilation.output.contains('*((Map_string_main__Entry*)')
-	assert !compilation.output.contains('} (Map_string_main__Entry*)')
+	// The lookup goes through a generated helper rather than a `({ ... })`
+	// statement expression, which is a GNU extension MSVC cannot parse.
+	assert !compilation.output.contains('({ map*')
+	assert compilation.output.contains('*ADDR(Map_string_main__Entry, _v_map_get_or_zero_Map_string_main__Entry(')
+	// A hit returns the stored map; only a miss builds the default, so no
+	// lookup allocates a carrier for a value it is about to throw away.
+	assert compilation.output.contains('if (v) { return *(Map_string_main__Entry*)v; }')
 	assert !compilation.output.contains('builtin__memdup(ADDR(Map_string_main__Entry')
 }
 

--- a/vlib/v/gen/c/index.v
+++ b/vlib/v/gen/c/index.v
@@ -5,6 +5,7 @@ module c
 
 import v.ast
 import v.util
+import strings
 
 struct IndexOperatorMethodInfo {
 	method        ast.Fn
@@ -1010,20 +1011,73 @@ fn (mut g Gen) index_of_map(node ast.IndexExpr, sym ast.TypeSymbol) {
 	}
 }
 
+struct MapValueLookupFn {
+	fn_name      string
+	val_type     ast.Type
+	val_type_str string
+	insert       bool
+}
+
+// map_value_lookup_fn names the helper that performs a lazily-defaulted lookup for
+// `val_type_str`, registering it for emission on first use. A statement expression
+// would be shorter, but `({ ... })` is a GNU extension that MSVC rejects, and this
+// lookup was the only place cgen still needed one.
+fn (mut g Gen) map_value_lookup_fn(val_type ast.Type, val_type_str string, insert bool) string {
+	fn_name := if insert {
+		'_v_map_get_or_insert_${val_type_str}'
+	} else {
+		'_v_map_get_or_zero_${val_type_str}'
+	}
+	for existing in g.map_value_lookup_fns {
+		if existing.fn_name == fn_name {
+			return fn_name
+		}
+	}
+	g.map_value_lookup_fns << MapValueLookupFn{
+		fn_name: fn_name
+		val_type: val_type
+		val_type_str: val_type_str
+		insert: insert
+	}
+	return fn_name
+}
+
+// write_map_value_lookup_fn emits the body of a helper registered by
+// map_value_lookup_fn. The default is built inside the helper, so a lookup that
+// finds its key never constructs - and never leaks - a map header.
+fn (mut g Gen) write_map_value_lookup_fn(fun MapValueLookupFn) {
+	val_type_str := fun.val_type_str
+	zero := g.type_default(fun.val_type)
+	ret_type := if fun.insert { '${val_type_str}*' } else { val_type_str }
+	signature := '${ret_type} ${fun.fn_name}(map* m, void* key)'
+	g.definitions.writeln('${signature};')
+	mut sb := strings.new_builder(256)
+	sb.writeln('${signature} {')
+	sb.writeln('\tvoid* v = builtin__map_get_check(m, key);')
+	if fun.insert {
+		sb.writeln('\tif (!v) { v = builtin__map_get_and_set(m, key, &(${val_type_str}[]){ ${zero} }); }')
+		sb.writeln('\treturn (${val_type_str}*)v;')
+	} else {
+		sb.writeln('\tif (v) { return *(${val_type_str}*)v; }')
+		sb.writeln('\t${val_type_str} zero = ${zero};')
+		sb.writeln('\treturn zero;')
+	}
+	sb.writeln('}\n')
+	g.auto_fn_definitions << sb.str()
+}
+
 // gen_map_value_lookup emits a lookup whose empty map fallback is constructed only
 // when the key is absent. A map default owns a heap-allocated header, so passing it
 // eagerly to map_get would leak the discarded header for every successful lookup.
 fn (mut g Gen) gen_map_value_lookup(node ast.IndexExpr, key_type ast.Type, val_type ast.Type, val_type_str string, left_is_ptr bool, left_is_shared bool, insert_if_missing bool, addressable bool) {
-	map_tmp := g.new_tmp_var()
-	key_tmp := g.new_tmp_var()
-	value_tmp := g.new_tmp_var()
+	fn_name := g.map_value_lookup_fn(val_type, val_type_str, insert_if_missing)
 	if insert_if_missing {
-		g.write('(*({ map* ${map_tmp} = (map*)')
+		g.write('(*${fn_name}((map*)')
 	} else if addressable {
-		// The outer ADDR carrier keeps the copied value alive after the statement expression ends.
-		g.write('(*ADDR(${val_type_str}, ({ map* ${map_tmp} = (map*)')
+		// The ADDR carrier gives the returned copy a stable address.
+		g.write('(*ADDR(${val_type_str}, ${fn_name}((map*)')
 	} else {
-		g.write('({ map* ${map_tmp} = (map*)')
+		g.write('${fn_name}((map*)')
 	}
 	if insert_if_missing {
 		// Mutating lookups must retain the address of the original map.
@@ -1054,19 +1108,16 @@ fn (mut g Gen) gen_map_value_lookup(node ast.IndexExpr, key_type ast.Type, val_t
 			g.write(')')
 		}
 	}
-	g.write('; void* ${key_tmp} = ')
+	g.write(', ')
 	old_is_assign_lhs := g.is_assign_lhs
 	g.is_assign_lhs = false
 	g.write_map_key_arg(node.index, key_type)
 	g.is_assign_lhs = old_is_assign_lhs
-	g.write('; void* ${value_tmp} = builtin__map_get_check(${map_tmp}, ${key_tmp}); ')
-	zero := g.type_default(val_type)
 	if insert_if_missing {
-		g.write('if (!${value_tmp}) { ${value_tmp} = builtin__map_get_and_set(${map_tmp}, ${key_tmp}, &(${val_type_str}[]){ ${zero} }); } (${val_type_str}*)${value_tmp}; }))')
+		g.write('))')
 	} else if addressable {
-		zero_tmp := g.new_tmp_var()
-		g.write('${val_type_str} ${zero_tmp}; if (!${value_tmp}) { ${zero_tmp} = ${zero}; ${value_tmp} = &${zero_tmp}; } *((${val_type_str}*)${value_tmp}); })))')
+		g.write(')))')
 	} else {
-		g.write('${value_tmp} ? *((${val_type_str}*)${value_tmp}) : ${zero}; })')
+		g.write(')')
 	}
 }

--- a/vlib/v/gen/c/map_value_lookup_msvc_codegen_test.v
+++ b/vlib/v/gen/c/map_value_lookup_msvc_codegen_test.v
@@ -1,0 +1,40 @@
+import os
+
+const vroot = os.dir(@VEXE)
+const test_vexe = os.quoted_path(@VEXE)
+
+// A map-of-map index is the one lookup that has to build its default lazily, so
+// that a hit never constructs - and never leaks - a map header. It used to do
+// that with a `({ ... })` statement expression, which is a GNU extension: MSVC
+// rejects it outright, and the whole `makev.bat -msvc` build failed on it.
+fn nested_map_generated_c() string {
+	src := os.join_path(os.vtmp_dir(), 'v_map_value_lookup_${os.getpid()}.v')
+	os.write_file(src, "fn main() {
+	mut m := map[string]map[string]int{}
+	m['a']['x'] = 1
+	println(m['a']['x'])
+	println(m['b'].len)
+}
+") or { panic(err) }
+	defer {
+		os.rm(src) or {}
+	}
+	cmd := '${test_vexe} -old-compiler -o - ${os.quoted_path(src)}'
+	res := os.execute(cmd)
+	assert res.exit_code == 0, '${cmd}\n${res.output}'
+	return res.output
+}
+
+fn test_nested_map_lookup_does_not_emit_a_statement_expression() {
+	generated := nested_map_generated_c()
+	assert !generated.contains('({ map*'), generated
+}
+
+fn test_nested_map_lookup_calls_the_generated_helpers() {
+	generated := nested_map_generated_c()
+	// The reading lookup returns the value, the mutating one returns a pointer
+	// into the map so the nested assignment can write through it.
+	assert generated.contains('_v_map_get_or_zero_')
+	assert generated.contains('_v_map_get_or_insert_')
+	assert generated.contains('builtin__map_get_check(m, key)')
+}

--- a/vlib/v/gen/c/testdata/map_value_lookup_lazy_default.c.must_have
+++ b/vlib/v/gen/c/testdata/map_value_lookup_lazy_default.c.must_have
@@ -1,6 +1,6 @@
-builtin__map_get_check(_t2, _t3); _t4 ? *((Map_string_int*)_t4) : builtin__new_map
-if (!_t3) { _t3 = builtin__map_get_and_set(_t1, _t2, &(Map_string_int[]){ builtin__new_map
-Map_string_main__Entry _t
+if (v) { return *(Map_string_int*)v; }
+if (!v) { v = builtin__map_get_and_set(m, key, &(Map_string_int[]){ builtin__new_map
+Map_string_main__Entry _v_map_get_or_zero_Map_string_main__Entry(map* m, void* key)
 builtin____new_array_with_map_default(2, 0, sizeof(Map_string_int)
 }[0], true)
 }[0], false)


### PR DESCRIPTION
`makev.bat -msvc` has failed to build V since #28466, at the final `v_stage.exe -cc msvc -o ./v_up.exe cmd/v` step:

```
checker_tail.v(9962): error C2059: syntax error: '{'
checker_tail.v(9962): error C2065: '_t8': undeclared identifier
checker_tail.v(9964): error C2065: 'label_aliases': undeclared identifier
... every later name in the function, for ~100 more lines
```

#28466 made a map-of-map index build its empty-map default lazily, so that a lookup which finds its key no longer constructs and leaks a map header. It did that with `({ ... })` — a GNU statement expression, which MSVC does not implement. One `({` derails cl.exe's parser for the rest of the function, which is why a single construct produced a hundred unrelated errors.

(The MSVC lane's *Build* step was green as recently as 09-08; it has been failing on this since #28466 landed.)

## Change

Emit the same logic as a generated helper, registered per value type the way sumtype casting fns already are, so the default is still built only on a miss:

```c
Map_string_Array_int _v_map_get_or_zero_Map_string_Array_int(map* m, void* key) {
	void* v = builtin__map_get_check(m, key);
	if (v) { return *(Map_string_Array_int*)v; }
	Map_string_Array_int zero = new_map(...);
	return zero;
}
```

The mutating form returns `ValT*` and keeps the `map_get_and_set` insert.

This was cgen's only remaining statement expression: the C emitted for `-cc msvc -os windows -o cmd/v` now contains none outside string literals (the 8 remaining hits are V3 cgen's own source text compiled into the binary).

## Generated C is otherwise unchanged

Normalising temp-variable numbering — the old form burned three `_tN` per lookup, the new one none — every line the diff removes is one of these statement expressions and nothing else:

```
$ diff <(sed -E 's/_t[0-9]+/_tN/g' before.c) <(sed -E 's/_t[0-9]+/_tN/g' after.c) \
    | grep '^<' | grep -vc '(\{ map\* _tN'
0
```

## Testing

- New `vlib/v/gen/c/map_value_lookup_msvc_codegen_test.v`; it fails on master (`assert !generated.contains('({ map*')`) and passes with the change.
- V self-hosts through the changed path on macOS.
- All 13 map / nested-map test files pass.
- 68/70 of the first `vlib/v/tests` slice pass; the two `autofree_*` failures are identical before and after.
- `v test-cleancode`: 6436/6436.

I do not have MSVC to run the Windows lane locally, so this is verified through the generated C and the non-Windows suites — the MSVC lane itself will be the real check.