### PR TITLE
cmd, v3: forward the child's exit code when V re-executes itself on Windows

### DIFF
--- a/cmd/v/macos_v3_dispatch.c.v
+++ b/cmd/v/macos_v3_dispatch.c.v
@@ -129,11 +129,26 @@ fn launch_macos_v1_fallback(executable string, args []string, is_verbose bool, r
 	if is_verbose || os.getenv('V3_CACHE_TRACE') != '' {
 		eprintln('${reason}; retrying with `${executable}`.')
 	}
-	os.execvp(executable, macos_v1_fallback_args(args)) or {
+	fallback_args := macos_v1_fallback_args(args)
+	$if windows {
+		// Windows has no exec. The CRT's `_execvp` starts the child and then
+		// terminates this process with status 0, so the compatibility
+		// compiler's exit code never reaches whoever ran `v` - a failed
+		// compilation looks like a success to every caller, including
+		// `os.execute` in the test suite. Run it as a child and forward its
+		// status, the way `v.util`'s tool launcher already does.
+		exit(os.system(exec_command(executable, fallback_args)))
+	}
+	os.execvp(executable, fallback_args) or {
 		eprintln('failed to launch the V1 compatibility compiler `${executable}`: ${err}')
 		exit(1)
 	}
 	exit(1)
+}
+
+// exec_command renders an argv for a shell, for the platforms that cannot exec.
+fn exec_command(executable string, args []string) string {
+	return '${os.quoted_path(executable)} ${util.args_quote_paths(args)}'.trim_space()
 }
 
 fn macos_v1_fallback_args(args []string) []string {

--- a/cmd/v/v1_fallback_exit_code_test.v
+++ b/cmd/v/v1_fallback_exit_code_test.v
@@ -1,0 +1,34 @@
+import os
+
+const test_vexe = os.quoted_path(@VEXE)
+
+// `v -old-compiler ...` hands the build to the separately built V1 compatibility
+// compiler. On platforms with exec that replaces this process, so the compiler's
+// status is the one the caller sees; Windows has no exec, and the CRT's
+// `_execvp` used to start the child and then exit this process with status 0 -
+// a failed compilation reported its error and still looked like a success.
+fn run_old_compiler(src string, name string) os.Result {
+	wrkdir := os.join_path(os.vtmp_dir(), 'v1_fallback_exit_code')
+	os.mkdir_all(wrkdir) or { panic(err) }
+	source_path := os.join_path(wrkdir, '${name}.v')
+	os.write_file(source_path, src) or { panic(err) }
+	defer {
+		os.rm(source_path) or {}
+	}
+	output_path := os.join_path(wrkdir, '${name}.exe')
+	defer {
+		os.rm(output_path) or {}
+	}
+	return os.execute('${test_vexe} -old-compiler -o ${os.quoted_path(output_path)} ${os.quoted_path(source_path)}')
+}
+
+fn test_a_failed_v1_fallback_build_reports_a_failing_exit_code() {
+	res := run_old_compiler('fn main() {\n\tprintln(undefined_name_here)\n}\n', 'broken')
+	assert res.exit_code != 0, 'a failing build must not report success: ${res.output}'
+	assert res.output.contains('undefined_name_here'), res.output
+}
+
+fn test_a_successful_v1_fallback_build_reports_success() {
+	res := run_old_compiler('fn main() {\n\tprintln(1 + 1)\n}\n', 'fine')
+	assert res.exit_code == 0, res.output
+}

--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -12319,6 +12319,9 @@ pub fn run(args []string) {
 						regeneration_args << arg
 					}
 				}
+				$if windows {
+					exit(os.system(v3_exec_command(os.executable(), regeneration_args)))
+				}
 				os.execvp(os.executable(), regeneration_args) or {
 					eprintln('failed to restart monolithic C compilation: ${err.msg()}')
 					exit(1)
@@ -13630,18 +13633,26 @@ fn restart_v3_with_args(extra_args []string) {
 	mut args := extra_args.clone()
 	args << os.args[1..]
 	os.setenv(v3_internal_restart_env, '1', true)
-	$if js {
-		mut command := [os.quoted_path(executable)]
-		for arg in args {
-			command << os.quoted_path(arg)
-		}
-		exit(os.system(command.join(' ')))
+	$if js || windows {
+		// Windows has no exec either: `_execvp` would start the child and then
+		// exit this process with status 0, dropping the restarted build's
+		// result on the floor.
+		exit(os.system(v3_exec_command(executable, args)))
 	} $else {
 		os.execvp(executable, args) or {
 			eprintln('failed to restart ${executable}: ${err.msg()}')
 			exit(1)
 		}
 	}
+}
+
+// v3_exec_command renders an argv for a shell, for the platforms that cannot exec.
+fn v3_exec_command(executable string, args []string) string {
+	mut command := [os.quoted_path(executable)]
+	for arg in args {
+		command << os.quoted_path(arg)
+	}
+	return command.join(' ')
 }
 
 fn cache_external_input_owner_modules(state &V3ModuleCacheState, a &flat.FlatAst, unscoped_inputs map[string][]string, static_inputs map[string][]string, user_files []string, c_flags []string, ccompiler string, target pref.Target) (map[string]bool, bool) {


### PR DESCRIPTION
The wasm lane's `scalar_option_result_error_test.v` fails on windows-2022 while passing on ubuntu, and its own assertion message shows why:

```
expected a compile error, got: .../scalar_option.v:1:8: error: option types are not implemented
```

The error is there. The exit code is 0.

Those tests run `v -old-compiler -b wasm ...`, which hands the build to the separately built V1 compatibility compiler through `os.execvp`. On POSIX that replaces the process, so the compiler's status is the one the caller sees. **Windows has no exec**: the CRT's `_execvp` starts the child and then terminates the calling process with status 0, so a failed compilation reports its error and still looks like a success to everyone upstream — `os.execute` in the test suite, `make`, a shell.

## Change

Run the child through `os.system` on Windows and exit with its status, the way `v.util`'s tool launcher (`cmd_system`/`tool_launch_command`) already sidesteps the same problem for external tools.

The two V3 driver restart paths had the same hole and are fixed alongside:
- the `-d v3_parallel_cc_monolithic` regeneration restart, and
- the generic restart, which only special-cased the JS backend.

POSIX still execs and is unchanged.

## Testing

- `cmd/v/v1_fallback_exit_code_test.v` asserts both directions — a broken build must not report success, a good one must not report failure — through the same dispatch the wasm tests use, so the property is checked on every host rather than only where the wasm backend runs.
- `vlib/v/gen/wasm/tests/scalar_option_result_error_test.v` passes locally on macOS (it already did there; Windows is the lane this unblocks).
- `cmd/v` test files: 6/6 pass.
- `v test-cleancode`: 6436/6436.

I do not have Windows to run that lane locally, so the mechanism is established from the CI output plus the CRT's documented `_execvp` behaviour; the Windows lanes will be the real check.