### PR TITLE
tools: check-md: use only the first fence info-string token as the language

### DIFF
--- a/cmd/tools/vcheck-md.v
+++ b/cmd/tools/vcheck-md.v
@@ -329,6 +329,12 @@ const default_command = 'compile'
 // fence languages that begin with `v` but hold something other than V source
 const non_v_fence_languages = ['vml']
 
+// fence_language returns the first token of a code fence's info string.
+fn fence_language(line string) string {
+	fields := line.replace('```', '').fields()
+	return if fields.len > 0 { fields[0] } else { '' }
+}
+
 struct VCodeExample {
 mut:
 	text    []string
@@ -434,7 +440,9 @@ fn (mut f MDFile) check() CheckResult {
 }
 
 fn (mut f MDFile) parse_line(lnumber int, line string) {
-	if line.starts_with('```v') && line.replace('```', '').trim_space() !in non_v_fence_languages {
+	// Only the first word of a fence info string names the language; anything after it
+	// (e.g. `title=example`) is metadata and must not affect the decision.
+	if line.starts_with('```v') && fence_language(line) !in non_v_fence_languages {
 		if f.state == .markdown {
 			f.state = .vexample
 			mut command := line.replace('```v', '').trim_space()

--- a/cmd/tools/vcheck_test.v
+++ b/cmd/tools/vcheck_test.v
@@ -390,3 +390,32 @@ fn after_vml() {}
 	assert !res.output.contains('unrecognized command'), res.output
 	assert res.output.contains('Checked .md files: 1 | Ex.: 1 |'), res.output
 }
+
+fn test_check_md_vml_fence_with_info_string_metadata_is_not_a_v_example() {
+	md_dir := os.join_path(os.vtmp_dir(), 'vcheck_vml_fence_meta_${os.getpid()}')
+	os.rmdir_all(md_dir) or {}
+	os.mkdir_all(md_dir)!
+	defer {
+		os.rmdir_all(md_dir) or {}
+	}
+	md_path := os.join_path(md_dir, 'vml_meta.md')
+	// Only the first word of a fence info string is the language (CommonMark); trailing
+	// metadata such as `title=example` must not turn a ```vml block back into a V example.
+	write_text_file(md_path, '# VML fence with metadata
+
+```vml title=example
+Screen {
+    Button { text: "Save" on_tap: app.save() }
+}
+```
+
+```v ignore
+fn after_vml() {}
+```
+')!
+	res :=
+		os.execute('${os.quoted_path(vexe)} check-md -hide-warnings -silent ${os.quoted_path(md_path)}')
+	assert res.exit_code == 0, res.output
+	assert !res.output.contains('unrecognized command'), res.output
+	assert res.output.contains('Checked .md files: 1 | Ex.: 1 |'), res.output
+}


### PR DESCRIPTION
Follow-up to #28498, addressing the review note there.

### Problem

The non-V fence check in `parse_line` compared the **entire** info string against `non_v_fence_languages`, so a fence with trailing metadata was still treated as a V example — and then split on whitespace into multiple bogus commands:

```
$ v check-md meta.md      # containing ```vml title=example
meta.md:3:1: error: unrecognized command: "ml", ...
meta.md:3:1: error: unrecognized command: "title=example", ...
Checked .md files: 1 | Ex.: 1 | ... | Errors: 2 | Fmt errors: 2
```

Per CommonMark, only the first word of a fence's info string is the language; the rest is arbitrary metadata.

### Fix

Add `fence_language()` which returns the first info-string token, and use it for the `non_v_fence_languages` check. The existing V-command path is untouched.

### Tests

New `test_check_md_vml_fence_with_info_string_metadata_is_not_a_v_example`, exercising ```` ```vml title=example ```` followed by a real ```` ```v ```` example. Fails on master with the exact error above; passes with the fix (`Ex.: 1`, only the V example counted). `v -silent fmt -inprocess -verify` clean on both files; full `vcheck_test.v` passes.

🧙 Built with [WOZCODE](https://wozcode.com)
