### PR TITLE
v3: fix the V1 bootstrap build of the transform worker scopes

### DIFF
--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -4457,6 +4457,19 @@ fn transform_scope_owns(scope voidptr, ptr voidptr) bool {
 	return false
 }
 
+// transform_scope_address_range returns the union address range of the blocks
+// owned by `scope`, so callers can reject most pointers before the per-block
+// search in transform_scope_owns.
+fn transform_scope_address_range(scope voidptr) (usize, usize) {
+	$if prealloc {
+		unsafe {
+			lo, hi := prealloc_scope_address_range(scope)
+			return lo, hi
+		}
+	}
+	return 0, 0
+}
+
 // clone_scoped_worker_node publishes a node's owned fields through the
 // compilation text table before its helper arena is released.
 fn (mut t Transformer) clone_scoped_worker_node(idx int, scope voidptr) {

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -204,11 +204,7 @@ $if !windows {
 	// the arenas together with the preparation arena.
 	fn transform_pre_scan_index_thread(arg voidptr) voidptr {
 		mut t := unsafe { &Transformer(arg) }
-		scope := if t.retain_prescan_scopes {
-			transform_worker_scope_begin(true)
-		} else {
-			unsafe { nil }
-		}
+		scope := transform_worker_scope_begin(t.retain_prescan_scopes)
 		t.build_source_parent_index()
 		t.collect_multi_return_fn_ret_types()
 		t.rebuild_variadic_suffix_index()
@@ -236,11 +232,7 @@ $if !windows {
 	// caches and publishes only its completed declaration maps after joining.
 	fn transform_param_prep_thread(arg voidptr) voidptr {
 		mut w := unsafe { &Transformer(arg) }
-		scope := if w.retain_prescan_scopes {
-			transform_worker_scope_begin(true)
-		} else {
-			unsafe { nil }
-		}
+		scope := transform_worker_scope_begin(w.retain_prescan_scopes)
 		w.prepare_parallel_call_param_types()
 		transform_worker_scope_leave(scope)
 		return scope
@@ -343,7 +335,7 @@ fn scopes_address_range(scopes []voidptr) (usize, usize) {
 	mut hi := usize(0)
 	$if prealloc {
 		for scope in scopes {
-			scope_lo, scope_hi := unsafe { prealloc_scope_address_range(scope) }
+			scope_lo, scope_hi := transform_scope_address_range(scope)
 			if scope_hi <= scope_lo {
 				continue
 			}


### PR DESCRIPTION
Master tip (`4089ece6a4`, #28534) does not `make`: stage 2 (`./v1 -no-parallel -o v2 -gc none cmd/v`, i.e. the V1 checker from the `vc` snapshot) rejects two new source forms in `vlib/v3/transform`.

```
vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v:207:9: error: assignment mismatch: 1 variable 0 values
vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v:216:3: error: `scope` used as value
vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v:239:9: error: assignment mismatch: 1 variable 0 values
vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v:246:3: error: `scope` used as value
vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v:346:23: error: assignment mismatch: 2 variables 1 value
...
```

Two V1 limitations are involved:

* an `if` expression whose else branch is `unsafe { nil }` is typed `void`, so `scope := if cond { transform_worker_scope_begin(true) } else { unsafe { nil } }` fails and every later use of `scope` follows;
* a multi-return call wrapped in an `unsafe` *expression* counts as one value, so `scope_lo, scope_hi := unsafe { prealloc_scope_address_range(scope) }` fails (this one surfaces once the `$if prealloc` branch is checked, e.g. a `-prealloc` build).

Fixes:

* `transform_worker_scope_begin` already returns nil when `enabled` is false, so the conditional call collapses to passing the flag through — same behaviour, no `void`-typed `if` expression.
* the multi-return call moves into a `transform_scope_address_range` helper beside the existing `transform_scope_owns`, which keeps the `$if prealloc` gate and the `unsafe` block in one place and uses the statement form V1 accepts.

Generated code is unchanged (checked the emitted C for `transform__transform_scope_address_range`).

Verified on macOS/arm64 from a clean worktree at `4089ece6a4`:

* `make` fails before the patch, succeeds after (v1 → v2 → v1_fallback → v, no errors or warnings);
* `./v1 -no-parallel -prealloc -o ... cmd/v` reproduces the full error list before, is clean after;
* v3 self-host generation chain (`v` → `v_new` → `v3gen` → `v4gen`) passes, plus a `-prealloc` build of `cmd/v`;
* `vlib/v3/transform/{scoped_merge_notd_v3_no_parallel,ast_snapshot}_test.v` pass; `transform_parallel_test.v` fails identically before and after (pre-existing assert at `:919` and the segfault that follows it).