### PR TITLE
v3: keep `&` on a function value when the context asks for a pointer

### DIFF
--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -12523,6 +12523,16 @@ fn (g &FlatGen) c_typedef_cast_call_name(node flat.Node) string {
 	return ''
 }
 
+// context_wants_pointer_to_fn reports whether the expression being generated is
+// consumed as a pointer to a function rather than as a callable value.
+fn (g &FlatGen) context_wants_pointer_to_fn() bool {
+	expected := cgen_unalias_type(g.expected_expr_type)
+	if expected is types.Pointer {
+		return cgen_unalias_type(expected.base_type) is types.FnType
+	}
+	return false
+}
+
 // gen_expr_with_possible_enum_type emits expr with possible enum type output for c.
 fn (mut g FlatGen) gen_expr_with_possible_enum_type(id flat.NodeId, expected types.Type) {
 	node := g.a.nodes[int(id)]
@@ -14496,9 +14506,14 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 		.prefix {
 			child_id := g.a.child(node, 0)
 			child := g.a.nodes[int(child_id)]
-			if node.op == .amp && cgen_unalias_type(g.usable_expr_type(child_id)) is types.FnType {
-				// Function values are already C pointers. Taking the address of a local
-				// function value would store a pointer to its stack slot instead.
+			if node.op == .amp && cgen_unalias_type(g.usable_expr_type(child_id)) is types.FnType
+				&& !g.context_wants_pointer_to_fn() {
+				// A function value is already a C pointer, so `&` on one is a no-op
+				// wherever the context wants a callable: `Holder{ f: &local }` has to
+				// store the function, not the address of a stack slot that dies with
+				// the frame. Only a context that asks for a pointer to a function
+				// - `ref := &f`, read back through `*ref` - needs the address, and
+				// dropping it there leaves the dereference reading code as data.
 				g.gen_expr(child_id)
 				return
 			}

--- a/vlib/v3/tests/fn_value_decl_type_test.v
+++ b/vlib/v3/tests/fn_value_decl_type_test.v
@@ -576,6 +576,25 @@ fn main() {
 	assert out == '7'
 }
 
+fn test_pointer_to_local_fn_value_round_trips_through_a_deref() {
+	v3_bin := build_v3()
+	// The mirror image of the case above: here the pointer *is* the point, so the
+	// `&` cannot be dropped - `*ref` would otherwise read the function's code as
+	// if it were a stored function pointer.
+	out := run_good(v3_bin, 'deref_of_address_of_local_fn_value', 'fn answer() int {
+	return 42
+}
+
+fn main() {
+	f := answer
+	ref := &f
+	deref := *ref
+	println(deref())
+}
+')
+	assert out == '42'
+}
+
 fn test_const_generic_fn_factory_value_call_uses_const_storage() {
 	v3_bin := build_v3()
 	out := run_good(v3_bin, 'const_generic_fn_factory_value_call', '


### PR DESCRIPTION
`vlib/v/tests/closure_with_fn_ref_var_test.v` crashes on master under V3 and passes under V1:

```
ref=0x10462eb40
a
deref=0x910003fda9b27bfd      <- garbage, then SIGBUS
```

V3 emitted the address-of as if it were not there:

```c
_fn_ptr_3cc4b7ed4d72750d f = f_a;
_fn_ptr_3cc4b7ed4d72750d* ref = f;      // `ref = &f` was wanted
_fn_ptr_3cc4b7ed4d72750d deref = *ref;
```

so `ref` held the function itself and `*ref` read its code as a stored pointer.

## Cause

cgen dropped `&` for **every** operand whose type is a function:

```v
if node.op == .amp && cgen_unalias_type(g.usable_expr_type(child_id)) is types.FnType {
	g.gen_expr(child_id)
	return
}
```

That is right in the case it was written for (#28327) — `Holder{ f: &local }`, where the field is a plain `fn (int) int`, has to store the callable, because a pointer to `local`'s stack slot dies with the frame. But a function value is already a C pointer only while the result is *consumed as a callable*. When the context asks for a pointer **to** a function, `&` carries the whole meaning.

I checked that this is what the rule protects rather than assuming: removing it outright fixes the closure test and breaks `fn_value_decl_type_test.v`'s `address_of_local_fn_value` case with a SIGSEGV.

## Change

Gate the elision on the consuming context: keep `&` when the expected type is a pointer whose base is a function, elide it otherwise. Neither the operand's own type nor the result type distinguishes the two — both are `fn (…)` and `&fn (…)` in either case; the expected type is `&fn () int` for `ref := &f` and `Holder` for `Holder{ f: &local }`.

## Testing

Both directions are now pinned in `fn_value_decl_type_test.v`, next to each other:
- the existing `address_of_local_fn_value` case fails if the elision is removed outright,
- the new `deref_of_address_of_local_fn_value` case fails (SIGBUS, exit 10) without this change and passes with it.

`vlib/v/tests/closure_with_fn_ref_var_test.v` goes from SIGBUS to passing.

Sweep of 132 files (`vlib/v/tests` slice + every `*fn*`/`*closure*`/`*anon*` test + `vlib/v/gen/c`): 128 pass, and the 4 failures are all pre-existing on clean master, verified with a compiler built from untouched `origin/master` — `autofree_discarded_call_return_value_test.v`, `autofree_labeled_continue_scope_test.v`, `generic_multi_return_interface_cast_test.v`, and `comptime_generic_comptime_variant_test.v` (a separate SIGSEGV crasher I have not touched).

`v test-cleancode`: 6434/6434.