### PR TITLE
make: install 0.5.2 release as V1 fallback

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,6 +7,7 @@ VROOT  ?= .
 VC     ?= ./vc
 VEXE   ?= ./v
 V1_FALLBACK_EXE = $(dir $(VEXE))v1_fallback$(EXE_EXT)
+V1_FALLBACK_INSTALLER = $(VROOT)/cmd/tools/install_v1_fallback.sh
 # Portable VC snapshots do not embed V3. Keep their v1 executable on the full
 # compatibility compiler path even when the generated C is built on a V3 host.
 VC_BOOTSTRAP_DEFINE := -DCUSTOM_DEFINE_v1_fallback
@@ -216,7 +217,7 @@ all: latest_vc latest_tcc latest_legacy
 ifdef WIN32
 	$(CC) $(CPPFLAGS) $(BOOTSTRAP_VC_CC_CFLAGS) $(VC_BOOTSTRAP_DEFINE) -std=c99 -municode -w -o v1$(EXE_EXT) $(VC)/$(VCFILE) $(LDFLAGS) -lws2_32 || cmd/tools/cc_compilation_failed_windows.sh
 	./v1$(EXE_EXT) -no-parallel -o v2$(EXE_EXT) $(BOOTSTRAP_GC_VFLAG) $(VFLAGS) $(BOOTSTRAP_VC_VFLAGS) cmd/v
-	./v1$(EXE_EXT) -no-parallel -d v1_fallback -o $(V1_FALLBACK_EXE) $(BOOTSTRAP_GC_VFLAG) $(VFLAGS) $(BOOTSTRAP_VC_VFLAGS) cmd/v
+	sh "$(V1_FALLBACK_INSTALLER)" "./v1$(EXE_EXT)" "$(V1_FALLBACK_EXE)"
 	./v2$(EXE_EXT) -o $(VEXE)$(EXE_EXT) $(BOOTSTRAP_GC_VFLAG) $(VFLAGS) $(BOOTSTRAP_VFLAGS) cmd/v
 	$(RM) v1$(EXE_EXT)
 	$(RM) v2$(EXE_EXT)
@@ -235,7 +236,7 @@ endif
 ifdef NETBSD
 	paxctl +m v2$(EXE_EXT)
 endif
-	./v1$(EXE_EXT) -no-parallel -d v1_fallback -o $(V1_FALLBACK_EXE) $(BOOTSTRAP_GC_VFLAG) $(VFLAGS) $(BOOTSTRAP_VC_VFLAGS) cmd/v
+	sh "$(V1_FALLBACK_INSTALLER)" "./v1$(EXE_EXT)" "$(V1_FALLBACK_EXE)"
 ifdef NETBSD
 	paxctl +m $(V1_FALLBACK_EXE)
 endif

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -217,7 +217,7 @@ all: latest_vc latest_tcc latest_legacy
 ifdef WIN32
 	$(CC) $(CPPFLAGS) $(BOOTSTRAP_VC_CC_CFLAGS) $(VC_BOOTSTRAP_DEFINE) -std=c99 -municode -w -o v1$(EXE_EXT) $(VC)/$(VCFILE) $(LDFLAGS) -lws2_32 || cmd/tools/cc_compilation_failed_windows.sh
 	./v1$(EXE_EXT) -no-parallel -o v2$(EXE_EXT) $(BOOTSTRAP_GC_VFLAG) $(VFLAGS) $(BOOTSTRAP_VC_VFLAGS) cmd/v
-	sh "$(V1_FALLBACK_INSTALLER)" "./v1$(EXE_EXT)" "$(V1_FALLBACK_EXE)"
+	CC="$(CC)" OLDV_CCOPTIONS="$(BOOTSTRAP_VC_CFLAGS)" OLDV_LDFLAGS="$(BOOTSTRAP_LDFLAGS)" sh "$(V1_FALLBACK_INSTALLER)" "./v1$(EXE_EXT)" "$(V1_FALLBACK_EXE)"
 	./v2$(EXE_EXT) -o $(VEXE)$(EXE_EXT) $(BOOTSTRAP_GC_VFLAG) $(VFLAGS) $(BOOTSTRAP_VFLAGS) cmd/v
 	$(RM) v1$(EXE_EXT)
 	$(RM) v2$(EXE_EXT)
@@ -236,7 +236,7 @@ endif
 ifdef NETBSD
 	paxctl +m v2$(EXE_EXT)
 endif
-	sh "$(V1_FALLBACK_INSTALLER)" "./v1$(EXE_EXT)" "$(V1_FALLBACK_EXE)"
+	CC="$(CC)" OLDV_CCOPTIONS="$(BOOTSTRAP_VC_CFLAGS)" OLDV_LDFLAGS="$(BOOTSTRAP_LDFLAGS)" sh "$(V1_FALLBACK_INSTALLER)" "./v1$(EXE_EXT)" "$(V1_FALLBACK_EXE)"
 ifdef NETBSD
 	paxctl +m $(V1_FALLBACK_EXE)
 endif

--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ v:
 	fi; \
 	set -- "$$@" cmd/v; \
 	"$$@"; \
-	sh ./cmd/tools/install_v1_fallback.sh ./v1 ./v1_fallback; \
+	CC="$(CC)" OLDV_CCOPTIONS="$$bootstrap_ccflags" OLDV_LDFLAGS="$$ldflags" sh ./cmd/tools/install_v1_fallback.sh ./v1 ./v1_fallback; \
 	set -- ./v2 -o v $$bootstrap_gcflags $(VFLAGS); \
 	if [ -n "$$bootstrap_ccompiler" ]; then \
 		set -- "$$@" -cc "$$bootstrap_ccompiler"; \

--- a/Makefile
+++ b/Makefile
@@ -125,18 +125,7 @@ v:
 	fi; \
 	set -- "$$@" cmd/v; \
 	"$$@"; \
-	set -- ./v1 -no-parallel -d v1_fallback -o v1_fallback $$bootstrap_gcflags $(VFLAGS); \
-	if [ -n "$$bootstrap_ccompiler" ]; then \
-		set -- "$$@" -cc "$$bootstrap_ccompiler"; \
-	fi; \
-	if [ -n "$$bootstrap_ccflags" ]; then \
-		set -- "$$@" -cflags "$$bootstrap_ccflags"; \
-	fi; \
-	if [ -n "$$ldflags" ]; then \
-		set -- "$$@" -ldflags "$$ldflags"; \
-	fi; \
-	set -- "$$@" cmd/v; \
-	"$$@"; \
+	sh ./cmd/tools/install_v1_fallback.sh ./v1 ./v1_fallback; \
 	set -- ./v2 -o v $$bootstrap_gcflags $(VFLAGS); \
 	if [ -n "$$bootstrap_ccompiler" ]; then \
 		set -- "$$@" -cc "$$bootstrap_ccompiler"; \

--- a/cmd/tools/install_v1_fallback.sh
+++ b/cmd/tools/install_v1_fallback.sh
@@ -1,0 +1,140 @@
+#!/bin/sh
+
+# Install the V 0.5.2 release compiler used by cmd/v as its V1 fallback.
+# If GitHub does not provide a binary for this host, or the binary cannot be
+# downloaded and verified, use the existing oldv tool to build the same tag.
+
+set -u
+
+release_version=0.5.2
+release_base_url=https://github.com/vlang/v/releases/download/$release_version
+
+if [ "$#" -ne 2 ]; then
+	echo "usage: $0 <bootstrap-v> <v1-fallback-output>" >&2
+	exit 2
+fi
+
+bootstrap_v=$1
+fallback_output=$2
+system=$(uname -s 2>/dev/null || echo unknown)
+architecture=$(uname -m 2>/dev/null || echo unknown)
+
+fallback_dir=$(dirname "$fallback_output")
+mkdir -p "$fallback_dir" || exit 1
+fallback_dir=$(cd "$fallback_dir" && pwd) || exit 1
+fallback_output=$fallback_dir/$(basename "$fallback_output")
+
+work_dir=$(mktemp -d "${TMPDIR:-/tmp}/v1-fallback.XXXXXX") || exit 1
+archive=$work_dir/release.zip
+candidate=$work_dir/v1_fallback
+trap 'rm -rf "$work_dir"' EXIT HUP INT TERM
+
+asset=
+member=v/v
+expected_sha256=
+case "$system:$architecture" in
+	Linux:x86_64|Linux:amd64)
+		asset=v_linux.zip
+		expected_sha256=86caf9e70c3342d48ef19eb4f6c47b709f18c90ae86255520d5c29df6b482e23
+		;;
+	Linux:arm64|Linux:aarch64)
+		asset=v_linux_arm64.zip
+		expected_sha256=7e102f0ecc722bc59fea83ab1c99ae49c2f7be8f30abee9443220e452a439ed3
+		;;
+	Darwin:arm64|Darwin:aarch64)
+		asset=v_macos_arm64.zip
+		expected_sha256=e539a8dc3aeea47267f3cf00c25c4f0a364d8037fb13f5379d2a574a7abac8ee
+		;;
+	Darwin:x86_64|Darwin:amd64)
+		asset=v_macos_x86_64.zip
+		expected_sha256=de19ef02874aec502f091b75e504e4836da38f627ddf7f7f9ecf6e8cf262f9d0
+		;;
+	MSYS*:x86_64|MSYS*:amd64|MINGW*:x86_64|MINGW*:amd64)
+		asset=v_windows.zip
+		member=v/v.exe
+		expected_sha256=5f1d619b6b04a2b54b4ad21826a25bdcba2acf75a941c8f72fc95672b6b064ca
+		;;
+esac
+
+sha256_of() {
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "$1" | awk '{print $1}'
+	elif command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 "$1" | awk '{print $1}'
+	elif command -v sha256 >/dev/null 2>&1; then
+		sha256 -q "$1"
+	elif command -v openssl >/dev/null 2>&1; then
+		openssl dgst -sha256 "$1" | awk '{print $NF}'
+	else
+		return 1
+	fi
+}
+
+download_release() {
+	[ -n "$asset" ] || return 1
+	url=${V1_FALLBACK_RELEASE_URL:-$release_base_url/$asset}
+	if command -v curl >/dev/null 2>&1; then
+		curl -fL --retry 2 --connect-timeout 15 -o "$archive" "$url" || return 1
+	elif command -v wget >/dev/null 2>&1; then
+		wget -O "$archive" "$url" || return 1
+	else
+		return 1
+	fi
+	actual_sha256=$(sha256_of "$archive") || return 1
+	if [ "$actual_sha256" != "${V1_FALLBACK_RELEASE_SHA256:-$expected_sha256}" ]; then
+		echo "V $release_version fallback archive checksum mismatch" >&2
+		return 1
+	fi
+	if command -v unzip >/dev/null 2>&1; then
+		unzip -p "$archive" "$member" > "$candidate" || return 1
+	elif command -v bsdtar >/dev/null 2>&1; then
+		bsdtar -xOf "$archive" "$member" > "$candidate" || return 1
+	elif command -v tar >/dev/null 2>&1; then
+		tar -xOf "$archive" "$member" > "$candidate" || return 1
+	else
+		return 1
+	fi
+	chmod +x "$candidate" || return 1
+}
+
+build_with_oldv() {
+	echo "Building the V $release_version fallback with oldv..."
+	oldv_target=$candidate
+	oldv_copy='cp ./v "$V1_FALLBACK_TARGET"'
+	case "$system" in
+		MSYS*|MINGW*)
+			oldv_copy='copy /Y .\v.exe "%V1_FALLBACK_TARGET%" >NUL'
+			if command -v cygpath >/dev/null 2>&1; then
+				oldv_target=$(cygpath -w "$candidate")
+			fi
+			;;
+	esac
+	V1_FALLBACK_TARGET=$oldv_target "$bootstrap_v" -no-parallel -gc none run \
+		cmd/tools/oldv.v --command "$oldv_copy" "$release_version" || return 1
+	chmod +x "$candidate" || return 1
+}
+
+if download_release; then
+	echo "Installed the V $release_version release fallback from $asset"
+else
+	echo "Could not install a V $release_version release asset for $system/$architecture." >&2
+	build_with_oldv || {
+		echo "Could not build the V $release_version fallback with oldv." >&2
+		exit 1
+	}
+fi
+
+fallback_version=$("$candidate" version 2>/dev/null) || {
+	echo "The staged V1 fallback is not executable." >&2
+	exit 1
+}
+case "$fallback_version" in
+	"V $release_version "*) ;;
+	*)
+		echo "Expected V $release_version fallback, got: $fallback_version" >&2
+		exit 1
+		;;
+esac
+
+rm -f "$fallback_output"
+mv "$candidate" "$fallback_output" || exit 1

--- a/cmd/tools/install_v1_fallback.sh
+++ b/cmd/tools/install_v1_fallback.sh
@@ -70,6 +70,14 @@ sha256_of() {
 	fi
 }
 
+candidate_has_expected_version() {
+	candidate_version=$("$candidate" version 2>/dev/null) || return 1
+	case "$candidate_version" in
+		"V $release_version "*) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
 download_release() {
 	[ -n "$asset" ] || return 1
 	url=${V1_FALLBACK_RELEASE_URL:-$release_base_url/$asset}
@@ -95,6 +103,10 @@ download_release() {
 		return 1
 	fi
 	chmod +x "$candidate" || return 1
+	candidate_has_expected_version || {
+		echo "The V $release_version release fallback cannot run on this host." >&2
+		return 1
+	}
 }
 
 build_with_oldv() {
@@ -110,7 +122,7 @@ build_with_oldv() {
 			;;
 	esac
 	V1_FALLBACK_TARGET=$oldv_target "$bootstrap_v" -no-parallel -gc none run \
-		cmd/tools/oldv.v --command "$oldv_copy" "$release_version" || return 1
+		cmd/tools/oldv.v --cache=false --command "$oldv_copy" "$release_version" || return 1
 	chmod +x "$candidate" || return 1
 }
 
@@ -124,17 +136,14 @@ else
 	}
 fi
 
-fallback_version=$("$candidate" version 2>/dev/null) || {
-	echo "The staged V1 fallback is not executable." >&2
+candidate_has_expected_version || {
+	if [ -n "${candidate_version:-}" ]; then
+		echo "Expected V $release_version fallback, got: $candidate_version" >&2
+	else
+		echo "The staged V1 fallback is not executable." >&2
+	fi
 	exit 1
 }
-case "$fallback_version" in
-	"V $release_version "*) ;;
-	*)
-		echo "Expected V $release_version fallback, got: $fallback_version" >&2
-		exit 1
-		;;
-esac
 
 rm -f "$fallback_output"
 mv "$candidate" "$fallback_output" || exit 1

--- a/cmd/tools/modules/vgit/vgit.v
+++ b/cmd/tools/modules/vgit/vgit.v
@@ -86,8 +86,7 @@ pub fn prepare_vc_source(vcdir string, cdir string, commit string) (string, stri
 	if vcbefore_subject_match.len > 3 {
 		_, vccommit = line_to_timestamp_and_commit(vcbefore_subject_match)
 	} else {
-		scripting.verbose_trace(@FN,
-			'the v commit did not match anything in the vc log; try --timestamp instead.')
+		scripting.verbose_trace(@FN, 'the v commit did not match anything in the vc log; try --timestamp instead.')
 		vcbefore := scripting.run('git rev-list HEAD -n1 --timestamp --before=${v_timestamp} ')
 		_, vccommit = line_to_timestamp_and_commit(vcbefore)
 	}
@@ -152,7 +151,8 @@ pub struct VGitContext {
 pub:
 	cc          string = 'cc' // what C compiler to use for bootstrapping
 	cc_options  string // what additional C compiler options to use for bootstrapping
-	workdir     string = '/tmp'   // the base working folder
+	cc_ldflags  string // what additional linker options to use for bootstrapping
+	workdir     string = '/tmp' // the base working folder
 	commit_v    string = 'master' // the commit-ish that needs to be prepared
 	path_v      string // where is the local working copy v repo
 	path_vc     string // where is the local working copy vc repo
@@ -162,18 +162,17 @@ pub mut:
 	// these will be filled by vgitcontext.compile_oldv_if_needed()
 	commit_v__hash string // the git commit of the v repo that should be prepared
 	commit_vc_hash string // the git commit of the vc repo, corresponding to commit_v__hash
-	commit_v__ts   u64    // unix timestamp, that corresponds to commit_v__hash; filled by prepare_vc_source
+	commit_v__ts   u64 // unix timestamp, that corresponds to commit_v__hash; filled by prepare_vc_source
 	vexename       string // v or v.exe
 	vexepath       string // the full absolute path to the prepared v/v.exe
 	vvlocation     string // v.v or compiler/ or cmd/v, depending on v version
-	make_fresh_tcc bool   // whether to do 'make fresh_tcc' before compiling an old V.
-	show_vccommit  bool   // show the V and VC commits, corresponding to the V commit-ish, that can be used to build V
+	make_fresh_tcc bool // whether to do 'make fresh_tcc' before compiling an old V.
+	show_vccommit  bool // show the V and VC commits, corresponding to the V commit-ish, that can be used to build V
 }
 
 pub fn (mut vgit_context VGitContext) compile_oldv_if_needed() {
 	vgit_context.vexename = if os.user_os() == 'windows' { 'v.exe' } else { 'v' }
-	vgit_context.vexepath = os.real_path(os.join_path_single(vgit_context.path_v,
-		vgit_context.vexename))
+	vgit_context.vexepath = os.real_path(os.join_path_single(vgit_context.path_v, vgit_context.vexename))
 	if os.is_dir(vgit_context.path_v) && os.is_executable(vgit_context.vexepath)
 		&& !vgit_context.show_vccommit {
 		// already compiled, no need to compile that specific v executable again
@@ -193,8 +192,7 @@ pub fn (mut vgit_context VGitContext) compile_oldv_if_needed() {
 		vgit_context.commit_v__hash = get_current_folder_commit_hash()
 		return
 	}
-	v_commithash, vccommit_before, v_timestamp := prepare_vc_source(vgit_context.path_vc,
-		vgit_context.path_v, 'HEAD')
+	v_commithash, vccommit_before, v_timestamp := prepare_vc_source(vgit_context.path_vc, vgit_context.path_v, 'HEAD')
 	vgit_context.commit_v__hash = v_commithash
 	vgit_context.commit_v__ts = v_timestamp
 	vgit_context.commit_vc_hash = vccommit_before
@@ -256,15 +254,21 @@ pub fn (mut vgit_context VGitContext) compile_oldv_if_needed() {
 		if vgit_context.commit_v__ts >= 1699341818 && !vgit_context.cc.contains('msvc') {
 			c_flags += '-lws2_32'
 		}
-		command_for_building_v_from_c_source = c(vgit_context.cc,
-			'${vc_v_cpermissive_flags} ${c_flags} -o cv.exe "${vc_source_file_location}" ${c_ldflags}')
-		command_for_selfbuilding = c('.\\cv.exe',
-			'${vc_v_bootstrap_flags} -cflags "${vc_v_cpermissive_flags}" -o ${vgit_context.vexename} {SOURCE}')
+		c_ldflags = vgit_context.cc_ldflags
 	} else {
-		command_for_building_v_from_c_source = c(vgit_context.cc,
-			'${vc_v_cpermissive_flags} ${c_flags} -o cv "${vc_source_file_location}" ${c_ldflags}')
-		command_for_selfbuilding = c('./cv',
-			'${vc_v_bootstrap_flags} -cflags "${vc_v_cpermissive_flags}" -o ${vgit_context.vexename} {SOURCE}')
+		c_ldflags = '${c_ldflags} ${vgit_context.cc_ldflags}'.trim_space()
+	}
+	selfbuild_ldflags := if vgit_context.cc_ldflags == '' {
+		''
+	} else {
+		'-ldflags "${vgit_context.cc_ldflags}"'
+	}
+	if 'windows' == os.user_os() {
+		command_for_building_v_from_c_source = c(vgit_context.cc, '${vc_v_cpermissive_flags} ${c_flags} -o cv.exe "${vc_source_file_location}" ${c_ldflags}')
+		command_for_selfbuilding = c('.\\cv.exe', '${vc_v_bootstrap_flags} -cflags "${vc_v_cpermissive_flags}" ${selfbuild_ldflags} -o ${vgit_context.vexename} {SOURCE}')
+	} else {
+		command_for_building_v_from_c_source = c(vgit_context.cc, '${vc_v_cpermissive_flags} ${c_flags} -o cv "${vc_source_file_location}" ${c_ldflags}')
+		command_for_selfbuilding = c('./cv', '${vc_v_bootstrap_flags} -cflags "${vc_v_cpermissive_flags}" ${selfbuild_ldflags} -o ${vgit_context.vexename} {SOURCE}')
 	}
 
 	scripting.run(command_for_building_v_from_c_source)
@@ -284,15 +288,13 @@ pub mut:
 	workdir     string = os.temp_dir() // the working folder (typically /tmp), where the tool will write
 	v_repo_url  string // the url of the V repository. It can be a local folder path, if you want to eliminate network operations...
 	vc_repo_url string // the url of the vc repository. It can be a local folder path, if you want to eliminate network operations...
-	show_help   bool   // whether to show the usage screen
-	verbose     bool   // should the tool be much more verbose
+	show_help   bool // whether to show the usage screen
+	verbose     bool // should the tool be much more verbose
 }
 
 pub fn add_common_tool_options(mut context VGitOptions, mut fp flag.FlagParser) []string {
-	context.workdir = os.real_path(fp.string('workdir', `w`, context.workdir,
-		'A writable base folder. Default: ${context.workdir}'))
-	context.v_repo_url = fp.string('vrepo', 0, context.v_repo_url,
-		'The url of the V repository. You can clone it locally too. See also --vcrepo below.')
+	context.workdir = os.real_path(fp.string('workdir', `w`, context.workdir, 'A writable base folder. Default: ${context.workdir}'))
+	context.v_repo_url = fp.string('vrepo', 0, context.v_repo_url, 'The url of the V repository. You can clone it locally too. See also --vcrepo below.')
 	context.vc_repo_url = fp.string('vcrepo', 0, context.vc_repo_url, 'The url of the vc repository. You can clone it
 ${flag.space}beforehand, and then just give the local folder
 ${flag.space}path here. That will eliminate the network ops

--- a/cmd/tools/oldv.v
+++ b/cmd/tools/oldv.v
@@ -41,6 +41,7 @@ mut:
 	show_vccommit bool // show the V and VC commits, corresponding to the V commit-ish, that can be used to build V
 	cc            string = 'cc' // the C compiler to use for bootstrapping.
 	cc_options    string // additional options to pass to the C compiler while bootstrapping.
+	cc_ldflags    string // additional linker options to use while bootstrapping.
 }
 
 fn (mut c Context) compile_oldv_if_needed() {
@@ -50,6 +51,7 @@ fn (mut c Context) compile_oldv_if_needed() {
 		vc_repo_url: c.vgo.vc_repo_url
 		cc: c.cc
 		cc_options: c.cc_options
+		cc_ldflags: c.cc_ldflags
 		commit_v: c.commit_v
 		path_v: c.path_v
 		path_vc: c.path_vc
@@ -90,14 +92,14 @@ fn sync_cache() {
 	scripting.verbose_trace(@FN, 'done')
 }
 
-fn oldv_required_tools(use_cache bool) []string {
+fn oldv_required_tools(use_cache bool, cc string) []string {
 	mut tools := ['git', 'wc', 'make']
 	if os.user_os() == 'windows' {
 		if use_cache {
 			tools << 'robocopy'
 		}
 	} else {
-		tools << 'cc'
+		tools << cc
 		if use_cache {
 			tools << 'rsync'
 		}
@@ -127,13 +129,22 @@ fn main() {
 		context.vgo.v_repo_url = 'https://github.com/vlang/v'
 		context.vgo.vc_repo_url = 'https://github.com/vlang/vc'
 	}
-	scripting.used_tools_must_exist(oldv_required_tools(context.use_cache))
 	context.cc = fp.string('cc', 0, 'cc', 'Use this C compiler for bootstrapping v.c (defaults to `cc`).')
 	context.cc_options = fp.string('ccoptions', 0, '', 'Use these C compiler options for bootstrapping v.c (defaults to ``).')
+	context.cc_ldflags = fp.string('ldflags', 0, '', 'Use these linker options while bootstrapping (defaults to ``).')
+	env_cc := os.getenv('CC')
+	if env_cc != '' {
+		context.cc = env_cc
+	}
 	env_cc_options := os.getenv('OLDV_CCOPTIONS')
 	if env_cc_options != '' {
 		context.cc_options = env_cc_options
 	}
+	env_ldflags := os.getenv('OLDV_LDFLAGS')
+	if env_ldflags != '' {
+		context.cc_ldflags = env_ldflags
+	}
+	scripting.used_tools_must_exist(oldv_required_tools(context.use_cache, context.cc))
 	context.cleanup = fp.bool('clean', 0, false, 'Clean before running (slower).')
 	context.fresh_tcc = fp.bool('fresh_tcc', 0, true, 'Do `make fresh_tcc` when preparing a V compiler.')
 	context.cmd_to_run = fp.string('command', `c`, '', 'Command to run in the old V repo.\n')
@@ -174,10 +185,6 @@ fn main() {
 	if !os.is_dir(context.vgo.workdir) {
 		eprintln('Work folder: ${context.vgo.workdir} , does not exist.')
 		exit(2)
-	}
-	ecc := os.getenv('CC')
-	if ecc != '' {
-		context.cc = ecc
 	}
 	if context.cleanup {
 		scripting.rmrf(context.path_v)

--- a/cmd/tools/oldv.v
+++ b/cmd/tools/oldv.v
@@ -34,27 +34,27 @@ mut:
 	path_v        string // the full path to the v folder inside workdir.
 	path_vc       string // the full path to the vc folder inside workdir.
 	cmd_to_run    string // the command that you want to run *in* the oldv repo
-	cleanup       bool   // should the tool run a cleanup first
-	use_cache     bool   // use local cached copies for --vrepo and --vcrepo in
-	fresh_tcc     bool   // do use `make fresh_tcc`
-	is_bisect     bool   // bisect mode; usage: `cmd/tools/oldv -b -c './v run bug.v'`
-	show_vccommit bool   // show the V and VC commits, corresponding to the V commit-ish, that can be used to build V
+	cleanup       bool // should the tool run a cleanup first
+	use_cache     bool // use local cached copies for --vrepo and --vcrepo in
+	fresh_tcc     bool // do use `make fresh_tcc`
+	is_bisect     bool // bisect mode; usage: `cmd/tools/oldv -b -c './v run bug.v'`
+	show_vccommit bool // show the V and VC commits, corresponding to the V commit-ish, that can be used to build V
 	cc            string = 'cc' // the C compiler to use for bootstrapping.
 	cc_options    string // additional options to pass to the C compiler while bootstrapping.
 }
 
 fn (mut c Context) compile_oldv_if_needed() {
 	c.vgcontext = vgit.VGitContext{
-		workdir:        c.vgo.workdir
-		v_repo_url:     c.vgo.v_repo_url
-		vc_repo_url:    c.vgo.vc_repo_url
-		cc:             c.cc
-		cc_options:     c.cc_options
-		commit_v:       c.commit_v
-		path_v:         c.path_v
-		path_vc:        c.path_vc
+		workdir: c.vgo.workdir
+		v_repo_url: c.vgo.v_repo_url
+		vc_repo_url: c.vgo.vc_repo_url
+		cc: c.cc
+		cc_options: c.cc_options
+		commit_v: c.commit_v
+		path_v: c.path_v
+		path_vc: c.path_vc
 		make_fresh_tcc: c.fresh_tcc
-		show_vccommit:  c.show_vccommit
+		show_vccommit: c.show_vccommit
 	}
 	c.vgcontext.compile_oldv_if_needed()
 	c.commit_v_hash = c.vgcontext.commit_v__hash
@@ -90,13 +90,22 @@ fn sync_cache() {
 	scripting.verbose_trace(@FN, 'done')
 }
 
-fn main() {
+fn oldv_required_tools(use_cache bool) []string {
+	mut tools := ['git', 'wc', 'make']
 	if os.user_os() == 'windows' {
-		scripting.used_tools_must_exist(['git', 'wc', 'make', 'robocopy'])
+		if use_cache {
+			tools << 'robocopy'
+		}
 	} else {
-		scripting.used_tools_must_exist(['git', 'wc', 'make', 'rsync', 'cc'])
+		tools << 'cc'
+		if use_cache {
+			tools << 'rsync'
+		}
 	}
+	return tools
+}
 
+fn main() {
 	// Resetting VEXE here allows for `v run cmd/tools/oldv.v'.
 	// the parent V would have set VEXE, which later will
 	// affect the V's run from the tool itself.
@@ -110,8 +119,7 @@ fn main() {
 	fp.description(tool_description)
 	fp.arguments_description('VCOMMIT')
 	fp.skip_executable()
-	context.use_cache = fp.bool('cache', `u`, true,
-		'Use a cache of local repositories for --vrepo and --vcrepo in \$HOME/.cache/oldv/')
+	context.use_cache = fp.bool('cache', `u`, true, 'Use a cache of local repositories for --vrepo and --vcrepo in \$HOME/.cache/oldv/')
 	if context.use_cache {
 		context.vgo.v_repo_url = cache_oldv_folder_v
 		context.vgo.vc_repo_url = cache_oldv_folder_vc
@@ -119,22 +127,18 @@ fn main() {
 		context.vgo.v_repo_url = 'https://github.com/vlang/v'
 		context.vgo.vc_repo_url = 'https://github.com/vlang/vc'
 	}
-	context.cc = fp.string('cc', 0, 'cc',
-		'Use this C compiler for bootstrapping v.c (defaults to `cc`).')
-	context.cc_options = fp.string('ccoptions', 0, '',
-		'Use these C compiler options for bootstrapping v.c (defaults to ``).')
+	scripting.used_tools_must_exist(oldv_required_tools(context.use_cache))
+	context.cc = fp.string('cc', 0, 'cc', 'Use this C compiler for bootstrapping v.c (defaults to `cc`).')
+	context.cc_options = fp.string('ccoptions', 0, '', 'Use these C compiler options for bootstrapping v.c (defaults to ``).')
 	env_cc_options := os.getenv('OLDV_CCOPTIONS')
 	if env_cc_options != '' {
 		context.cc_options = env_cc_options
 	}
 	context.cleanup = fp.bool('clean', 0, false, 'Clean before running (slower).')
-	context.fresh_tcc = fp.bool('fresh_tcc', 0, true,
-		'Do `make fresh_tcc` when preparing a V compiler.')
+	context.fresh_tcc = fp.bool('fresh_tcc', 0, true, 'Do `make fresh_tcc` when preparing a V compiler.')
 	context.cmd_to_run = fp.string('command', `c`, '', 'Command to run in the old V repo.\n')
-	context.show_vccommit = fp.bool('show_VC_commit', 0, false,
-		'Show the VC commit, that can be used to compile the given V commit, and exit.\n')
-	context.is_bisect = fp.bool('bisect', `b`, false,
-		'Bisect mode. Use the current commit in the repo where oldv is.')
+	context.show_vccommit = fp.bool('show_VC_commit', 0, false, 'Show the VC commit, that can be used to compile the given V commit, and exit.\n')
+	context.is_bisect = fp.bool('bisect', `b`, false, 'Bisect mode. Use the current commit in the repo where oldv is.')
 
 	should_sync := fp.bool('cache-sync', `s`, false, 'Update the local cache')
 	if !should_sync && !context.is_bisect {

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -137,16 +137,27 @@ fn test_netbsd_marks_the_v1_compatibility_compiler() {
 fn test_gnumake_builds_the_v1_fallback_executable_for_every_native_host() {
 	source := os.read_file(os.join_path(macos_v3_test_vroot, 'GNUmakefile'))!
 	assert source.contains('V1_FALLBACK_EXE = \$(dir \$(VEXE))v1_fallback\$(EXE_EXT)')
-	fallback_build := './v1\$(EXE_EXT) -no-parallel -d v1_fallback -o \$(V1_FALLBACK_EXE)'
-	assert source.count(fallback_build) == 2
-	assert !source.contains('V1_FALLBACK_BUILD')
+	installer := 'sh "\$(V1_FALLBACK_INSTALLER)" "./v1\$(EXE_EXT)" "\$(V1_FALLBACK_EXE)"'
+	assert source.count(installer) == 2
+	assert !source.contains('-d v1_fallback -o \$(V1_FALLBACK_EXE)')
 }
 
 fn test_portable_make_builds_the_v1_fallback_executable_for_every_native_host() {
 	source := os.read_file(os.join_path(macos_v3_test_vroot, 'Makefile'))!
-	fallback_build := 'set -- ./v1 -no-parallel -d v1_fallback -o v1_fallback'
-	assert source.count(fallback_build) == 1
-	assert !source.contains('rm -f v1_fallback')
+	assert source.count('sh ./cmd/tools/install_v1_fallback.sh ./v1 ./v1_fallback') == 1
+	assert !source.contains('set -- ./v1 -no-parallel -d v1_fallback -o v1_fallback')
+}
+
+fn test_v1_fallback_installer_downloads_0_5_2_and_uses_oldv_on_failure() {
+	source := os.read_file(os.join_path(macos_v3_test_vroot, 'cmd', 'tools', 'install_v1_fallback.sh'))!
+	assert source.contains('release_version=0.5.2')
+	assert source.contains('https://github.com/vlang/v/releases/download/\$release_version')
+	for asset in ['v_linux.zip', 'v_linux_arm64.zip', 'v_macos_arm64.zip', 'v_macos_x86_64.zip',
+		'v_windows.zip'] {
+		assert source.contains('asset=${asset}'), asset
+	}
+	assert source.contains('cmd/tools/oldv.v --command "\$oldv_copy" "\$release_version"')
+	assert source.contains('actual_sha256=\$(sha256_of "\$archive")')
 }
 
 fn test_windows_makev_builds_the_v1_fallback_executable() {
@@ -164,19 +175,14 @@ fn test_windows_makev_builds_the_v1_fallback_executable() {
 	assert normalized.count('call :move_updated_to_v\nif !ERRORLEVEL! NEQ 0 goto :compile_error') == 5
 }
 
-fn test_v1_fallback_can_bootstrap_cmd_v_without_target_define() {
+fn test_v1_fallback_reports_the_requested_release_version() {
 	fallback := macos_v3_v1_fallback_executable()
 	if !os.is_executable(fallback) {
 		return
 	}
-	compiler := os.join_path(os.vtmp_dir(), 'v1_bootstrap_cmd_v_${os.getpid()}')
-	defer {
-		os.rm(compiler) or {}
-	}
-	result := run_macos_v3_test_process(fallback, ['-no-parallel', '-nocache', '-gc', 'none', '-o',
-		compiler, 'cmd/v'], macos_v3_test_vroot, {})
+	result := os.execute('${os.quoted_path(fallback)} version')
 	assert result.exit_code == 0, result.output
-	assert os.is_executable(compiler)
+	assert result.output.starts_with('V 0.5.2 '), result.output
 }
 
 fn test_macos_v3_old_compiler_uses_external_v1_command() {

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -139,12 +139,15 @@ fn test_gnumake_builds_the_v1_fallback_executable_for_every_native_host() {
 	assert source.contains('V1_FALLBACK_EXE = \$(dir \$(VEXE))v1_fallback\$(EXE_EXT)')
 	installer := 'sh "\$(V1_FALLBACK_INSTALLER)" "./v1\$(EXE_EXT)" "\$(V1_FALLBACK_EXE)"'
 	assert source.count(installer) == 2
+	oldv_environment := 'CC="\$(CC)" OLDV_CCOPTIONS="\$(BOOTSTRAP_VC_CFLAGS)" OLDV_LDFLAGS="\$(BOOTSTRAP_LDFLAGS)"'
+	assert source.count(oldv_environment) == 2
 	assert !source.contains('-d v1_fallback -o \$(V1_FALLBACK_EXE)')
 }
 
 fn test_portable_make_builds_the_v1_fallback_executable_for_every_native_host() {
 	source := os.read_file(os.join_path(macos_v3_test_vroot, 'Makefile'))!
 	assert source.count('sh ./cmd/tools/install_v1_fallback.sh ./v1 ./v1_fallback') == 1
+	assert source.contains('CC="\$(CC)" OLDV_CCOPTIONS="\$\$bootstrap_ccflags" OLDV_LDFLAGS="\$\$ldflags"')
 	assert !source.contains('set -- ./v1 -no-parallel -d v1_fallback -o v1_fallback')
 }
 
@@ -161,7 +164,12 @@ fn test_v1_fallback_installer_downloads_0_5_2_and_uses_oldv_on_failure() {
 	assert source.contains('actual_sha256=\$(sha256_of "\$archive")')
 	oldv_source := os.read_file(os.join_path(macos_v3_test_vroot, 'cmd', 'tools', 'oldv.v'))!
 	assert oldv_source.contains("if use_cache {\n\t\t\ttools << 'rsync'")
-	assert oldv_source.contains('oldv_required_tools(context.use_cache)')
+	assert oldv_source.contains('oldv_required_tools(context.use_cache, context.cc)')
+	assert oldv_source.contains('tools << cc')
+	assert oldv_source.contains("env_ldflags := os.getenv('OLDV_LDFLAGS')")
+	vgit_source := os.read_file(os.join_path(macos_v3_test_vroot, 'cmd', 'tools', 'modules', 'vgit', 'vgit.v'))!
+	assert vgit_source.contains("c_ldflags = '\${c_ldflags} \${vgit_context.cc_ldflags}'.trim_space()")
+	assert vgit_source.contains('\'-ldflags "\${vgit_context.cc_ldflags}"\'')
 }
 
 fn test_windows_makev_builds_the_v1_fallback_executable() {

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -156,8 +156,12 @@ fn test_v1_fallback_installer_downloads_0_5_2_and_uses_oldv_on_failure() {
 		'v_windows.zip'] {
 		assert source.contains('asset=${asset}'), asset
 	}
-	assert source.contains('cmd/tools/oldv.v --command "\$oldv_copy" "\$release_version"')
+	assert source.contains('candidate_has_expected_version || {')
+	assert source.contains('cmd/tools/oldv.v --cache=false --command "\$oldv_copy" "\$release_version"')
 	assert source.contains('actual_sha256=\$(sha256_of "\$archive")')
+	oldv_source := os.read_file(os.join_path(macos_v3_test_vroot, 'cmd', 'tools', 'oldv.v'))!
+	assert oldv_source.contains("if use_cache {\n\t\t\ttools << 'rsync'")
+	assert oldv_source.contains('oldv_required_tools(context.use_cache)')
 }
 
 fn test_windows_makev_builds_the_v1_fallback_executable() {

--- a/doc/docs.md
+++ b/doc/docs.md
@@ -81,8 +81,10 @@ build, including compiler self-builds, is compiled by V3 in-process. The CLI and
 tool commands remain in `cmd/v`; commands such as `test` and `fmt` are external
 tools, and non-C backends remain separate builder tools.
 
-The standard bootstrap builds a sibling `v1_fallback` executable
-(`v1_fallback.exe` on Windows). `-old-compiler` launches it explicitly, and
+The standard bootstrap installs the V 0.5.2 release compiler as the sibling
+`v1_fallback` executable (`v1_fallback.exe` on Windows). It downloads and
+verifies the matching GitHub release asset, or builds the tag with `oldv` when
+the asset is unavailable. `-old-compiler` launches it explicitly, and
 ordinary user builds retry through it after a V3 compiler or C compilation
 failure. Explicit `-new-compiler` builds and native compiler self-builds remain
 strict V3 operations, except for `-new-compiler -cc msvc` on Windows. V3 does

--- a/vlib/v3/README.md
+++ b/vlib/v3/README.md
@@ -44,11 +44,13 @@ Commands such as `test` remain external tools, while each discovered test file i
 Non-C backends remain separate builder tools.
 
 `-new-compiler` remains accepted for command-line compatibility and normally selects the same
-in-process V3 driver. The standard bootstrap also builds `v1_fallback` (`v1_fallback.exe` on
-Windows) beside `v`; `-old-compiler` launches it explicitly, and ordinary user builds retry through
-it after a V3 compiler or C compilation failure. A separately built V3-only executable without
-that sibling cannot use the fallback. On portable cross-VC builds, the V3 driver is not embedded
-and `cmd/v` retains the established compiler.
+in-process V3 driver. The standard bootstrap also installs the V 0.5.2 release compiler as
+`v1_fallback` (`v1_fallback.exe` on Windows) beside `v`; it verifies a matching GitHub release
+asset, or builds the tag with `oldv` when no asset can be installed. `-old-compiler` launches it
+explicitly, and ordinary user builds retry through it after a V3 compiler or C compilation
+failure. A separately built V3-only executable without that sibling cannot use the fallback. On
+portable cross-VC builds, the V3 driver is not embedded and `cmd/v` retains the established
+compiler.
 
 The in-process path supports the split module cache and uses parallel stages while the input
 remains within its scratch-memory safety limit.


### PR DESCRIPTION
Summary:
- replace the source-built V1 fallback in GNUmakefile and the portable Makefile with verified V 0.5.2 release assets
- support Linux x86_64/arm64, macOS x86_64/arm64, and Windows x86_64 downloads
- build tag 0.5.2 through oldv when no release asset can be downloaded, verified, or extracted
- update bootstrap documentation and coverage expectations

Testing:
- not run after final changes (per request)