### PR TITLE
v3: restore the V1 bootstrap build of the transform worker scopes

### DIFF
--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -4457,6 +4457,19 @@ fn transform_scope_owns(scope voidptr, ptr voidptr) bool {
 	return false
 }
 
+// transform_scope_address_range returns the union address range of the blocks
+// owned by `scope`, so callers can reject most pointers before the per-block
+// search in transform_scope_owns.
+fn transform_scope_address_range(scope voidptr) (usize, usize) {
+	$if prealloc {
+		unsafe {
+			lo, hi := prealloc_scope_address_range(scope)
+			return lo, hi
+		}
+	}
+	return 0, 0
+}
+
 // clone_scoped_worker_node publishes a node's owned fields through the
 // compilation text table before its helper arena is released.
 fn (mut t Transformer) clone_scoped_worker_node(idx int, scope voidptr) {

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -204,11 +204,7 @@ $if !windows {
 	// the arenas together with the preparation arena.
 	fn transform_pre_scan_index_thread(arg voidptr) voidptr {
 		mut t := unsafe { &Transformer(arg) }
-		scope := if t.retain_prescan_scopes {
-			transform_worker_scope_begin(true)
-		} else {
-			unsafe { nil }
-		}
+		scope := transform_worker_scope_begin(t.retain_prescan_scopes)
 		t.build_source_parent_index()
 		t.collect_multi_return_fn_ret_types()
 		t.rebuild_variadic_suffix_index()
@@ -236,11 +232,7 @@ $if !windows {
 	// caches and publishes only its completed declaration maps after joining.
 	fn transform_param_prep_thread(arg voidptr) voidptr {
 		mut w := unsafe { &Transformer(arg) }
-		scope := if w.retain_prescan_scopes {
-			transform_worker_scope_begin(true)
-		} else {
-			unsafe { nil }
-		}
+		scope := transform_worker_scope_begin(w.retain_prescan_scopes)
 		w.prepare_parallel_call_param_types()
 		transform_worker_scope_leave(scope)
 		return scope
@@ -343,7 +335,7 @@ fn scopes_address_range(scopes []voidptr) (usize, usize) {
 	mut hi := usize(0)
 	$if prealloc {
 		for scope in scopes {
-			scope_lo, scope_hi := unsafe { prealloc_scope_address_range(scope) }
+			scope_lo, scope_hi := transform_scope_address_range(scope)
 			if scope_hi <= scope_lo {
 				continue
 			}


### PR DESCRIPTION
Commit 4089ece6a4 made the clean bootstrap fail when the temporary V1 compiler
from the 0.5.2-era `vc` snapshot compiled the current V3 transform sources.
V1 types the conditional `voidptr` initializer as `void` and loses the two
return values from the direct unsafe address-range call.

Pass the existing enable flag directly to the scope helper and isolate the
unsafe multi-return call behind a typed wrapper. Runtime behavior stays the
same, while the old bootstrap checker can type both forms correctly.

Validation:

- `make clean && make`
- strict V3 `-prealloc` build of `cmd/v`
- second strict V3 `-prealloc` self-host build
- `vlib/v3/transform/fn_test.v` under strict V3
