### PR TITLE
make: keep parallel V3 sources out of V1 bootstrap

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -11,6 +11,8 @@ V1_FALLBACK_INSTALLER = $(VROOT)/cmd/tools/install_v1_fallback.sh
 # Portable VC snapshots do not embed V3. Keep their v1 executable on the full
 # compatibility compiler path even when the generated C is built on a V3 host.
 VC_BOOTSTRAP_DEFINE := -DCUSTOM_DEFINE_v1_fallback
+# V1 only builds a serial V3 seed; that V3 stage builds the full compiler.
+BOOTSTRAP_V3_SEED_VFLAG := -d v3_no_parallel
 VCREPO ?= https://github.com/vlang/vc
 TCCREPO ?= https://github.com/vlang/tccbin
 LEGACYREPO ?= https://github.com/macports/macports-legacy-support
@@ -216,7 +218,7 @@ BOOTSTRAP_VFLAGS := $(BOOTSTRAP_CCOMPILER_VFLAG) $(if $(strip $(BOOTSTRAP_CFLAGS
 all: latest_vc latest_tcc latest_legacy
 ifdef WIN32
 	$(CC) $(CPPFLAGS) $(BOOTSTRAP_VC_CC_CFLAGS) $(VC_BOOTSTRAP_DEFINE) -std=c99 -municode -w -o v1$(EXE_EXT) $(VC)/$(VCFILE) $(LDFLAGS) -lws2_32 || cmd/tools/cc_compilation_failed_windows.sh
-	./v1$(EXE_EXT) -no-parallel -o v2$(EXE_EXT) $(BOOTSTRAP_GC_VFLAG) $(VFLAGS) $(BOOTSTRAP_VC_VFLAGS) cmd/v
+	./v1$(EXE_EXT) -no-parallel $(BOOTSTRAP_V3_SEED_VFLAG) -o v2$(EXE_EXT) $(BOOTSTRAP_GC_VFLAG) $(VFLAGS) $(BOOTSTRAP_VC_VFLAGS) cmd/v
 	CC="$(CC)" OLDV_CCOPTIONS="$(BOOTSTRAP_VC_CFLAGS)" OLDV_LDFLAGS="$(BOOTSTRAP_LDFLAGS)" sh "$(V1_FALLBACK_INSTALLER)" "./v1$(EXE_EXT)" "$(V1_FALLBACK_EXE)"
 	./v2$(EXE_EXT) -o $(VEXE)$(EXE_EXT) $(BOOTSTRAP_GC_VFLAG) $(VFLAGS) $(BOOTSTRAP_VFLAGS) cmd/v
 	$(RM) v1$(EXE_EXT)
@@ -232,7 +234,7 @@ endif
 ifdef NETBSD
 	paxctl +m v1$(EXE_EXT)
 endif
-	./v1$(EXE_EXT) -no-parallel -o v2$(EXE_EXT) $(BOOTSTRAP_GC_VFLAG) $(VFLAGS) $(BOOTSTRAP_VC_VFLAGS) cmd/v
+	./v1$(EXE_EXT) -no-parallel $(BOOTSTRAP_V3_SEED_VFLAG) -o v2$(EXE_EXT) $(BOOTSTRAP_GC_VFLAG) $(VFLAGS) $(BOOTSTRAP_VC_VFLAGS) cmd/v
 ifdef NETBSD
 	paxctl +m v2$(EXE_EXT)
 endif

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ LDFLAGS ?=
 # Portable VC snapshots do not embed V3. Keep their v1 executable on the full
 # compatibility compiler path even when the generated C is built on a V3 host.
 VC_BOOTSTRAP_DEFINE = -DCUSTOM_DEFINE_v1_fallback
+# V1 only builds a serial V3 seed; that V3 stage builds the full compiler.
+BOOTSTRAP_V3_SEED_VFLAG = -d v3_no_parallel
 
 all: download_vc v
 
@@ -113,7 +115,7 @@ v:
 			;; \
 	esac; \
 	$(CC) $$bootstrap_ccflags $(VC_BOOTSTRAP_DEFINE) -std=gnu11 -w -o v1 vc/v.c -lm -lpthread $$ldflags || cmd/tools/cc_compilation_failed_non_windows.sh; \
-	set -- ./v1 -no-parallel -o v2 $$bootstrap_gcflags $(VFLAGS); \
+	set -- ./v1 -no-parallel $(BOOTSTRAP_V3_SEED_VFLAG) -o v2 $$bootstrap_gcflags $(VFLAGS); \
 	if [ -n "$$bootstrap_ccompiler" ]; then \
 		set -- "$$@" -cc "$$bootstrap_ccompiler"; \
 	fi; \

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -129,6 +129,17 @@ fn test_vc_bootstrap_builds_a_v1_compatibility_compiler() {
 	}
 }
 
+fn test_vc_bootstrap_excludes_parallel_v3_sources_from_the_v1_stage() {
+	gnumake := os.read_file(os.join_path(macos_v3_test_vroot, 'GNUmakefile'))!
+	assert gnumake.contains('BOOTSTRAP_V3_SEED_VFLAG := -d v3_no_parallel')
+	seed_build := './v1\$(EXE_EXT) -no-parallel \$(BOOTSTRAP_V3_SEED_VFLAG) -o v2\$(EXE_EXT)'
+	assert gnumake.count(seed_build) == 2
+
+	portable_make := os.read_file(os.join_path(macos_v3_test_vroot, 'Makefile'))!
+	assert portable_make.contains('BOOTSTRAP_V3_SEED_VFLAG = -d v3_no_parallel')
+	assert portable_make.contains('set -- ./v1 -no-parallel \$(BOOTSTRAP_V3_SEED_VFLAG) -o v2')
+}
+
 fn test_netbsd_marks_the_v1_compatibility_compiler() {
 	makefile := os.read_file(os.join_path(macos_v3_test_vroot, 'GNUmakefile'))!
 	assert makefile.contains('paxctl +m \$(V1_FALLBACK_EXE)')

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -4457,19 +4457,6 @@ fn transform_scope_owns(scope voidptr, ptr voidptr) bool {
 	return false
 }
 
-// transform_scope_address_range returns the union address range of the blocks
-// owned by `scope`, so callers can reject most pointers before the per-block
-// search in transform_scope_owns.
-fn transform_scope_address_range(scope voidptr) (usize, usize) {
-	$if prealloc {
-		unsafe {
-			lo, hi := prealloc_scope_address_range(scope)
-			return lo, hi
-		}
-	}
-	return 0, 0
-}
-
 // clone_scoped_worker_node publishes a node's owned fields through the
 // compilation text table before its helper arena is released.
 fn (mut t Transformer) clone_scoped_worker_node(idx int, scope voidptr) {

--- a/vlib/v3/transform/transform_parallel_d_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_d_v3_no_parallel.v
@@ -50,6 +50,12 @@ pub fn scan_scoped_text_flags_parallel(_ &flat.FlatAst, _ voidptr, mut _ []u8) b
 	return false
 }
 
+// scan_scoped_text_flags_parallel_multi keeps the multi-scope scan serial when
+// v3 is built with the internal `v3_no_parallel` define.
+pub fn scan_scoped_text_flags_parallel_multi(_ &flat.FlatAst, _ []voidptr, mut _ []u8) bool {
+	return false
+}
+
 fn free_worker_scopes_parallel(_ &flat.FlatAst, _ []voidptr) bool {
 	return false
 }

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -204,7 +204,11 @@ $if !windows {
 	// the arenas together with the preparation arena.
 	fn transform_pre_scan_index_thread(arg voidptr) voidptr {
 		mut t := unsafe { &Transformer(arg) }
-		scope := transform_worker_scope_begin(t.retain_prescan_scopes)
+		scope := if t.retain_prescan_scopes {
+			transform_worker_scope_begin(true)
+		} else {
+			unsafe { nil }
+		}
 		t.build_source_parent_index()
 		t.collect_multi_return_fn_ret_types()
 		t.rebuild_variadic_suffix_index()
@@ -232,7 +236,11 @@ $if !windows {
 	// caches and publishes only its completed declaration maps after joining.
 	fn transform_param_prep_thread(arg voidptr) voidptr {
 		mut w := unsafe { &Transformer(arg) }
-		scope := transform_worker_scope_begin(w.retain_prescan_scopes)
+		scope := if w.retain_prescan_scopes {
+			transform_worker_scope_begin(true)
+		} else {
+			unsafe { nil }
+		}
 		w.prepare_parallel_call_param_types()
 		transform_worker_scope_leave(scope)
 		return scope
@@ -335,7 +343,7 @@ fn scopes_address_range(scopes []voidptr) (usize, usize) {
 	mut hi := usize(0)
 	$if prealloc {
 		for scope in scopes {
-			scope_lo, scope_hi := transform_scope_address_range(scope)
+			scope_lo, scope_hi := unsafe { prealloc_scope_address_range(scope) }
 			if scope_hi <= scope_lo {
 				continue
 			}


### PR DESCRIPTION
A clean bootstrap selected `transform_parallel_notd_v3_no_parallel.v` while the VC/V1 stage built `v2`. That made current parallel V3 implementation details part of the V1 compatibility surface and broke on V1's handling of the unsafe multi-return expression.

Build the intermediate `cmd/v` with `-d v3_no_parallel` instead. V1 now selects only the serial V3 implementations; the resulting V3 stage builds the full compiler and selects the parallel implementation. The serial transform variant gains the multi-scope scan stub needed by that seed build. This also removes the typed wrapper merged in #28545, leaving the parallel implementation unchanged from its original V3 form.

The separately installed compatibility compiler remains the verified V 0.5.2 release from #28542.

Validation:

- `make clean && make`
- `./v -new-compiler -g -keepc -o ./vnew cmd/v`
- `./vnew -new-compiler -silent -run-only test_vc_bootstrap_excludes_parallel_v3_sources_from_the_v1_stage cmd/v/macos_v3_test.v`
