### PR TITLE
make: prepare legacy support for lazy V1

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -259,6 +259,15 @@ ifdef WIN32
 	mv -f "$$candidate" "$(V1_FALLBACK_EXE)"; \
 	echo "Built V1 compatibility compiler: $(V1_FALLBACK_EXE)"
 else
+ifdef LEGACY
+	@set -e; \
+	if [ ! -f "$(LEGACYLIBS)/lib/libMacportsLegacySupport.a" ]; then \
+		'$(MAKE)' latest_legacy; \
+		'$(MAKE)' -C "$(TMPLEGACY)" CPPFLAGS='$(CPPFLAGS)' CFLAGS='$(CFLAGS)' LDFLAGS='$(LDFLAGS)'; \
+		'$(MAKE)' -C "$(TMPLEGACY)" PREFIX="$(abspath $(LEGACYLIBS))" CPPFLAGS='$(CPPFLAGS)' CFLAGS='$(CFLAGS)' LDFLAGS='$(LDFLAGS)' install; \
+		rm -rf "$(TMPLEGACY)"; \
+	fi
+endif
 	@set -e; \
 	if [ ! -f "$(VC)/$(VCFILE)" ]; then '$(MAKE)' latest_vc; fi; \
 	mkdir -p "$(dir $(V1_FALLBACK_EXE))"; \

--- a/cmd/v/macos_v3_test.v
+++ b/cmd/v/macos_v3_test.v
@@ -145,6 +145,16 @@ fn test_gnumake_builds_the_v1_fallback_only_on_demand() {
 	assert source.contains('\nv1:\n')
 	assert source.contains('candidate="\$(V1_FALLBACK_EXE).tmp.\$\$\$\$"')
 	assert source.contains('Built V1 compatibility compiler: \$(V1_FALLBACK_EXE)')
+	v1_recipe := source.all_after('\nv1:\n').all_before('\nclean:\n')
+	legacy_prepare := "'\$(MAKE)' latest_legacy"
+	assert v1_recipe.contains('lib/libMacportsLegacySupport.a')
+	assert v1_recipe.contains(legacy_prepare)
+	assert v1_recipe.contains('\'\$(MAKE)\' -C "\$(TMPLEGACY)"')
+	assert v1_recipe.contains('PREFIX="\$(abspath \$(LEGACYLIBS))"')
+	legacy_prepare_index := v1_recipe.index(legacy_prepare) or { -1 }
+	compile_index := v1_recipe.last_index('if ! \$(CC)') or { -1 }
+	assert legacy_prepare_index >= 0
+	assert legacy_prepare_index < compile_index
 	assert !source.contains('-d v1_fallback -o \$(V1_FALLBACK_EXE)')
 }
 


### PR DESCRIPTION
Follow-up to #28549, which merged before its final review fix was included.

On Darwin kernel versions <= 16, `make clean` removes MacPorts legacy support while the lazy `make v1` target still links against it. Before compiling the fallback, the legacy branch now:

- checks whether the installed static library exists
- restores the legacy sources with `latest_legacy` when needed
- builds and installs them with the same flags used by the full bootstrap
- removes the temporary source checkout

The preparation is skipped when the installed library already exists. Focused coverage verifies the preparation commands and their ordering before the fallback link.

Fixes review feedback: https://github.com/vlang/v/pull/28549#discussion_r3998107124

Validation:
- `./vnew -silent cmd/v/macos_v3_test.v`
- `make v1 local=1 VEXE=./v`
- `./v1_fallback version`
- `git diff --check origin/master..HEAD`