### PR TITLE
v3: reduce self-host peak memory by another ~10%, performance-neutral

### DIFF
--- a/vlib/v3/driver/driver.v
+++ b/vlib/v3/driver/driver.v
@@ -5500,7 +5500,7 @@ fn c_hash_monomorph_node(initial u64, a &flat.FlatAst, id flat.NodeId, cacheable
 	}
 	node := a.nodes[idx]
 	mut hash := c_hash_bytes(initial, [u8(node.kind), u8(node.op), u8(node.is_mut),
-		u8(node.skip_ownership_drops), u8(node.is_static_type_method)])
+		u8(node.skip_ownership_drops()), u8(node.is_static_type_method())])
 	hash = c_hash_tag(hash, node.children_count)
 	hash = c_hash_bytes(hash, node.typ.bytes())
 	hash = c_hash_bytes(hash, [u8(0)])
@@ -5610,7 +5610,7 @@ fn incremental_qualified_fn_name(module_name string, name string) string {
 
 fn incremental_hash_node_header(initial u64, node &flat.Node, include_value bool) u64 {
 	mut hash := c_hash_bytes(initial, [u8(node.kind), u8(node.op), u8(node.is_mut),
-		u8(node.skip_ownership_drops), u8(node.is_static_type_method)])
+		u8(node.skip_ownership_drops()), u8(node.is_static_type_method())])
 	hash = c_hash_tag(hash, node.children_count)
 	hash = c_hash_bytes(hash, node.typ.bytes())
 	hash = c_hash_bytes(hash, [u8(0)])
@@ -5627,7 +5627,7 @@ fn incremental_hash_node_header(initial u64, node &flat.Node, include_value bool
 
 fn incremental_hash_fn_declaration(initial u64, node &flat.Node) u64 {
 	mut hash := c_hash_bytes(initial, [u8(node.kind), u8(node.op), u8(node.is_mut),
-		u8(node.skip_ownership_drops), u8(node.is_static_type_method)])
+		u8(node.skip_ownership_drops()), u8(node.is_static_type_method())])
 	hash = c_hash_bytes(hash, node.typ.bytes())
 	hash = c_hash_bytes(hash, [u8(0)])
 	hash = c_hash_bytes(hash, node.value.bytes())
@@ -6239,7 +6239,7 @@ fn promote_scoped_node(mut node flat.Node, scope voidptr) {
 	if old_params.len == 0 {
 		return
 	}
-	mut needs_promotion := scoped_value_owned(scope, node.payload)
+	mut needs_promotion := scoped_value_owned(scope, node.payload_ptr())
 		|| scoped_value_owned(scope, old_params.data)
 	if !needs_promotion {
 		for param in old_params {
@@ -6353,7 +6353,7 @@ fn canonicalize_scoped_node_cached(mut ast flat.FlatAst, idx int, scope voidptr,
 	if old_params.len == 0 {
 		return
 	}
-	mut needs_params := scoped_value_owned(scope, node.payload)
+	mut needs_params := scoped_value_owned(scope, node.payload_ptr())
 		|| scoped_value_owned(scope, old_params.data)
 	if !needs_params {
 		for param in old_params {
@@ -6395,7 +6395,7 @@ fn canonicalize_scoped_node(mut ast flat.FlatAst, idx int, scope voidptr) {
 	if old_params.len == 0 {
 		return
 	}
-	mut needs_params := scoped_value_owned(scope, node.payload)
+	mut needs_params := scoped_value_owned(scope, node.payload_ptr())
 		|| scoped_value_owned(scope, old_params.data)
 	if !needs_params {
 		for param in old_params {
@@ -6573,9 +6573,6 @@ fn promote_scoped_checker_node_caches(mut tc types.TypeChecker, a &flat.FlatAst,
 			if idx < tc.resolved_call_set.len && tc.resolved_call_set[idx] {
 				tc.resolved_call_names[idx] = types.promote_cached_name(tc.resolved_call_names[idx], scope)
 			}
-			if idx < tc.resolved_fn_value_set.len && tc.resolved_fn_value_set[idx] {
-				tc.resolved_fn_value_names[idx] = types.promote_cached_name(tc.resolved_fn_value_names[idx], scope)
-			}
 			if idx >= generated_start && idx < tc.expr_type_set.len && tc.expr_type_set[idx] {
 				tc.expr_type_values[idx] = types.clone_owned_type(tc.expr_type_values[idx])
 			}
@@ -6598,12 +6595,6 @@ fn promote_scoped_checker_node_caches(mut tc types.TypeChecker, a &flat.FlatAst,
 	}
 	if scoped_value_owned(scope, tc.resolved_call_set.data) {
 		tc.resolved_call_set = tc.resolved_call_set.clone()
-	}
-	if scoped_value_owned(scope, tc.resolved_fn_value_names.data) {
-		tc.resolved_fn_value_names = tc.resolved_fn_value_names.clone()
-	}
-	if scoped_value_owned(scope, tc.resolved_fn_value_set.data) {
-		tc.resolved_fn_value_set = tc.resolved_fn_value_set.clone()
 	}
 	if scoped_value_owned(scope, tc.statement_nodes.data) {
 		tc.statement_nodes = tc.statement_nodes.clone()
@@ -7264,16 +7255,10 @@ fn restore_transformed_fn_value_types(mut tc types.TypeChecker, a &flat.FlatAst,
 		tc.expr_type_values << types.Type(types.void_)
 		tc.expr_type_set << false
 	}
-	limit := if tc.resolved_fn_value_names.len < a.nodes.len {
-		tc.resolved_fn_value_names.len
-	} else {
-		a.nodes.len
-	}
-	for idx in 0 .. limit {
-		if idx >= tc.resolved_fn_value_set.len || !tc.resolved_fn_value_set[idx] {
+	for idx, name in tc.sparse_resolved_fn_values {
+		if idx < 0 || idx >= a.nodes.len {
 			continue
 		}
-		name := tc.resolved_fn_value_names[idx].value
 		params := tc.fn_param_types[name] or { continue }
 		ret := tc.fn_ret_types[name] or { continue }
 		tc.expr_type_values[idx] = types.FnType{
@@ -10989,11 +10974,8 @@ pub fn run(args []string) {
 								}
 							}
 						}
-						if idx < pre_tc.resolved_fn_value_set.len
-							&& pre_tc.resolved_fn_value_set[idx] {
-							name := pre_tc.resolved_fn_value_names[idx]
-							if scoped_value_owned(transform_scope, name)
-								|| scoped_value_owned(transform_scope, name.value.str) {
+						if name := pre_tc.sparse_resolved_fn_values[idx] {
+							if scoped_value_owned(transform_scope, name.str) {
 								leaked_fv++
 							}
 						}

--- a/vlib/v3/eval/eval.v
+++ b/vlib/v3/eval/eval.v
@@ -744,7 +744,7 @@ fn (mut e Eval) register_function(module_name string, file_name string, id flat.
 	if module_name != 'main' && module_name != 'builtin' {
 		e.functions[module_name]['${module_name}.${node.value}'] = def
 	}
-	if !node.is_static_type_method && node.value.contains('.') {
+	if !node.is_static_type_method() && node.value.contains('.') {
 		short := node.value.all_after_last('.')
 		receiver := node.value.all_before_last('.').all_after_last('.')
 		e.functions[module_name]['${receiver}.${short}'] = def

--- a/vlib/v3/flat/flat.v
+++ b/vlib/v3/flat/flat.v
@@ -196,8 +196,9 @@ pub:
 // Node payloads live in one process-wide table: a node carries a 4-byte id
 // (0 = none) instead of a pointer, so copying a node copies the id and the
 // node header stays 80 bytes. The table only grows (payloads are rare and
-// tiny), its chunks are plain C allocations that outlive every arena, and ids
-// are handed out under a spin lock while lookups are lock-free.
+// tiny), its chunks outlive every arena, and ids are handed out under a spin
+// lock while lookups are lock-free. The lock and the raw allocations live in
+// flat_payload.c.v.
 const node_payload_chunk_bits = 12
 const node_payload_chunk_size = 1 << node_payload_chunk_bits
 const node_payload_chunk_mask = node_payload_chunk_size - 1
@@ -212,19 +213,6 @@ mut:
 __global g_node_payload_table &NodePayloadTable
 __global g_node_payload_lock i32
 
-fn C.v_prealloc_atomic_cas_i32(ptr &i32, expected int, desired int) int
-
-fn C.v_prealloc_atomic_store_i32(ptr &i32, val int) int
-
-fn node_payload_lock() {
-	for C.v_prealloc_atomic_cas_i32(&g_node_payload_lock, 0, 1) == 0 {
-	}
-}
-
-fn node_payload_unlock() {
-	C.v_prealloc_atomic_store_i32(&g_node_payload_lock, 0)
-}
-
 // node_payload registers an uncommon node payload and returns its id, or 0
 // for an empty list.
 pub fn node_payload(generic_params []string) u32 {
@@ -237,7 +225,7 @@ pub fn node_payload(generic_params []string) u32 {
 	node_payload_lock()
 	mut table := g_node_payload_table
 	if isnil(table) {
-		table = unsafe { &NodePayloadTable(C.calloc(1, sizeof(NodePayloadTable))) }
+		table = node_payload_new_table()
 		if isnil(table) {
 			node_payload_unlock()
 			panic('v3: could not allocate the node payload table')
@@ -251,7 +239,7 @@ pub fn node_payload(generic_params []string) u32 {
 		panic('v3: too many node payloads (${idx})')
 	}
 	if isnil(table.chunks[chunk_idx]) {
-		table.chunks[chunk_idx] = C.calloc(node_payload_chunk_size, sizeof(voidptr))
+		table.chunks[chunk_idx] = node_payload_new_chunk()
 		if isnil(table.chunks[chunk_idx]) {
 			node_payload_unlock()
 			panic('v3: could not allocate a node payload chunk')

--- a/vlib/v3/flat/flat.v
+++ b/vlib/v3/flat/flat.v
@@ -1,3 +1,4 @@
+@[has_globals]
 module flat
 
 import v3.token
@@ -192,30 +193,166 @@ pub:
 	pos  token.Pos
 }
 
-// node_payload creates an uncommon node payload, or nil for an empty list.
-pub fn node_payload(generic_params []string) &NodePayload {
-	if generic_params.len == 0 {
-		return &NodePayload(unsafe { nil })
+// Node payloads live in one process-wide table: a node carries a 4-byte id
+// (0 = none) instead of a pointer, so copying a node copies the id and the
+// node header stays 80 bytes. The table only grows (payloads are rare and
+// tiny), its chunks are plain C allocations that outlive every arena, and ids
+// are handed out under a spin lock while lookups are lock-free.
+const node_payload_chunk_bits = 12
+const node_payload_chunk_size = 1 << node_payload_chunk_bits
+const node_payload_chunk_mask = node_payload_chunk_size - 1
+const node_payload_max_chunks = 4096
+
+struct NodePayloadTable {
+mut:
+	chunks [node_payload_max_chunks]voidptr
+	count  int
+}
+
+__global g_node_payload_table &NodePayloadTable
+__global g_node_payload_lock i32
+
+fn C.v_prealloc_atomic_cas_i32(ptr &i32, expected int, desired int) int
+
+fn C.v_prealloc_atomic_store_i32(ptr &i32, val int) int
+
+fn node_payload_lock() {
+	for C.v_prealloc_atomic_cas_i32(&g_node_payload_lock, 0, 1) == 0 {
 	}
-	return &NodePayload{
+}
+
+fn node_payload_unlock() {
+	C.v_prealloc_atomic_store_i32(&g_node_payload_lock, 0)
+}
+
+// node_payload registers an uncommon node payload and returns its id, or 0
+// for an empty list.
+pub fn node_payload(generic_params []string) u32 {
+	if generic_params.len == 0 {
+		return 0
+	}
+	payload := &NodePayload{
 		generic_params: generic_params
 	}
+	node_payload_lock()
+	mut table := g_node_payload_table
+	if isnil(table) {
+		table = unsafe { &NodePayloadTable(C.calloc(1, sizeof(NodePayloadTable))) }
+		if isnil(table) {
+			node_payload_unlock()
+			panic('v3: could not allocate the node payload table')
+		}
+		g_node_payload_table = table
+	}
+	idx := table.count
+	chunk_idx := idx >> node_payload_chunk_bits
+	if chunk_idx >= node_payload_max_chunks {
+		node_payload_unlock()
+		panic('v3: too many node payloads (${idx})')
+	}
+	if isnil(table.chunks[chunk_idx]) {
+		table.chunks[chunk_idx] = C.calloc(node_payload_chunk_size, sizeof(voidptr))
+		if isnil(table.chunks[chunk_idx]) {
+			node_payload_unlock()
+			panic('v3: could not allocate a node payload chunk')
+		}
+	}
+	unsafe {
+		mut chunk := &&NodePayload(table.chunks[chunk_idx])
+		chunk[idx & node_payload_chunk_mask] = payload
+	}
+	table.count = idx + 1
+	node_payload_unlock()
+	return u32(idx + 1)
+}
+
+// node_payload_at resolves a payload id registered by node_payload; 0 yields nil.
+pub fn node_payload_at(id u32) &NodePayload {
+	if id == 0 {
+		return &NodePayload(unsafe { nil })
+	}
+	idx := int(id) - 1
+	table := g_node_payload_table
+	if isnil(table) || idx >= table.count {
+		return &NodePayload(unsafe { nil })
+	}
+	unsafe {
+		chunk := &&NodePayload(table.chunks[idx >> node_payload_chunk_bits])
+		return chunk[idx & node_payload_chunk_mask]
+	}
+}
+
+// node_flag_skip_ownership_drops marks a block/if/for/fn node whose scope must
+// not consume ownership drops (see Node.skip_ownership_drops()).
+pub const node_flag_skip_ownership_drops = u8(1)
+// node_flag_static_type_method marks a `fn Type.method()` declaration.
+pub const node_flag_static_type_method = u8(2)
+
+// node_flags packs the two rare node bools into Node.flags.
+@[inline]
+pub fn node_flags(skip_ownership_drops bool, is_static_type_method bool) u8 {
+	mut flags := u8(0)
+	if skip_ownership_drops {
+		flags |= node_flag_skip_ownership_drops
+	}
+	if is_static_type_method {
+		flags |= node_flag_static_type_method
+	}
+	return flags
 }
 
 // Node represents node data used by flat.
 pub struct Node {
 pub mut:
-	value                 string
-	typ                   string
-	payload               &NodePayload = unsafe { nil }
-	children_start        i32
-	is_mut                bool
-	kind                  NodeKind
-	op                    Op
-	skip_ownership_drops  bool
-	is_static_type_method bool
-	children_count        i32
-	pos                   token.Pos
+	value          string
+	typ            string
+	children_start i32
+	payload        u32 // node_payload() id, 0 = none; see payload_ptr/generic_params
+	is_mut         bool
+	kind           NodeKind
+	op             Op
+	flags          u8 // node_flag_* bits; see skip_ownership_drops/is_static_type_method
+	children_count i32
+	pos            token.Pos
+}
+
+// skip_ownership_drops reports whether this scope node must not consume
+// ownership drops.
+@[inline]
+pub fn (n &Node) skip_ownership_drops() bool {
+	return (n.flags & node_flag_skip_ownership_drops) != 0
+}
+
+// set_skip_ownership_drops updates the skip-ownership-drops flag.
+@[inline]
+pub fn (mut n Node) set_skip_ownership_drops(value bool) {
+	if value {
+		n.flags |= node_flag_skip_ownership_drops
+	} else {
+		n.flags &= ~node_flag_skip_ownership_drops
+	}
+}
+
+// is_static_type_method reports whether this fn_decl is a `fn Type.method()`.
+@[inline]
+pub fn (n &Node) is_static_type_method() bool {
+	return (n.flags & node_flag_static_type_method) != 0
+}
+
+// set_is_static_type_method updates the static-type-method flag.
+@[inline]
+pub fn (mut n Node) set_is_static_type_method(value bool) {
+	if value {
+		n.flags |= node_flag_static_type_method
+	} else {
+		n.flags &= ~node_flag_static_type_method
+	}
+}
+
+// payload_ptr resolves this node's uncommon payload, or nil when it has none.
+@[inline]
+pub fn (n &Node) payload_ptr() &NodePayload {
+	return node_payload_at(n.payload)
 }
 
 // type_text_id returns the compact canonical identity carried in this node's
@@ -235,10 +372,10 @@ pub fn (mut n Node) set_type_text_id(id u16) {
 // generic_params returns this node's uncommon generic/attribute metadata.
 @[inline]
 pub fn (n &Node) generic_params() []string {
-	if isnil(n.payload) {
+	if n.payload == 0 {
 		return []string{}
 	}
-	return n.payload.generic_params
+	return node_payload_at(n.payload).generic_params
 }
 
 // set_generic_params replaces this node's uncommon managed payload.
@@ -757,8 +894,7 @@ pub fn (n Node) with_shifted_children(shift i32) Node {
 		kind: n.kind
 		op: n.op
 		is_mut: n.is_mut
-		skip_ownership_drops: n.skip_ownership_drops
-		is_static_type_method: n.is_static_type_method
+		flags: n.flags
 	}
 }
 
@@ -774,8 +910,7 @@ pub fn (n Node) with_pos(pos token.Pos) Node {
 		kind: n.kind
 		op: n.op
 		is_mut: n.is_mut
-		skip_ownership_drops: n.skip_ownership_drops
-		is_static_type_method: n.is_static_type_method
+		flags: n.flags
 	}
 }
 
@@ -795,8 +930,7 @@ pub fn (n Node) clone_owned() Node {
 		kind: n.kind
 		op: n.op
 		is_mut: n.is_mut
-		skip_ownership_drops: n.skip_ownership_drops
-		is_static_type_method: n.is_static_type_method
+		flags: n.flags
 	}
 }
 

--- a/vlib/v3/flat/flat_payload.c.v
+++ b/vlib/v3/flat/flat_payload.c.v
@@ -1,0 +1,30 @@
+module flat
+
+// C interop behind the process-wide node payload table (see node_payload in
+// flat.v): the insert spin lock and the raw chunk allocations. The table and
+// its chunks are plain C allocations so they outlive every prealloc arena.
+
+fn C.v_prealloc_atomic_cas_i32(ptr &i32, expected int, desired int) int
+
+fn C.v_prealloc_atomic_store_i32(ptr &i32, val int) int
+
+// node_payload_lock takes the payload table's insert lock.
+fn node_payload_lock() {
+	for C.v_prealloc_atomic_cas_i32(&g_node_payload_lock, 0, 1) == 0 {
+	}
+}
+
+// node_payload_unlock releases the payload table's insert lock.
+fn node_payload_unlock() {
+	C.v_prealloc_atomic_store_i32(&g_node_payload_lock, 0)
+}
+
+// node_payload_new_table allocates the zeroed payload table, or nil.
+fn node_payload_new_table() &NodePayloadTable {
+	return unsafe { &NodePayloadTable(C.calloc(1, sizeof(NodePayloadTable))) }
+}
+
+// node_payload_new_chunk allocates one zeroed chunk of payload pointers, or nil.
+fn node_payload_new_chunk() voidptr {
+	return unsafe { C.calloc(node_payload_chunk_size, sizeof(voidptr)) }
+}

--- a/vlib/v3/flat/flat_test.v
+++ b/vlib/v3/flat/flat_test.v
@@ -95,8 +95,7 @@ fn test_node_owned_clone_preserves_semantic_flags_and_payload() {
 		kind: .for_stmt
 		op: .plus
 		is_mut: true
-		skip_ownership_drops: true
-		is_static_type_method: true
+		flags: node_flags(true, true)
 	}
 	cloned := node.clone_owned()
 	assert cloned.value == node.value
@@ -107,8 +106,8 @@ fn test_node_owned_clone_preserves_semantic_flags_and_payload() {
 	assert cloned.kind == node.kind
 	assert cloned.op == node.op
 	assert cloned.is_mut
-	assert cloned.skip_ownership_drops
-	assert cloned.is_static_type_method
+	assert cloned.skip_ownership_drops()
+	assert cloned.is_static_type_method()
 }
 
 fn test_static_type_method_name_round_trip_with_marker_in_both_parts() {

--- a/vlib/v3/gen/c/cleanc.v
+++ b/vlib/v3/gen/c/cleanc.v
@@ -11591,7 +11591,7 @@ fn (mut g FlatGen) gen_pointer_alias_value_cast_expr(id flat.NodeId, expected ty
 }
 
 fn (g &FlatGen) array_index_type_for_expected_arg(actual types.Type, node flat.Node) types.Type {
-	if isnil(node.payload) || spread_index_expected_type_marker !in node.payload.generic_params {
+	if node.payload == 0 || spread_index_expected_type_marker !in node.generic_params() {
 		return actual
 	}
 	expected := g.expected_expr_type
@@ -14876,8 +14876,8 @@ fn (mut g FlatGen) gen_expr(id flat.NodeId) {
 			mut clone_receiver_fn := ''
 			mut generated_variant_access := false
 			mut borrow_receiver := false
-			if !isnil(node.payload) {
-				params := node.payload.generic_params
+			if node.payload != 0 {
+				params := node.generic_params()
 				generated_variant_access = '__v3_generated_variant_access' in params
 				borrow_receiver = flat.method_value_borrow_receiver_marker in params
 				for param in params {
@@ -21991,11 +21991,18 @@ fn (mut g FlatGen) write_fixed_array_elem_initializer(mut builder strings.Builde
 }
 
 fn (mut g FlatGen) precompute_consts() string {
+	names := g.const_emission_order_owned()
+	return g.precompute_consts_in_order(names)
+}
+
+// precompute_consts_in_order lowers the const initializers in the given
+// emission order (see precompute_consts_scoped, which resolves that order on
+// the master, whose dependency memos are warm, before lowering on a worker).
+fn (mut g FlatGen) precompute_consts_in_order(names []string) string {
 	old_sb := g.sb
 	old_line_start := g.line_start
 	g.sb = strings.new_builder(1024)
 	g.line_start = true
-	names := g.const_emission_order_owned()
 	for name in names {
 		val_id := g.const_vals[name]
 		g.emit_const(name, val_id)

--- a/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/gen/c/fn_parallel_notd_v3_no_parallel.v
@@ -258,6 +258,43 @@ $if !windows {
 		return
 	}
 
+	// precompute_consts_scoped lowers every const initializer on a private worker
+	// inside a disposable arena. The emitter's expression scratch (fixed-array
+	// tables, type lookups, name buffers) is by far the largest garbage this
+	// pool thread would otherwise leave in its persistent arena; only the C text,
+	// the runtime-init queue and the usual batch side tables are published.
+	fn (mut g FlatGen) precompute_consts_scoped() {
+		if !g.scope_parallel_workers {
+			g.parallel_const_code = g.precompute_consts()
+			return
+		}
+		// The dependency order comes from the master, whose memos are warm; a
+		// fresh worker would rescan the AST for every const reference.
+		names := g.const_emission_order_owned()
+		scope := cgen_worker_scope_begin(true)
+		mut worker := g.new_parallel_worker(max_flat_cgen_jobs + 2)
+		// Const initializers number their temporaries from the master counter.
+		worker.tmp_count = g.tmp_count
+		const_code := worker.precompute_consts_in_order(names)
+		cgen_worker_scope_leave(scope)
+		g.parallel_const_code = const_code.clone()
+		g.tmp_count = worker.tmp_count
+		// The worker started from a copy of the master's init queue and an empty
+		// module list, so its new entries are inits[base..] paired with modules[0..].
+		base := g.const_runtime_inits.len
+		for i in base .. worker.const_runtime_inits.len {
+			g.const_runtime_inits << worker.const_runtime_inits[i].clone()
+			mod_idx := i - base
+			g.const_runtime_init_modules << if mod_idx < worker.const_runtime_init_modules.len {
+				worker.const_runtime_init_modules[mod_idx].clone()
+			} else {
+				''
+			}
+		}
+		g.absorb_scoped_cgen_batch(worker, true)
+		cgen_worker_scope_free(scope)
+	}
+
 	fn parallel_type_decls_thread(arg voidptr) voidptr {
 		mut w := unsafe { &FlatGen(arg) }
 		tdsw := time.new_stopwatch()
@@ -272,7 +309,7 @@ $if !windows {
 		// repeatedly copying a geometrically growing builder.
 		w.sb.ensure_cap(4 * 1024 * 1024)
 		mut tdpsw := time.new_stopwatch()
-		w.parallel_const_code = w.precompute_consts()
+		w.precompute_consts_scoped()
 		w.timing_profile('  [ttime]       td consts    ${f64(tdpsw.elapsed().microseconds()) / 1000.0:7.2f} ms')
 		tdpsw.restart()
 		w.gen_translation_unit_prefix()
@@ -2891,8 +2928,6 @@ fn (g &FlatGen) clone_parallel_type_checker_legacy() &types.TypeChecker {
 		errors: g.tc.errors.clone()
 		resolved_call_names: g.tc.resolved_call_names
 		resolved_call_set: g.tc.resolved_call_set
-		resolved_fn_value_names: g.tc.resolved_fn_value_names
-		resolved_fn_value_set: g.tc.resolved_fn_value_set
 		statement_nodes: g.tc.statement_nodes
 		expr_type_values: g.tc.expr_type_values
 		expr_type_set: g.tc.expr_type_set

--- a/vlib/v3/gen/c/for.v
+++ b/vlib/v3/gen/c/for.v
@@ -177,7 +177,7 @@ fn (mut g FlatGen) gen_for(node flat.Node) {
 	if !emitted_continue_label {
 		g.gen_loop_continue_label(label_state.label)
 	}
-	if !node.skip_ownership_drops {
+	if !node.skip_ownership_drops() {
 		g.gen_loop_iteration_ownership_drops_for_label(label_state.label)
 	}
 	g.trim_defers(defer_start)
@@ -188,7 +188,7 @@ fn (mut g FlatGen) gen_for(node flat.Node) {
 			g.writeln('${g.loop_control_c_label(label_state.label, false)}: {}')
 			g.emitted_loop_break_labels[label_state.label] = true
 		}
-		if !node.skip_ownership_drops {
+		if !node.skip_ownership_drops() {
 			g.gen_scope_ownership_drops()
 		}
 		g.indent--
@@ -500,7 +500,7 @@ fn (mut g FlatGen) gen_for_in(node flat.Node) {
 			if !emitted_continue_label {
 				g.gen_loop_continue_label(label_state.label)
 			}
-			if !node.skip_ownership_drops {
+			if !node.skip_ownership_drops() {
 				g.gen_loop_iteration_ownership_drops_for_label(label_state.label)
 			}
 			g.trim_defers(defer_start)
@@ -529,7 +529,7 @@ fn (mut g FlatGen) gen_for_in(node flat.Node) {
 	if !emitted_continue_label {
 		g.gen_loop_continue_label(label_state.label)
 	}
-	if !node.skip_ownership_drops {
+	if !node.skip_ownership_drops() {
 		g.gen_loop_iteration_ownership_drops_for_label(label_state.label)
 	}
 	g.trim_defers(defer_start)
@@ -609,7 +609,7 @@ fn (mut g FlatGen) gen_range_for_in(node flat.Node, key_id flat.NodeId, low_id f
 	if !emitted_continue_label {
 		g.gen_loop_continue_label(label)
 	}
-	if !node.skip_ownership_drops {
+	if !node.skip_ownership_drops() {
 		g.gen_loop_iteration_ownership_drops_for_label(label)
 	}
 	g.trim_defers(defer_start)

--- a/vlib/v3/gen/c/if.v
+++ b/vlib/v3/gen/c/if.v
@@ -55,7 +55,7 @@ fn (mut g FlatGen) gen_if(node flat.Node) {
 			}
 		}
 		g.gen_defers_from(defer_start)
-		if !cur.skip_ownership_drops && !then_scope_drops_consumed {
+		if !cur.skip_ownership_drops() && !then_scope_drops_consumed {
 			g.gen_scope_ownership_drop_count(then_scope_drop_prefix_count)
 			g.gen_scope_ownership_drops()
 		}
@@ -108,7 +108,7 @@ fn (mut g FlatGen) gen_if(node flat.Node) {
 				else_scope_drops_consumed = true
 			}
 			g.gen_defers_from(else_defer_start)
-			if !cur.skip_ownership_drops && !else_scope_drops_consumed {
+			if !cur.skip_ownership_drops() && !else_scope_drops_consumed {
 				g.gen_scope_ownership_drop_count(else_scope_drop_prefix_count)
 				g.gen_scope_ownership_drops()
 			}

--- a/vlib/v3/gen/v/gen.v
+++ b/vlib/v3/gen/v/gen.v
@@ -241,7 +241,7 @@ fn (g &Gen) collect_json_migration_declarations(ids []flat.NodeId, mut declared_
 			for field_id in g.a.children_of(n) {
 				declared_names[g.a.node(field_id).value] = true
 			}
-		} else if n.kind == .fn_decl && !n.value.contains('.') && !n.is_static_type_method {
+		} else if n.kind == .fn_decl && !n.value.contains('.') && !n.is_static_type_method() {
 			declared_names[n.value] = true
 		} else if n.kind == .c_fn_decl && n.value.starts_with('V:') && !n.value[2..].contains('.') {
 			declared_names[n.value[2..]] = true
@@ -3102,7 +3102,7 @@ fn (mut g Gen) fn_decl(id flat.NodeId) {
 		} else {
 			g.write('C.${name}')
 		}
-	} else if n.is_static_type_method {
+	} else if n.is_static_type_method() {
 		if receiver, method := flat.decode_static_type_method_name(name) {
 			g.write('${receiver}.${method}')
 		} else {

--- a/vlib/v3/modulecache/modulecache.v
+++ b/vlib/v3/modulecache/modulecache.v
@@ -6179,7 +6179,7 @@ fn fn_text(a &flat.FlatAst, module_name string, node flat.Node, is_c bool, decla
 		}
 	}
 	decl_name := node.value
-	name := if node.is_static_type_method {
+	name := if node.is_static_type_method() {
 		if receiver, method := flat.decode_static_type_method_name(decl_name) {
 			'${receiver}.${method}'
 		} else {
@@ -6191,7 +6191,7 @@ fn fn_text(a &flat.FlatAst, module_name string, node flat.Node, is_c bool, decla
 	visibility := if !is_c && (node.op == .arrow || source_is_public) { 'pub ' } else { '' }
 	mut head := if is_c { 'fn C.${name}' } else { '${visibility}fn ${name}' }
 	mut param_start := 0
-	if !is_c && !node.is_static_type_method && name.contains('.') && params.len > 0 {
+	if !is_c && !node.is_static_type_method() && name.contains('.') && params.len > 0 {
 		receiver_type := name.all_before_last('.')
 		first_type := clean_receiver_type(params[0].typ)
 		if first_type == receiver_type

--- a/vlib/v3/parser/parser.v
+++ b/vlib/v3/parser/parser.v
@@ -1473,7 +1473,7 @@ fn (mut p Parser) fn_decl_body(name string, receiver_name string, receiver_type 
 			payload: flat.node_payload(generic_params)
 			children_start: start
 			children_count: flat.child_count(param_ids.len)
-			is_static_type_method: is_static_type_method
+			flags: flat.node_flags(false, is_static_type_method)
 			// Function nodes do not otherwise use is_mut. On a .vh declaration it
 			// records that the body lives in a cached object and must not be emitted;
 			// on a C declaration it preserves the parser's implicit unsafe/trusted state.
@@ -1568,7 +1568,7 @@ fn (mut p Parser) fn_decl_body(name string, receiver_name string, receiver_type 
 		payload: flat.node_payload(generic_params)
 		children_start: start
 		children_count: flat.child_count(all_ids.len)
-		is_static_type_method: is_static_type_method
+		flags: flat.node_flags(false, is_static_type_method)
 	})
 	if p.prefs.is_fmt && formatter_end > 0 {
 		p.a.formatter_node_ends[int(id)] = formatter_end

--- a/vlib/v3/transform/array.v
+++ b/vlib/v3/transform/array.v
@@ -201,7 +201,7 @@ fn (mut t Transformer) make_owned_array_repeat_value(base_id flat.NodeId, count_
 	t.pending_stmts = t.pending_stmts[..pending_start].clone()
 	body << t.make_assign(t.make_index(t.make_ident(out_name), t.make_ident(idx_name), elem_type), cloned_elem)
 	t.pending_stmts << t.make_for_stmt(init, cond, post, body, flat.Node{
-		skip_ownership_drops: true
+		flags: flat.node_flag_skip_ownership_drops
 	})
 	if source_is_owned_temporary {
 		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
@@ -570,7 +570,7 @@ fn (mut t Transformer) lower_array_init_to_runtime(id flat.NodeId, node flat.Nod
 	// slot, the following real loop's per-iteration drops would be emitted here
 	// (referencing a variable not in scope) and dropped from their real loop.
 	for_id := t.make_for_stmt(init_idx, cond, post, loop_body, node)
-	t.a.nodes[int(for_id)].skip_ownership_drops = true
+	t.a.nodes[int(for_id)].set_skip_ownership_drops(true)
 	t.pending_stmts << for_id
 	result := t.make_ident(tmp_name)
 	t.set_node_typ(int(result), '[]${elem_type}')
@@ -795,7 +795,7 @@ fn (mut t Transformer) append_array_literal_spread(out_name string, spread_id fl
 		t.make_prefix(.amp, t.make_ident(value_name)),
 	], 'void'))
 	t.pending_stmts << t.make_for_stmt(init, cond, post, body, flat.Node{
-		skip_ownership_drops: true
+		flags: flat.node_flag_skip_ownership_drops
 	})
 	if source_is_owned_temporary {
 		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
@@ -2706,7 +2706,7 @@ fn (mut t Transformer) lower_array_filter_call(node flat.Node, fn_node flat.Node
 	then_block := t.make_block(then_body)
 	loop_body << t.make_if(predicate, then_block, t.make_empty())
 	prefix << t.make_for_stmt(init, cond, post, loop_body, flat.Node{
-		skip_ownership_drops: true
+		flags: flat.node_flag_skip_ownership_drops
 	})
 	if source_needs_drop {
 		prefix << t.make_expr_stmt(t.make_call_typed('drop_owned', [base], 'void'))
@@ -2960,7 +2960,7 @@ fn (mut t Transformer) lower_array_map_call(node flat.Node, fn_node flat.Node, b
 		t.make_prefix(.amp, t.make_ident(pushed_name)),
 	], 'void'))
 	prefix << t.make_for_stmt(init, cond, post, loop_body, flat.Node{
-		skip_ownership_drops: true
+		flags: flat.node_flag_skip_ownership_drops
 	})
 	if source_needs_drop {
 		prefix << t.make_expr_stmt(t.make_call_typed('drop_owned', [base], 'void'))
@@ -5842,7 +5842,7 @@ fn (mut t Transformer) lower_array_count_call(node flat.Node, fn_node flat.Node,
 	inc := t.make_assign_op(t.make_ident(result_name), t.make_int_literal(1), .plus_assign)
 	loop_body << t.make_if(predicate, t.make_block([inc]), t.make_empty())
 	prefix << t.make_for_stmt(init, cond, post, loop_body, flat.Node{
-		skip_ownership_drops: true
+		flags: flat.node_flag_skip_ownership_drops
 	})
 	if source_is_owned_temporary {
 		prefix << t.make_expr_stmt(t.make_call_typed('drop_owned', [base], 'void'))
@@ -5916,7 +5916,7 @@ fn (mut t Transformer) lower_array_any_all_call(node flat.Node, fn_node flat.Nod
 		loop_body << t.make_if(predicate, t.make_block([assign_true]), t.make_empty())
 	}
 	prefix << t.make_for_stmt(init, cond, post, loop_body, flat.Node{
-		skip_ownership_drops: true
+		flags: flat.node_flag_skip_ownership_drops
 	})
 	if source_is_owned_temporary {
 		prefix << t.make_expr_stmt(t.make_call_typed('drop_owned', [base], 'void'))

--- a/vlib/v3/transform/expr.v
+++ b/vlib/v3/transform/expr.v
@@ -3510,7 +3510,7 @@ fn (mut t Transformer) make_map_elementwise_eq_call_with_seen(lhs flat.NodeId, r
 		children_count: flat.child_count(3 + body.len)
 		pos: src.pos
 		value: '3'
-		skip_ownership_drops: true
+		flags: flat.node_flag_skip_ownership_drops
 	})
 	result := t.make_ident(result_name)
 	t.set_node_typ(int(result), 'bool')

--- a/vlib/v3/transform/fn.v
+++ b/vlib/v3/transform/fn.v
@@ -9390,7 +9390,7 @@ fn (mut t Transformer) make_compiler_default_array_clone_value(source flat.NodeI
 	t.pending_stmts = t.pending_stmts[..pending_start].clone()
 	body << t.make_assign_without_ownership_drop(t.make_index(t.make_ident(out_name), t.make_ident(idx_name), elem_type), cloned_elem)
 	t.pending_stmts << t.make_for_stmt(init, cond, post, body, flat.Node{
-		skip_ownership_drops: true
+		flags: flat.node_flag_skip_ownership_drops
 	})
 	if source_is_owned_temporary {
 		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
@@ -9427,7 +9427,7 @@ fn (mut t Transformer) make_compiler_default_fixed_array_clone_value(source flat
 	t.pending_stmts = t.pending_stmts[..pending_start].clone()
 	body << t.make_assign_without_ownership_drop(t.make_index(t.make_ident(out_name), t.make_ident(idx_name), elem_type), cloned_elem)
 	t.pending_stmts << t.make_for_stmt(init, cond, post, body, flat.Node{
-		skip_ownership_drops: true
+		flags: flat.node_flag_skip_ownership_drops
 	})
 	if source_is_owned_temporary {
 		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
@@ -9512,7 +9512,7 @@ fn (mut t Transformer) make_compiler_default_map_clone_value(source flat.NodeId,
 		children_start: start
 		children_count: flat.child_count(3 + body.len)
 		value: '3'
-		skip_ownership_drops: true
+		flags: flat.node_flag_skip_ownership_drops
 	})
 	if source_is_owned_temporary {
 		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
@@ -10180,7 +10180,7 @@ fn (mut t Transformer) lower_owned_array_removal_call(node flat.Node, base_id fl
 			kind: .if_expr
 			children_start: start
 			children_count: 2
-			skip_ownership_drops: true
+			flags: flat.node_flag_skip_ownership_drops
 		})
 	}
 
@@ -10209,7 +10209,7 @@ fn (mut t Transformer) append_owned_array_drop_prefix(array_value flat.NodeId, e
 	elem := t.make_index(array_value, t.make_ident(idx_name), elem_type)
 	drop_stmt := t.make_expr_stmt(t.make_call_typed('drop_owned', [elem], 'void'))
 	stmts << t.make_for_stmt(init, cond, post, [drop_stmt], flat.Node{
-		skip_ownership_drops: true
+		flags: flat.node_flag_skip_ownership_drops
 	})
 }
 
@@ -10221,7 +10221,7 @@ fn (mut t Transformer) append_owned_array_drop_range(array_value flat.NodeId, el
 	elem := t.make_index(array_value, t.make_ident(idx_name), elem_type)
 	drop_stmt := t.make_expr_stmt(t.make_call_typed('drop_owned', [elem], 'void'))
 	stmts << t.make_for_stmt(init, cond, post, [drop_stmt], flat.Node{
-		skip_ownership_drops: true
+		flags: flat.node_flag_skip_ownership_drops
 	})
 }
 
@@ -10297,7 +10297,7 @@ fn (mut t Transformer) try_lower_ignored_owned_array_pop_stmt(call_id flat.NodeI
 			kind: .if_expr
 			children_start: start
 			children_count: 2
-			skip_ownership_drops: true
+			flags: flat.node_flag_skip_ownership_drops
 		})
 	} else {
 		result << drop_result
@@ -10648,7 +10648,7 @@ fn (mut t Transformer) make_owned_map_items_value(source flat.NodeId, map_type s
 		children_start: start
 		children_count: flat.child_count(3 + body.len)
 		value: '3'
-		skip_ownership_drops: true
+		flags: flat.node_flag_skip_ownership_drops
 	})
 	if source_is_owned_temporary {
 		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [
@@ -10715,7 +10715,7 @@ fn (mut t Transformer) append_owned_map_entries_drop_before_reset(map_expr flat.
 		children_start: start
 		children_count: flat.child_count(3 + body.len)
 		value: '3'
-		skip_ownership_drops: true
+		flags: flat.node_flag_skip_ownership_drops
 	})
 }
 
@@ -10780,7 +10780,7 @@ fn (mut t Transformer) append_owned_map_entry_delete_with_drops(map_expr flat.No
 		kind: .if_expr
 		children_start: start
 		children_count: 2
-		skip_ownership_drops: true
+		flags: flat.node_flag_skip_ownership_drops
 	})
 	return true
 }

--- a/vlib/v3/transform/fn_test.v
+++ b/vlib/v3/transform/fn_test.v
@@ -1033,15 +1033,12 @@ fn test_merged_resolution_cache_initializes_gaps_and_preserves_entries() {
 	assert tc.resolved_call_set[1]
 	assert tc.resolved_call_names[4096].value == 'main.last'
 	assert tc.resolved_call_set[4096]
-	assert tc.resolved_fn_value_names[2].value == 'main.callback'
-	assert tc.resolved_fn_value_set[2]
-	assert tc.resolved_fn_value_names[8192].value == 'main.final_callback'
-	assert tc.resolved_fn_value_set[8192]
+	assert tc.resolved_fn_value_name(2)? == 'main.callback'
+	assert tc.resolved_fn_value_name(8192)? == 'main.final_callback'
 	for i in 3 .. 4096 {
 		assert isnil(tc.resolved_call_names[i])
 		assert !tc.resolved_call_set[i]
-		assert isnil(tc.resolved_fn_value_names[i])
-		assert !tc.resolved_fn_value_set[i]
+		assert tc.resolved_fn_value_name(i) == none
 	}
 }
 

--- a/vlib/v3/transform/for.v
+++ b/vlib/v3/transform/for.v
@@ -131,14 +131,14 @@ fn (mut t Transformer) transform_for_body(id flat.NodeId, node flat.Node) []flat
 		start := t.a.children.len
 		t.a.children << new_children
 		t.a.add_node(flat.Node{
-			kind:                 .for_stmt
-			op:                   node.op
-			children_start:       start
-			children_count:       flat.child_count(new_children.len)
-			pos:                  node.pos
-			value:                node.value
-			typ:                  node.typ
-			skip_ownership_drops: node.skip_ownership_drops
+			kind:           .for_stmt
+			op:             node.op
+			children_start: start
+			children_count: flat.child_count(new_children.len)
+			pos:            node.pos
+			value:          node.value
+			typ:            node.typ
+			flags:          flat.node_flags(node.skip_ownership_drops(), false)
 		})
 	}
 	if synthetic_continue_label.len > 0 {
@@ -676,14 +676,14 @@ fn (mut t Transformer) rebuild_for_in_stmt(_id flat.NodeId, node flat.Node) []fl
 		})
 	}
 	prefix << t.a.add_node(flat.Node{
-		kind:                 .for_in_stmt
-		op:                   node.op
-		children_start:       start
-		children_count:       flat.child_count(ids.len)
-		pos:                  node.pos
-		value:                node.value
-		typ:                  if iter_type.len > 0 { iter_type } else { node.typ }
-		skip_ownership_drops: node.skip_ownership_drops
+		kind:           .for_in_stmt
+		op:             node.op
+		children_start: start
+		children_count: flat.child_count(ids.len)
+		pos:            node.pos
+		value:          node.value
+		typ:            if iter_type.len > 0 { iter_type } else { node.typ }
+		flags:          flat.node_flags(node.skip_ownership_drops(), false)
 	})
 	if cleanup_owned_container {
 		prefix << t.make_expr_stmt(t.make_call_typed('drop_owned', [new_container], 'void'))
@@ -1218,13 +1218,13 @@ fn (mut t Transformer) make_for_stmt(init flat.NodeId, cond flat.NodeId, post fl
 		t.a.children << id
 	}
 	return t.a.add_node(flat.Node{
-		kind:                 .for_stmt
-		op:                   src.op
-		children_start:       start
-		children_count:       flat.child_count(3 + body.len)
-		pos:                  src.pos
-		typ:                  src.typ
-		skip_ownership_drops: src.skip_ownership_drops || src.kind == .empty
+		kind:           .for_stmt
+		op:             src.op
+		children_start: start
+		children_count: flat.child_count(3 + body.len)
+		pos:            src.pos
+		typ:            src.typ
+		flags:          flat.node_flags(src.skip_ownership_drops() || src.kind == .empty, false)
 	})
 }
 

--- a/vlib/v3/transform/map.v
+++ b/vlib/v3/transform/map.v
@@ -1970,7 +1970,7 @@ fn (mut t Transformer) lower_owned_map_index_move(source_id flat.NodeId, map_exp
 		kind: .if_expr
 		children_start: start
 		children_count: 2
-		skip_ownership_drops: true
+		flags: flat.node_flag_skip_ownership_drops
 	})
 	if !map_type.starts_with('&') && !t.expr_can_take_address(source_id) {
 		t.pending_stmts << t.make_expr_stmt(t.make_call_typed('drop_owned', [map_expr], 'void'))

--- a/vlib/v3/transform/monomorphize.v
+++ b/vlib/v3/transform/monomorphize.v
@@ -1173,15 +1173,17 @@ fn (t &Transformer) generic_struct_interfaces_by_method() map[string][]string {
 
 fn (t &Transformer) used_generic_method_names() map[string]bool {
 	mut methods := map[string]bool{}
-	for name, used in t.used_fns {
-		if !used || name.len == 0 {
-			continue
-		}
-		if name.contains('.') {
-			methods[name.all_after_last('.')] = true
-		}
-		if name.contains('__') {
-			methods[name.all_after_last('__')] = true
+	for used_map in t.used_fn_maps() {
+		for name, used in *used_map {
+			if !used || name.len == 0 {
+				continue
+			}
+			if name.contains('.') {
+				methods[name.all_after_last('.')] = true
+			}
+			if name.contains('__') {
+				methods[name.all_after_last('__')] = true
+			}
 		}
 	}
 	return methods
@@ -1472,10 +1474,12 @@ fn (t &Transformer) interface_dispatch_method_used(iface_name string, method str
 	}
 	semantic_prefix := '${iface_name}['
 	c_prefix := '${c_name(iface_name)}_'
-	for used_name, used in t.used_fns {
-		if used && ((used_name.starts_with(semantic_prefix) && used_name.ends_with('.${method}'))
-			|| (used_name.starts_with(c_prefix) && used_name.ends_with('__${method}'))) {
-			return true
+	for used_map in t.used_fn_maps() {
+		for used_name, used in *used_map {
+			if used && ((used_name.starts_with(semantic_prefix) && used_name.ends_with('.${method}'))
+				|| (used_name.starts_with(c_prefix) && used_name.ends_with('__${method}'))) {
+				return true
+			}
 		}
 	}
 	if decl_key := t.tc.interface_method_signature_key(iface_name, method) {
@@ -2674,7 +2678,7 @@ fn (mut t Transformer) collect_generic_sum_decls() map[string]GenericSumDecl {
 				if node.generic_params().len == 0 || node.children_count == 0 {
 					continue
 				}
-				module_id := t.node_module_map_cache[i] or { u32(0) }
+				module_id := t.node_module_map_cache[i] or { u16(0) }
 				module_name := if module_id != 0 {
 					t.node_context_text(module_id)
 				} else {
@@ -3413,8 +3417,8 @@ fn (mut t Transformer) ensure_node_module_map() {
 		return
 	}
 	if t.node_module_map_nodes < 0 || t.node_module_map_nodes > t.a.nodes.len {
-		t.node_module_map_cache = []u32{len: t.a.nodes.len, cap: t.a.nodes.cap}
-		t.node_file_map_cache = []u32{len: t.a.nodes.len, cap: t.a.nodes.cap}
+		t.node_module_map_cache = []u16{len: t.a.nodes.len, cap: t.a.nodes.cap}
+		t.node_file_map_cache = []u16{len: t.a.nodes.len, cap: t.a.nodes.cap}
 		t.node_module_map_nodes = 0
 	} else {
 		t.ensure_node_context_map_capacity()
@@ -3454,14 +3458,14 @@ fn (mut t Transformer) ensure_node_context_map_capacity() {
 	grow_node_context_cache(mut t.node_file_map_cache, t.a.nodes.len, t.a.nodes.cap)
 }
 
-fn grow_node_context_cache(mut cache []u32, size int, capacity int) {
+fn grow_node_context_cache(mut cache []u16, size int, capacity int) {
 	old_len := cache.len
 	if old_len >= size {
 		return
 	}
 	if cache.cap < capacity {
 		// Use the AST's reserved size without rounding each side table up again.
-		mut grown := []u32{cap: capacity}
+		mut grown := []u16{cap: capacity}
 		grown << cache
 		// Transfer the new backing; this local has no other surviving reference.
 		cache = unsafe { grown }
@@ -3469,7 +3473,7 @@ fn grow_node_context_cache(mut cache []u32, size int, capacity int) {
 	// Extend in place instead of retaining a temporary zero-filled array.
 	unsafe {
 		cache.grow_len(size - old_len)
-		vmemset(&cache[old_len], 0, isize(size - old_len) * isize(sizeof(u32)))
+		vmemset(&cache[old_len], 0, isize(size - old_len) * isize(sizeof(u16)))
 	}
 }
 
@@ -3477,14 +3481,19 @@ fn grow_node_context_cache(mut cache []u32, size int, capacity int) {
 // module/file tables. Id 0 means "unset". Only the owning transformer interns
 // (workers run with node_context_read_only set), so the shared table needs no
 // synchronization.
-fn (mut t Transformer) node_context_text_id(value string) u32 {
+fn (mut t Transformer) node_context_text_id(value string) u16 {
 	if value.len == 0 {
 		return 0
 	}
 	if id := t.node_context_text_ids[value] {
 		return id
 	}
-	id := u32(t.node_context_texts.len + 1)
+	if t.node_context_texts.len >= max_u16 {
+		// Two bytes per node keep these whole-AST tables small; one compilation
+		// never declares anywhere near 65535 distinct file and module names.
+		panic('v3 transform: too many distinct declaration contexts (${t.node_context_texts.len})')
+	}
+	id := u16(t.node_context_texts.len + 1)
 	t.node_context_texts << value
 	t.node_context_text_ids[value] = id
 	return id
@@ -3492,7 +3501,7 @@ fn (mut t Transformer) node_context_text_id(value string) u32 {
 
 // node_context_text resolves an interned declaration-context spelling.
 @[inline]
-fn (t &Transformer) node_context_text(id u32) string {
+fn (t &Transformer) node_context_text(id u16) string {
 	idx := int(id) - 1
 	if idx < 0 || idx >= t.node_context_texts.len {
 		return ''
@@ -3714,8 +3723,7 @@ fn (mut t Transformer) emit_generic_fn_specialization(decl GenericFnDecl, args [
 			children_start: cloned_fn.children_start
 			children_count: cloned_fn.children_count
 			is_mut: cloned_fn.is_mut
-			skip_ownership_drops: true
-			is_static_type_method: cloned_fn.is_static_type_method
+			flags: flat.node_flags(true, cloned_fn.is_static_type_method())
 		})
 	}
 	t.a.specialized_fn_nodes[int(clone_id)] = true
@@ -9952,7 +9960,7 @@ fn (mut t Transformer) clone_generic_node_from(node flat.Node, args []string, is
 			typ: cloned_typ
 			value: t.subst_node_value(node, args)
 			is_mut: node.is_mut
-			is_static_type_method: node.is_static_type_method
+			flags: flat.node_flags(false, node.is_static_type_method())
 		})
 		if node.kind == .ident && t.mut_param_values[node.value] {
 			t.mut_value_ident_nodes[int(clone_id)] = true
@@ -10023,7 +10031,7 @@ fn (mut t Transformer) clone_generic_node_from(node flat.Node, args []string, is
 		typ: final_typ
 		value: cloned_value
 		is_mut: node.is_mut
-		is_static_type_method: node.is_static_type_method
+		flags: flat.node_flags(false, node.is_static_type_method())
 	})
 	if t.specialization_node_start >= 0 && node.kind == .decl_assign && children.len >= 2 {
 		lhs := t.a.nodes[int(children[0])]
@@ -11054,9 +11062,8 @@ fn (mut t Transformer) copy_cloned_resolution_forked(src_idx int, dst_idx int) {
 	} else {
 		''
 	}
-	if fn_value.len == 0 && src_idx < t.tc.resolved_fn_value_set.len
-		&& t.tc.resolved_fn_value_set[src_idx] {
-		fn_value = t.tc.resolved_fn_value_names[src_idx].value
+	if fn_value.len == 0 {
+		fn_value = t.tc.sparse_resolved_fn_values[src_idx] or { '' }
 	}
 	if fn_value.len > 0 {
 		overlay.resolved_fn_values[dst_idx] = fn_value

--- a/vlib/v3/transform/monomorphize_test.v
+++ b/vlib/v3/transform/monomorphize_test.v
@@ -4,16 +4,16 @@ import v3.flat
 import v3.types
 
 fn test_node_context_cache_growth_preserves_ids_and_initializes_new_slots() {
-	mut cache := []u32{}
+	mut cache := []u16{}
 	grow_node_context_cache(mut cache, 3, 8)
 	cache[0] = 7
 	cache[2] = 9
 	grow_node_context_cache(mut cache, 6, 8)
-	assert cache == [u32(7), 0, 9, 0, 0, 0]
+	assert cache == [u16(7), 0, 9, 0, 0, 0]
 	cache[5] = 11
 	grow_node_context_cache(mut cache, 12, 16)
-	assert cache[..6] == [u32(7), 0, 9, 0, 0, 11]
-	assert cache[6..] == [u32(0), 0, 0, 0, 0, 0]
+	assert cache[..6] == [u16(7), 0, 9, 0, 0, 11]
+	assert cache[6..] == [u16(0), 0, 0, 0, 0, 0]
 	grow_node_context_cache(mut cache, 2, 16)
 	assert cache.len == 12
 	assert cache[5] == 11

--- a/vlib/v3/transform/struct.v
+++ b/vlib/v3/transform/struct.v
@@ -269,13 +269,13 @@ fn (mut t Transformer) clone_promoted_default_in_decl_scope(id flat.NodeId, modu
 		if name.len > 0 {
 			if key := t.const_type_key_in_context(name, module_name, file) {
 				return t.a.add_node(flat.Node{
-					kind:                 .ident
-					op:                   node.op
-					pos:                  node.pos
-					value:                key
-					typ:                  node.typ
-					is_mut:               node.is_mut
-					skip_ownership_drops: node.skip_ownership_drops
+					kind:   .ident
+					op:     node.op
+					pos:    node.pos
+					value:  key
+					typ:    node.typ
+					is_mut: node.is_mut
+					flags:  flat.node_flags(node.skip_ownership_drops(), false)
 				})
 			}
 		}
@@ -289,16 +289,16 @@ fn (mut t Transformer) clone_promoted_default_in_decl_scope(id flat.NodeId, modu
 		t.a.children << child
 	}
 	return t.a.add_node(flat.Node{
-		kind:                 node.kind
-		op:                   node.op
-		pos:                  node.pos
-		value:                node.value
-		typ:                  node.typ
-		payload:              node.payload
-		is_mut:               node.is_mut
-		children_start:       start
-		children_count:       flat.child_count(children.len)
-		skip_ownership_drops: node.skip_ownership_drops
+		kind:           node.kind
+		op:             node.op
+		pos:            node.pos
+		value:          node.value
+		typ:            node.typ
+		payload:        node.payload
+		is_mut:         node.is_mut
+		children_start: start
+		children_count: flat.child_count(children.len)
+		flags:          flat.node_flags(node.skip_ownership_drops(), false)
 	})
 }
 
@@ -1543,7 +1543,7 @@ fn (mut t Transformer) fixed_array_value_to_owned_array(value_id flat.NodeId, fi
 		t.make_prefix(.amp, t.make_ident(value_name)),
 	], 'void'))
 	t.pending_stmts << t.make_for_stmt(init, cond, post, body, flat.Node{
-		skip_ownership_drops: true
+		flags: flat.node_flag_skip_ownership_drops
 	})
 	result := t.make_ident(out_name)
 	t.set_node_typ(int(result), array_type)

--- a/vlib/v3/transform/transform.v
+++ b/vlib/v3/transform/transform.v
@@ -436,10 +436,10 @@ mut:
 	// (0 == unset) into node_context_texts. A whole-AST table of 24-byte string
 	// headers costs hundreds of MiB on a compiler-sized program; the id table is
 	// 4 bytes per node and resolves to the same canonical spelling.
-	node_module_map_cache  []u32
-	node_file_map_cache    []u32
+	node_module_map_cache  []u16
+	node_file_map_cache    []u16
 	node_context_texts     []string
-	node_context_text_ids  map[string]u32
+	node_context_text_ids  map[string]u16
 	node_module_map_nodes  int = -1
 	node_context_read_only bool
 	// used_fns_log records names newly inserted into used_fns while the
@@ -1751,6 +1751,21 @@ fn (mut t Transformer) mark_used_fn_key(key string) {
 		t.used_fns_log << key
 	}
 	t.used_fns[key] = true
+}
+
+// used_fn_maps lists every map used_fn_contains_name consults. Scans over the
+// whole used set must walk all of them: a worker keeps only its own discoveries
+// in used_fns and reads the rest through its parent and root snapshots.
+fn (t &Transformer) used_fn_maps() []&map[string]bool {
+	mut maps := []&map[string]bool{cap: 3}
+	maps << unsafe { &t.used_fns }
+	if !isnil(t.used_fns_parent) {
+		maps << t.used_fns_parent
+	}
+	if !isnil(t.used_fns_root) {
+		maps << t.used_fns_root
+	}
+	return maps
 }
 
 fn (t &Transformer) has_any_used_fns() bool {
@@ -3820,7 +3835,6 @@ fn (t &Transformer) fork_worker_config(ast &flat.FlatAst, wtc &types.TypeChecker
 		map[string]bool{}
 	}
 	mut w := t.fork_program_view(ast, wtc, used, copy_used_fns)
-	w.used_struct_operator_fns = t.used_struct_operator_fns.clone()
 	if !copy_used_fns {
 		if t.node_context_read_only && isnil(t.used_fns_parent) && !isnil(t.used_fns_root) {
 			// A shared-base master is still recording helper names while its workers
@@ -3897,7 +3911,7 @@ fn (t &Transformer) fork_worker_config(ast &flat.FlatAst, wtc &types.TypeChecker
 		w.node_module_map_nodes = t.node_module_map_nodes
 		w.node_context_read_only = true
 	} else {
-		w.node_module_map_cache = []u32{}
+		w.node_module_map_cache = []u16{}
 		w.node_module_map_nodes = -1
 	}
 	w.var_types = []VarTypeBinding{}
@@ -4026,7 +4040,7 @@ fn (t &Transformer) fork_scan_worker(wtc &types.TypeChecker) &Transformer {
 	w.generic_fn_decls_ready = false
 	w.generic_call_spec_cache = map[int]GenericCallSpec{}
 	w.generic_call_spec_misses = map[int]bool{}
-	w.node_module_map_cache = []u32{}
+	w.node_module_map_cache = []u16{}
 	w.node_module_map_nodes = -1
 	w.var_types = []VarTypeBinding{}
 	w.var_type_indices = map[string]int{}
@@ -4485,12 +4499,12 @@ fn (mut t Transformer) clone_scoped_worker_node(idx int, scope voidptr) {
 		_, typ := t.a.intern_text(node.typ)
 		node.typ = typ
 	}
-	if isnil(node.payload) {
+	if node.payload == 0 {
 		return
 	}
 	old_params := node.generic_params()
 	if old_params.len > 0 {
-		mut needs_owned_params := transform_scope_owns(scope, node.payload)
+		mut needs_owned_params := transform_scope_owns(scope, node.payload_ptr())
 			|| transform_scope_owns(scope, old_params.data)
 		if !needs_owned_params {
 			for param in old_params {
@@ -4882,25 +4896,7 @@ fn (mut t Transformer) set_generated_resolved_call(id flat.NodeId, name string) 
 }
 
 fn (mut t Transformer) set_resolved_fn_value_entry(idx int, name string) {
-	if t.tc.parallel_check_sparse && idx >= t.tc.resolved_fn_value_names.len {
-		t.tc.sparse_resolved_fn_values[idx] = t.tc.canonical_symbol(name)
-		return
-	}
-	if t.tc.resolved_fn_value_names.len <= idx {
-		start := t.tc.resolved_fn_value_names.len
-		set_start := t.tc.resolved_fn_value_set.len
-		amount := idx + 1 - start
-		// Merging an appended worker region can leave a large gap. Initialize
-		// that range once instead of growing both caches one element at a time.
-		unsafe {
-			t.tc.resolved_fn_value_names.grow_len(amount)
-			t.tc.resolved_fn_value_set.grow_len(amount)
-			vmemset(&t.tc.resolved_fn_value_names[start], 0, isize(amount) * isize(sizeof(&types.CachedName)))
-			vmemset(&t.tc.resolved_fn_value_set[set_start], 0, isize(amount))
-		}
-	}
-	t.tc.resolved_fn_value_names[idx] = types.cached_name(t.tc.canonical_symbol(name))
-	t.tc.resolved_fn_value_set[idx] = true
+	t.tc.sparse_resolved_fn_values[idx] = t.tc.canonical_symbol(name)
 }
 
 fn (mut t Transformer) record_refined_node_type(idx int, typ string) {
@@ -4929,19 +4925,6 @@ fn (mut t Transformer) clear_typechecker_node_cache_range(start int, end int) {
 		}
 		for k in start .. call_end {
 			t.tc.resolved_call_names[k] = unsafe { nil }
-		}
-	}
-	fn_value_end := if end < t.tc.resolved_fn_value_set.len {
-		end
-	} else {
-		t.tc.resolved_fn_value_set.len
-	}
-	if start < fn_value_end {
-		unsafe {
-			vmemset(&t.tc.resolved_fn_value_set[start], 0, fn_value_end - start)
-		}
-		for k in start .. fn_value_end {
-			t.tc.resolved_fn_value_names[k] = unsafe { nil }
 		}
 	}
 	expr_end := if end < t.tc.expr_type_set.len { end } else { t.tc.expr_type_set.len }
@@ -4982,10 +4965,6 @@ fn (mut t Transformer) clear_typechecker_node_cache(idx int) {
 	if idx < t.tc.resolved_call_set.len {
 		t.tc.resolved_call_names[idx] = unsafe { nil }
 		t.tc.resolved_call_set[idx] = false
-	}
-	if idx < t.tc.resolved_fn_value_set.len {
-		t.tc.resolved_fn_value_names[idx] = unsafe { nil }
-		t.tc.resolved_fn_value_set[idx] = false
 	}
 	if idx < t.tc.expr_type_set.len {
 		t.tc.expr_type_set[idx] = false
@@ -8831,7 +8810,7 @@ fn (mut t Transformer) transform_fn_body(fn_idx int) {
 	// Generic specializations carry a template's `manualfree` attribute in the
 	// function node because the checker's declaration-attribute index only
 	// contains parsed declarations.
-	t.cur_fn_manualfree = fn_node.skip_ownership_drops
+	t.cur_fn_manualfree = fn_node.skip_ownership_drops()
 		|| t.tc.declaration_has_attribute(flat.NodeId(fn_idx), 'manualfree')
 	param_count := t.fn_body_param_count(fn_node)
 	param_types := t.fn_body_param_types(fn_node, param_count)
@@ -8999,8 +8978,7 @@ fn (mut t Transformer) transform_fn_body(fn_idx int) {
 			value: fn_node.value
 			typ: fn_node.typ
 			payload: fn_node.payload
-			skip_ownership_drops: fn_node.skip_ownership_drops
-			is_static_type_method: fn_node.is_static_type_method
+			flags: fn_node.flags
 		})
 	}
 	t.smartcast_stack.clear()
@@ -11611,7 +11589,7 @@ fn (mut t Transformer) transform_assign_stmt(id flat.NodeId, node flat.Node) []f
 		t.update_option_assignment_smartcast(t.a.child(&node, 0), t.a.child(&node, 1))
 	}
 	if node.kind in [.assign, .selector_assign, .index_assign] && node.op == .assign
-		&& !node.skip_ownership_drops && node.children_count == 2 && !isnil(t.tc) {
+		&& !node.skip_ownership_drops() && node.children_count == 2 && !isnil(t.tc) {
 		lhs_id := t.a.child(&node, 0)
 		rhs_id := t.a.child(&node, 1)
 		lhs_node := t.a.nodes[int(lhs_id)]
@@ -11736,7 +11714,7 @@ fn (mut t Transformer) transform_assign_stmt(id flat.NodeId, node flat.Node) []f
 			pos: node.pos
 			value: node.value
 			typ: node.typ
-			skip_ownership_drops: node.skip_ownership_drops
+			flags: flat.node_flags(node.skip_ownership_drops(), false)
 		})
 	}
 	if node.kind == .assign && node.op == .left_shift_assign {
@@ -15357,7 +15335,7 @@ fn (mut t Transformer) rewrite_multi_return_match_assign(node flat.Node, lhs_ids
 			children_count: flat.child_count(branch_children.len)
 			pos: branch.pos
 			is_mut: branch.is_mut
-			skip_ownership_drops: branch.skip_ownership_drops
+			flags: flat.node_flags(branch.skip_ownership_drops(), false)
 		})
 	}
 	start := t.a.children.len
@@ -15372,7 +15350,7 @@ fn (mut t Transformer) rewrite_multi_return_match_assign(node flat.Node, lhs_ids
 		children_count: flat.child_count(match_children.len)
 		pos: node.pos
 		is_mut: node.is_mut
-		skip_ownership_drops: node.skip_ownership_drops
+		flags: flat.node_flags(node.skip_ownership_drops(), false)
 	}
 }
 
@@ -22289,7 +22267,7 @@ fn (mut t Transformer) make_assign_without_ownership_drop(lhs flat.NodeId, rhs f
 		op: .assign
 		children_start: start
 		children_count: 2
-		skip_ownership_drops: true
+		flags: flat.node_flag_skip_ownership_drops
 	})
 }
 
@@ -22298,7 +22276,7 @@ fn (mut t Transformer) make_assign_without_ownership_drop(lhs flat.NodeId, rhs f
 // nodes, so mark this assignment to prevent a second drop-before-assign pass.
 fn (mut t Transformer) make_assign_after_owned_drop(lhs flat.NodeId, rhs flat.NodeId) flat.NodeId {
 	id := t.make_assign(lhs, rhs)
-	t.a.nodes[int(id)].skip_ownership_drops = true
+	t.a.nodes[int(id)].set_skip_ownership_drops(true)
 	return id
 }
 
@@ -22405,14 +22383,14 @@ fn (mut t Transformer) make_if_with_ownership_drop_mode(cond flat.NodeId, then_b
 			kind: .if_expr
 			children_start: start
 			children_count: 3
-			skip_ownership_drops: skip_ownership_drops
+			flags: flat.node_flags(skip_ownership_drops, false)
 		})
 	}
 	return t.a.add_node(flat.Node{
 		kind: .if_expr
 		children_start: start
 		children_count: 2
-		skip_ownership_drops: skip_ownership_drops
+		flags: flat.node_flags(skip_ownership_drops, false)
 	})
 }
 
@@ -24706,7 +24684,7 @@ fn (mut t Transformer) clone_match_variant_sizeof(id flat.NodeId, subject string
 		is_mut: node.is_mut
 		children_start: start
 		children_count: node.children_count
-		skip_ownership_drops: node.skip_ownership_drops
+		flags: flat.node_flags(node.skip_ownership_drops(), false)
 	})
 }
 

--- a/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
+++ b/vlib/v3/transform/transform_parallel_notd_v3_no_parallel.v
@@ -35,7 +35,7 @@ const shared_transform_chunks_per_job = 1
 const shared_expansion_pool_divisor = 2
 const max_parallel_monomorph_jobs = 18
 // Recycle scratch arenas throughout large self-hosting transforms.
-const scoped_transform_batches = 8
+const scoped_transform_batches = 16
 const scoped_selfhost_transform_batches = 4
 const scoped_transform_max_batch_items = 2048
 const scoped_monomorph_batch_specs = 512
@@ -318,7 +318,7 @@ fn node_has_any_scoped_text(node &flat.Node, scopes []voidptr, lo usize, hi usiz
 	value_addr := usize(voidptr(node.value.str))
 	typ_addr := usize(voidptr(node.typ.str))
 	if (node.value.len == 0 || value_addr < lo || value_addr >= hi)
-		&& (node.typ.len == 0 || typ_addr < lo || typ_addr >= hi) && isnil(node.payload) {
+		&& (node.typ.len == 0 || typ_addr < lo || typ_addr >= hi) && node.payload == 0 {
 		return false
 	}
 	for scope in scopes {
@@ -357,13 +357,13 @@ fn node_has_scoped_text(node &flat.Node, scope voidptr) bool {
 	if node.typ.len > 0 && transform_scope_owns(scope, node.typ.str) {
 		return true
 	}
-	if isnil(node.payload) {
+	if node.payload == 0 {
 		return false
 	}
-	if transform_scope_owns(scope, node.payload) {
+	if transform_scope_owns(scope, node.payload_ptr()) {
 		return true
 	}
-	params := node.payload.generic_params
+	params := node.generic_params()
 	if params.len == 0 {
 		return false
 	}
@@ -584,7 +584,7 @@ fn scan_literal_decl_flags_parallel(t &Transformer, limit int, mut flags []u8, m
 // need erasure.
 @[inline]
 fn fn_decl_generic_candidate_prescreen(a &flat.FlatAst, node &flat.Node, prefix_param_scan bool) bool {
-	if !isnil(node.payload) && node.payload.generic_params.len > 0 {
+	if node.payload != 0 && node.generic_params().len > 0 {
 		return true
 	}
 	if generic_placeholder_prescreen(node.typ) || generic_placeholder_prescreen(node.value) {
@@ -675,14 +675,14 @@ $if !windows {
 			if node.typ.len > 0 && transform_scope_owns(a.scope, node.typ.str) {
 				node.typ = promote_scoped_text_read_only(ast, node.typ)
 			}
-			if isnil(node.payload) {
+			if node.payload == 0 {
 				continue
 			}
-			params := node.payload.generic_params
+			params := node.generic_params()
 			if params.len == 0 {
 				continue
 			}
-			mut needs := transform_scope_owns(a.scope, node.payload)
+			mut needs := transform_scope_owns(a.scope, node.payload_ptr())
 				|| transform_scope_owns(a.scope, params.data)
 			if !needs {
 				for param in params {
@@ -788,9 +788,6 @@ $if !windows {
 		for idx in a.start .. a.end {
 			if idx < tc.resolved_call_set.len && tc.resolved_call_set[idx] {
 				tc.resolved_call_names[idx] = types.promote_cached_name(tc.resolved_call_names[idx], a.scope)
-			}
-			if idx < tc.resolved_fn_value_set.len && tc.resolved_fn_value_set[idx] {
-				tc.resolved_fn_value_names[idx] = types.promote_cached_name(tc.resolved_fn_value_names[idx], a.scope)
 			}
 			if idx >= a.generated_start && idx < tc.expr_type_set.len && tc.expr_type_set[idx]
 				&& idx < tc.expr_type_values.len {
@@ -1874,14 +1871,14 @@ fn (mut t Transformer) promote_scoped_node_to_current(idx int, scope voidptr) {
 	if node.typ.len > 0 && transform_scope_owns(scope, node.typ.str) {
 		node.typ = t.promote_scoped_result_text(node.typ)
 	}
-	if isnil(node.payload) {
+	if node.payload == 0 {
 		return
 	}
 	old_params := node.generic_params()
 	if old_params.len == 0 {
 		return
 	}
-	mut needs_owned_params := transform_scope_owns(scope, node.payload)
+	mut needs_owned_params := transform_scope_owns(scope, node.payload_ptr())
 		|| transform_scope_owns(scope, old_params.data)
 	if !needs_owned_params {
 		for param in old_params {
@@ -2269,8 +2266,7 @@ fn (mut t Transformer) clone_deferred_worker_writes_from(start int) {
 						kind: write.node.kind
 						op: write.node.op
 						is_mut: write.node.is_mut
-						skip_ownership_drops: write.node.skip_ownership_drops
-						is_static_type_method: write.node.is_static_type_method
+						flags: write.node.flags
 					}
 				}
 			}
@@ -2636,7 +2632,11 @@ fn (mut t Transformer) run_parallel_transform_shared(items []FnWorkItem, base_no
 			view_ms := f64(sfsw.elapsed().microseconds()) / 1000.0
 			wtc := t.tc.fork_for_parallel_transform(view)
 			tc_ms := f64(sfsw.elapsed().microseconds()) / 1000.0
-			mut ww := t.fork_worker(view, wtc)
+			// Helpers read the immutable used-function snapshot installed above and
+			// record only their own discoveries, so they need no private copy of the
+			// whole used set (one clone per helper, and the merge re-inserted every
+			// entry of every copy).
+			mut ww := t.fork_worker_config(view, wtc, false)
 			ww.defer_oor_writes = false
 			args[ci + 1] = SharedChunkArgs{
 				worker: voidptr(ww)

--- a/vlib/v3/transform/transform_parallel_test.v
+++ b/vlib/v3/transform/transform_parallel_test.v
@@ -4892,7 +4892,7 @@ fn test_deferred_worker_node_clone_preserves_skip_ownership_drops() {
 					kind: 2
 					node: flat.Node{
 						kind: .for_stmt
-						skip_ownership_drops: true
+						flags: flat.node_flag_skip_ownership_drops
 					}
 				},
 			]
@@ -4901,7 +4901,7 @@ fn test_deferred_worker_node_clone_preserves_skip_ownership_drops() {
 		t.clone_deferred_worker_writes_from(0)
 		cloned := t.deferred_base_writes[0].node
 		assert cloned.kind == .for_stmt
-		assert cloned.skip_ownership_drops
+		assert cloned.skip_ownership_drops()
 	}
 }
 

--- a/vlib/v3/types/checker.v
+++ b/vlib/v3/types/checker.v
@@ -768,41 +768,39 @@ pub mut:
 	interface_impl_indexes                map[string]&InterfaceImplIndex
 	interface_query_indexes_ready         bool
 
-	c_globals               map[string]Type
-	global_names            map[string]bool
-	shared_global_names     map[string]bool
-	const_types             map[string]Type
-	const_exprs             map[string]flat.NodeId
-	const_modules           map[string]string
-	const_files             map[string]string
-	const_suffixes          map[string]string // dot-suffix -> full const key (O(1) lookup; '' if ambiguous)
-	declaration_visibility  map[string]DeclarationVisibility
-	checked_const_names     map[string]bool
-	imports                 map[string]string // alias -> short module name
-	file_imports            map[string]string
-	file_selective_imports  map[string][]string
-	file_imports_by_file    map[string]&FileImportInfo
-	file_modules            map[string]string
-	translated_files        map[string]bool
-	has_globals_files       map[string]bool
-	deprecated_symbols      map[string]DeprecationInfo
-	file_scope              &Scope = unsafe { nil }
-	cur_scope               &Scope = unsafe { nil }
-	scope_pool              []&Scope
-	scope_pool_index        int
-	has_builtins            bool
-	cur_module              string
-	cur_file                string
-	unsafe_depth            int
-	lock_depth              int
-	comptime_static_depth   int
-	errors                  []TypeError
-	notices                 []TypeError
-	resolved_call_names     []&CachedName // node_id -> resolved function name
-	resolved_call_set       []bool
-	resolved_fn_value_names []&CachedName // node_id -> resolved function value name
-	resolved_fn_value_set   []bool
-	statement_nodes         []bool
+	c_globals              map[string]Type
+	global_names           map[string]bool
+	shared_global_names    map[string]bool
+	const_types            map[string]Type
+	const_exprs            map[string]flat.NodeId
+	const_modules          map[string]string
+	const_files            map[string]string
+	const_suffixes         map[string]string // dot-suffix -> full const key (O(1) lookup; '' if ambiguous)
+	declaration_visibility map[string]DeclarationVisibility
+	checked_const_names    map[string]bool
+	imports                map[string]string // alias -> short module name
+	file_imports           map[string]string
+	file_selective_imports map[string][]string
+	file_imports_by_file   map[string]&FileImportInfo
+	file_modules           map[string]string
+	translated_files       map[string]bool
+	has_globals_files      map[string]bool
+	deprecated_symbols     map[string]DeprecationInfo
+	file_scope             &Scope = unsafe { nil }
+	cur_scope              &Scope = unsafe { nil }
+	scope_pool             []&Scope
+	scope_pool_index       int
+	has_builtins           bool
+	cur_module             string
+	cur_file               string
+	unsafe_depth           int
+	lock_depth             int
+	comptime_static_depth  int
+	errors                 []TypeError
+	notices                []TypeError
+	resolved_call_names    []&CachedName // node_id -> resolved function name
+	resolved_call_set      []bool
+	statement_nodes        []bool
 	// Exact call/function-value dependencies recorded while each function is
 	// checked. Consumers such as markused can walk these resolved Symbol-like
 	// names instead of reconstructing import and receiver resolution from syntax.
@@ -846,7 +844,7 @@ pub mut:
 	check_range_lo                int = -1
 	check_range_hi                int = -1
 	sparse_resolved_call_names    map[int]string
-	sparse_resolved_fn_values     map[int]string
+	sparse_resolved_fn_values     map[int]string // the only fn-value name store: a few dozen entries, a node-indexed array cost ~12 MB
 	sparse_statement_nodes        map[int]bool
 	sparse_expr_type_values       map[int]Type
 	sparse_checking_nodes         map[int]bool
@@ -1100,8 +1098,6 @@ pub fn TypeChecker.new(a &flat.FlatAst) TypeChecker {
 		// used without a collect() call.
 		resolved_call_names: []&CachedName{}
 		resolved_call_set: []bool{}
-		resolved_fn_value_names: []&CachedName{}
-		resolved_fn_value_set: []bool{}
 		statement_nodes: []bool{}
 		method_values_by_fn: map[int][]string{}
 		method_value_locals: map[string]bool{}
@@ -1267,8 +1263,6 @@ fn (tc &TypeChecker) fork_program_view(ast &flat.FlatAst, direct_dependencies_by
 		notices: []TypeError{}
 		resolved_call_names: tc.resolved_call_names
 		resolved_call_set: tc.resolved_call_set
-		resolved_fn_value_names: tc.resolved_fn_value_names
-		resolved_fn_value_set: tc.resolved_fn_value_set
 		statement_nodes: tc.statement_nodes
 		direct_dependencies_by_fn: direct_dependencies_by_fn
 		method_values_by_fn: tc.method_values_by_fn
@@ -1703,7 +1697,7 @@ pub fn (mut tc TypeChecker) free_parallel_transform_caches() {
 
 // reset_node_caches updates reset node caches state for types.
 fn (mut tc TypeChecker) reset_node_caches(n int) {
-	for group in 0 .. 3 {
+	for group in 0 .. 2 {
 		tc.reset_node_cache_group(n, group)
 	}
 }
@@ -1713,11 +1707,6 @@ fn (mut tc TypeChecker) reset_node_cache_group(n int, group int) {
 	if group == 0 {
 		tc.resolved_call_names = new_zeroed_name_cache(n)
 		tc.resolved_call_set = []bool{len: n}
-		return
-	}
-	if group == 1 {
-		tc.resolved_fn_value_names = new_zeroed_name_cache(n)
-		tc.resolved_fn_value_set = []bool{len: n}
 		return
 	}
 	tc.statement_nodes = []bool{len: n}
@@ -2094,8 +2083,8 @@ fn (mut tc TypeChecker) build_fn_declaration_indexes(a &flat.FlatAst) {
 		if qname !in tc.declaration_param_mutability {
 			tc.declaration_param_mutability[qname] = param_mutability
 		}
-		if node.value.contains('.') || node.is_static_type_method {
-			is_static := node.is_static_type_method || node.children_count == 0
+		if node.value.contains('.') || node.is_static_type_method() {
+			is_static := node.is_static_type_method() || node.children_count == 0
 				|| a.child_node(&node, 0).kind != .param || a.child_node(&node, 0).op != .dot
 			if node.value !in tc.static_associated_fn_keys {
 				tc.static_associated_fn_keys[node.value] = is_static
@@ -2194,14 +2183,12 @@ fn (mut tc TypeChecker) extend_node_caches(n int) {
 	if tc.parallel_check_sparse {
 		return
 	}
-	if n <= tc.resolved_call_names.len && n <= tc.resolved_fn_value_names.len
-		&& n <= tc.statement_nodes.len && n <= tc.expr_type_values.len && n <= tc.checking_nodes.len {
+	if n <= tc.resolved_call_names.len && n <= tc.statement_nodes.len
+		&& n <= tc.expr_type_values.len && n <= tc.checking_nodes.len {
 		return
 	}
 	extend_name_cache(mut tc.resolved_call_names, n)
 	extend_bool_cache(mut tc.resolved_call_set, n)
-	extend_name_cache(mut tc.resolved_fn_value_names, n)
-	extend_bool_cache(mut tc.resolved_fn_value_set, n)
 	extend_bool_cache(mut tc.statement_nodes, n)
 	extend_type_cache(mut tc.expr_type_values, n)
 	extend_bool_cache(mut tc.expr_type_set, n)
@@ -2213,8 +2200,6 @@ fn (mut tc TypeChecker) extend_node_caches(n int) {
 pub fn (mut tc TypeChecker) reserve_transform_node_caches(n int) {
 	reserve_name_cache(mut tc.resolved_call_names, n)
 	reserve_bool_cache(mut tc.resolved_call_set, n)
-	reserve_name_cache(mut tc.resolved_fn_value_names, n)
-	reserve_bool_cache(mut tc.resolved_fn_value_set, n)
 	reserve_bool_cache(mut tc.statement_nodes, n)
 	reserve_type_cache(mut tc.expr_type_values, n)
 	reserve_bool_cache(mut tc.expr_type_set, n)
@@ -2240,12 +2225,6 @@ pub fn (mut tc TypeChecker) materialize_sparse_transform_node_caches(n int, capa
 			tc.resolved_call_set[idx] = true
 		}
 	}
-	for idx, name in tc.sparse_resolved_fn_values {
-		if idx >= 0 && idx < n {
-			tc.resolved_fn_value_names[idx] = cached_name(name)
-			tc.resolved_fn_value_set[idx] = true
-		}
-	}
 	for idx, is_statement in tc.sparse_statement_nodes {
 		if is_statement && idx >= 0 && idx < n {
 			tc.statement_nodes[idx] = true
@@ -2258,7 +2237,6 @@ pub fn (mut tc TypeChecker) materialize_sparse_transform_node_caches(n int, capa
 		}
 	}
 	tc.sparse_resolved_call_names = map[int]string{}
-	tc.sparse_resolved_fn_values = map[int]string{}
 	tc.sparse_statement_nodes = map[int]bool{}
 	tc.sparse_expr_type_values = map[int]Type{}
 	tc.sparse_checking_nodes = map[int]bool{}
@@ -6943,7 +6921,7 @@ pub fn (mut tc TypeChecker) diagnose_unused_private_declarations(used_fns map[st
 		if node.kind == .fn_decl {
 			if node.op == .arrow || node.value in ['main', 'init', 'cleanup']
 				|| is_v_test_fn_name(node.value) || node.value.starts_with('__anon_fn_')
-				|| node.value.contains('.') || node.is_static_type_method {
+				|| node.value.contains('.') || node.is_static_type_method() {
 				continue
 			}
 			if tc.declaration_contains_error(node) {
@@ -8423,19 +8401,10 @@ pub fn (tc &TypeChecker) resolved_fn_value_name(id flat.NodeId) ?string {
 			return name
 		}
 	}
-	if tc.parallel_check_sparse {
-		if tc.in_check_range(idx) {
-			if idx < tc.resolved_fn_value_set.len && tc.resolved_fn_value_set[idx] {
-				return tc.resolved_fn_value_names[idx].value
-			}
-			return none
-		}
-		return tc.sparse_resolved_fn_values[idx] or { none }
+	if idx < 0 {
+		return none
 	}
-	if idx >= 0 && idx < tc.resolved_fn_value_set.len && tc.resolved_fn_value_set[idx] {
-		return tc.resolved_fn_value_names[idx].value
-	}
-	return none
+	return tc.sparse_resolved_fn_values[idx] or { none }
 }
 
 // clear_resolved_fn_value removes stale function-value metadata after a later
@@ -8447,10 +8416,6 @@ pub fn (mut tc TypeChecker) clear_resolved_fn_value(id flat.NodeId) {
 	}
 	if !isnil(tc.fork_overlay) {
 		tc.fork_overlay.resolved_fn_values.delete(idx)
-	}
-	if idx < tc.resolved_fn_value_set.len {
-		tc.resolved_fn_value_names[idx] = unsafe { nil }
-		tc.resolved_fn_value_set[idx] = false
 	}
 	if tc.sparse_resolved_fn_values.len > 0 {
 		tc.sparse_resolved_fn_values.delete(idx)
@@ -8671,22 +8636,9 @@ fn (mut tc TypeChecker) remember_resolved_fn_value(id flat.NodeId, name string) 
 	}
 	symbol_id, canonical := tc.intern_symbol(name)
 	tc.record_direct_dependency(symbol_id)
-	if tc.parallel_check_sparse {
-		if tc.in_check_range(idx) && idx < tc.resolved_fn_value_names.len {
-			tc.resolved_fn_value_names[idx] = cached_name(canonical)
-			tc.resolved_fn_value_set[idx] = true
-			return
-		}
-		tc.sparse_resolved_fn_values[idx] = canonical
-		return
-	}
-	if idx >= tc.resolved_fn_value_names.len {
-		tc.extend_node_caches(tc.a.nodes.len)
-	}
-	if idx < tc.resolved_fn_value_names.len {
-		tc.resolved_fn_value_names[idx] = cached_name(canonical)
-		tc.resolved_fn_value_set[idx] = true
-	}
+	// Parallel check workers write their private map; merge_worker_sparse_caches
+	// publishes it into the master's.
+	tc.sparse_resolved_fn_values[idx] = canonical
 }
 
 fn (mut tc TypeChecker) remember_resolved_fn_value_chain(id flat.NodeId, name string) {
@@ -9486,12 +9438,12 @@ fn (mut tc TypeChecker) check_fn_declaration_name(id flat.NodeId, node flat.Node
 	tc.check_fn_if_attribute_return(id, node)
 	tc.check_imported_module_prefix(id, node.value, 'fn')
 	mut name := node.value.all_after_last('.')
-	if node.is_static_type_method {
+	if node.is_static_type_method() {
 		if _, method := flat.decode_static_type_method_name(node.value) {
 			name = method
 		}
 	}
-	if !node.value.contains('.') && !node.is_static_type_method
+	if !node.value.contains('.') && !node.is_static_type_method()
 		&& tc.cur_module in ['', 'main'] && is_builtin_type_name(name) {
 		tc.record_error_at(.duplicate_decl, 'top level declaration cannot shadow builtin type', id, tc.fn_declaration_diagnostic_pos(node))
 	}
@@ -9508,7 +9460,7 @@ fn (mut tc TypeChecker) check_fn_declaration_name(id flat.NodeId, node flat.Node
 	if name.len == 0 || (!name[0].is_letter() && name[0] != `_`) || snake_case_name_is_valid(name) {
 		return
 	}
-	tc.check_snake_case_name(id, name, if node.value.contains('.') || node.is_static_type_method {
+	tc.check_snake_case_name(id, name, if node.value.contains('.') || node.is_static_type_method() {
 		'method name'
 	} else {
 		'function name'
@@ -11178,8 +11130,8 @@ fn (mut tc TypeChecker) check_decl_type_strings(node_id flat.NodeId, node flat.N
 		&& (node.children_count > 0 || split_sum_variant_texts(node.typ).len > 1) {
 		tc.check_sum_type_decl(node_id, node)
 	}
-	if node.kind == .fn_decl && (node.value.contains('.') || node.is_static_type_method) {
-		is_marked_static := node.is_static_type_method
+	if node.kind == .fn_decl && (node.value.contains('.') || node.is_static_type_method()) {
+		is_marked_static := node.is_static_type_method()
 		receiver_name := if is_marked_static {
 			if receiver, _ := flat.decode_static_type_method_name(node.value) {
 				receiver.all_after_last('.')

--- a/vlib/v3/types/checker_parallel.v
+++ b/vlib/v3/types/checker_parallel.v
@@ -241,7 +241,7 @@ fn (mut tc TypeChecker) prepare_collect_index_parallel(a &flat.FlatAst) bool {
 		args << CollectIndexPrepArgs{ tc: voidptr(tc), a: a, kind: 0, start: start, end: end }
 		start = end
 	}
-	for kind in [u8(1), 2, 3, 4] {
+	for kind in [u8(1), 2, 3] {
 		args << CollectIndexPrepArgs{ tc: voidptr(tc), a: a, kind: kind, n: a.nodes.len }
 	}
 	mut tasks := []workers.Task{cap: args.len}
@@ -1592,10 +1592,6 @@ fn (mut tc TypeChecker) merge_own_sparse_caches() {
 		tc.resolved_call_names[idx] = cached_name(name)
 		tc.resolved_call_set[idx] = true
 	}
-	for idx, name in tc.sparse_resolved_fn_values {
-		tc.resolved_fn_value_names[idx] = cached_name(name)
-		tc.resolved_fn_value_set[idx] = true
-	}
 	for idx, _ in tc.sparse_statement_nodes {
 		tc.statement_nodes[idx] = true
 	}
@@ -1604,7 +1600,6 @@ fn (mut tc TypeChecker) merge_own_sparse_caches() {
 		tc.expr_type_set[idx] = true
 	}
 	tc.sparse_resolved_call_names.clear()
-	tc.sparse_resolved_fn_values.clear()
 	tc.sparse_statement_nodes.clear()
 	tc.sparse_expr_type_values.clear()
 	tc.sparse_checking_nodes.clear()
@@ -2943,9 +2938,6 @@ fn check_clone_chunk_thread(arg voidptr) voidptr {
 			if idx < tc.resolved_call_set.len && tc.resolved_call_set[idx] {
 				tc.resolved_call_names[idx] = promote_cached_name_value(tc.resolved_call_names[idx], mut names)
 			}
-			if idx < tc.resolved_fn_value_set.len && tc.resolved_fn_value_set[idx] {
-				tc.resolved_fn_value_names[idx] = promote_cached_name_value(tc.resolved_fn_value_names[idx], mut names)
-			}
 			if idx < tc.expr_type_set.len && tc.expr_type_set[idx] {
 				if canonical := tc.cached_check_type_promotion(tc.expr_type_values[idx], mut cache, false) {
 					tc.expr_type_values[idx] = canonical
@@ -2989,9 +2981,6 @@ fn (mut tc TypeChecker) clone_parallel_worker_node_caches(items []CheckWorkItem)
 		for idx in item.range_lo .. item.fn_idx + 1 {
 			if idx < tc.resolved_call_set.len && tc.resolved_call_set[idx] {
 				tc.resolved_call_names[idx] = promote_cached_name_value(tc.resolved_call_names[idx], mut names)
-			}
-			if idx < tc.resolved_fn_value_set.len && tc.resolved_fn_value_set[idx] {
-				tc.resolved_fn_value_names[idx] = promote_cached_name_value(tc.resolved_fn_value_names[idx], mut names)
 			}
 			if idx < tc.expr_type_set.len && tc.expr_type_set[idx] {
 				tc.expr_type_values[idx] = tc.cached_check_type_promotion(tc.expr_type_values[idx], mut cache, true) or {
@@ -3091,12 +3080,7 @@ fn (mut tc TypeChecker) merge_parallel_check_worker_scoped(w &TypeChecker, scope
 	}
 	for idx, name in w.sparse_resolved_fn_values {
 		owned_name := if scoped { name.clone() } else { name }
-		if tc.parallel_check_sparse {
-			tc.sparse_resolved_fn_values[idx] = owned_name
-		} else {
-			tc.resolved_fn_value_names[idx] = cached_name(owned_name)
-			tc.resolved_fn_value_set[idx] = true
-		}
+		tc.sparse_resolved_fn_values[idx] = owned_name
 	}
 	for idx, _ in w.sparse_statement_nodes {
 		if tc.parallel_check_sparse {

--- a/vlib/v3/types/checker_parallel_test.v
+++ b/vlib/v3/types/checker_parallel_test.v
@@ -282,14 +282,13 @@ fn test_nested_parallel_checker_merge_keeps_out_of_range_caches_sparse() {
 		assert false
 	}
 	assert !tc.resolved_call_set[2]
-	assert !tc.resolved_fn_value_set[2]
 	assert !tc.statement_nodes[2]
 	assert !tc.expr_type_set[2]
 
 	tc.parallel_check_sparse = false
 	tc.merge_own_sparse_caches()
 	assert tc.resolved_call_names[2].value == 'main.answer'
-	assert tc.resolved_fn_value_names[2].value == 'main.callback'
+	assert tc.resolved_fn_value_name(2)? == 'main.callback'
 	assert tc.statement_nodes[2]
 	assert tc.expr_type_values[2] is Primitive
 	worker.free_parallel_check_worker_cache()

--- a/vlib/v3/types/checker_tail.v
+++ b/vlib/v3/types/checker_tail.v
@@ -3861,7 +3861,7 @@ fn (mut tc TypeChecker) check_c_alias_cast_call(id flat.NodeId, node flat.Node, 
 		pos: node.pos
 		is_mut: node.is_mut
 		op: node.op
-		skip_ownership_drops: node.skip_ownership_drops
+		flags: flat.node_flags(node.skip_ownership_drops(), false)
 	}
 	tc.check_cast_expr(id, cast_node)
 	return true

--- a/vlib/v3/types/type_cache_test.v
+++ b/vlib/v3/types/type_cache_test.v
@@ -8,18 +8,12 @@ fn test_node_cache_reset_clears_string_slots_and_set_bits() {
 	for n in [0, 1, 257, 33] {
 		tc.reset_node_caches(n)
 		assert tc.resolved_call_names.len == n
-		assert tc.resolved_fn_value_names.len == n
 		assert tc.resolved_call_set.len == n
-		assert tc.resolved_fn_value_set.len == n
 		for i in 0 .. n {
 			assert isnil(tc.resolved_call_names[i])
-			assert isnil(tc.resolved_fn_value_names[i])
 			assert !tc.resolved_call_set[i]
-			assert !tc.resolved_fn_value_set[i]
 			tc.resolved_call_names[i] = cached_name('previous.call')
-			tc.resolved_fn_value_names[i] = cached_name('previous.value')
 			tc.resolved_call_set[i] = true
-			tc.resolved_fn_value_set[i] = true
 		}
 	}
 }


### PR DESCRIPTION
Fourth pass on the v3 self-host peak (after #28534). Benchmark as before:

```
cd vlib/v3
../../v -gc none -prealloc -prod -o v3 v3.v && ./v3 -nocache -building-v -o v4 v3.v
```

`/usr/bin/time -l`, interleaved baseline/new pairs, prod binaries:

| | baseline | this PR |
|---|---|---|
| peak footprint, idle machine, 3 pairs (vs 4089ece6a4) | 692 / 706 / 693 MiB | 622 / 625 / 625 MiB (**-10.5%**) |
| peak footprint, load avg ~8, 7 pairs (vs current master) | median 697 MiB | median 636 MiB (**-8.9%**) |
| max RSS, idle | 700 / 713 / 701 MiB | 631 / 632 / 632 MiB (-10.3%) |
| instructions retired | 45.7-46.0 G | 45.7-46.0 G (equal) |

The absolute gain moves a little with machine load (the new binary's peak varies more than the baseline's), so both measurements are given. Bench stage peaks: transform 656 -> 613, cgen 662 -> 621 MB RSS.

### What was cut

- **`flat.Node` 88 -> 80 bytes.** The payload pointer becomes a `u32` id into a process-wide chunked table (`node_payload` / `node_payload_at`: spin lock on insert, lock-free lookups). Copying a node copies the id, so no parser or transform merge path needs remapping. The two rare bools (`skip_ownership_drops`, `is_static_type_method`) become bits in a `flags` byte behind accessor methods. About -18 MB at both the transform and the cgen peak.
- **Resolved fn-value names are sparse-only.** The dense per-node `resolved_fn_value_names` array plus its set bits cost 12 MB and held 81 entries after the check (call names: 93k, expression types: 600k, so those stay dense). `sparse_resolved_fn_values` is now the only store; parallel-check forks get fresh maps and merge after the join.
- **Shared transform helpers no longer clone `used_fns`.** They read the immutable root snapshot the master installs and record only their own discoveries (17 clones of an 11k-entry map gone from the setup arena), and the merge no longer re-inserts every entry of every copy. The two whole-set scans walk own, parent and root maps.
- **Transform helper batches 8 -> 16**, halving the batch arenas live at the transform peak; node module/file context caches `u32 -> u16`.
- **cgen: const initializer lowering runs on a private worker inside a disposable arena** (`precompute_consts_scoped`). It was 12 MB of the type-declaration task's permanent base garbage. The emission order still comes from the master, whose dependency memos are warm; only the C text, the runtime-init queue and the usual batch side tables are published.
- Tests that hard-coded the removed fields or the old cache width are updated.

### Validation

- Codegen is byte-identical to the baseline compiler on identical sources, also under `-d prealloc_no_recycle` (freed arenas unmapped), and the compiler reproduces itself (gen2).
- All v3 module suites and `vlib/v3/tests` were run; every failure fails identically on pristine master (checked in a separate worktree). `parallel_cgen_test`, which does a `-prod` self-build through the parallel cgen and the new const worker, passes.

Not from this PR, but worth knowing: under heavy CPU load both master and this branch occasionally emit the `.map()` iteration variable in `parser__VmlCompiler__expr` by reference instead of by value (a 6-line C diff), so codegen-equality checks should run on an idle machine.
